### PR TITLE
feat(wez): notify サブコマンド + Lua 統合方針 ADR

### DIFF
--- a/docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md
+++ b/docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md
@@ -1,0 +1,156 @@
+---
+id: "01KPT49WX219D2VFWTWMWAXWSQ"
+title: "仮説駆動探索の再現性 — 設計判断における網羅的選択肢探索"
+date: 2026-04-22
+type: discussion
+status: draft
+related:
+  - type: evidence_for
+    ref: projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+    reason: "TTY direct write 発見プロセス — 本 discussion の具体的な事例"
+  - type: design_context
+    ref: projects/agent-verification-flow/docs/DESIGN_PRINCIPLES.md
+    reason: "案B 逐次専門化（事実収集→仮説生成→仮説検証）のパターン"
+  - type: design_context
+    ref: ideas/20260208/hypothesis-second-opinion-review-flow.md
+    reason: "SO レビューフローの仮説 — 反証担当の固定が核心"
+  - type: sibling
+    ref: docs/specs/2026-04-06-discussion-multi-round-control-loop.md
+    reason: "多周制御の仕様 — findings 収束管理。本 discussion は仮説拡張の方向"
+  - type: design_context
+    ref: projects/orchestration-research/synthesis/architecture-sketch.md
+    reason: "認知協調層（arena=発散、peer-review=収束）の位置づけ"
+  - type: design_context
+    ref: projects/orchestration-research/concepts/domain/06-feedback-validation.md
+    reason: "BeeAI RequirementAgent の min_invocations パターン"
+  - type: design_context
+    ref: projects/arena-compare/docs/episodes/2026-03-04-exploration-mode-and-command-path.md
+    reason: "探索モード — persistent-exploration の行動制約を SO/Arena に自動注入"
+  - type: design_context
+    reason: "別プロジェクトの Sentry 調査中に抽出されたコードパス網羅原則。同じ「網羅性が保証される前に結論に飛ぶな」構造"
+tags: [hypothesis-driven, exploration, so-compare, arena-compare, persistent-exploration, reproducibility, exhaustion-before-conclusion]
+---
+
+# 仮説駆動探索の再現性 — 設計判断における網羅的選択肢探索
+
+## 1. 問題
+
+wez notify の設計検証で、SO ゼロベースレビューにより初期選択肢セット（A/B）に含まれていなかった option C（TTY 直接書き込み）が発見され、最適解として採用された（詳細: [episode](../../projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md)）。
+
+この発見は**人間の即興的判断**に依存していた。「確定したけど、もう一回ゼロベースで聞いてみよう」という判断がなければ、副作用のある command string 方式で確定していた。
+
+**問い**: この種の「確定する前に、未探索の代替案がないか網羅的に探索する」パターンを、再現可能な仕組みにできないか。
+
+## 2. 発見プロセスの構造分析
+
+### 今回揃った4条件
+
+| # | 条件 | 今回の具体例 | 再現の障壁 |
+|---|------|-------------|-----------|
+| 1 | 確定後のゼロベース再探索 | A に確定した後で SO に「他に選択肢はないか」と依頼 | 人間が「もう一回聞いてみよう」と判断する必要がある |
+| 2 | 反証可能なプロンプト | 「確認して」ではなく「ゼロベースで検証して」 | プロンプト設計が暗黙知 |
+| 3 | 提案の即時実機検証 | Claude の提案をその場で検証コマンド実行 | 検証コマンドの生成と実行が手動 |
+| 4 | 検証環境の即時利用可能性 | WezTerm が動いていてすぐ試せた | ドメイン依存 |
+
+条件1と2はプロンプト構造化で対処可能。条件3は半自動化の余地あり。条件4はドメイン固有で仕組み化が難しい。
+
+### コードパス網羅原則との構造的類似
+
+別プロジェクトの Sentry 調査中に、同じ構造の問題がバグ調査ドメインで発生・記録されている。
+
+**事象**: エラー調査で、入力→出力のコードパスに未読区間が残った状態で外部仮説（インフラ差異）に飛んだ。コードを全て読んでいれば 2 ステップで解決するところを 6 ステップかかった。
+
+**抽出された原則 — コードパス網羅原則（Code Path Exhaustion Principle）**:
+> エラー調査において、入力から出力までのコードパスに未読区間がある限り、外部要因の仮説に進むな。
+
+**仮説ファイルによるループ検出**: 各仮説を `tmp/hypothesis-NNN.md` に外部化し、空転（同じ抽象度での横移動）を物理的に可視化する概念。N 個蓄積で Hook/オーケストレーション層が介入（スキル強制ロード等）。
+
+### 共通する上位原則
+
+| バグ調査（コードパス網羅） | 設計判断（今回） |
+|---|---|
+| コードパスに未読区間がある状態で外部仮説に飛ぶ | 選択肢に未探索の代替案がある状態で確定する |
+| 「全て読んでから外部仮説に進め」 | 「ゼロベースで代替案を探索してから確定しろ」 |
+| 仮説ファイルの外部化でループ検出 | 選択肢の外部化で探索網羅性を可視化 |
+| N 個蓄積で介入 | 確定前にゼロベース SO を強制 |
+
+**Exhaustion Before Conclusion**: 網羅性が保証される前に結論に飛ぶな。
+
+## 3. 既存ツール群のギャップ
+
+| 今回起きたこと | 既存ツールでの対応 | ギャップ |
+|---|---|---|
+| 確定後にゼロベース再探索 | **なし** | persistent-exploration は「不可能」判定時のみ発動。設計判断の「確定」前には発動しない |
+| 選択肢の拡張（A,B → A,B,C） | arena-compare（発散） | arena は「同一質問を複数モデルに聞く」。**「知らない選択肢を生成させる」プロンプト構造がない** |
+| 即時実機検証 | **なし** | SO/Arena の出力は読むだけ。検証コマンドの生成・実行は人間が手動 |
+| 検証結果の再注入 | `so-compare --prev` | 手動チェーン。「検証結果を踏まえて再提案」のループが構造化されていない |
+
+最大のギャップ: 「A で確定、先に進む」が通常フローで、「確定前にまだ探索する」トリガーがない。
+
+## 4. 学術的アプローチとの接続
+
+2026年の最新研究で、今回のパターンと構造的に類似するアプローチが複数報告されている。
+
+| 研究 | アプローチ | 今回との接点 |
+|------|-----------|-------------|
+| **EXPERIGEN** | Generator（仮説提案）+ Experimenter（実験的検証）の2相。ベイジアン最適化的探索 | 「SO が提案→即時検証」のループと同型 |
+| **Nomad** | Exploration Map を構築し系統的に traversal。独立 Verifier がチェック | 選択肢の構造化 + 独立検証の分離 |
+| **Re-TRAC** | trajectory 後に「証拠・不確実性・失敗・今後の計画」を要約し次の条件に | 検証結果のフィードバックループ |
+| **DeepVerifier** | 失敗分類（5大分類・13小分類）から rubric を自動生成 | 探索の網羅性を rubric で保証 |
+
+共通するパターン: **仮説生成と仮説検証を分離し、検証結果を構造化してフィードバックする**。
+
+## 5. 既存の蓄積との接続
+
+### agent-verification-flow 案B（逐次専門化）
+
+バグ調査で実証済みのパターン: 事実収集者→仮説生成者→仮説検証者+対立仮説探索者。設計判断への未適用。
+
+### 多周制御（discussion-multi-round-control-loop）
+
+SO の findings 収束を管理する仕様。findings の**縮小**（resolved/dismissed で閉じる）は定義済みだが、findings の**拡張**（新しい選択肢の生成）は未定義。
+
+### 探索モード（arena-compare exploration-mode）
+
+persistent-exploration の行動制約を peer-ai-review / arena に自動注入。ただしトリガーは「不可能」回答 or モデル間の結論分裂。「確定前の網羅性チェック」はトリガーに含まれない。
+
+### BeeAI RequirementAgent
+
+`min_invocations` / `force_at_step` で試行回数を宣言的に強制。「確定前にゼロベース探索を最低1回実行」をルールとして表現可能な概念。
+
+## 6. 方向性
+
+### 層1: プロンプト構造化（即効性あり）
+
+SO / Arena に投げるプロンプトに「選択肢拡張セクション」を構造テンプレートとして追加する。
+
+```markdown
+## 選択肢拡張（必須）
+- 上記の選択肢以外に、技術的に可能な代替アプローチを提案してください
+- 提案には「検証可能な条件」を必ず付与してください
+- 「なぜこの選択肢が元の選択肢群に含まれていなかったか」を説明してください
+```
+
+適用タイミング: 設計判断（DJ-N）を含むキックオフや SO レビュー時。so-compare スキルのプロンプト設計原則セクションに追加。
+
+### 層2: スキルまたはコマンドの新設
+
+persistent-exploration の設計判断版。形態（スキル / コマンド / 既存スキル拡張）は層1 の実践結果を見て決定。
+
+考えられる要素:
+- トリガー: 設計判断の「確定」直前
+- 行動制約: 最低1回のゼロベース SO を実施してから確定
+- 探索木: 選択肢とその検証結果を構造化（persistent-exploration の探索木フォーマット応用）
+- 完了条件: 「新規選択肢なし」または「新規選択肢を検証して採否を決定」
+- 仮説ファイルプロトコル: コードパス網羅原則で提案された外部化メカニズムの設計判断版
+
+### 層3: 検証ループ半自動化（将来）
+
+オーケストレーション研究の BeeAI RequirementAgent パターン（`min_invocations`, `force_at_step`）を参考に、SO/Arena の出力から「検証可能な仮説」を抽出して検証コマンドを提案するフローを構造化。EXPERIGEN の Generator + Experimenter パターンとも整合。
+
+## 7. 次のアクション
+
+- [ ] 層1: so-compare スキルの「プロンプト設計原則」に選択肢拡張テンプレートを追加
+- [ ] 層1 を次の設計判断（wez notify 実装中、または別タスク）で実践し、効果を観察
+- [ ] 実践結果を踏まえて層2 の形態（スキル / コマンド / 既存拡張）を判断
+- [ ] コードパス網羅原則の仮説ファイルプロトコルと合わせて、設計判断版の外部化メカニズムを検討

--- a/docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md
+++ b/docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md
@@ -27,7 +27,8 @@ related:
     ref: projects/arena-compare/docs/episodes/2026-03-04-exploration-mode-and-command-path.md
     reason: "探索モード — persistent-exploration の行動制約を SO/Arena に自動注入"
   - type: design_context
-    reason: "別プロジェクトの Sentry 調査中に抽出されたコードパス網羅原則。同じ「網羅性が保証される前に結論に飛ぶな」構造"
+    ref: "#"
+    reason: "別プロジェクトの Sentry 調査中に抽出されたコードパス網羅原則。同じ「網羅性が保証される前に結論に飛ぶな」構造（外部リポジトリのため ref 省略）"
 tags: [hypothesis-driven, exploration, so-compare, arena-compare, persistent-exploration, reproducibility, exhaustion-before-conclusion]
 ---
 

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -155,6 +155,8 @@ Options:
 ペイロード形式: `title|body|timeout` を base64 エンコードし、user-var `ai_notify` として送信。
 
 **制約**:
+- title: 必須、最大 500 文字
+- body: 任意、最大 2000 文字
 - title と body に `|`（パイプ文字）および制御文字（改行・タブなど）を含めることはできない
 - timeout の範囲: 100〜60000 ミリ秒
 

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -4,7 +4,7 @@ WezTerm の **Human Mode（tmux 維持）** と **AI Mode（`wezterm cli` 上乗
 
 ## ステータス
 
-**Phase 1 実装中** — `wez discover` + `wez pane` が動作する状態。[Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) で `notify` 等を追加予定。
+**Phase 1 実装中** — `wez discover` + `wez pane` + `wez notify` が動作する状態。[Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) で追加機能を予定。
 
 ## クイックスタート
 
@@ -24,6 +24,10 @@ WEZTERM_UNIX_SOCKET=$(./projects/wezterm-ai-mode/bin/wez discover --quiet)
 ./projects/wezterm-ai-mode/bin/wez pane send <pane-id> "echo hello"
 ./projects/wezterm-ai-mode/bin/wez pane capture <pane-id> --lines 5
 ./projects/wezterm-ai-mode/bin/wez pane kill <pane-id>
