### PR TITLE
feat(hooks): タスク完了時の未コミット変更検知ゲートを追加

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -77,6 +77,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 |--------|-----------|------|
 | 破壊コマンドブロック | `hooks/scripts/block-destructive.sh` | `rm -rf /`, `DROP TABLE` 等の破壊的コマンドをブロック |
 | force push ブロック | `hooks/scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
+| コミットゲート | `hooks/scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（Claude Code のみ） |
 
 ## ツール固有拡張
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -13,6 +13,7 @@
 |--------|-----------|------|
 | 破壊コマンドブロック | `scripts/block-destructive.sh` | `rm -rf /`, `chmod -R 777 /`, `DROP TABLE` 等の破壊的コマンドをブロック |
 | force push ブロック | `scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
+| コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
 
 ## ツール別カバレッジ
 
@@ -20,6 +21,7 @@
 |--------|--------|-------------|-------|
 | 破壊コマンドブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | force push ブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
+| コミットゲート | — | `TaskCompleted` | — |
 
 ## block-destructive.sh
 
@@ -59,6 +61,29 @@
 
 - `--force-with-lease`（safer alternative）
 - `--force-if-includes`
+
+## commit-gate.sh
+
+タスク完了時（`TaskCompleted` イベント）に未コミット変更を検知し、エージェントに通知する advisory フック。ブロックはしない。
+
+### 発火条件
+
+- `TaskCompleted` イベントが発火（タスクが completed に遷移）
+- `cwd` が git リポジトリ内
+- 現在のブランチが `main` / `master` 以外（detached HEAD も対象外）
+- `git status --porcelain` で未コミット変更がある
+
+### 出力
+
+変更がある場合、`user_message` でエージェントに以下を通知:
+
+- 変更ファイル一覧（上限10件）
+- コミットまたはスキップ理由の記録を促すガイダンス
+- スキップ理由フォーマット: `Skip-Reason: {WIP / batch with next step / investigation only}`
+
+### 対象ツール
+
+Claude Code のみ。Cursor / Codex は `TaskCompleted` 相当のイベントを持たないため対象外。
 
 ## 設定ファイル
 

--- a/canonical/hooks/claude.hooks.json
+++ b/canonical/hooks/claude.hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/commit-gate.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/canonical/hooks/scripts/commit-gate.sh
+++ b/canonical/hooks/scripts/commit-gate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# commit-gate.sh — TaskCompleted フック
+# タスク完了時に未コミット変更があればエージェントに通知する（advisory）。
+# master/main 上では発火しない。
+
+notify() {
+  jq -n --arg msg "$1" '{"user_message":$msg}'
+  exit 0
+}
+
+silent_exit() {
+  exit 0
+}
+
+main() {
+  local input cwd branch dirty file_count file_list msg
+
+  input="$(cat)"
+  cwd="$(jq -r '.cwd // ""' <<< "$input")"
+
+  if [[ -z "$cwd" || "$cwd" == "null" ]]; then
+    silent_exit
+  fi
+
+  # git リポジトリ外なら何もしない
+  if ! git -C "$cwd" rev-parse --is-inside-work-tree &>/dev/null; then
+    silent_exit
+  fi
+
+  # ブランチ取得（detached HEAD なら空文字列）
+  branch="$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || echo "")"
+
+  # detached HEAD → 対象外
+  if [[ -z "$branch" ]]; then
+    silent_exit
+  fi
+
+  # master/main → 対象外
+  case "$branch" in
+    main|master) silent_exit ;;
+  esac
+
+  # 未コミット変更の検出
+  dirty="$(git -C "$cwd" status --porcelain 2>/dev/null || echo "")"
+
+  if [[ -z "$dirty" ]]; then
+    silent_exit
+  fi
+
+  # 変更ファイル一覧（上限10件）
+  file_count="$(echo "$dirty" | wc -l | tr -d ' ')"
+  file_list="$(echo "$dirty" | head -10)"
+
+  msg="[commit-gate] Task completed with uncommitted changes on branch '${branch}'.
+
+Changed files (${file_count}):
+${file_list}"
+
+  if (( file_count > 10 )); then
+    msg="${msg}
+... and $((file_count - 10)) more"
+  fi
+
+  msg="${msg}
+
+Action required: commit these changes, or record a skip reason.
+Skip-Reason format: Skip-Reason: {WIP / batch with next step / investigation only}"
+
+  notify "$msg"
+}
+
+main


### PR DESCRIPTION
## Summary

- TaskCompleted イベントで発火する advisory フック `commit-gate.sh` を追加
- feature ブランチ上でタスク完了時に未コミット変更があればエージェントに通知し、コミットまたはスキップ理由の記録を促す
- master/main/detached HEAD では発火しない。Claude Code のみ対応（Cursor/Codex は TaskCompleted 相当イベントなし）

## 設計判断

- **イベント**: `TaskCompleted`（Peer AI Review で `PostToolUse(TaskUpdate)` から変更。「完了の手段」ではなく「完了の事実」に結びつく）
- **介入レベル**: advisory（`user_message` 通知のみ、ブロックしない）
- **ブランチ判定**: `git symbolic-ref --short HEAD` + detached HEAD ガード
- **スキップ理由永続化**: 初回スコープ外（監査ログ基盤との統合設計を待つ）

## 変更ファイル

| ファイル | 操作 |
|---------|------|
| `canonical/hooks/scripts/commit-gate.sh` | 新規作成 |
| `canonical/hooks/claude.hooks.json` | TaskCompleted エントリ追加 |
| `canonical/hooks/README.md` | フック一覧・カバレッジ表・ドキュメント追加 |
| `canonical/CATALOG.md` | Hooks テーブル追加 |

## Test plan

- [x] shellcheck パス
- [x] git repo 外 → silent exit
- [x] master ブランチ → silent exit
- [x] cwd 空 → silent exit
- [x] detached HEAD → silent exit
- [x] feature ブランチ + 変更あり → user_message 出力
- [ ] `sync.sh claude` 実行後に `~/.claude/settings.json` に反映されることを確認
- [ ] 実セッションでタスク完了時に通知が表示されることを確認

## Related

- Closes #39
- Epic #37, Epic #24
- 設計背景: `docs/draft/commit-gate-and-rule-observability.md`
- Peer AI Review: `tmp/so-20260406-103139/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)