### PR TITLE
feat(hooks): Phase 3 — CC形式チェックフック + Cursorパス修正 + sync --check

### DIFF
--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -14,6 +14,7 @@
 | 破壊コマンドブロック | `scripts/block-destructive.sh` | `rm -rf /`, `chmod -R 777 /`, `DROP TABLE` 等の破壊的コマンドをブロック |
 | force push ブロック | `scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
 | コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
+| CC 形式チェック | `scripts/cc-lint.sh` | `git commit -m` のメッセージが Conventional Commits 形式に準拠しているかチェック |
 
 ## ツール別カバレッジ
 
@@ -22,6 +23,7 @@
 | 破壊コマンドブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | force push ブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | コミットゲート | — | `TaskCompleted` | — |
+| CC 形式チェック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 
 ## block-destructive.sh
 
@@ -84,6 +86,36 @@
 ### 対象ツール
 
 Claude Code のみ。Cursor / Codex は `TaskCompleted` 相当のイベントを持たないため対象外。
+
+## cc-lint.sh
+
+`git commit -m "..."` のコミットメッセージが Conventional Commits 形式に準拠しているかチェックする。
+
+### チェック対象
+
+`git commit` コマンドで `-m` フラグを含むもの。`&&` チェーン内の `git commit` も抽出して検証する。
+
+### 許可される型
+
+`conventional-commits` スキル定義に準拠する13型:
+
+`feat`, `fix`, `ui`, `refactor`, `style`, `test`, `docs`, `revert`, `ci`, `infra`, `chore`, `local`, `wip`
+
+### CC 形式
+
+```
+<type>(<optional scope>): <description>
+```
+
+### allow されるケース
+
+- `-m` なし（エディタ起動）: `git commit`, `git commit --amend`
+- `--fixup=<sha>` / `--squash=<sha>`: 一時コミットのため無条件 allow
+- HEREDOC / コマンド置換を含むメッセージ: パース困難なため allow（保守的設計）
+
+### deny 時の出力
+
+フォーマット例と型リストを含むメッセージを出力する。
 
 ## 設定ファイル
 

--- a/canonical/hooks/claude.hooks.json
+++ b/canonical/hooks/claude.hooks.json
@@ -21,6 +21,10 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/block-force-push.sh"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/cc-lint.sh"
           }
         ]
       }

--- a/canonical/hooks/codex.hooks.json
+++ b/canonical/hooks/codex.hooks.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "$HOME/.codex/hooks/block-force-push.sh"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.codex/hooks/cc-lint.sh"
           }
         ]
       }

--- a/canonical/hooks/cursor.hooks.json
+++ b/canonical/hooks/cursor.hooks.json
@@ -9,6 +9,10 @@
       {
         "command": "$HOME/.cursor/hooks/block-force-push.sh",
         "failClosed": true
+      },
+      {
+        "command": "$HOME/.cursor/hooks/cc-lint.sh",
+        "failClosed": true
       }
     ]
   }

--- a/canonical/hooks/cursor.hooks.json
+++ b/canonical/hooks/cursor.hooks.json
@@ -3,11 +3,11 @@
   "hooks": {
     "beforeShellExecution": [
       {
-        "command": "./hooks/block-destructive.sh",
+        "command": "$HOME/.cursor/hooks/block-destructive.sh",
         "failClosed": true
       },
       {
-        "command": "./hooks/block-force-push.sh",
+        "command": "$HOME/.cursor/hooks/block-force-push.sh",
         "failClosed": true
       }
     ]

--- a/canonical/hooks/scripts/block-destructive.sh
+++ b/canonical/hooks/scripts/block-destructive.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 SAFE_DIRS_RE='^(node_modules|dist|\.next|build|coverage|__pycache__|\.cache|tmp|\.turbo|\.parcel-cache)$'
 
 deny() {
-  jq -n --arg msg "$1" '{"permission":"deny","user_message":$msg}'
+  local msg="$1"
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    jq -n --arg msg "$msg" '{"permission":"deny","user_message":$msg}'
+  else
+    echo "$msg" >&2
+  fi
   exit 2
 }
 
 allow() {
-  echo '{"permission":"allow"}'
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    echo '{"permission":"allow"}'
+  fi
   exit 0
 }
 

--- a/canonical/hooks/scripts/block-force-push.sh
+++ b/canonical/hooks/scripts/block-force-push.sh
@@ -2,12 +2,19 @@
 set -euo pipefail
 
 deny() {
-  jq -n --arg msg "$1" '{"permission":"deny","user_message":$msg}'
+  local msg="$1"
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    jq -n --arg msg "$msg" '{"permission":"deny","user_message":$msg}'
+  else
+    echo "$msg" >&2
+  fi
   exit 2
 }
 
 allow() {
-  echo '{"permission":"allow"}'
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    echo '{"permission":"allow"}'
+  fi
   exit 0
 }
 

--- a/canonical/hooks/scripts/cc-lint.sh
+++ b/canonical/hooks/scripts/cc-lint.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 CC_TYPES="feat|fix|ui|refactor|style|test|docs|revert|ci|infra|chore|local|wip"
 
 deny() {
-  jq -n --arg msg "$1" '{"permission":"deny","user_message":$msg}'
+  local msg="$1"
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    jq -n --arg msg "$msg" '{"permission":"deny","user_message":$msg}'
+  else
+    echo "$msg" >&2
+  fi
   exit 2
 }
 
 allow() {
-  echo '{"permission":"allow"}'
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    echo '{"permission":"allow"}'
+  fi
   exit 0
 }
 

--- a/canonical/hooks/scripts/cc-lint.sh
+++ b/canonical/hooks/scripts/cc-lint.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CC_TYPES="feat|fix|ui|refactor|style|test|docs|revert|ci|infra|chore|local|wip"
+
+deny() {
+  jq -n --arg msg "$1" '{"permission":"deny","user_message":$msg}'
+  exit 2
+}
+
+allow() {
+  echo '{"permission":"allow"}'
+  exit 0
+}
+
+extract_commit_segment() {
+  local cmd="$1"
+  if [[ "$cmd" == *"&&"* ]]; then
+    local segment
+    segment="$(echo "$cmd" | grep -oE '(^|&&)[[:space:]]*git[[:space:]]+commit[^&]*' | head -1 | sed 's/^[[:space:]]*&&[[:space:]]*//')"
+    if [[ -n "$segment" ]]; then
+      echo "$segment"
+      return 0
+    fi
+  fi
+  echo "$cmd"
+}
+
+extract_message() {
+  local cmd="$1"
+  if [[ "$cmd" =~ \$\( ]] || [[ "$cmd" =~ \` ]]; then
+    return 1
+  fi
+
+  local msg=""
+  local -a tokens
+  local in_m=false
+
+  read -ra tokens <<< "$cmd"
+  for token in "${tokens[@]}"; do
+    if $in_m; then
+      if [[ -z "$msg" ]]; then
+        msg="$token"
+      else
+        msg="$msg $token"
+      fi
+      if [[ "$msg" == \"*\" ]] || [[ "$msg" == \'*\' ]]; then
+        msg="${msg#[\"\']}"
+        msg="${msg%[\"\']}"
+        echo "$msg"
+        return 0
+      fi
+      if [[ "$msg" != \"* ]] && [[ "$msg" != \'* ]]; then
+        echo "$msg"
+        return 0
+      fi
+      if [[ "$msg" == *\" ]] || [[ "$msg" == *\' ]]; then
+        msg="${msg#[\"\']}"
+        msg="${msg%[\"\']}"
+        echo "$msg"
+        return 0
+      fi
+      continue
+    fi
+    case "$token" in
+      -m|--message)
+        in_m=true
+        ;;
+      -m=*)
+        msg="${token#-m=}"
+        msg="${msg#[\"\']}"
+        msg="${msg%[\"\']}"
+        echo "$msg"
+        return 0
+        ;;
+      --message=*)
+        msg="${token#--message=}"
+        msg="${msg#[\"\']}"
+        msg="${msg%[\"\']}"
+        echo "$msg"
+        return 0
+        ;;
+      -[a-zA-Z]*m)
+        in_m=true
+        ;;
+    esac
+  done
+
+  if $in_m && [[ -n "$msg" ]]; then
+    msg="${msg#[\"\']}"
+    msg="${msg%[\"\']}"
+    echo "$msg"
+    return 0
+  fi
+
+  return 1
+}
+
+main() {
+  local input cmd
+
+  input="$(cat)"
+  cmd="$(jq -r '.tool_input.command // .command' <<< "$input")"
+
+  if [[ -z "$cmd" || "$cmd" == "null" ]]; then
+    allow
+  fi
+
+  local commit_segment
+  commit_segment="$(extract_commit_segment "$cmd")"
+
+  if [[ ! "$commit_segment" =~ ^[[:space:]]*git[[:space:]]+(.*[[:space:]]+)?commit([[:space:]]|$) ]]; then
+    allow
+  fi
+
+  if [[ "$commit_segment" =~ --fixup[=[:space:]] ]] || [[ "$commit_segment" =~ --squash[=[:space:]] ]]; then
+    allow
+  fi
+
+  if [[ ! "$commit_segment" =~ [[:space:]]-[a-zA-Z]*m ]] && [[ ! "$commit_segment" =~ --message ]]; then
+    allow
+  fi
+
+  local message
+  if ! message="$(extract_message "$commit_segment")"; then
+    allow
+  fi
+
+  if [[ -z "$message" ]]; then
+    allow
+  fi
+
+  local cc_pattern="^(${CC_TYPES})(\(.+\))?: .+"
+  if [[ "$message" =~ $cc_pattern ]]; then
+    allow
+  fi
+
+  deny "Commit message does not follow Conventional Commits format.
+Expected: <type>(<optional scope>): <description>
+Types: feat, fix, ui, refactor, style, test, docs, revert, ci, infra, chore, local, wip
+Example: feat(hooks): add cc-lint pre-command hook
+Got: $message"
+}
+
+main

--- a/docs/issues/38/plans/kickoff-phase3-hooks-implementation.md
+++ b/docs/issues/38/plans/kickoff-phase3-hooks-implementation.md
@@ -3,7 +3,7 @@ id: 01KP1E4N7X8RFTV0J2AQNE3K9H
 title: "Phase 3: Hooks 実装 + Deployment 修正"
 date: 2026-04-13
 type: kickoff
-status: draft
+status: completed
 scope: canonical/hooks
 related:
   - type: parent_epic

--- a/docs/issues/38/results/phase3-hooks-verification-results.md
+++ b/docs/issues/38/results/phase3-hooks-verification-results.md
@@ -1,0 +1,204 @@
+---
+title: "Issue #69: Phase 3 Hooks Implementation — 検証結果"
+date: 2026-04-14
+status: completed
+tags: [canonical, hooks, cross-agent, phase3, verification]
+related_issues:
+  - https://github.com/stlwolf/ai-development-hub/issues/69
+  - https://github.com/stlwolf/ai-development-hub/issues/38
+  - https://github.com/stlwolf/ai-development-hub/issues/24
+pr: https://github.com/stlwolf/ai-development-hub/pull/70
+kickoff: ../plans/kickoff-phase3-hooks-implementation.md
+---
+
+# Issue #69: Phase 3 Hooks Implementation — 検証結果
+
+## 概要
+
+Phase 3 では以下を実装・検証した:
+
+1. Cursor hooks パス修正（`./hooks/` → `$HOME/.cursor/hooks/`）
+2. Conventional Commits 形式チェックフック（`cc-lint.sh`）
+3. クロスツール互換性修正（Codex `PreToolUse` JSON スキーマ対応）
+4. `sync.sh --check` モード
+
+## 実装成果物
+
+| 成果物 | コミット | ファイル |
+|--------|---------|---------|
+| Cursor hooks パス修正 | `71e8965` | `canonical/hooks/cursor.hooks.json` |
+| cc-lint.sh | `d34ca2d` | `canonical/hooks/scripts/cc-lint.sh` |
+| 3ツール hooks.json + README | `57979d5` | `canonical/hooks/{cursor,claude,codex}.hooks.json`, `canonical/hooks/README.md` |
+| sync --check モード | `48008f6` | `scripts/sync.sh` |
+| クロスツール互換性修正 | `dd9b62e` | `canonical/hooks/scripts/{block-destructive,block-force-push,cc-lint}.sh` |
+
+## 1. cc-lint.sh スクリプト単体テスト
+
+24 ケース全合格。
+
+| # | テストケース | 入力 | 期待 | 結果 |
+|---|-------------|------|------|------|
+| 1 | 非 commit コマンド | `git status` | allow | PASS |
+| 2 | CC 形式（型のみ） | `git commit -m "feat: add feature"` | allow | PASS |
+| 3 | CC 形式（スコープ付き） | `git commit -m "fix(hooks): resolve path"` | allow | PASS |
+| 4 | CC 非準拠 | `git commit -m "bad message"` | deny | PASS |
+| 5 | `--fixup` | `git commit --fixup=abc123` | allow | PASS |
+| 6 | `--squash` | `git commit --squash=abc123` | allow | PASS |
+| 7 | `-am` 結合フラグ（非 CC） | `git commit -am "bad message"` | deny | PASS |
+| 8 | `-am` 結合フラグ（CC） | `git commit -am "feat: good"` | allow | PASS |
+| 9 | `-m` なし（エディタ起動） | `git commit` | allow | PASS |
+| 10 | `--message=` 形式 | `git commit --message="feat: test"` | allow | PASS |
+| 11 | パイプ連結 | `git add . && git commit -m "feat: test"` | allow | PASS |
+| 12 | パイプ連結（非 CC） | `git add . && git commit -m "bad"` | deny | PASS |
+| 13-24 | 全13型の個別検証 | `feat`, `fix`, `ui`, ..., `wip` | allow | 全 PASS |
+
+## 2. クロスツール互換性テスト
+
+30 ケース全合格。
+
+### 2.1 基本動作（exit code）
+
+| # | テストケース | 期待 exit | 結果 |
+|---|-------------|----------|------|
+| 1-6 | block-destructive: allow/deny 各パターン | 0 / 2 | 6/6 PASS |
+| 7-10 | block-force-push: allow/deny 各パターン | 0 / 2 | 4/4 PASS |
+| 11-16 | cc-lint: allow/deny 各パターン | 0 / 2 | 6/6 PASS |
+
+### 2.2 Codex 互換（環境変数なし）
+
+| # | スクリプト | ケース | 期待 stdout | 期待 stderr | 結果 |
+|---|-----------|--------|------------|------------|------|
+| 17 | block-destructive | allow | 空 | - | PASS |
+| 18 | block-force-push | allow | 空 | - | PASS |
+| 19 | cc-lint | allow | 空 | - | PASS |
+| 20 | block-destructive | deny | 空 | メッセージあり | PASS |
+| 21 | block-force-push | deny | 空 | メッセージあり | PASS |
+| 22 | cc-lint | deny | 空 | メッセージあり | PASS |
+
+### 2.3 Cursor 互換（`CURSOR_PROJECT_DIR` 設定時）
+
+| # | スクリプト | ケース | 期待 stdout | 結果 |
+|---|-----------|--------|------------|------|
+| 23 | block-destructive | allow | `{"permission":"allow"}` | PASS |
+| 24 | block-force-push | allow | `{"permission":"allow"}` | PASS |
+| 25 | cc-lint | allow | `{"permission":"allow"}` | PASS |
+| 26 | block-destructive | deny | `{"permission":"deny",...}` | PASS |
+| 27 | block-force-push | deny | `{"permission":"deny",...}` | PASS |
+| 28 | cc-lint | deny | `{"permission":"deny",...}` | PASS |
+
+### 2.4 Claude Code 互換（`CLAUDE_PROJECT_DIR` 設定時）
+
+| # | スクリプト | ケース | 期待 stdout | 結果 |
+|---|-----------|--------|------------|------|
+| 29 | block-destructive | allow | `{"permission":"allow"}` | PASS |
+| 30 | block-destructive | deny | `{"permission":"deny",...}` | PASS |
+
+## 3. E2E インテグレーションテスト
+
+### 3.1 Cursor（エージェント実行）
+
+| # | コマンド | 期待 | 結果 |
+|---|---------|------|------|
+| 1 | `ls -la` | allow | PASS |
+| 2 | `git status` | allow | PASS |
+| 3 | `git commit -m "bad message"` | deny (cc-lint) | PASS |
+| 4 | `git commit -m "feat: test"` | allow | PASS（ステージ対象なしで commit 自体は未実行） |
+
+### 3.2 Claude Code（ユーザー手動実行）
+
+| # | コマンド | 期待 | 結果 |
+|---|---------|------|------|
+| 1 | `ls -la` | allow | PASS |
+| 2 | `git status` | allow | PASS |
+| 3 | `git log --oneline -3` | allow | PASS |
+| 4 | `git commit -m "bad message"` | deny (cc-lint) | PASS — フックがブロック |
+| 5 | `git commit -m "docs: test hook verification"` | allow | PASS（ステージ対象なしで commit 自体は未実行） |
+
+### 3.3 Codex（ユーザー手動実行）
+
+#### 修正前（`dd9b62e` 以前）
+
+| # | コマンド | 期待 | 結果 | 問題 |
+|---|---------|------|------|------|
+| 1 | `ls -la` | allow | allow（警告付き） | `PreToolUse hook (failed): invalid pre-tool-use JSON output` |
+| 2 | `git commit -m "bad message"` | deny | allow（sandbox error） | フック JSON が無効のため deny 不発 |
+
+**原因**: `allow()` が `{"permission":"allow"}` を stdout に出力。Codex は `exit 0` のみを allow として認識し、JSON 出力を "invalid" として扱う。
+
+#### 修正後（`dd9b62e`）
+
+| # | コマンド | 期待 | 結果 | 問題 |
+|---|---------|------|------|------|
+| 1 | `ls -la` | allow | PASS | エラーなし |
+| 2 | `git status` | allow | PASS | エラーなし |
+| 3 | `git log --oneline -3` | allow | PASS | エラーなし |
+| 4 | `git commit -m "bad message"` | deny (cc-lint) | PASS | CC 違反メッセージ表示 |
+| 5 | `git commit -m "docs: test hook verification"` | allow | PASS（ステージ対象なしで commit 自体は未実行） |
+
+## 4. sync.sh --check 検証
+
+| ターゲット | 結果 |
+|-----------|------|
+| cursor | up to date |
+| claude | up to date |
+| codex | up to date |
+| bin | up to date |
+
+## 5. クロスツール互換性の設計判断
+
+### 問題
+
+3ツールの `PreToolUse` フック応答プロトコルが異なる:
+
+| | allow | deny |
+|--|-------|------|
+| Cursor | exit 0 + `{"permission":"allow"}` JSON **必須**（`failClosed: true` 時） | exit 2 + `{"permission":"deny","user_message":"..."}` |
+| Claude Code | exit 0 + JSON（任意） | exit 2 + JSON（任意） |
+| Codex | exit 0 のみ（stdout JSON は "invalid" エラーになる） | exit 2 + stderr メッセージ |
+
+### 解決策
+
+環境変数によるツール検出分岐:
+
+- `CURSOR_PROJECT_DIR`: Cursor がフック実行時に設定
+- `CLAUDE_PROJECT_DIR`: Claude Code がフック実行時に設定（Cursor も互換エイリアスとして設定）
+- どちらも未設定: Codex（または他ツール）
+
+```bash
+deny() {
+  local msg="$1"
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    jq -n --arg msg "$msg" '{"permission":"deny","user_message":$msg}'
+  else
+    echo "$msg" >&2
+  fi
+  exit 2
+}
+
+allow() {
+  if [[ -n "${CURSOR_PROJECT_DIR:-}" || -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    echo '{"permission":"allow"}'
+  fi
+  exit 0
+}
+```
+
+### 学び
+
+- Cursor `failClosed: true` では、`exit 0` だけでは不十分。stdout に JSON が必要。`exit 0` + 空 stdout → "returned no output" → 全コマンドブロック（自爆）
+- Codex は `exit 0` のみを allow と認識。stdout に JSON を出すと "invalid pre-tool-use JSON output" エラー（fail-open なのでコマンド自体は実行される）
+- Claude Code は最も寛容。Cursor 互換の JSON でも `exit 0` のみでも動作する
+
+## 6. #24 フック拡充エピックへの申し送り
+
+Phase 1-3 で明示的に Out of Scope としたもの、または保留としたもの:
+
+| 項目 | 由来 | 優先度 | 備考 |
+|------|------|--------|------|
+| H-1: shellcheck-on-edit | #24 Tier 1 | 高 | `afterFileEdit` / `PostToolUse(Edit)` |
+| H-3: block-destructive パイプ/サブシェル拡張 | hooks README | 中 | `cmd1 | cmd2`、`$(cmd)` パターン |
+| 提案1: スキルロード監査 | Phase 2 設計 | 低 | ツール API でスキル参照痕跡の検出が困難 |
+| 提案3: implementation-gate 構造的強制 | Phase 2 設計 | 中 | #19 MVP が前提 |
+| H-4〜H-8: session-start, loop detection, quality-gate 等 | #24 Tier 2 | 中 | H-2（cc-lint）完了により着手可能 |
+| H-9〜H-11: Third-party hooks 統合, Cursor Tab, Claude advanced | #24 Tier 3 | 低 | プラットフォーム調査が必要 |
+| `allow()`/`deny()` の共通ライブラリ化 | Phase 3 学び | 中 | 3ファイルで同一パターン重複。`hooks/lib/response.sh` 等に抽出検討 |

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -10,6 +10,8 @@
 #   ./scripts/sync.sh claude codex     # 複数指定
 #   ./scripts/sync.sh --cursor --bin   # フラグ形式も可
 #   ./scripts/sync.sh --list           # 利用可能ターゲット一覧
+#   ./scripts/sync.sh --check          # 全ターゲットの整合チェック
+#   ./scripts/sync.sh --check cursor   # cursor のみチェック
 #
 # Available targets:
 #   cursor  — canonical + cursor-specific → ~/.cursor/
@@ -58,6 +60,136 @@ list_targets() {
     exit 0
 }
 
+resolve_path() {
+    if command -v realpath &>/dev/null; then
+        realpath "$1" 2>/dev/null
+    elif command -v python3 &>/dev/null; then
+        python3 -c "import os; print(os.path.realpath('$1'))" 2>/dev/null
+    else
+        echo "$1"
+    fi
+}
+
+check_symlink() {
+    local target="$1" expected_source="$2" label="$3"
+    local diffs_ref="$4"
+
+    if [[ ! -e "${target}" ]]; then
+        warn "  Missing: ${label} → ${target}"
+        eval "${diffs_ref}=true"
+        return
+    fi
+
+    if [[ -L "${target}" ]]; then
+        local actual_source
+        actual_source="$(resolve_path "${target}")"
+        local canonical_source
+        canonical_source="$(resolve_path "${expected_source}")"
+        if [[ "${actual_source}" != "${canonical_source}" ]]; then
+            warn "  Mismatch: ${label}"
+            warn "    expected: ${canonical_source}"
+            warn "    actual:   ${actual_source}"
+            eval "${diffs_ref}=true"
+        fi
+    else
+        if ! diff -q "${expected_source}" "${target}" &>/dev/null; then
+            warn "  Content differs: ${label} (not a symlink)"
+            eval "${diffs_ref}=true"
+        fi
+    fi
+}
+
+check_symlinks_dir() {
+    local source_dir="$1" target_dir="$2" pattern="$3" label="$4"
+    local diffs_ref="$5"
+
+    if [[ ! -d "${source_dir}" ]]; then
+        return
+    fi
+
+    while IFS= read -r -d '' file; do
+        local filename
+        filename="$(basename "$file")"
+        check_symlink "${target_dir}/${filename}" "${file}" "${label}/${filename}" "${diffs_ref}"
+    done < <(find "${source_dir}" -maxdepth 1 -type f -name "${pattern}" -print0 2>/dev/null)
+}
+
+check_skill_dirs() {
+    local source_dir="$1" target_dir="$2" label="$3"
+    local diffs_ref="$4"
+
+    for item_dir in "${source_dir}"/*/; do
+        [[ ! -d "${item_dir}" ]] && continue
+        [[ ! -f "${item_dir}/SKILL.md" ]] && continue
+        local dirname
+        dirname="$(basename "$item_dir")"
+        check_symlink "${target_dir}/${dirname}" "${item_dir%/}" "${label}/${dirname}" "${diffs_ref}"
+    done
+}
+
+check_target() {
+    local target="$1"
+    local repo_root
+    repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+    local canonical="${repo_root}/canonical"
+    local has_diffs=false
+
+    header "check-${target}"
+
+    case "${target}" in
+        cursor)
+            local base="${HOME}/.cursor"
+            check_symlinks_dir "${canonical}/commands" "${base}/commands" "*.md" "commands" has_diffs
+            check_skill_dirs "${canonical}/skills" "${base}/skills" "skills" has_diffs
+            check_symlinks_dir "${canonical}/agents" "${base}/agents" "*.md" "agents" has_diffs
+            check_symlink "${base}/mcp.json" "${canonical}/mcp/cursor.json" "mcp.json" has_diffs
+            check_symlink "${base}/hooks.json" "${canonical}/hooks/cursor.hooks.json" "hooks.json" has_diffs
+            check_symlinks_dir "${canonical}/hooks/scripts" "${base}/hooks" "*.sh" "hook-scripts" has_diffs
+            ;;
+        claude)
+            local base="${HOME}/.claude"
+            check_symlinks_dir "${canonical}/rules" "${base}/rules" "*.md" "rules" has_diffs
+            check_skill_dirs "${canonical}/skills" "${base}/skills" "skills" has_diffs
+            check_symlinks_dir "${canonical}/agents" "${base}/agents" "*.md" "agents" has_diffs
+            check_symlinks_dir "${canonical}/commands" "${base}/commands" "*.md" "commands" has_diffs
+            check_symlinks_dir "${canonical}/hooks/scripts" "${base}/hooks" "*.sh" "hook-scripts" has_diffs
+            if [[ -f "${base}/settings.json" ]]; then
+                local expected_hooks actual_hooks
+                expected_hooks="$(jq -S '.hooks' "${canonical}/hooks/claude.hooks.json" 2>/dev/null)"
+                actual_hooks="$(jq -S '.hooks' "${base}/settings.json" 2>/dev/null)"
+                if [[ "${expected_hooks}" != "${actual_hooks}" ]]; then
+                    warn "  Hooks section differs in settings.json"
+                    has_diffs=true
+                fi
+            fi
+            ;;
+        codex)
+            local base="${HOME}/.codex"
+            check_skill_dirs "${canonical}/skills" "${base}/skills" "skills" has_diffs
+            check_symlink "${base}/AGENTS.md" "${canonical}/codex/AGENTS.md" "AGENTS.md" has_diffs
+            check_symlink "${base}/hooks.json" "${canonical}/hooks/codex.hooks.json" "hooks.json" has_diffs
+            check_symlinks_dir "${canonical}/hooks/scripts" "${base}/hooks" "*.sh" "hook-scripts" has_diffs
+            ;;
+        bin)
+            local base="${HOME}/bin"
+            local so_compare="${repo_root}/scripts/so-compare.sh"
+            local arena_compare="${repo_root}/projects/arena-compare/arena-compare.sh"
+            [[ -f "${so_compare}" ]] && check_symlink "${base}/so-compare" "${so_compare}" "so-compare" has_diffs
+            [[ -f "${arena_compare}" ]] && check_symlink "${base}/arena-compare" "${arena_compare}" "arena-compare" has_diffs
+            ;;
+    esac
+
+    if [[ "${has_diffs}" == true ]]; then
+        error "  ${target}: diffs found"
+        echo ""
+        return 1
+    fi
+
+    info "  ${target}: up to date"
+    echo ""
+    return 0
+}
+
 run_target() {
     local target="$1"
     local script="${SYNC_DIR}/sync-${target}.sh"
@@ -73,24 +205,23 @@ run_target() {
 }
 
 main() {
-    # Parse arguments
     local targets=()
+    local check_mode=false
 
     for arg in "$@"; do
         case "${arg}" in
             -h|--help) usage ;;
             -l|--list) list_targets ;;
+            --check) check_mode=true ;;
             --*) targets+=("${arg#--}") ;;
             *) targets+=("${arg}") ;;
         esac
     done
 
-    # Default: all targets
     if [[ ${#targets[@]} -eq 0 ]]; then
         targets=("${ALL_TARGETS[@]}")
     fi
 
-    # Validate targets
     for target in "${targets[@]}"; do
         local valid=false
         for known in "${ALL_TARGETS[@]}"; do
@@ -106,10 +237,26 @@ main() {
         fi
     done
 
+    if [[ "${check_mode}" == true ]]; then
+        info "Check mode: ${targets[*]}"
+        echo ""
+        local failed=()
+        for target in "${targets[@]}"; do
+            if ! check_target "${target}"; then
+                failed+=("${target}")
+            fi
+        done
+        if [[ ${#failed[@]} -gt 0 ]]; then
+            error "Targets with diffs: ${failed[*]}"
+            exit 1
+        fi
+        info "All targets up to date."
+        exit 0
+    fi
+
     info "Targets: ${targets[*]}"
     echo ""
 
-    # Run each target, collect failures
     local failed=()
     for target in "${targets[@]}"; do
         if ! run_target "${target}"; then
@@ -117,7 +264,6 @@ main() {
         fi
     done
 
-    # Summary
     if [[ ${#failed[@]} -gt 0 ]]; then
         error "Failed targets: ${failed[*]}"
         exit 1


### PR DESCRIPTION
## 概要

Phase 3: Hooks 実装 + Deployment 修正。Epic #38 (canonical cross-agent optimization) の最終フェーズ。

## 変更内容

### P0: Cursor hooks パス修正（ブロッカー）
- `cursor.hooks.json` のパスを `./hooks/...`（ワークスペース相対）から `$HOME/.cursor/hooks/...` に変更
- Phase 2 マージ後に `failClosed: true` と相まって全 Shell コマンドがブロックされていた問題を修正
- Claude Code / Codex と同じ `$HOME` ベースの絶対パスに統一

### P1: cc-lint.sh（CC 形式チェックフック）
- `git commit -m` のメッセージが Conventional Commits 形式に準拠しているか pre-command でチェック
- `conventional-commits` スキル定義の13型を正とする型リスト（変数に外出し）
- `--fixup` / `--squash` は無条件 allow、`-m` なしは allow（保守的設計）
- 3ツール（Cursor / Claude Code / Codex）の hooks.json に追加

### P2: sync.sh --check モード
- `./scripts/sync.sh --check [target...]` で展開先が canonical と一致しているか検証
- symlink の参照先チェック + Claude settings.json hooks セクション比較
- 差分があれば exit 1、なければ exit 0

## 検証結果

- スクリプト単体テスト: 24/24 合格（cc-lint）、13/13 合格（E2E 全フック）
- Cursor インテグレーション: 通常コマンド allow、フック正常動作
- sync --check: 全4ターゲット pass
- Claude Code / Codex: ユーザー手動テスト待ち

## 影響範囲

- `canonical/hooks/` — スクリプト追加 + JSON 更新 + README 更新
- `scripts/sync.sh` — `--check` モード追加

Refs #69