+
+# 通知（user-var 送信）
+./projects/wezterm-ai-mode/bin/wez notify "Build Complete" "All tests passed"
+./projects/wezterm-ai-mode/bin/wez notify --json --timeout 8000 "Deploy" "Production"
 ```
 
 ## CLI リファレンス
@@ -134,6 +138,44 @@ Options:
 
 確認プロンプトなしで即座にペインを閉じる。
 
+### `wez notify`
+
+WezTerm ペインに user-var（OSC 1337 SetUserVar）を送信する。送信方式は TTY 直接書き込み（primary）と command string（fallback）の2段階。
+
+```
+Usage: wez notify [options] <title> [body]
+
+Options:
+  --pane-id <ID>    Target pane (default: auto-detect first pane)
+  --timeout <MS>    Toast duration in milliseconds (default: 4000)
+  --socket <path>   WezTerm socket path (default: auto-detect)
+  --json            Output result as JSON
+```
+
+ペイロード形式: `title|body|timeout` を base64 エンコードし、user-var `ai_notify` として送信。
+
+**制約**:
+- title と body に `|`（パイプ文字）と改行を含めることはできない
+- timeout の範囲: 100〜60000 ミリ秒
+
+**送信方式（ADR-007）**:
+- **Primary**: `wezterm cli list` から `tty_name` を取得し、TTY デバイスに OSC を直接書き込み。history 汚染なし、プロンプト状態非依存
+- **Fallback**: `tty_name` が利用不可の場合、`printf` コマンド文字列を `send-text --no-paste` で送信。history にコマンドが残る
+
+**toast 通知の表示**: Phase 1 では CLI（user-var 送信）のみ。デスクトップ通知を表示するには `.wezterm.lua` に Lua イベントハンドラが必要（Phase 2、ADR-006）。
+
+**JSON 出力スキーマ** (`--json`):
+
+```json
+{
+  "pane_id": 0,
+  "status": "sent",
+  "method": "tty",
+  "title": "Build Complete",
+  "timeout": 4000
+}
+```
+
 ### `wez help`
 
 サブコマンド一覧を表示。
@@ -165,7 +207,8 @@ projects/wezterm-ai-mode/
 ├── lib/
 │   ├── common.sh        # 共通: カラー、ログ関数、exit code 定数
 │   ├── discover.sh      # wez discover の実装
-│   └── pane.sh          # wez pane の実装（list/split/send/capture/kill）
+│   ├── pane.sh          # wez pane の実装（list/split/send/capture/kill）
+│   └── notify.sh        # wez notify の実装（TTY direct write + fallback）
 ├── docs/
 │   ├── VERIFICATION_MATRIX.md
 │   ├── decisions/       # ADR（設計判断記録）

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -155,7 +155,7 @@ Options:
 ペイロード形式: `title|body|timeout` を base64 エンコードし、user-var `ai_notify` として送信。
 
 **制約**:
-- title と body に `|`（パイプ文字）と改行を含めることはできない
+- title と body に `|`（パイプ文字）および制御文字（改行・タブなど）を含めることはできない
 - timeout の範囲: 100〜60000 ミリ秒
 
 **送信方式（ADR-007）**:

--- a/projects/wezterm-ai-mode/bin/wez
+++ b/projects/wezterm-ai-mode/bin/wez
@@ -22,6 +22,8 @@ source "$WEZ_ROOT/lib/common.sh"
 source "$WEZ_ROOT/lib/discover.sh"
 # shellcheck source=../lib/pane.sh
 source "$WEZ_ROOT/lib/pane.sh"
+# shellcheck source=../lib/notify.sh
+source "$WEZ_ROOT/lib/notify.sh"
 
 wez_help() {
   cat <<EOF
@@ -32,6 +34,7 @@ Usage: wez <command> [options]
 Commands:
   discover    Auto-detect WezTerm socket and verify connection
   pane        Manage WezTerm panes (list, split, send, capture, kill)
+  notify      Send a notification via user-var (OSC 1337)
   help        Show this help message
   version     Show version
 
@@ -49,6 +52,9 @@ wez_main() {
       ;;
     pane)
       wez_cmd_pane "$@"
+      ;;
+    notify)
+      wez_cmd_notify "$@"
       ;;
     help|--help|-h)
       wez_help

--- a/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
+++ b/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
@@ -38,7 +38,7 @@ use_when:
 |----|---------|------|------|------|
 | A-2-1 | `wez discover` 単体・全サブコマンド前提 | 実施済み | PASSED | Issue #28, E2E 9/9 パス |
 | A-2-2 | `wez pane`（list / split / send / capture / kill） | 実施済み | PASSED | Issue #29, E2E 12/12 パス |
-| A-2-3 | `wez notify`（運用 Lua 統合方針確定後） | 未実施 | - | 同上 |
+| A-2-3 | `wez notify`（user-var 送信 + Lua 統合方針 ADR） | 実施済み | PASSED（CLI 層。toast は Phase 2） | Issue #30, E2E 12/12 パス, ADR-006/007 |
 | A-2-4 | 複数 WezTerm インスタンス時のソケット選択 | 設計済み | DESIGNED | ADR-002: mtime+verify ハイブリッド方式。単一インスタンスで E2E 検証済み |
 | A-2-5 | 新ペイン tmux auto-attach 後のコマンド送信（ポーリング等） | 実施済み | PASSED（--wait-ready） | ADR-003: ポーリング方式採用。E2E で send → capture 正常動作確認 |
 

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-006-lua-integration-policy.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-006-lua-integration-policy.md
@@ -1,0 +1,51 @@
+---
+title: "ADR-006: Lua ハンドラ統合方針 — Phase 2 先送りの判断根拠"
+date: 2026-04-22
+type: decision
+related:
+  - type: implements
+    ref: ../plans/2026-04-22-kickoff-wez-notify.md
+    reason: "キックオフの Lua 統合方針に基づく"
+  - type: depends_on
+    ref: ADR-001-cli-file-structure.md
+    reason: "CLI の責務範囲を前提"
+  - type: design_context
+    ref: ../../../poc/wezterm-ai-mode/wezterm-config/ai-mode-events.lua
+    reason: "Phase 2 で統合予定の Lua ハンドラ参考実装"
+tags: [lua, wezterm, notification, phase2, architecture]
+---
+
+# ADR-006: Lua ハンドラ統合方針 — Phase 2 先送りの判断根拠
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+`wez notify` は OSC 1337 SetUserVar でペイロードを送信するが、WezTerm でデスクトップ通知（toast）を表示するには `.wezterm.lua` に Lua イベントハンドラ（`user-var-changed` → `toast_notification`）が必要。PoC-04 に参考実装（`ai-mode-events.lua`）があり、Phase 1 で統合するか Phase 2 に先送りするかが論点。
+
+## 判断
+
+**Phase 1 = CLI のみ（user-var 送信まで）。Lua 統合は Phase 2 で dotfiles リポジトリに実装。**
+
+### 検討した選択肢
+
+| 選択肢 | 内容 | 評価 |
+|--------|------|------|
+| A: Phase 1 で `.wezterm.lua` に直接追記 | 最短経路 | `.wezterm.lua` は dotfiles リポジトリ管轄。本リポジトリからの変更はスコープ越境 |
+| B: Phase 1 で `require` パターンで外部ファイル化 | モジュール分離 | `require` パスの解決が環境依存（XDG, symlink）。設定が複雑化 |
+| **C: Phase 2 で dotfiles 統合** | CLI と Lua の責務を分離 | Phase 1 は CLI 検証に集中できる。toast は Phase 2 の検証対象 |
+
+### 採用理由
+
+1. **責務分離**: `wez` CLI（本リポジトリ）と `.wezterm.lua`（dotfiles）は管轄が異なる。Phase 1 は CLI の機能完成度に集中
+2. **検証の段階化**: CLI が user-var を正しく送信できることを先に確立し、toast 表示は独立した検証項目とする（VERIFICATION_MATRIX A-1-4 が PARTIAL のまま）
+3. **PoC 参考実装の品質**: `ai-mode-events.lua` の `gmatch('[^|]+')` パーサは空セグメント問題あり（DJ-3）。Phase 2 で Lua パーサ修正と同時に統合する方が効率的
+4. **YAGNI**: 現時点で toast 通知を必要とする運用ケースがない。Phase 2 の agent 連携設計で需要が具体化してから統合
+
+## 結果
+
+- Phase 1 の `wez notify` はユーザー観点で「無音」（user-var は送信されるが toast は出ない）
+- `--help` と README に「toast 表示には `.wezterm.lua` に Lua ハンドラが必要（Phase 2）」と明記
+- Phase 2 の scope: Lua ハンドラの dotfiles 統合、`gmatch` パーサ修正、`allow-passthrough` 対応

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-007-notify-design-decisions.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-007-notify-design-decisions.md
@@ -1,0 +1,79 @@
+---
+title: "ADR-007: notify サブコマンドの設計判断集"
+date: 2026-04-22
+type: decision
+related:
+  - type: implements
+    ref: ../plans/2026-04-22-kickoff-wez-notify.md
+    reason: "DJ-1〜DJ-5 の検証結果と採用判断を記録"
+  - type: depends_on
+    ref: ADR-004-pane-design-decisions.md
+    reason: "exit code 体系、send-text パターンを踏襲"
+  - type: depends_on
+    ref: ADR-005-bash-shell-standards.md
+    reason: "bash 3.2 互換ルール"
+  - type: evidence_for
+    ref: ../episodes/2026-04-22-episode-wez-notify.md
+    reason: "DJ-1 の実機検証プロセスを記録"
+tags: [notify, tty, osc1337, user-var, design-decision, base64]
+---
+
+# ADR-007: notify サブコマンドの設計判断集
+
+## ステータス
+
+Accepted
+
+## DJ-1: 送信方式 — TTY 直接書き込み（primary）+ command string（fallback）
+
+3方式を実機検証し、option C（TTY 直接書き込み）を primary として採用。
+
+| 選択肢 | 検証結果 | history 汚染 | プロンプト依存 |
+|--------|---------|-------------|-------------|
+| A: command string（PoC 踏襲） | OK | あり | あり |
+| B: raw OSC via send-text | **NG** | - | - |
+| **C: TTY 直接書き込み** | **OK** | **なし** | **なし** |
+
+**option B が NG の原理**: `send-text` は PTY 入力（キーボード側）に書き込む。WezTerm は PTY 出力のみで OSC を解釈するため、原理的に動作しない。
+
+**option C の原理**: `wezterm cli list --format json` の `tty_name`（`/dev/ttysXXX`）に OSC バイト列を書き込む。TTY slave への書き込みは PTY master 経由で WezTerm のターミナルエミュレータに到達し、OSC を直接解釈する。
+
+**fallback（option A）が必要なケース**: `tty_name` が JSON に含まれない旧バージョン、SSH セッション経由のペイン、TTY デバイスの書き込み権限がない場合。
+
+**実装**: `_wez_notify_send_user_var()` で `tty_name` の存在と `-w` 権限を確認し、primary を試行。失敗時に fallback へ降格。`--json` 出力の `method` フィールド（`"tty"` / `"send-text"`）でどちらが使われたか判別可能。
+
+**発見経緯**: option A に一旦確定した後の so-compare ゼロベースレビューで Claude が提案。即時実機検証で確認。詳細は [episode](../episodes/2026-04-22-episode-wez-notify.md) セクション1 に記録。
+
+## DJ-2: ペイン選択のデフォルト挙動
+
+2段階フォールバック:
+
+1. `--pane-id <ID>`（明示指定）
+2. `wezterm cli list --format json` の最初のペイン（auto-detect）
+
+notify は「WezTerm ウィンドウへの通知」であり、`pane send`（特定ペインでコマンド実行）とは意味が異なる。`user-var-changed` イベントは window 単位で発火するため送信先の厳密さは不要。
+
+`$WEZTERM_PANE` は Phase 1 では YAGNI として組み込まない。Cursor → WezTerm（外部）が primary use case であり、`$WEZTERM_PANE` は未設定。
+
+## DJ-3: ペイロード区切り `|` の脆弱性対応
+
+`title|body|timeout` 形式で base64 エンコード。Lua ハンドラの `gmatch('[^|]+')` は空セグメント消失の問題があるが、Phase 1 では Lua 未適用のため実害なし。
+
+Phase 1: title/body に `|` を含む入力は `WEZ_EXIT_USAGE` で拒否。Phase 2 の Lua 統合時に区切り文字変更（`\x1f`）または JSON 化を検討。
+
+## DJ-4: タイムアウトフラグの命名
+
+`--timeout`（ミリ秒単位）を採用。help に `(milliseconds, default: 4000)` と明記。
+
+`pane split --timeout`（秒単位、待機タイムアウト）とは用途が異なるため混同リスクは低いと判断。Phase 2 で `--timeout-ms` への変更が必要になれば、`--timeout` をエイリアスとして残す。
+
+## DJ-5: base64 エンコーディングの改行対策
+
+macOS の `base64` は 76 文字ごとに改行を挿入する。OSC シーケンス内に改行が入ると破損するため、`tr -d '\n'` で明示的にストリップ。PoC には対策なし（短い入力で発生しなかったため）。
+
+## Peer Review で追加された修正
+
+so-compare（Codex + Claude）のレビューで以下を検出・修正:
+
+- **jq-less `--json` パスの JSON エスケープ**: title 内の `"` `\` が未エスケープだった。`${title//\\/\\\\}` + `${title//\"/\\\"}` で修正
+- **jq-less grep パターンの堅牢化**: `"pane_id":[0-9]*` → `"pane_id":[[:space:]]*[0-9]+` でスペース入り JSON にも対応（pane.sh との一貫性）

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-007-notify-design-decisions.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-007-notify-design-decisions.md
@@ -40,7 +40,7 @@ Accepted
 
 **fallback（option A）が必要なケース**: `tty_name` が JSON に含まれない旧バージョン、SSH セッション経由のペイン、TTY デバイスの書き込み権限がない場合。
 
-**実装**: `_wez_notify_send_user_var()` で `tty_name` の存在と `-w` 権限を確認し、primary を試行。失敗時に fallback へ降格。`--json` 出力の `method` フィールド（`"tty"` / `"send-text"`）でどちらが使われたか判別可能。
+**実装**: `_wez_notify_send_user_var()` で `tty_name` の存在を確認し、`-c`（character device）かつ `-w`（書き込み可能）を検証してから primary を試行。`-c` チェックにより通常ファイルへの OSC 誤書き込みを防止。失敗時に fallback へ降格。`--json` 出力の `method` フィールド（`"tty"` / `"send-text"`）でどちらが使われたか判別可能。
 
 **発見経緯**: option A に一旦確定した後の so-compare ゼロベースレビューで Claude が提案。即時実機検証で確認。詳細は [episode](../episodes/2026-04-22-episode-wez-notify.md) セクション1 に記録。
 

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -160,6 +160,43 @@ E2E パス後、キックオフの必須停止 GATE に従い `so-compare` を�
 
 レビューログ: `tmp/peer-review-20260422-201901/review-log.md`
 
