### PR TITLE
feat(skills): ブランチ完了判定フロースキル + workflow-awareness ルール (#14)

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -2,12 +2,13 @@
 
 `canonical/` 配下の全リソース一覧。AI がコンテキスト読み込みの起点に使うためのエントリポイント。
 
-## Skills (17)
+## Skills (18)
 
 | 名前 | 説明 | パス | depends |
 |------|------|------|---------|
 | adversarial-review | Plan/Specの品質チェック（Plan Review）と、実装完了後の仕様照合（Compliance Review）を行う | `skills/adversarial-review/SKILL.md` | — |
 | arena-compare | arena-compare.shで複数モデルに同一プロンプトを並列投入し、回答を比較する | `skills/arena-compare/SKILL.md` | cli: arena-compare |
+| branch-finish | ブランチ完了判定フロー（検証→4択→実行→クリーンアップ） | `skills/branch-finish/SKILL.md` | skill: worktrunk-worktrees, skill: pr-conventions, skill: conventional-commits |
 | branch-naming | ブランチ命名規則を適用する | `skills/branch-naming/SKILL.md` | — |
 | conventional-commits | コミットメッセージをConventional Commits規約に従って生成する | `skills/conventional-commits/SKILL.md` | — |
 | implementer-contract | サブエージェントへの実装委譲時の返却契約 | `skills/implementer-contract/SKILL.md` | — |
@@ -31,7 +32,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 
 | チェーン | フロー | 備考 |
 |---------|--------|------|
-| Issue → Branch → Worktree | `issue-conventions` → `branch-naming` → `worktrunk-worktrees` | 新規タスク開始時の典型フロー |
+| Issue → Branch → Worktree → Finish | `issue-conventions` → `branch-naming` → `worktrunk-worktrees` → `branch-finish` | タスク開始〜完了の全フロー |
 
 ## Commands (6)
 
@@ -52,7 +53,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | playwright-agent | Playwright MCPでブラウザ操作を実行し、結果を要約して報告するエージェント | `agents/playwright-agent.md` |
 | vendor-inspector | Dependency and vendor code deep-reading agent. Investigates local vendor/, node_modules/, and external repository code | `agents/vendor-inspector.md` |
 
-## Rules (10)
+## Rules (11)
 
 | 名前 | 説明 | パス |
 |------|------|------|
@@ -66,6 +67,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | output-format-rule | 結論→根拠→手順→リスク→リンクの出力構造 | `rules/output-format-rule.md` |
 | skill-first-operations-rule | 定型的な開発操作はスキルに従う。操作前にスキル定義を確認 | `rules/skill-first-operations-rule.md` |
 | subagent-strategy-rule | サブエージェント活用方針、カスタムエージェント優先、1タスク1エージェント | `rules/subagent-strategy-rule.md` |
+| workflow-awareness-rule | GitHub Flow 採用。Issue 起点の作業はブランチ作成を自律的に開始 | `rules/workflow-awareness-rule.md` |
 
 ## Hooks
 

--- a/canonical/rules/workflow-awareness-rule.md
+++ b/canonical/rules/workflow-awareness-rule.md
@@ -1,0 +1,4 @@
+# Workflow Awareness
+- 現在の開発ワークフローは GitHub Flow（feature branch → デフォルトブランチにマージ）
+- Issue 起点の作業では、ブランチ作成・worktree 作成を明示的に指示されなくても自律的に開始する
+- Issue 起点でない作業（探索・調査・ドラフト等）はデフォルトブランチでの作業も許容する

--- a/canonical/skills/branch-finish/SKILL.md
+++ b/canonical/skills/branch-finish/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: branch-finish
+description: ブランチ完了判定フロー。テスト検証→4択（マージ/PR/保留/破棄）→実行→クリーンアップ。実装完了後のブランチ処理に使用する。
+depends:
+  - skill: worktrunk-worktrees
+  - skill: pr-conventions
+  - skill: conventional-commits
+---
+
+# ブランチ完了判定フロー
+
+## いつ使うか
+
+- 実装完了後、ブランチの処理方法を決める時点
+- `wt` CLI + worktree 運用が前提（未導入時は本スキル対象外）
+
+## フロー
+
+1. 検証（テスト・動作確認）
+2. 4択提示
+3. 選択肢の実行
+
+## Step 1: 検証
+
+テストスイートがある場合:
+
+```bash
+# プロジェクトのテストスイートを実行
+npm test / cargo test / pytest / go test ./... / shellcheck <script>
+```
+
+テストが失敗した場合は先に進まない。修正してから再実行する。
+
+テストスイートがない場合:
+- 動作確認が完了しているかユーザーに確認する
+- 未確認なら確認を促し、完了後に Step 2 に進む
+
+ベース同期は `wt merge` が rebase で処理するため、このステップでの手動同期は不要。
+
+## Step 2: 4択提示
+
+以下を簡潔に提示する。説明は付けない。
+
+```
+実装が完了しました。どうしますか？
+
+1. wt merge でデフォルトブランチにマージ
+2. Push して PR 作成
+3. ブランチ・worktree をそのまま保持
+4. 作業を破棄
+```
+
+## Step 3: 選択肢の実行
+
+### Option 1: マージ
+
+```bash
+# squash + rebase + FF + worktree 削除
+wt merge
+
+# コミット履歴を保持する場合
+wt merge --no-squash
+```
+
+- `wt merge` はベース同期（rebase + FF）を含む
+- squash 時のコミットメッセージは Conventional Commits 形式で書き直す（conventional-commits スキル参照）
+- 複数の独立した論理変更を含むブランチでは `--no-squash` を検討
+
+### Option 2: PR 作成
+
+```bash
+git push -u origin <branch>
+```
+
+PR 作成は pr-conventions スキルに従う。worktree は残す（レビュー中の修正対応のため）。
+
+### Option 3: 保留
+
+現状を報告して終了。ブランチ・worktree はそのまま維持する。
+
+```
+ブランチ <name> を保持します。worktree: <path>
+```
+
+### Option 4: 破棄
+
+実行前に削除対象を提示し、ユーザーの明示的な確認を得る。
+
+```
+以下を削除します:
+- ブランチ: <name>
+- コミット: <commit-list>
+- worktree: <path>
+
+続行しますか？
+```
+
+確認後:
+
+```bash
+wt remove -D
+```
+
+## pr-conventions との役割分担
+
+branch-finish = 完了フロー全体のオーケストレーション、pr-conventions = PR 作成の規約詳細。Option 2 で pr-conventions に委譲する。


### PR DESCRIPTION
## Summary

obra/superpowers の `finishing-a-development-branch` を wt CLI + 既存スキルに適応し、ブランチ完了判定フローをスキル化。

- `branch-finish` スキル新規作成: テスト検証→4択（マージ/PR/保留/破棄）→実行→クリーンアップ
- `workflow-awareness-rule` 新規作成: GitHub Flow 採用宣言 + Issue 起点のブランチ作成自律化
- CATALOG.md: Skills 17→18、Rules 10→11、Workflow Chains を全フローに拡張

## peer-ai-review 結果

- Codex: 「1ブランチ周期での試用」未計画を指摘 → self-dogfooding ステップ追加で解消
- Cursor: ベース同期の明示、sync 対象、非 wt 環境スコープを指摘 → 全反映

## self-dogfooding

本 PR 自体が branch-finish スキルの試用。branch-naming → worktrunk-worktrees → branch-finish（Option 2: PR 作成）の Workflow Chain を一周。

Refs #14