+### Copilot Review 対応
+
+PR 作成後、GitHub Copilot レビューで 4件の指摘を受領し対応:
+
+| # | 内容 | 対応 |
+|---|------|------|
+| C-1 | kickoff の `WEZTERM_PANE` 記載矛盾 | 修正（YAGNI に統一） |
+| C-2 | episode の DJ 番号が ADR-007 と不整合 | 修正（DJ-4 追加、DJ-3/DJ-5 明確化） |
+| C-3 | timeout validation で先頭ゼロが octal 問題を引き起こす | 修正（regex `^(0\|[1-9][0-9]*)$` + `10#` prefix） |
+| C-4 | discussion frontmatter の `ref:` 欠落 | 修正（`ref: "#"` placeholder 追加） |
+
+修正コミット: `2085b84 fix(wez): address copilot review findings`
+
+### Debugger-role Peer Review: so-compare 第2ラウンド
+
+デバッガー/バグハンター観点でゼロベースレビューを実施。プロンプト設計で `so-compare` のタイムアウト問題に遭遇（実行指示が複雑すぎたため）、v2 プロンプトでコード分析特化に変更して成功。
+
+**参加者**: Codex CLI + Claude Code。2者とも成功。
+
+**検出事項:**
+
+| # | 重大度 | 内容 | 発見者 | 対応 |
+|---|--------|------|--------|------|
+| DB-1 | 🟡 | `tty_name` の `-w` チェックが通常ファイルでも通る → OSC 誤書き込みリスク | Codex + Claude | **修正済み**（`-c` チェック追加） |
+| DB-2 | 🟡 | title/body 長さ上限なし → base64 ペイロードが PIPE_BUF 超過時の atomic 性問題 | Claude | **修正済み**（title 500/body 2000 文字制限） |
+| DB-3 | 🟢 | jq parse エラーの silent suppress | Codex | 許容（Phase 1: jq は optional） |
+| DB-4 | 🟢 | `base64` パイプ失敗で `set -e` 時にスクリプト中断 | Claude | 許容（`set -e` 不使用の設計方針） |
+| DB-5 | 🟢 | `send-text` の stdout が JSON 出力に混入する可能性 | Codex | 許容（`2>/dev/null` で stderr 抑制済み、stdout は空想定） |
+| DB-6 | 🟢 | fallback が非シェルペイン・fish 互換性に問題あり | Codex + Claude | 許容（Phase 1 スコープ外、ドキュメント化済み） |
+| DB-7 | 🟢 | 並行 TTY 書き込み時のインターリーブリスク | Claude | 許容（DB-2 の長さ制限で緩和） |
+
+**対応方針**: DB-1, DB-2 は低コスト・高インパクトのため即時実装。DB-3〜DB-7 は Phase 1 で許容し、Epic コメントで残課題として言及。
+
+修正コミット: `ccfb579 fix(wez): add character device check and length limits for notify`
+
+**プロンプト設計の教訓**: `so-compare` でロールを変える（レビューア → デバッガー）場合、「コマンド実行してテストせよ」のような指示はサンドボックス制約でタイムアウトを引き起こす。コード分析特化のプロンプトに限定すべき。
+
 ---
 
 ## 3. 振り返り（後で追記）

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -158,7 +158,7 @@ E2E パス後、キックオフの必須停止 GATE に従い `so-compare` を�
 
 修正コミット: `3e3ee9f fix(wez): escape title in jq-less JSON output + harden grep pattern`
 
-レビューログ: `tmp/peer-review-20260422-201901/review-log.md`
+レビューログ: `tmp/peer-review-20260422-201901/review-log.md`（ローカル限定、リポジトリ未追跡）
 
 ### Copilot Review 対応
 

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -111,8 +111,9 @@ option C は初期の選択肢セット（A/B）に含まれていなかった�
 
 - **DJ-1**: TTY direct write が primary。E2E で `--json` 出力の `"method": "tty"` を確認
 - **DJ-2**: 2段階フォールバック（`--pane-id` 指定 → first pane auto-detect）
-- **DJ-3**: `title|body|timeout` 形式、base64 + `tr -d '\n'`
-- **DJ-5**: pipe 文字・改行禁止、timeout 範囲チェック（100-60000）
+- **DJ-3**: `title|body|timeout` 形式、pipe 文字・改行禁止
+- **DJ-4**: `--timeout`（ms）、help に単位明記
+- **DJ-5**: base64 エンコード時に `tr -d '\n'` で改行除去
 
 コミット: `88d0b01 feat(wez): add notify subcommand with TTY direct write`
 

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -92,9 +92,72 @@ option C は初期の選択肢セット（A/B）に含まれていなかった�
 
 ---
 
-## 2. 実装（後で追記）
+## 2. 実装 + Peer Review（2026-04-22）
 
-<!-- Issue #30 の実装記録をここに追記 -->
+### 実装（Step 1）
+
+`lib/notify.sh` を新規作成し、`bin/wez` にルーティングを追加。キックオフの Step 1-1〜1-4 を実行。
+
+構成:
+
+| 関数 | 責務 |
+|------|------|
+| `_wez_notify_resolve_pane(opt_pane_id)` | `--pane-id` 指定 or auto-detect。`wezterm cli list` から `pane_id` + `tty_name` を同時取得 |
+| `_wez_notify_encode_payload(title, body, timeout)` | `title\|body\|timeout` を base64 エンコード（`tr -d '\n'`） |
+| `_wez_notify_send_user_var(pane_id, var_name, encoded, tty_name)` | primary: TTY 直接書き込み、fallback: command string via `send-text --no-paste` |
+| `wez_cmd_notify()` | メインディスパッチャ。ソケット探索 → バリデーション → ペイン解決 → 送信 → 出力 |
+
+設計判断の実装状況:
+
+- **DJ-1**: TTY direct write が primary。E2E で `--json` 出力の `"method": "tty"` を確認
+- **DJ-2**: 2段階フォールバック（`--pane-id` 指定 → first pane auto-detect）
+- **DJ-3**: `title|body|timeout` 形式、base64 + `tr -d '\n'`
+- **DJ-5**: pipe 文字・改行禁止、timeout 範囲チェック（100-60000）
+
+コミット: `88d0b01 feat(wez): add notify subcommand with TTY direct write`
+
+### E2E 検証（Step 2）
+
+12項目すべてパス:
+
+| ケース | 結果 |
+|--------|------|
+| 通常送信（title + body） | exit 0 |
+| body 省略 | exit 0 |
+| `--pane-id` 指定 | exit 0 |
+| `--timeout 8000` | exit 0 |
+| `--json` 出力 | JSON + `method: "tty"` |
+| title なし | exit 64 |
+| pipe 文字入り title | exit 64 |
+| timeout 範囲外（0） | exit 64 |
+| timeout 非数値 | exit 64 |
+| 存在しないペイン | exit 3 |
+| `--help` | ヘルプ表示 |
+| shellcheck | pass |
+
+### Peer Review: so-compare（GATE）
+
+E2E パス後、キックオフの必須停止 GATE に従い `so-compare` を実施。
+
+**参加者**: Codex CLI (v0.121.0) + Claude Code。2者とも成功。
+
+**検出事項:**
+
+| # | 重大度 | 内容 | 発見者 | 対応 |
+|---|--------|------|--------|------|
+| Bug-1 | 🔴 | jq-less `--json` パスで title の `"` `\` が未エスケープ → 不正 JSON | Codex + Claude | 修正済み |
+| Obs-1 | 🟡 | jq-less `pane_id` 抽出の grep がスペース入り JSON に非対応（pane.sh との不整合） | Claude | 修正済み |
+| Obs-2 | 🟡 | `discover_socket` の exit code case が網羅的でない（pane.sh も同じ） | Claude | 許容 |
+| Obs-3 | 🟡 | fallback 時のペイン汚染（設計上の受容事項） | Codex + Claude | 許容 |
+| Obs-4 | 🟡 | `--pane-id` のペイン存在検証が遅延（pane.sh と同じパターン） | Claude + 自分 | 許容 |
+
+**合意判定**: 3者合意。Bug-1 は修正必須、Obs-1 はついでに改善、残りは Phase 1 で許容。
+
+**見落としの教訓**: pane.sh では JSON に user-controlled 文字列を含めていなかったため、jq-less パスのエスケープ問題が顕在化していなかった。notify は `title` を JSON に含めるため、この差異が新たなバグを生んだ。新規ファイル作成時は、既存ファイルとの「入力性質の差」を意識してレビューすべき。
+
+修正コミット: `3e3ee9f fix(wez): escape title in jq-less JSON output + harden grep pattern`
+
+レビューログ: `tmp/peer-review-20260422-201901/review-log.md`
 
 ---
 

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -204,6 +204,40 @@ PR 作成後、GitHub Copilot レビューで 4件の指摘を受領し対応:
 3. **`set -e` 下の command substitution**: 裸の `var=$(cmd)` は失敗時にサイレント中断。`if ! var=$(cmd)` でガードが必須。DB-4 の当初の「`set -e` 不使用」判断は誤りで、`bin/wez` は `set -euo pipefail` 前提
 4. **Copilot の反復レビュー効果**: 修正プッシュごとに差分を再レビューするため、修正で生じた新たな不整合や見落としを段階的に検出。合計 6 ラウンドで収束
 
+### レビュー起因の実装変更コンテキスト
+
+以下はレビュー（so-compare / Copilot）で検出・変更された実装判断のうち、ADR-007 のスコープ外だがコンテキストを残すべきもの。
+
+#### 制御文字バリデーションの拡張（`\n`/`\r` → `[[:cntrl:]]`）
+
+当初は title/body に改行（`\n`/`\r`）のみ禁止していた。Copilot R2 で「jq-less JSON 出力パスでタブ等の制御文字が未エスケープのまま出力される」問題を指摘され、制御文字全般に拡張。
+
+判断根拠: JSON 仕様（RFC 8259）は U+0000–U+001F を文字列内でエスケープ必須と定めている。jq パスでは jq 自身がエスケープするが、jq-less パスでは手動エスケープが必要。制御文字をすべてエスケープするより、入力段階で拒否する方がシンプルで安全。`[[:cntrl:]]` は POSIX character class で bash 3.2 互換。
+
+#### title/body 長さ制限（title 500 / body 2000）
+
+当初は長さ制限なし。Debugger SO レビュー（DB-2）で「base64 エンコード後のペイロードが `PIPE_BUF`（macOS: 512 bytes）を超えると TTY 書き込みの atomic 性が崩れ、並行書き込み時にインターリーブするリスク」を指摘された。
+
+数値選定: title 500 文字 + body 2000 文字 + timeout + pipe 区切り → 最大 ~2500 文字。base64 で約 4/3 倍 → ~3400 bytes。`PIPE_BUF` は超えるが、単独書き込みは問題なく、並行書き込みのリスクを「実用上の上限」で緩和する意図。Phase 1 で並行通知を想定しておらず、過度に制約するより許容可能な上限を設定。
+
+#### jq 依存モデルの変更（jq 必須 → jq optional で TTY primary 利用可能）
+
+当初 jq-less パスは `pane_id` のみ grep で抽出し、`tty_name` は抽出しなかった。結果として jq 未インストール環境では TTY direct write（primary）が使えず、send-text fallback に固定されていた。
+
+ADR-007 DJ-1 は「jq は optional」と宣言していたが、実態として primary 方式に jq が必要という矛盾があった。Copilot R2/R3 の指摘で auto-detect・`--pane-id` 両パスに grep ベースの `tty_name` 抽出を追加し、設計意図（jq optional）と実装が一致。
+
+#### timeout 先頭ゼロ拒否 + base-10 強制
+
+当初の timeout バリデーションは `^[0-9]+$` で先頭ゼロ（例: `08`）を許容していた。Copilot R1（C-3）で bash の `(( ))` 算術評価が先頭ゼロを octal として解釈する問題を指摘。`08` → octal 8 は不正で `value too great for base` エラー、`010` → octal 8 で意図と異なる比較結果になる。
+
+対策: regex を `^(0|[1-9][0-9]*)$` に変更（先頭ゼロ拒否）し、算術比較に `10#$opt_timeout` を付けて base-10 解釈を強制。二重防御。
+
+#### fallback printf の raw ESC 埋め込み
+
+fallback の command string builder で `cmd=$(printf "printf '\\033]...\\007' ...")` としていたが、外側 `printf` が `\033` を octal 解釈し raw ESC バイト（0x1B）を `$cmd` に埋め込んでいた。`send-text` で target shell に送信すると、Readline が raw ESC を escape sequence 開始として消費し、残りがゴミ入力になる。
+
+これは primary（TTY direct write）が成功する環境では到達しないため E2E で検出されなかった。`\\\\033`/`\\\\007` に修正し、outer printf が literal `\033`/`\007` を出力 → target shell の printf が ESC/BEL に展開する正しいチェインに。
+
 ### Debugger-role Peer Review: so-compare 第2ラウンド
 
 デバッガー/バグハンター観点でゼロベースレビューを実施。プロンプト設計で `so-compare` のタイムアウト問題に遭遇（実行指示が複雑すぎたため）、v2 プロンプトでコード分析特化に変更して成功。

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -1,0 +1,103 @@
+---
+id: "01KPT49WWP05M91AN9NRMGC4QS"
+title: "wez notify サブコマンド実装（Issue #30）"
+date: 2026-04-22
+type: episode
+status: draft
+related:
+  - type: implements
+    ref: ../plans/2026-04-22-kickoff-wez-notify.md
+    reason: "キックオフに基づく実装"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/30"
+    reason: "feat(wez): notify サブコマンド + Lua 統合方針確定（1-3）"
+  - type: spawns
+    ref: ../../../../docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md
+    reason: "事前検証の TTY 発見プロセスから仮説駆動探索の再現性 discussion を派生"
+tags: [notify, implementation, so-compare, tty-direct-write, hypothesis-driven]
+---
+
+# wez notify サブコマンド実装（Issue #30）
+
+## 概要
+
+Issue #30 として `wez notify` サブコマンドを実装。OSC 1337 SetUserVar 経由で WezTerm にデスクトップ通知を送信する機能。Phase 1 は CLI のみ、Lua 統合は Phase 2 で dotfiles リポジトリに実装予定。
+
+---
+
+## 1. 事前検証（2026-04-22）
+
+### 設計判断: 送信方式の選定
+
+Issue の背景にあった PoC-04 は、`printf` コマンド文字列を `wezterm cli send-text` でペインに送り、シェルに実行させて OSC を発生させる方式（command string）。副作用として history 汚染・プロンプト状態依存がある。
+
+初期フレーミングでは以下の2択で検討を開始:
+
+| 選択肢 | 方式 | 想定 |
+|--------|------|------|
+| A | command string（PoC 踏襲） | 実績あり。副作用は Phase 2 で対処 |
+| B | raw OSC を `send-text` で直接送信 | 副作用なし。未検証 |
+
+### option B の実機検証 → NG
+
+```bash
+printf '\033]1337;SetUserVar=ai_notify=%s\007' "$(printf 'Test|Body|5000' | base64 | tr -d '\n')" \
+  | wezterm cli send-text --pane-id 0 --no-paste
+```
+
+結果: ペインのシェルに `q1337;SetUserVar=...` が可視テキストとして入力され、`command not found` エラー。
+
+原因: `send-text` は PTY **入力**（キーボード側）にバイトを書き込む。WezTerm のターミナルエミュレータが OSC を解釈するのは PTY **出力**（プロセスの stdout）のみ。ESC（`\033`）がシェルの readline に消費され、残りが通常のテキスト入力として処理された。
+
+### option A での「確定」
+
+option B が原理的に不可であることを確認し、option A（command string）で一旦確定。キックオフに検証結果を反映。
+
+### SO ゼロベースレビュー → option C の発見
+
+確定後に `so-compare` でキックオフ全体の設計レビューを実施。プロンプトで「ゼロベースで他の選択肢がないか検証して」と明示的に依頼。
+
+Claude の回答から **option C: TTY 直接書き込み** が提案された。`wezterm cli list --format json` の `tty_name` フィールド（`/dev/ttysXXX`）に OSC バイト列を直接書き込む方式。
+
+### option C の即時実機検証 → OK
+
+```bash
+TTY=$(wezterm cli list --format json | jq -r '.[0].tty_name')
+printf '\033]1337;SetUserVar=ai_notify=%s\007' \
+  "$(printf 'Test|Body|5000' | base64 | tr -d '\n')" > "$TTY"
+```
+
+結果: 成功。history 汚染なし、プロンプト状態非依存、ペイン表示への汚染なし。
+
+原理: TTY slave デバイスへの書き込みは PTY master 側に転送され、WezTerm のターミナルエミュレータが OSC を直接解釈する。シェルの stdin を一切経由しない。
+
+### 最終決定
+
+| 選択肢 | 結果 | 採否 |
+|--------|------|------|
+| A: command string | OK | fallback（`tty_name` 取得不可時） |
+| B: raw OSC via send-text | NG | 不可（原理的制約） |
+| **C: TTY 直接書き込み** | **OK** | **primary** |
+
+### メタ観察: 発見プロセスの再現性
+
+option C は初期の選択肢セット（A/B）に含まれていなかった。発見には4つの条件が揃う必要があった:
+
+1. **確定後のゼロベース再探索**: A に確定した後で、なお SO に「他に選択肢はないか」と聞いた
+2. **反証可能なプロンプト**: 「この方式を確認して」ではなく「ゼロベースで検証して」
+3. **提案の即時実機検証**: Claude の提案を「良さそう」で終わらせず、その場で検証コマンドを実行
+4. **検証環境の即時利用可能性**: WezTerm が動いていて仮説をすぐに試せた
+
+この発見プロセス自体の再現性を高める方法について、別途 [discussion: 仮説駆動探索の再現性](../../../../docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md) として議論を開始。
+
+---
+
+## 2. 実装（後で追記）
+
+<!-- Issue #30 の実装記録をここに追記 -->
+
+---
+
+## 3. 振り返り（後で追記）
+
+<!-- 実装完了後のレトロスペクティブをここに追記 -->

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -168,7 +168,7 @@ PR 作成後、GitHub Copilot レビューで 4件の指摘を受領し対応:
 |---|------|------|
 | C-1 | kickoff の `WEZTERM_PANE` 記載矛盾 | 修正（YAGNI に統一） |
 | C-2 | episode の DJ 番号が ADR-007 と不整合 | 修正（DJ-4 追加、DJ-3/DJ-5 明確化） |
-| C-3 | timeout validation で先頭ゼロが octal 問題を引き起こす | 修正（regex `^(0\|[1-9][0-9]*)$` + `10#` prefix） |
+| C-3 | timeout validation で先頭ゼロが octal 問題を引き起こす | 修正（先頭ゼロ拒否 regex + `10#` prefix で base-10 強制） |
 | C-4 | discussion frontmatter の `ref:` 欠落 | 修正（`ref: "#"` placeholder 追加） |
 
 修正コミット: `2085b84 fix(wez): address copilot review findings`
@@ -186,12 +186,12 @@ PR 作成後、GitHub Copilot レビューで 4件の指摘を受領し対応:
 | DB-1 | 🟡 | `tty_name` の `-w` チェックが通常ファイルでも通る → OSC 誤書き込みリスク | Codex + Claude | **修正済み**（`-c` チェック追加） |
 | DB-2 | 🟡 | title/body 長さ上限なし → base64 ペイロードが PIPE_BUF 超過時の atomic 性問題 | Claude | **修正済み**（title 500/body 2000 文字制限） |
 | DB-3 | 🟢 | jq parse エラーの silent suppress | Codex | 許容（Phase 1: jq は optional） |
-| DB-4 | 🟢 | `base64` パイプ失敗で `set -e` 時にスクリプト中断 | Claude | 許容（`set -e` 不使用の設計方針） |
+| DB-4 | 🟡 | `base64` パイプ失敗で `set -euo pipefail` 時にスクリプト中断 | Claude | **修正済み**（encode を `if` ガードで `set -e` 適用外に） |
 | DB-5 | 🟢 | `send-text` の stdout が JSON 出力に混入する可能性 | Codex | 許容（`2>/dev/null` で stderr 抑制済み、stdout は空想定） |
 | DB-6 | 🟢 | fallback が非シェルペイン・fish 互換性に問題あり | Codex + Claude | 許容（Phase 1 スコープ外、ドキュメント化済み） |
 | DB-7 | 🟢 | 並行 TTY 書き込み時のインターリーブリスク | Claude | 許容（DB-2 の長さ制限で緩和） |
 
-**対応方針**: DB-1, DB-2 は低コスト・高インパクトのため即時実装。DB-3〜DB-7 は Phase 1 で許容し、Epic コメントで残課題として言及。
+**対応方針**: DB-1, DB-2, DB-4 は低コスト・高インパクトのため即時実装。DB-3, DB-5〜DB-7 は Phase 1 で許容し、Epic コメントで残課題として言及。
 
 修正コミット: `ccfb579 fix(wez): add character device check and length limits for notify`
 

--- a/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md
@@ -173,6 +173,37 @@ PR 作成後、GitHub Copilot レビューで 4件の指摘を受領し対応:
 
 修正コミット: `2085b84 fix(wez): address copilot review findings`
 
+### Copilot Review 継続対応（Round 2〜6）
+
+修正プッシュごとに Copilot が再レビューを実施。累計 6 ラウンド・18 スレッド対応。Round 1 の 4 件に加え、以下が重要な追加検出:
+
+**コード品質:**
+
+| Round | 内容 | 重大度 | 対応 |
+|-------|------|--------|------|
+| R2 | title/body バリデーションを `[[:cntrl:]]` に拡張（U+0000–U+001F 全対応） | 中 | 修正 `1cebdbf` |
+| R2 | jq-less auto-detect で `tty_name` 未抽出 → TTY direct write が jq 依存 | 中 | 修正 `1cebdbf` |
+| R3 | `--pane-id` 指定時も jq-less `tty_name` 未抽出（R2 で auto-detect のみ修正） | 中 | 修正 `4e6af81` |
+| R5 | **fallback printf が `\033`/`\007` を raw ESC/BEL に展開** → send-text 先 shell の Readline が消費 | **高** | 修正 `ff36793` |
+| R6 | **encode パイプ `set -euo pipefail` 下でサイレント中断** → `if` ガードで `set -e` 適用外に | **高** | 修正 `89067f2` |
+
+**ドキュメント整合性:**
+
+| Round | 内容 | 対応 |
+|-------|------|------|
+| R2 | kickoff / episode の `tmp/` 参照が壊れたリンク | 削除・注記追加 |
+| R3 | CONVENTIONS.md パス不正（`../` → `../../`） | 修正 |
+| R4 | title/body 長さ制限が `--help` / README 未記載 | 追記 |
+| R4 | ADR-007 の TTY チェック記述に `-c` 未反映 | 更新 |
+| R5 | PoC 参照パス不正（`../../poc` → `../../../poc`） | 修正 |
+
+**教訓:**
+
+1. **jq-less パスの網羅性**: auto-detect と `--pane-id` の両分岐で抽出ロジックが必要。一方だけ修正すると他方に漏れが出る
+2. **printf のエスケープレベル管理**: 「外側 printf → 内側 printf → target shell の printf」の 3 段階エスケープは間違いやすい。`od -c` での実バイト列確認が有効
+3. **`set -e` 下の command substitution**: 裸の `var=$(cmd)` は失敗時にサイレント中断。`if ! var=$(cmd)` でガードが必須。DB-4 の当初の「`set -e` 不使用」判断は誤りで、`bin/wez` は `set -euo pipefail` 前提
+4. **Copilot の反復レビュー効果**: 修正プッシュごとに差分を再レビューするため、修正で生じた新たな不整合や見落としを段階的に検出。合計 6 ラウンドで収束
+
 ### Debugger-role Peer Review: so-compare 第2ラウンド
 
 デバッガー/バグハンター観点でゼロベースレビューを実施。プロンプト設計で `so-compare` のタイムアウト問題に遭遇（実行指示が複雑すぎたため）、v2 プロンプトでコード分析特化に変更して成功。

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -15,10 +15,10 @@ related:
     ref: "./2026-04-20-kickoff-wez-pane.md"
     reason: "1-2 で確立した pane 操作パターンを前提とする"
   - type: derived_from
-    ref: "../../poc/wezterm-ai-mode/04-notification.sh"
+    ref: "../../../poc/wezterm-ai-mode/04-notification.sh"
     reason: "通知 PoC のコアロジック元"
   - type: derived_from
-    ref: "../../poc/wezterm-ai-mode/wezterm-config/ai-mode-events.lua"
+    ref: "../../../poc/wezterm-ai-mode/wezterm-config/ai-mode-events.lua"
     reason: "Lua ハンドラの参考実装"
   - type: design_context
     ref: "../VERIFICATION_MATRIX.md"

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -38,9 +38,6 @@ related:
   - type: reference
     ref: "../CONVENTIONS.md"
     reason: "ドキュメント規約・実行フロー"
-  - type: evidence_for
-    ref: "../../tmp/peer-review-20260422-135027/review-log.md"
-    reason: "設計レビューの SO 比較ログ"
 tags: [wez, cli, notify, phase1, bash, user-var, osc1337, lua]
 keywords: [wezterm, wez, notify, user-var, SetUserVar, OSC 1337, toast_notification, ai_notify, base64]
 use_when:

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -304,8 +304,6 @@ Options:
 - [ ] `shellcheck` パス（全ファイル）
 - [ ] コミット: `feat(wez): add notify subcommand with user-var injection`
 
-!! GATE（必須・停止）: Step 1 完了後、**ここで実装を停止しユーザーに報告する**。`so-compare` によるコードレビューを実施する。検証観点: DJ-1 の TTY direct write + fallback 実装、base64 エンコード、入力バリデーション、`pane.sh` との一貫性。so-compare の指摘対応が完了するまで Step 2 に進まない。
-
 ### Step 2: E2E 検証（概算: 15分）
 
 ```bash
@@ -330,6 +328,8 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 - [ ] Lua ハンドラ適用済み環境での toast 通知表示（Phase 1 では参考確認。成功基準には含めない）
 
 !! GATE: E2E 全項目パス。失敗がある場合は Step 1 に戻って修正。
+
+!! GATE（必須・停止）: E2E パス後、**ここで停止しユーザーに報告する**。`so-compare` によるコードレビューを実施する。検証観点: DJ-1 の TTY direct write + fallback 実装、base64 エンコード、入力バリデーション、`pane.sh` との一貫性。テスト済みコードに対してレビューすることで、レビュー指摘の手戻りを最小化する。so-compare の指摘対応が完了するまで Step 3 に進まない。
 
 ### Step 3: ドキュメント・ADR・記録（概算: 15分）
 
@@ -369,10 +369,10 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 
 | タイミング | ツール | 特性 | 上限 |
 |-----------|--------|------|------|
-| **Step 1 完了後（PR 前・必須・停止）** | `so-compare` | 少数・構造的（bash 3.2 互換、設計整合性等） | 指摘対応完了まで |
+| **Step 2 完了後（E2E パス後・PR 前・必須・停止）** | `so-compare` | 少数・構造的（bash 3.2 互換、設計整合性等） | 指摘対応完了まで |
 | **Step 4 PR 作成時** | Copilot (`--reviewer @copilot`) | 多数・局所的（バリデーション漏れ、ドキュメント整合等） | 3ラウンド |
 
-so-compare と Copilot の重複はほぼゼロ（#29 retro で確認済み）。so-compare は push 不要で手元で即実行できるため、PR 前に入れるのがイテレーション的に最速。
+so-compare と Copilot の重複はほぼゼロ（#29 retro で確認済み）。so-compare は E2E 完了後のテスト済みコードに対して実施する。未テストコードのレビューは手戻りを生むため、E2E パスを前提条件とする。
 
 ## ADR 作成チェックリスト
 

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -246,7 +246,7 @@ command string 方式（option A）は正常動作を確認。その後 SO ゼ�
 
 #### 0-2: `WEZTERM_PANE` 環境変数の確認（実機検証済み — 存在確認）
 
-WezTerm ペイン内で `WEZTERM_PANE=0` を確認。Cursor 統合ターミナルでは未設定。**DJ-2 の優先順位に `$WEZTERM_PANE` を挿入済み。**
+WezTerm ペイン内で `WEZTERM_PANE=0` を確認。Cursor 統合ターミナルでは未設定。**存在は確認したが、Phase 1 の DJ-2 優先順位には組み込まない（YAGNI）。**
 
 #### 0-3: 前提確認
 

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -304,7 +304,7 @@ Options:
 - [ ] `shellcheck` パス（全ファイル）
 - [ ] コミット: `feat(wez): add notify subcommand with user-var injection`
 
-!! GATE（必須）: Step 1 完了後、`so-compare.sh` によるコードレビュー実施。DJ-1 の送信方式実装、base64 エンコード、入力バリデーション、`pane.sh` との一貫性を検証。
+!! GATE（必須・停止）: Step 1 完了後、**ここで実装を停止しユーザーに報告する**。`so-compare` によるコードレビューを実施する。検証観点: DJ-1 の TTY direct write + fallback 実装、base64 エンコード、入力バリデーション、`pane.sh` との一貫性。so-compare の指摘対応が完了するまで Step 2 に進まない。
 
 ### Step 2: E2E 検証（概算: 15分）
 
@@ -341,15 +341,16 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 - [ ] エピソード記録（`docs/episodes/2026-04-22-wez-notify.md`）
 - [ ] コミット: `docs(wez): add notify ADR and Lua integration policy`
 
-### Step 4: PR 作成（概算: 10分）
+### Step 4: PR 作成 + Copilot レビュー（概算: 10分 + Copilot 対応）
 
 - [ ] `git fetch origin && git rebase origin/master`
 - [ ] `shellcheck` 最終確認
 - [ ] PR 本文作成（変更概要、DJ サマリ、E2E 結果、`Refs #30`）
-- [ ] `gh pr create --assignee @me`
+- [ ] `gh pr create --assignee @me --reviewer @copilot`
+- [ ] Copilot レビュー対応（3ラウンド上限。収束しない残件は Phase 2 バックログへ）
 - [ ] Epic #20 に報告コメント
 
-!! GATE: PR 作成 + CI パス。
+!! GATE: PR 作成 + CI パス + Copilot 対応完了。
 
 ## リスクと対処
 
@@ -362,9 +363,16 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 | Lua ハンドラ未適用で toast が出ない | ユーザー混乱 | README + help に「`.wezterm.lua` に Lua ハンドラが必要」と明記。CLI の責務は user-var 送信まで |
 | tmux 内ペインで OSC 1337 が吸収される | tmux 配下では通知が届かない | README に `.tmux.conf` の `allow-passthrough on` 要件を記載。Phase 2 で対応 |
 
-## peer-ai-review 実施ポイント
+## レビュー戦略（retro #28/#29 準拠）
 
-1. **Step 1 完了後（必須）**: notify 実装のコードレビュー（`so-compare.sh`）。送信方式、base64 エンコード、バリデーション、既存パターンとの一貫性を検証
+レビュー順序: so-compare（コードレビュー gate）→ push → PR + Copilot → 最終判断
+
+| タイミング | ツール | 特性 | 上限 |
+|-----------|--------|------|------|
+| **Step 1 完了後（PR 前・必須・停止）** | `so-compare` | 少数・構造的（bash 3.2 互換、設計整合性等） | 指摘対応完了まで |
+| **Step 4 PR 作成時** | Copilot (`--reviewer @copilot`) | 多数・局所的（バリデーション漏れ、ドキュメント整合等） | 3ラウンド |
+
+so-compare と Copilot の重複はほぼゼロ（#29 retro で確認済み）。so-compare は push 不要で手元で即実行できるため、PR 前に入れるのがイテレーション的に最速。
 
 ## ADR 作成チェックリスト
 
@@ -387,7 +395,8 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 - [ ] `docs/VERIFICATION_MATRIX.md` の A-2-3 が更新されている
 - [ ] `README.md` に notify セクションが追加されている
 - [ ] so-compare によるコードレビュー gate を実施し、指摘への対応を記録している
-- [ ] PR が作成され `Refs #30` で Issue と連携している
+- [ ] PR が作成され `Refs #30` で Issue と連携し、`--reviewer @copilot` でアサインされている
+- [ ] Copilot レビュー対応が完了している（3ラウンド上限）
 
 ## 実行フロー
 

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -242,7 +242,7 @@ printf '\033]1337;SetUserVar=...\007' | wezterm cli send-text --pane-id 0 --no-p
 # → -bash: q1337: コマンドが見つかりません
 ```
 
-command string 方式は正常動作を確認。`printf` コマンドがペイン内シェルで実行され、stdout の OSC を WezTerm が消費。**DJ-1 は option A（command string）に確定。**
+command string 方式（option A）は正常動作を確認。その後 SO ゼロベースレビューで option C（TTY 直接書き込み）が提案され、実機検証で成功。**DJ-1 は option C（TTY 直接書き込み）を primary、option A（command string）を fallback に確定。**
 
 #### 0-2: `WEZTERM_PANE` 環境変数の確認（実機検証済み — 存在確認）
 
@@ -256,7 +256,7 @@ WezTerm ペイン内で `WEZTERM_PANE=0` を確認。Cursor 統合ターミナ�
 - [ ] `lib/pane.sh` の `_wez_pane_send` 実装を精読（send-text パターンの参照）
 - [ ] PoC-04（`04-notification.sh`）のロジック精読
 
-!! GATE: 実機検証完了（DJ-1: command string に確定、DJ-2: 3段階フォールバックに確定）。前提確認後に続行。
+!! GATE: 実機検証完了（DJ-1: TTY direct write primary + command string fallback に確定、DJ-2: 2段階フォールバックに確定）。前提確認後に続行。
 
 ### Step 1: notify サブコマンド実装（概算: 30分）
 
@@ -290,14 +290,14 @@ Options:
 5. timeout バリデーション: 正の整数（100〜60000）
 6. ペイン解決: `--pane-id` 指定あり → そのまま使用。なし → `_wez_notify_auto_pane` で auto-detect
 7. ペイロード構築: `title|body|timeout` → base64（`tr -d '\n'`）
-8. user-var 送信: `_wez_notify_send_user_var` で OSC 1337 を `send-text` に注入
-9. 結果出力: 成功時は無音。`--json` 時に `{"pane_id": N, "status": "sent", "title": "...", "timeout": N}`
+8. user-var 送信: `_wez_notify_send_user_var` で OSC 1337 を送信（primary: TTY 直接書き込み、fallback: command string via `send-text`）
+9. 結果出力: 成功時は無音。`--json` 時に `{"pane_id": N, "status": "sent", "method": "tty"|"send-text", "title": "...", "timeout": N}`
 
 #### 1-3: ヘルパー関数
 
-- [ ] `_wez_notify_auto_pane()`: `wezterm cli list --format json` から最初の pane_id を取得。jq フォールバック（`grep -o` パターン）付き。取得失敗 → `WEZ_EXIT_PANE_NOT_FOUND`
+- [ ] `_wez_notify_resolve_pane(opt_pane_id)`: `--pane-id` 指定時はその値を使用。未指定時は `wezterm cli list --format json` から最初のペインの `pane_id` と `tty_name` を同時に取得。jq フォールバック（`grep -o` パターン）付き。取得失敗 → `WEZ_EXIT_PANE_NOT_FOUND`
 - [ ] `_wez_notify_encode_payload(title, body, timeout)`: `title|body|timeout` を base64 エンコード。`tr -d '\n'` で改行除去
-- [ ] `_wez_notify_send_user_var(pane_id, var_name, encoded_value)`: OSC 1337 `SetUserVar` を発行する `printf` コマンド文字列を構築し、`_wez_pane_send` と同じ `send-text --no-paste` パターンでペインのシェルに実行させる（DJ-1 検証結果: command string 方式に確定）
+- [ ] `_wez_notify_send_user_var(pane_id, var_name, encoded_value)`: DJ-1 に基づく2段階送信。primary: `wezterm cli list` から `tty_name` を取得し、OSC バイト列を TTY デバイスに直接書き込む。fallback（`tty_name` 取得不可時）: command string 方式で `_wez_pane_send` と同じ `send-text --no-paste` パターンを使用
 
 #### 1-4: 品質チェック
 
@@ -314,7 +314,8 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 
 - [ ] `$WEZ notify "Test Title" "Test Body"` が正常終了（exit 0）
 - [ ] WezTerm debug overlay で user-var `ai_notify` が受信されたことを確認
-- [ ] 送信先ペインの shell history に `printf` コマンドが残ること（command string 方式の既知副作用として確認）
+- [ ] TTY direct write 時: 送信先ペインの shell history に痕跡が**残らない**ことを確認
+- [ ] fallback（command string）時: shell history に `printf` コマンドが残ることを確認
 - [ ] `$WEZ notify "Title Only"` — body 省略で正常動作
 - [ ] `$WEZ notify --pane-id <id> "Test" "Body"` — ペイン指定で正常動作
 - [ ] `$WEZ notify --timeout 8000 "Test" "Body"` — timeout 指定
@@ -354,8 +355,8 @@ WEZ="./projects/wezterm-ai-mode/bin/wez"
 
 | リスク | 影響 | 対処 |
 |--------|------|------|
-| command string 方式の history 汚染 | ペインの history に printf コマンドが残る | Phase 1 は許容。Phase 2 で `HISTCONTROL=ignorespace` + 先頭スペース付き送信を検討 |
-| ペインがプロンプト状態でない場合に失敗 | vim 中、ビルド中などで通知送信不可 | README に注意書き。Phase 3 の agent 連携設計で再評価 |
+| TTY direct write の画面描画干渉 | vim 等の curses プロセス前景時に一時的な描画乱れの可能性 | README に注意書き。Phase 2 で詳細調査 |
+| `tty_name` 取得不可時の fallback 品質 | command string fallback では history 汚染・プロンプト依存が発生 | fallback であることをログ/JSON 出力に明示。Phase 2 で SSH 対応を検討 |
 | base64 改行混入が長文 body で OSC を破壊 | 通知が届かない | `tr -d '\n'` で明示的にストリップ（DJ-5） |
 | `|` バリデーションで UX が制限される | title/body に `|` が書けない | Phase 1 は許容。Phase 2 で区切り文字変更を検討 |
 | Lua ハンドラ未適用で toast が出ない | ユーザー混乱 | README + help に「`.wezterm.lua` に Lua ハンドラが必要」と明記。CLI の責務は user-var 送信まで |

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -36,7 +36,7 @@ related:
     ref: "../decisions/ADR-005-bash-shell-standards.md"
     reason: "Bash 3.2 互換ルール"
   - type: reference
-    ref: "../CONVENTIONS.md"
+    ref: "../../CONVENTIONS.md"
     reason: "ドキュメント規約・実行フロー"
 tags: [wez, cli, notify, phase1, bash, user-var, osc1337, lua]
 keywords: [wezterm, wez, notify, user-var, SetUserVar, OSC 1337, toast_notification, ai_notify, base64]

--- a/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-04-22-kickoff-wez-notify.md
@@ -1,0 +1,412 @@
+---
+id: 019DB3A8D9BF294BACB5B6
+title: "wez notify サブコマンド + Lua 統合方針確定（Phase 1 ステップ 1-3）"
+date: 2026-04-22
+type: kickoff
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/30"
+    reason: "本キックオフの対象 Issue"
+  - type: parent_epic
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/20"
+    reason: "Phase 1 Epic"
+  - type: depends_on
+    ref: "./2026-04-20-kickoff-wez-pane.md"
+    reason: "1-2 で確立した pane 操作パターンを前提とする"
+  - type: derived_from
+    ref: "../../poc/wezterm-ai-mode/04-notification.sh"
+    reason: "通知 PoC のコアロジック元"
+  - type: derived_from
+    ref: "../../poc/wezterm-ai-mode/wezterm-config/ai-mode-events.lua"
+    reason: "Lua ハンドラの参考実装"
+  - type: design_context
+    ref: "../VERIFICATION_MATRIX.md"
+    reason: "A-2-3 の検証項目"
+  - type: design_context
+    ref: "../decisions/ADR-001-cli-file-structure.md"
+    reason: "lib/notify.sh 新設は ADR-001 の lib 分割方針に基づく"
+  - type: evidence_for
+    ref: "../episodes/2026-04-22-episode-wez-notify.md"
+    reason: "本キックオフに基づく実装エピソード"
+  - type: design_context
+    ref: "../decisions/ADR-004-pane-design-decisions.md"
+    reason: "send-text パターン、exit code 体系の前提"
+  - type: design_context
+    ref: "../decisions/ADR-005-bash-shell-standards.md"
+    reason: "Bash 3.2 互換ルール"
+  - type: reference
+    ref: "../CONVENTIONS.md"
+    reason: "ドキュメント規約・実行フロー"
+  - type: evidence_for
+    ref: "../../tmp/peer-review-20260422-135027/review-log.md"
+    reason: "設計レビューの SO 比較ログ"
+tags: [wez, cli, notify, phase1, bash, user-var, osc1337, lua]
+keywords: [wezterm, wez, notify, user-var, SetUserVar, OSC 1337, toast_notification, ai_notify, base64]
+use_when:
+  - "wez notify サブコマンドを実装するとき"
+  - "WezTerm user-var 通知経路の設計を確認するとき"
+  - "Lua ハンドラ統合の方針を確認するとき"
+---
+
+# wez notify サブコマンド + Lua 統合方針確定（Phase 1 ステップ 1-3）
+
+作業開始前に必ず以下を読むこと:
+- `projects/wezterm-ai-mode/CONVENTIONS.md` — ドキュメント規約・Stage 分離フロー
+- `projects/wezterm-ai-mode/bin/wez` + `lib/common.sh` + `lib/discover.sh` + `lib/pane.sh` — 既存の構造
+- `projects/poc/wezterm-ai-mode/04-notification.sh` — 通知 PoC
+- `projects/poc/wezterm-ai-mode/wezterm-config/ai-mode-events.lua` — Lua ハンドラ参考実装
+- `projects/wezterm-ai-mode/docs/decisions/` — ADR-001〜005
+- `projects/wezterm-ai-mode/docs/episodes/2026-04-20-retro-phase1-1-2.md` — #30 へのプロセス適用指針
+
+## 背景
+
+[Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) Phase 1 の3番目の実装ステップ。[#28](https://github.com/stlwolf/ai-development-hub/issues/28)（1-1: `wez discover`）で CLI 基盤、[#29](https://github.com/stlwolf/ai-development-hub/issues/29)（1-2: `wez pane`）でペイン操作が確立済み。
+
+本ステップでは AI エージェントが WezTerm のデスクトップ通知を発行するための `wez notify` サブコマンドを実装する。PoC-04 で user-var（OSC 1337 `SetUserVar`）送信は PASSED だが、**Lua イベントハンドラが `.wezterm.lua` 未適用のため PARTIAL PASS**。
+
+### プロセス方針（retro より）
+
+#30 は **#28 寄りの軽量スコープ**（サブコマンド1つ + Lua 統合方針）。arena 不要、キックオフ → so-compare の最短パスで進める。
+
+### #29 からの申し送り事項
+
+- `bin/wez` dispatcher への新 case 追加パターン確立済み
+- ソケット取得: `wez_discover_socket()` → `export WEZTERM_UNIX_SOCKET`
+- exit code 体系: 0/1/2/3/4/5/64/127（common.sh に定義済み）
+- `send-text --no-paste` パターン（`_wez_pane_send` の `printf '%s\n' | wezterm cli send-text`）
+- naming: public `wez_` / private `_wez_`
+- bash 3.2 互換: `local -n` 禁止、`printf` 優先、空配列展開パターン（ADR-005）
+
+### 確定済みの大方針（peer-ai-review で合意）
+
+- **Phase 1 = CLI のみ**: `wez notify` は user-var を WezTerm ペインに送信するところまでが責務
+- **Lua ハンドラは Phase 2**: `.wezterm.lua` への `ai-mode-events.lua` 統合は Phase 2（dotfiles 統合）で実施
+- **Lua 統合方針の ADR を作成**: Phase 2 先送りの判断根拠を記録
+
+## 目的
+
+`wez notify "title" "body"` で WezTerm ペインに user-var (`ai_notify`) を送信し、Phase 2 の Lua ハンドラと互換のペイロード形式であること。toast 通知の表示は Phase 2 の検証対象。
+
+## 成功基準
+
+- [ ] `wez notify "title" "body"` が WezTerm ペインに user-var を送信する
+- [ ] 送信方式の選定が検証に基づいて決定されている（DJ-1）
+- [ ] ペイロード形式が Phase 2 の Lua ハンドラと互換
+- [ ] `--pane-id` でペイン指定可、未指定時は auto-detect
+- [ ] `--json` で機械可読な結果出力
+- [ ] `shellcheck` が全ファイルで通る
+- [ ] Lua 統合方針の ADR が作成されている
+- [ ] `wez notify --help` でヘルプが表示される
+
+## スコープ
+
+### 対象
+
+- `projects/wezterm-ai-mode/lib/notify.sh` — notify サブコマンドの実装
+- `projects/wezterm-ai-mode/bin/wez` — notify ルーティング追加
+- `wez notify [options] <title> [body]` — user-var エンコード + WezTerm ペインへ送信
+- ペイロード形式: `title|body|timeout`（base64 エンコード、OSC 1337 `SetUserVar`）
+- Lua 統合方針の ADR 作成
+- `README.md` 更新（notify セクション追加）
+
+### 対象外
+
+- `.wezterm.lua` への Lua ハンドラ統合（Phase 2）
+- `.bashrc` の `WEZTERM_UNIX_SOCKET` 自動 export（Phase 2）
+- `.tmux.conf` の `allow-passthrough`（Phase 2）
+- `sync-bin.sh` への `wez` 追加（Phase 1 ステップ 1-5）
+- `wez notify` への user-var 名の汎用化（`ai_status` 等は Phase 2 で検討）
+
+## 設計判断が必要な事項
+
+### DJ-1: 送信方式 — TTY 直接書き込み（実機検証済み・確定）
+
+3 方式を実機検証し、option C（TTY 直接書き込み）を採用。
+
+**実機検証結果（2026-04-22）**:
+
+| 選択肢 | 検証結果 | history 汚染 | プロンプト依存 | Phase 3 互換 |
+|--------|---------|-------------|-------------|------------|
+| A: command string（PoC 踏襲） | OK | **あり** | **あり** | 致命的制約（agent 作業中のペインで機能しない） |
+| B: raw OSC via send-text | **NG** | - | - | - |
+| **C: TTY 直接書き込み** | **OK** | **なし** | **なし** | **問題なし** |
+
+**option B が NG の理由**: `send-text` は PTY 入力（キーボード側）にバイトを書き込む。WezTerm は PTY 出力のみで OSC を解釈するため、原理的に動作しない。ESC がシェルの readline に消費され、残りが可視テキストとしてシェルに入力された。
+
+**option C の原理**: `wezterm cli list --format json` の `tty_name` フィールドからペインの TTY デバイス（例: `/dev/ttys013`）を取得し、直接 OSC バイト列を書き込む。TTY slave への書き込みは PTY master 側に転送され、WezTerm のターミナルエミュレータが直接 OSC を解釈する。シェルの stdin を経由しないため、history 汚染もプロンプト状態依存も発生しない。
+
+```bash
+# 検証で実行（OK）
+TTY=$(wezterm cli list --format json | jq -r '.[0].tty_name')
+printf '\033]1337;SetUserVar=ai_notify=%s\007' "$(printf 'Test|Body|5000' | base64 | tr -d '\n')" > "$TTY"
+# → history 汚染なし、ペイン表示に汚染なし、exit 0
+```
+
+**確定方針**: C（TTY 直接書き込み）を primary。command string（A）を fallback。
+
+**fallback が必要なケース**:
+- `tty_name` が JSON に含まれない古い WezTerm バージョン
+- SSH セッション経由のペイン（local TTY を持たない）
+- TTY デバイスへの書き込み権限がない場合
+
+**option C の注意点**（SO レビューより）:
+- vim 等の curses プロセスが前景にある場合、描画上の一時的な干渉の可能性あり（WezTerm の OSC パーサ自体は正常動作するが、curses のカーソル位置管理に影響しうる）
+- SSH 経由のリモートペインでは local TTY がないため不可 → command string fallback
+
+### DJ-2: ペイン選択のデフォルト挙動
+
+| 選択肢 | メリット | デメリット |
+|--------|---------|----------|
+| A: `--pane-id` 必須（Codex 提案） | `pane send` と整合。誤配送防止 | Phase 3 agent 利用時に毎回 pane-id を渡す手間 |
+| B: auto-detect フォールバック（Claude 提案） | 手軽。`user-var-changed` は window 単位なのでどのペインでも通知は届く | first pane の決定論性が弱い |
+
+**確定方針**: 2段階フォールバック。
+
+1. `--pane-id <ID>`（明示指定）
+2. `wezterm cli list --format json` の最初のペイン（auto-detect）
+
+根拠: notify は「WezTerm ウィンドウへの通知」であり、`pane send`（特定ペインでコマンド実行）とは意味が異なる。`user-var-changed` イベントはペイン単位ではなく window 単位で発火するため、送信先の厳密さは不要。
+
+`$WEZTERM_PANE` について: 実機検証で WezTerm ペイン内に `WEZTERM_PANE=0` が設定されていることを確認済み。ただし primary use case は Cursor → WezTerm（外部）であり、`WEZTERM_PANE` は未設定。YAGNI の観点から Phase 1 では組み込まない。需要が確認されれば Phase 2 以降で追加。
+
+### DJ-3: ペイロード区切り `|` の脆弱性対応
+
+peer-ai-review で Codex・Claude 両者が指摘。Lua ハンドラの `gmatch('[^|]+')` は:
+- 空セグメントを消失させる: `"title||4000"` → body が消え timeout が body にずれる
+- `|` を含む title/body で壊れる
+
+| 選択肢 | メリット | デメリット |
+|--------|---------|----------|
+| A: `|` を入力バリデーションで拒否 | 最小変更。Phase 1 で完結。既存 Lua と互換 | UX 制限（`|` を含むメッセージが書けない） |
+| B: 区切りを `\x1f` に変更 | 堅牢 | Lua 側の修正が必要 → Phase 2 スコープ越境 |
+| C: ペイロードを JSON 化 | 最も拡張性が高い | Lua パーサ書き直し。Phase 1 の CLI 責務を超える |
+
+**暫定方針**: A（Phase 1）。title/body に `|` が含まれる場合は `WEZ_EXIT_USAGE` で拒否。Phase 2 の Lua 統合時に B or C を検討。
+
+空 body の扱い: CLI 側で body が空の場合もペイロードを `title||timeout` として**3フィールド固定**で生成し、Lua 側の `gmatch` パターン修正（`[^|]*` への変更）は Phase 2 の Lua 統合と同時に対応する。Phase 1 では空 body でも Lua ハンドラの既存パーサが `timeout` を `body` と誤認する可能性があるが、Phase 1 では Lua ハンドラ未適用なので**実害なし**。
+
+### DJ-4: タイムアウトフラグの命名
+
+| 選択肢 | メリット | デメリット |
+|--------|---------|----------|
+| A: `--timeout` | シンプル。PoC 踏襲 | `pane split --timeout`（秒単位）との単位混同リスク |
+| B: `--timeout-ms` | 単位が明示的 | フラグ名が長い |
+
+**暫定方針**: A（`--timeout`）。help に `(milliseconds, default: 4000)` と明記。notify の timeout は toast 表示時間であり、`pane split --timeout`（待機タイムアウト）とは用途が異なるため混同リスクは低い。
+
+### DJ-5: base64 エンコーディングの改行対策
+
+macOS の `base64` は長い入力で 76 文字ごとに改行を挿入する。OSC シーケンス内に改行が入ると破損する。
+
+**暫定方針**: エンコード結果を `tr -d '\n'` でストリップ。PoC には対策なし（短い入力で発生しなかったため）。本実装では明示的に対処する。
+
+## ブランチ・コミット・PR 戦略
+
+### ブランチ
+
+```
+feature/#30_wez_notify
+```
+
+### コミット戦略
+
+| Step | コミットメッセージ例 |
+|------|---------------------|
+| Step 0 | （コミットなし。検証 + 前提調査のみ） |
+| Step 1 | `feat(wez): add notify subcommand with user-var injection` |
+| Step 2 | （コミットなし。E2E 検証。不具合は `fix(wez): ...` で修正コミット） |
+| Step 3 | `docs(wez): add notify ADR and update verification matrix` |
+| Step 4 | （PR 作成） |
+
+### PR
+
+- タイトル: `feat(wez): notify サブコマンド + Lua 統合方針 ADR`
+- `Refs #30`
+- `--assignee @me`
+
+## 実装計画
+
+### Step 0: 実機検証 + 前提調査（概算: 20分）
+
+**目的**: DJ-1（送信方式）と DJ-2（`WEZTERM_PANE`）の未検証項目を実機で確認し、設計判断を確定させる。
+
+#### 0-1: raw OSC 直接送信の検証（実機検証済み — NG）
+
+raw OSC バイト列を `send-text --no-paste` で直接送信したが、WezTerm は user-var を受理しなかった。`send-text` は PTY 入力（キーボード）にバイトを書き込むため、WezTerm のターミナルエミュレータは OSC を解釈しない（PTY 出力のみで解釈）。ESC がシェルの readline に消費され、残りが可視テキストとしてシェルに入力された。
+
+```
+# 検証で実行（NG）
+printf '\033]1337;SetUserVar=...\007' | wezterm cli send-text --pane-id 0 --no-paste
+# → ペインに「q1337;SetUserVar=ai_notify=...」が可視テキストとして入力
+# → -bash: q1337: コマンドが見つかりません
+```
+
+command string 方式は正常動作を確認。`printf` コマンドがペイン内シェルで実行され、stdout の OSC を WezTerm が消費。**DJ-1 は option A（command string）に確定。**
+
+#### 0-2: `WEZTERM_PANE` 環境変数の確認（実機検証済み — 存在確認）
+
+WezTerm ペイン内で `WEZTERM_PANE=0` を確認。Cursor 統合ターミナルでは未設定。**DJ-2 の優先順位に `$WEZTERM_PANE` を挿入済み。**
+
+#### 0-3: 前提確認
+
+- [ ] master が最新か確認（`git pull`）
+- [ ] ブランチ作成: `feature/#30_wez_notify`
+- [ ] `bin/wez` + `lib/common.sh` の現状確認
+- [ ] `lib/pane.sh` の `_wez_pane_send` 実装を精読（send-text パターンの参照）
+- [ ] PoC-04（`04-notification.sh`）のロジック精読
+
+!! GATE: 実機検証完了（DJ-1: command string に確定、DJ-2: 3段階フォールバックに確定）。前提確認後に続行。
+
+### Step 1: notify サブコマンド実装（概算: 30分）
+
+`lib/notify.sh` を新規作成し、`bin/wez` にルーティングを追加する。
+
+#### 1-1: 骨格
+
+- [ ] `lib/notify.sh` 作成（shebang + sourced-only ヘッダー）
+- [ ] `bin/wez` に `source "$WEZ_ROOT/lib/notify.sh"` 追加
+- [ ] `bin/wez` の case 文に `notify)` 追加 → `wez_cmd_notify "$@"` にディスパッチ
+- [ ] `wez help` のサブコマンド一覧に `notify` を追加
+
+#### 1-2: `wez_cmd_notify()` 実装
+
+```
+Usage: wez notify [options] <title> [body]
+
+Options:
+  --pane-id <ID>    Target pane (default: auto-detect first pane)
+  --timeout <MS>    Toast duration in milliseconds (default: 4000)
+  --socket <path>   WezTerm socket path (default: auto-detect)
+  --json            Output result as JSON
+  -h, --help        Show help
+```
+
+処理フロー:
+1. オプションパース（`--socket`, `--pane-id`, `--timeout`, `--json`, `--help`）
+2. ソケット解決: `wez_discover_socket "$opt_socket"` → `export WEZTERM_UNIX_SOCKET`
+3. title バリデーション: 必須、`|` 禁止、改行禁止
+4. body バリデーション: 省略可、`|` 禁止、改行禁止
+5. timeout バリデーション: 正の整数（100〜60000）
+6. ペイン解決: `--pane-id` 指定あり → そのまま使用。なし → `_wez_notify_auto_pane` で auto-detect
+7. ペイロード構築: `title|body|timeout` → base64（`tr -d '\n'`）
+8. user-var 送信: `_wez_notify_send_user_var` で OSC 1337 を `send-text` に注入
+9. 結果出力: 成功時は無音。`--json` 時に `{"pane_id": N, "status": "sent", "title": "...", "timeout": N}`
+
+#### 1-3: ヘルパー関数
+
+- [ ] `_wez_notify_auto_pane()`: `wezterm cli list --format json` から最初の pane_id を取得。jq フォールバック（`grep -o` パターン）付き。取得失敗 → `WEZ_EXIT_PANE_NOT_FOUND`
+- [ ] `_wez_notify_encode_payload(title, body, timeout)`: `title|body|timeout` を base64 エンコード。`tr -d '\n'` で改行除去
+- [ ] `_wez_notify_send_user_var(pane_id, var_name, encoded_value)`: OSC 1337 `SetUserVar` を発行する `printf` コマンド文字列を構築し、`_wez_pane_send` と同じ `send-text --no-paste` パターンでペインのシェルに実行させる（DJ-1 検証結果: command string 方式に確定）
+
+#### 1-4: 品質チェック
+
+- [ ] `shellcheck` パス（全ファイル）
+- [ ] コミット: `feat(wez): add notify subcommand with user-var injection`
+
+!! GATE（必須）: Step 1 完了後、`so-compare.sh` によるコードレビュー実施。DJ-1 の送信方式実装、base64 エンコード、入力バリデーション、`pane.sh` との一貫性を検証。
+
+### Step 2: E2E 検証（概算: 15分）
+
+```bash
+WEZ="./projects/wezterm-ai-mode/bin/wez"
+```
+
+- [ ] `$WEZ notify "Test Title" "Test Body"` が正常終了（exit 0）
+- [ ] WezTerm debug overlay で user-var `ai_notify` が受信されたことを確認
+- [ ] 送信先ペインの shell history に `printf` コマンドが残ること（command string 方式の既知副作用として確認）
+- [ ] `$WEZ notify "Title Only"` — body 省略で正常動作
+- [ ] `$WEZ notify --pane-id <id> "Test" "Body"` — ペイン指定で正常動作
+- [ ] `$WEZ notify --timeout 8000 "Test" "Body"` — timeout 指定
+- [ ] `$WEZ notify --json "Test" "Body"` — JSON 出力
+- [ ] `$WEZ notify` — title なしで exit 64
+- [ ] `$WEZ notify "Bad|Title" "Body"` — `|` 含みで exit 64
+- [ ] `$WEZ notify --timeout 0 "Test"` — 範囲外 timeout で exit 64
+- [ ] `$WEZ notify --timeout abc "Test"` — 非数値 timeout で exit 64
+- [ ] `$WEZ notify --pane-id 99999 "Test"` — 存在しないペインで exit 3
+- [ ] `$WEZ notify --help` — ヘルプ表示
+- [ ] `shellcheck` が全ファイルで通ること
+- [ ] Lua ハンドラ適用済み環境での toast 通知表示（Phase 1 では参考確認。成功基準には含めない）
+
+!! GATE: E2E 全項目パス。失敗がある場合は Step 1 に戻って修正。
+
+### Step 3: ドキュメント・ADR・記録（概算: 15分）
+
+- [ ] ADR-006: Lua 統合方針（Phase 2 先送りの判断根拠。`require` パターン vs インライン vs Phase 2 dotfiles 統合の比較）
+- [ ] ADR-007: notify 送信方式（DJ-1 の検証結果と採用判断）
+- [ ] DJ-2〜DJ-5 の判断を ADR-007 に統合 or 個別 ADR 判断
+- [ ] `docs/VERIFICATION_MATRIX.md` の A-2-3 を更新
+- [ ] `README.md` に notify セクション追加
+- [ ] エピソード記録（`docs/episodes/2026-04-22-wez-notify.md`）
+- [ ] コミット: `docs(wez): add notify ADR and Lua integration policy`
+
+### Step 4: PR 作成（概算: 10分）
+
+- [ ] `git fetch origin && git rebase origin/master`
+- [ ] `shellcheck` 最終確認
+- [ ] PR 本文作成（変更概要、DJ サマリ、E2E 結果、`Refs #30`）
+- [ ] `gh pr create --assignee @me`
+- [ ] Epic #20 に報告コメント
+
+!! GATE: PR 作成 + CI パス。
+
+## リスクと対処
+
+| リスク | 影響 | 対処 |
+|--------|------|------|
+| command string 方式の history 汚染 | ペインの history に printf コマンドが残る | Phase 1 は許容。Phase 2 で `HISTCONTROL=ignorespace` + 先頭スペース付き送信を検討 |
+| ペインがプロンプト状態でない場合に失敗 | vim 中、ビルド中などで通知送信不可 | README に注意書き。Phase 3 の agent 連携設計で再評価 |
+| base64 改行混入が長文 body で OSC を破壊 | 通知が届かない | `tr -d '\n'` で明示的にストリップ（DJ-5） |
+| `|` バリデーションで UX が制限される | title/body に `|` が書けない | Phase 1 は許容。Phase 2 で区切り文字変更を検討 |
+| Lua ハンドラ未適用で toast が出ない | ユーザー混乱 | README + help に「`.wezterm.lua` に Lua ハンドラが必要」と明記。CLI の責務は user-var 送信まで |
+| tmux 内ペインで OSC 1337 が吸収される | tmux 配下では通知が届かない | README に `.tmux.conf` の `allow-passthrough on` 要件を記載。Phase 2 で対応 |
+
+## peer-ai-review 実施ポイント
+
+1. **Step 1 完了後（必須）**: notify 実装のコードレビュー（`so-compare.sh`）。送信方式、base64 エンコード、バリデーション、既存パターンとの一貫性を検証
+
+## ADR 作成チェックリスト
+
+- [ ] ADR-006: Lua 統合方針（Phase 2 先送り判断の根拠）→ Step 3
+- [ ] ADR-007: notify 設計判断（DJ-1 送信方式 + DJ-2〜DJ-5 の統合記録）→ Step 3
+
+## 完了条件
+
+- [ ] `lib/notify.sh` が存在し、`wez notify` サブコマンドが実装されている
+- [ ] `bin/wez` に notify ルーティングが追加されている
+- [ ] `wez notify "title" "body"` が WezTerm ペインに user-var を送信する
+- [ ] ペイロード形式が `title|body|timeout`（base64 エンコード）で Lua ハンドラ互換
+- [ ] `--pane-id` でペイン指定可、未指定時は auto-detect
+- [ ] `--json` で機械可読な結果出力
+- [ ] `--timeout` でタイムアウト指定可（デフォルト 4000ms）
+- [ ] title/body の `|` 含有が拒否される
+- [ ] `shellcheck` が全スクリプトで通る
+- [ ] Lua 統合方針の ADR（ADR-006）が作成されている
+- [ ] notify 設計判断の ADR（ADR-007）が作成されている
+- [ ] `docs/VERIFICATION_MATRIX.md` の A-2-3 が更新されている
+- [ ] `README.md` に notify セクションが追加されている
+- [ ] so-compare によるコードレビュー gate を実施し、指摘への対応を記録している
+- [ ] PR が作成され `Refs #30` で Issue と連携している
+
+## 実行フロー
+
+CONVENTIONS.md §「フェーズ実行フロー」に従う。
+
+### Stage 1: プラン策定（Agent mode）
+
+1. **コンテキスト読み込み**: 本キックオフ + `CONVENTIONS.md` + 既存コード + PoC-04
+2. **プラン作成**: Agent mode で `docs/plans/2026-04-22-plan-wez-notify.md` に作成
+3. **peer-ai-review**: プランの合意を取得
+4. **CP 確定**: 合意内容をプラン MD に反映し、ユーザーに報告
+
+**← Stage 1 完了後、ここで停止してユーザーに報告する。**
+
+### Stage 2: 実装（Plan mode）
+
+5. **プラン変換**: 確定済みプランを Plan mode のプランに変換
+6. **ビルド実行**: TODO に従って実装
+
+### Stage 3: 成果物記録（Agent mode）
+
+7. **成果物記録**: エピソード + ADR + VERIFICATION_MATRIX 更新
+8. **キックオフ突合**: 成功基準・完了条件と実装結果を突合し、未達成項目を明示

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -23,6 +23,10 @@ _wez_notify_resolve_pane() {
     if command -v jq >/dev/null 2>&1; then
       tty_name=$(jq -r --arg id "$opt_pane_id" \
         '.[] | select((.pane_id | tostring) == $id) | .tty_name // ""' <<< "$json" 2>/dev/null) || true
+    else
+      tty_name=$(grep -A 30 -E "\"pane_id\":[[:space:]]*${opt_pane_id}[^0-9]" <<< "$json" \
+        | grep -oE '"tty_name":[[:space:]]*"[^"]*"' | head -1 \
+        | grep -oE '/dev/[^"]+') || true
     fi
     printf '%s\t%s\n' "$opt_pane_id" "$tty_name"
     return 0

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -38,7 +38,7 @@ _wez_notify_resolve_pane() {
     pane_id=$(jq -r '.[0].pane_id // ""' <<< "$json" 2>/dev/null) || true
     tty_name=$(jq -r '.[0].tty_name // ""' <<< "$json" 2>/dev/null) || true
   else
-    pane_id=$(grep -o '"pane_id":[0-9]*' <<< "$json" | head -1 | grep -o '[0-9]*$') || true
+    pane_id=$(grep -oE '"pane_id":[[:space:]]*[0-9]+' <<< "$json" | head -1 | grep -oE '[0-9]+$') || true
   fi
 
   if [[ -z "$pane_id" ]]; then
@@ -261,8 +261,10 @@ wez_cmd_notify() {
         --arg timeout "$opt_timeout" \
         '{"pane_id": ($pane_id | tonumber), "status": $status, "method": $method, "title": $title, "timeout": ($timeout | tonumber)}'
     else
+      local escaped_title="${title//\\/\\\\}"
+      escaped_title="${escaped_title//\"/\\\"}"
       printf '{"pane_id":%s,"status":"sent","method":"%s","title":"%s","timeout":%s}\n' \
-        "$pane_id" "$method" "$title" "$opt_timeout"
+        "$pane_id" "$method" "$escaped_title" "$opt_timeout"
     fi
   fi
 }

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# notify.sh - Notification operations for wez CLI
+#
+# Sourced by bin/wez. Not intended for standalone execution.
+# Naming: wez_* for public, _wez_* for private.
+
+# --- Helper functions ---
+
+_wez_notify_resolve_pane() {
+  local opt_pane_id="$1"
+  local json
+
+  if [[ -n "$opt_pane_id" ]]; then
+    if ! [[ "$opt_pane_id" =~ ^[0-9]+$ ]]; then
+      wez_error "notify: invalid pane-id: $opt_pane_id"
+      return "${WEZ_EXIT_USAGE}"
+    fi
+    if ! json=$(wezterm cli list --format json 2>/dev/null); then
+      wez_error "notify: failed to list panes"
+      return "${WEZ_EXIT_PANE_OP_FAILED}"
+    fi
+    local tty_name=""
+    if command -v jq >/dev/null 2>&1; then
+      tty_name=$(jq -r --arg id "$opt_pane_id" \
+        '.[] | select((.pane_id | tostring) == $id) | .tty_name // ""' <<< "$json" 2>/dev/null) || true
+    fi
+    printf '%s\t%s\n' "$opt_pane_id" "$tty_name"
+    return 0
+  fi
+
+  if ! json=$(wezterm cli list --format json 2>/dev/null); then
+    wez_error "notify: failed to list panes"
+    return "${WEZ_EXIT_PANE_OP_FAILED}"
+  fi
+
+  local pane_id="" tty_name=""
+  if command -v jq >/dev/null 2>&1; then
+    pane_id=$(jq -r '.[0].pane_id // ""' <<< "$json" 2>/dev/null) || true
+    tty_name=$(jq -r '.[0].tty_name // ""' <<< "$json" 2>/dev/null) || true
+  else
+    pane_id=$(grep -o '"pane_id":[0-9]*' <<< "$json" | head -1 | grep -o '[0-9]*$') || true
+  fi
+
+  if [[ -z "$pane_id" ]]; then
+    wez_error "notify: no panes found"
+    return "${WEZ_EXIT_PANE_NOT_FOUND}"
+  fi
+
+  printf '%s\t%s\n' "$pane_id" "$tty_name"
+}
+
+_wez_notify_encode_payload() {
+  local title="$1"
+  local body="$2"
+  local timeout="$3"
+  printf '%s|%s|%s' "$title" "$body" "$timeout" | base64 | tr -d '\n'
+}
+
+_wez_notify_send_user_var() {
+  local pane_id="$1"
+  local var_name="$2"
+  local encoded_value="$3"
+  local tty_name="$4"
+
+  # Primary: TTY direct write
+  if [[ -n "$tty_name" ]] && [[ -w "$tty_name" ]]; then
+    if printf '\033]1337;SetUserVar=%s=%s\007' "$var_name" "$encoded_value" > "$tty_name" 2>/dev/null; then
+      printf 'tty\n'
+      return 0
+    fi
+  fi
+
+  # Fallback: command string via send-text
+  local cmd
+  cmd=$(printf "printf '\\033]1337;SetUserVar=%%s=%%s\\007' '%s' '%s'" "$var_name" "$encoded_value")
+  if printf '%s\n' "$cmd" | wezterm cli send-text --pane-id "$pane_id" --no-paste 2>/dev/null; then
+    printf 'send-text\n'
+    return 0
+  fi
+
+  if ! _wez_pane_exists "$pane_id"; then
+    wez_error "notify: pane ${pane_id} not found"
+    return "${WEZ_EXIT_PANE_NOT_FOUND}"
+  fi
+  wez_error "notify: failed to send user-var to pane ${pane_id}"
+  return "${WEZ_EXIT_PANE_OP_FAILED}"
+}
+
+# --- Main command ---
+
+_wez_notify_help() {
+  cat <<'EOF'
+Usage: wez notify [options] <title> [body]
+
+Send a notification via WezTerm user-var (OSC 1337 SetUserVar).
+The notification payload is sent as the 'ai_notify' user-var in the format
+'title|body|timeout' (base64 encoded). A Lua event handler in .wezterm.lua
+is required to display the actual toast notification (Phase 2).
+
+Options:
+  --pane-id <ID>    Target pane (default: auto-detect first pane)
+  --timeout <MS>    Toast duration in milliseconds (default: 4000)
+  --socket <path>   WezTerm socket path (default: auto-detect)
+  --json            Output result as JSON
+  -h, --help        Show this help
+
+Exit codes:
+  0    Success
+  1    Socket not found
+  2    Connection failed
+  3    Pane not found
+  5    Send operation failed
+  64   Usage error (missing title, invalid options, pipe char in text)
+  127  wezterm not installed
+EOF
+}
+
+wez_cmd_notify() {
+  local opt_socket=""
+  local opt_pane_id=""
+  local opt_timeout="4000"
+  local opt_json=false
+  local title=""
+  local body=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --socket)
+        if [[ -z "${2:-}" ]]; then
+          wez_error "notify: --socket requires a path argument"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        opt_socket="$2"; shift
+        ;;
+      --pane-id)
+        if [[ -z "${2:-}" ]]; then
+          wez_error "notify: --pane-id requires a value"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        opt_pane_id="$2"; shift
+        ;;
+      --timeout)
+        if [[ -z "${2:-}" ]]; then
+          wez_error "notify: --timeout requires a value"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        opt_timeout="$2"; shift
+        ;;
+      --json) opt_json=true ;;
+      --help|-h)
+        _wez_notify_help
+        return 0
+        ;;
+      -*)
+        wez_error "notify: unknown option: $1"
+        return "${WEZ_EXIT_USAGE}"
+        ;;
+      *)
+        if [[ -z "$title" ]]; then
+          title="$1"
+        elif [[ -z "$body" ]]; then
+          body="$1"
+        else
+          wez_error "notify: too many arguments"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        ;;
+    esac
+    shift
+  done
+
+  # --- Validation ---
+
+  if [[ -z "$title" ]]; then
+    wez_error "notify: title is required"
+    echo "Run 'wez notify --help' for usage information." >&2
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  if [[ "$title" == *'|'* ]]; then
+    wez_error "notify: title must not contain '|' (pipe character)"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+  if [[ "$title" == *$'\n'* ]] || [[ "$title" == *$'\r'* ]]; then
+    wez_error "notify: title must not contain newlines"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  if [[ -n "$body" ]]; then
+    if [[ "$body" == *'|'* ]]; then
+      wez_error "notify: body must not contain '|' (pipe character)"
+      return "${WEZ_EXIT_USAGE}"
+    fi
+    if [[ "$body" == *$'\n'* ]] || [[ "$body" == *$'\r'* ]]; then
+      wez_error "notify: body must not contain newlines"
+      return "${WEZ_EXIT_USAGE}"
+    fi
+  fi
+
+  if ! [[ "$opt_timeout" =~ ^[0-9]+$ ]]; then
+    wez_error "notify: --timeout requires a numeric value"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+  if (( opt_timeout < 100 || opt_timeout > 60000 )); then
+    wez_error "notify: --timeout must be between 100 and 60000 (milliseconds)"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  # --- Socket discovery ---
+
+  local socket exit_code=0
+  socket=$(wez_discover_socket "$opt_socket") || exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    case $exit_code in
+      "${WEZ_EXIT_NO_WEZTERM}")
+        wez_error "notify: wezterm is not installed" ;;
+      "${WEZ_EXIT_NOT_FOUND}")
+        if [[ -n "$opt_socket" ]]; then
+          wez_error "notify: specified socket not found: ${opt_socket}"
+        else
+          wez_error "notify: no WezTerm socket found"
+        fi
+        ;;
+      "${WEZ_EXIT_CONN_FAIL}")
+        wez_error "notify: socket connection failed" ;;
+    esac
+    return "$exit_code"
+  fi
+
+  if ! wez_verify_connection "$socket" >/dev/null; then
+    wez_error "notify: socket connection failed"
+    return "${WEZ_EXIT_CONN_FAIL}"
+  fi
+
+  export WEZTERM_UNIX_SOCKET="$socket"
+
+  # --- Resolve pane ---
+
+  local pane_info pane_id tty_name
+  pane_info=$(_wez_notify_resolve_pane "$opt_pane_id") || return $?
+  pane_id=$(printf '%s' "$pane_info" | cut -f1)
+  tty_name=$(printf '%s' "$pane_info" | cut -f2)
+
+  # --- Encode and send ---
+
+  local encoded
+  encoded=$(_wez_notify_encode_payload "$title" "$body" "$opt_timeout")
+
+  local method
+  method=$(_wez_notify_send_user_var "$pane_id" "ai_notify" "$encoded" "$tty_name") || return $?
+
+  # --- Output ---
+
+  if [[ "$opt_json" == true ]]; then
+    if command -v jq >/dev/null 2>&1; then
+      jq -n \
+        --arg pane_id "$pane_id" \
+        --arg status "sent" \
+        --arg method "$method" \
+        --arg title "$title" \
+        --arg timeout "$opt_timeout" \
+        '{"pane_id": ($pane_id | tonumber), "status": $status, "method": $method, "title": $title, "timeout": ($timeout | tonumber)}'
+    else
+      printf '{"pane_id":%s,"status":"sent","method":"%s","title":"%s","timeout":%s}\n' \
+        "$pane_id" "$method" "$title" "$opt_timeout"
+    fi
+  fi
+}

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -197,11 +197,11 @@ wez_cmd_notify() {
     fi
   fi
 
-  if ! [[ "$opt_timeout" =~ ^[0-9]+$ ]]; then
-    wez_error "notify: --timeout requires a numeric value"
+  if ! [[ "$opt_timeout" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    wez_error "notify: --timeout requires a numeric value (no leading zeros)"
     return "${WEZ_EXIT_USAGE}"
   fi
-  if (( opt_timeout < 100 || opt_timeout > 60000 )); then
+  if (( 10#$opt_timeout < 100 || 10#$opt_timeout > 60000 )); then
     wez_error "notify: --timeout must be between 100 and 60000 (milliseconds)"
     return "${WEZ_EXIT_USAGE}"
   fi

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -39,6 +39,7 @@ _wez_notify_resolve_pane() {
     tty_name=$(jq -r '.[0].tty_name // ""' <<< "$json" 2>/dev/null) || true
   else
     pane_id=$(grep -oE '"pane_id":[[:space:]]*[0-9]+' <<< "$json" | head -1 | grep -oE '[0-9]+$') || true
+    tty_name=$(grep -oE '"tty_name":[[:space:]]*"[^"]*"' <<< "$json" | head -1 | grep -oE '/dev/[^"]+') || true
   fi
 
   if [[ -z "$pane_id" ]]; then
@@ -191,8 +192,8 @@ wez_cmd_notify() {
     wez_error "notify: title must not contain '|' (pipe character)"
     return "${WEZ_EXIT_USAGE}"
   fi
-  if [[ "$title" == *$'\n'* ]] || [[ "$title" == *$'\r'* ]]; then
-    wez_error "notify: title must not contain newlines"
+  if [[ "$title" =~ [[:cntrl:]] ]]; then
+    wez_error "notify: title must not contain control characters"
     return "${WEZ_EXIT_USAGE}"
   fi
 
@@ -201,8 +202,8 @@ wez_cmd_notify() {
       wez_error "notify: body must not contain '|' (pipe character)"
       return "${WEZ_EXIT_USAGE}"
     fi
-    if [[ "$body" == *$'\n'* ]] || [[ "$body" == *$'\r'* ]]; then
-      wez_error "notify: body must not contain newlines"
+    if [[ "$body" =~ [[:cntrl:]] ]]; then
+      wez_error "notify: body must not contain control characters"
       return "${WEZ_EXIT_USAGE}"
     fi
   fi

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -62,8 +62,8 @@ _wez_notify_send_user_var() {
   local encoded_value="$3"
   local tty_name="$4"
 
-  # Primary: TTY direct write
-  if [[ -n "$tty_name" ]] && [[ -w "$tty_name" ]]; then
+  # Primary: TTY direct write (-c: character device check to avoid writing to regular files)
+  if [[ -n "$tty_name" ]] && [[ -c "$tty_name" ]] && [[ -w "$tty_name" ]]; then
     if printf '\033]1337;SetUserVar=%s=%s\007' "$var_name" "$encoded_value" > "$tty_name" 2>/dev/null; then
       printf 'tty\n'
       return 0
@@ -174,6 +174,16 @@ wez_cmd_notify() {
   if [[ -z "$title" ]]; then
     wez_error "notify: title is required"
     echo "Run 'wez notify --help' for usage information." >&2
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  if [[ ${#title} -gt 500 ]]; then
+    wez_error "notify: title must not exceed 500 characters"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  if [[ -n "$body" ]] && [[ ${#body} -gt 2000 ]]; then
+    wez_error "notify: body must not exceed 2000 characters"
     return "${WEZ_EXIT_USAGE}"
   fi
 

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -77,7 +77,7 @@ _wez_notify_send_user_var() {
 
   # Fallback: command string via send-text
   local cmd
-  cmd=$(printf "printf '\\033]1337;SetUserVar=%%s=%%s\\007' '%s' '%s'" "$var_name" "$encoded_value")
+  cmd=$(printf "printf '\\\\033]1337;SetUserVar=%%s=%%s\\\\007' '%s' '%s'" "$var_name" "$encoded_value")
   if printf '%s\n' "$cmd" | wezterm cli send-text --pane-id "$pane_id" --no-paste 2>/dev/null; then
     printf 'send-text\n'
     return 0

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -266,7 +266,10 @@ wez_cmd_notify() {
   # --- Encode and send ---
 
   local encoded
-  encoded=$(_wez_notify_encode_payload "$title" "$body" "$opt_timeout")
+  if ! encoded=$(_wez_notify_encode_payload "$title" "$body" "$opt_timeout"); then
+    wez_error "notify: failed to encode payload"
+    return "${WEZ_EXIT_PANE_OP_FAILED}"
+  fi
 
   local method
   method=$(_wez_notify_send_user_var "$pane_id" "ai_notify" "$encoded" "$tty_name") || return $?

--- a/projects/wezterm-ai-mode/lib/notify.sh
+++ b/projects/wezterm-ai-mode/lib/notify.sh
@@ -102,12 +102,19 @@ The notification payload is sent as the 'ai_notify' user-var in the format
 'title|body|timeout' (base64 encoded). A Lua event handler in .wezterm.lua
 is required to display the actual toast notification (Phase 2).
 
+Arguments:
+  <title>           Notification title (required, max 500 chars)
+  [body]            Notification body (optional, max 2000 chars)
+
 Options:
   --pane-id <ID>    Target pane (default: auto-detect first pane)
   --timeout <MS>    Toast duration in milliseconds (default: 4000)
   --socket <path>   WezTerm socket path (default: auto-detect)
   --json            Output result as JSON
   -h, --help        Show this help
+
+Constraints:
+  title and body must not contain '|' (pipe) or control characters.
 
 Exit codes:
   0    Success


### PR DESCRIPTION
## 概要

`wez notify` サブコマンドを実装。OSC 1337 SetUserVar 経由で WezTerm ペインに通知ペイロード（`ai_notify`）を送信する。

- **送信方式**: TTY 直接書き込み（primary）+ command string（fallback）
- **Phase 1 スコープ**: CLI（user-var 送信）のみ。toast 表示の Lua ハンドラは Phase 2

Refs #30

## 変更内容

### 実装

- `lib/notify.sh` 新規作成（270行）
  - `_wez_notify_resolve_pane()`: pane_id + tty_name 同時取得（auto-detect / 明示指定）
  - `_wez_notify_encode_payload()`: `title|body|timeout` → base64（`tr -d '\n'`）
  - `_wez_notify_send_user_var()`: TTY direct write → send-text fallback
  - `wez_cmd_notify()`: ソケット探索 → バリデーション → 送信 → JSON 出力
- `bin/wez`: notify ルーティング追加

### 設計判断（ADR）

- **ADR-006**: Lua 統合方針（Phase 2 先送りの判断根拠）
- **ADR-007**: notify 設計判断集（DJ-1〜DJ-5 + peer review 修正）

### ドキュメント

- VERIFICATION_MATRIX: A-2-3 を PASSED に更新
- README: notify セクション追加
- Episode: 実装 + peer review 記録

## 設計判断サマリ

| DJ | 判断 | 根拠 |
|----|------|------|
| DJ-1 送信方式 | TTY direct write (primary) + command string (fallback) | 実機検証で3方式比較。SO ゼロベースレビューで発見 |
| DJ-2 ペイン選択 | 2段階 fallback（--pane-id → first pane） | user-var-changed は window 単位。厳密さ不要 |
| DJ-3 ペイロード区切り | `\|` バリデーション拒否 | Phase 2 の Lua 統合時に区切り変更を検討 |
| DJ-4 timeout 命名 | `--timeout`（ms） | help に単位明記。pane split --timeout とは用途が異なる |
| DJ-5 base64 改行 | `tr -d '\n'` | macOS base64 の 76 文字折り返し対策 |

## E2E 検証結果

12/12 パス（正常系 5 + エラー系 5 + ヘルプ + shellcheck）

## Peer Review（so-compare）

- **参加者**: Codex CLI + Claude Code
- **検出・修正**: Bug-1（jq-less JSON エスケープ）, Obs-1（grep パターン堅牢化）
- **3者合意**: 修正済み。残り Obs-2/3/4 は Phase 1 で許容
