### PR TITLE
chore(wez): add wez to sync-bin and finalize Phase 1 docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ AI駆動開発のための統合リポジトリ。複数AIツール（Cursor / C
 ./scripts/sync/sync-cursor.sh          # canonical + cursor-specific → ~/.cursor/
 ./scripts/sync/sync-claude.sh          # canonical → ~/.claude/
 ./scripts/sync/sync-codex.sh           # canonical → ~/.codex/
-./scripts/sync/sync-bin.sh             # so-compare, arena-compare → ~/bin/
+./scripts/sync/sync-bin.sh             # so-compare, arena-compare, wez → ~/bin/
 
 # agent-verification-flow: API検証ツール
 cd projects/agent-verification-flow
@@ -34,6 +34,17 @@ so-compare -w "$(pwd)" "プロンプト" --codex-only  # Codex のみ
 # arena-compare: マルチモデル並列比較（Cursor CLI）
 arena-compare -w "$(pwd)" "プロンプト"            # デフォルト3モデル
 arena-compare --resume-from tmp/arena-XXXXXXXX "追加質問"  # セッション継続
+
+# wez: WezTerm AI Mode CLI（~/bin/wez として配置）
+wez discover                           # ソケット自動検出
+wez discover --json                    # JSON出力
+wez pane list                          # ペイン一覧
+wez pane split --bottom --percent 25   # ペイン分割
+wez pane send <pane-id> "command"      # コマンド送信
+wez pane capture <pane-id> --lines 10  # 出力キャプチャ
+wez pane kill <pane-id>                # ペイン削除
+wez notify "title" "body"              # 通知送信
+wez notify --json "title" "body"       # JSON出力付き通知
 
 # claude-safe: Cursor統合ターミナルからClaude CLIを安全に実行
 ./projects/claude-safe/claude-safe -p "prompt" --output-format text
@@ -61,6 +72,7 @@ ai-development-hub/
 │   ├── agent-verification-flow/  # AI駆動API検証（JWT/Session対応、curl+jq）
 │   ├── arena-compare/            # マルチモデル並列比較（Cursor CLI）
 │   ├── claude-safe/              # Claude CLIラッパー（nohupでTTY競合回避）
+│   ├── wezterm-ai-mode/          # WezTerm AI Mode CLI（wez discover/pane/notify）
 │   └── second-opinion-verification/  # セカンドオピニオン検証（タイムアウト付き）
 ├── ideas/                  # アイデア（YYYYMMDD形式、凍結スナップショット）
 ├── docs/draft/             # ドラフトドキュメント

--- a/projects/README.md
+++ b/projects/README.md
@@ -53,8 +53,11 @@ Cursorスレッド会話のMarkdownエクスポートとライフサイクル管
 
 ### wezterm-ai-mode
 
-WezTerm の Human Mode / AI Mode デュアル構成を支える `wez` CLI ツールキット（Bash）。PoC 成果は `projects/poc/wezterm-ai-mode/` に凍結。本ディレクトリは cursor-thread-tools と同型の CONVENTIONS・検証マトリクスで開発プロセスの2例目検証を行う。
+WezTerm の Human Mode / AI Mode デュアル構成を支える `wez` CLI ツールキット（Bash）。Phase 1 完了。
 
+- サブコマンド: `discover`（ソケット自動検出）/ `pane`（list/split/send/capture/kill）/ `notify`（OSC 1337 user-var 送信）
+- Cursor / Claude Code / Codex CLI の3ツールで E2E 検証済み
+- `~/bin/wez` として PATH 配置済み（`scripts/sync/sync-bin.sh`）
 - [Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) でスコープ・Phase をトラッキング
 - [CONVENTIONS.md](wezterm-ai-mode/CONVENTIONS.md)、[VERIFICATION_MATRIX.md](wezterm-ai-mode/docs/VERIFICATION_MATRIX.md)
 

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -7,7 +7,7 @@ WezTerm の **Human Mode（tmux 維持）** と **AI Mode（`wezterm cli` 上乗
 **Phase 1 完了** — `wez discover` + `wez pane` (list/split/send/capture/kill) + `wez notify` が動作し、Cursor / Claude Code / Codex CLI の3ツールで7ステップ統合フロー（discover → pane list → split → send → capture → notify → kill）の E2E 検証を完了。[Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) で Phase 2 以降の追加機能を予定。
 
 **既知制約**:
-- capture の出力に tmux statusbar / prompt 装飾が混入する（マーカー方式で回避可能、Phase 2 で `--raw` / フィルタ対応予定）
+- capture の出力に tmux statusbar / prompt 装飾が混入する。`wez pane capture --raw` は ANSI escape を保持するオプション（CLI リファレンス参照）であり、装飾除去ではない。マーカー方式で回避可能。装飾を落とすフィルタやオーケストレータ向けの専用オプションは Phase 2 で検討。
 - Cursor / Codex CLI のサンドボックス環境では `required_permissions: ["all"]` が必要（WezTerm の Unix ソケットへのアクセス制限）
 
 ## クイックスタート

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -4,7 +4,11 @@ WezTerm の **Human Mode（tmux 維持）** と **AI Mode（`wezterm cli` 上乗
 
 ## ステータス
 
-**Phase 1 実装中** — `wez discover` + `wez pane` + `wez notify` が動作する状態。[Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) で追加機能を予定。
+**Phase 1 完了** — `wez discover` + `wez pane` (list/split/send/capture/kill) + `wez notify` が動作し、Cursor / Claude Code / Codex CLI の3ツールで7ステップ統合フロー（discover → pane list → split → send → capture → notify → kill）の E2E 検証を完了。[Epic #20](https://github.com/stlwolf/ai-development-hub/issues/20) で Phase 2 以降の追加機能を予定。
+
+**既知制約**:
+- capture の出力に tmux statusbar / prompt 装飾が混入する（マーカー方式で回避可能、Phase 2 で `--raw` / フィルタ対応予定）
+- Cursor / Codex CLI のサンドボックス環境では `required_permissions: ["all"]` が必要（WezTerm の Unix ソケットへのアクセス制限）
 
 ## クイックスタート
 
@@ -239,6 +243,11 @@ projects/wezterm-ai-mode/
 - [docs/episodes/](docs/episodes/) — 実装エピソード
 - [docs/raw-logs/README.md](docs/raw-logs/README.md) — 層3の一時ログ置き場
 
-## sync-bin.sh 統合（未実施）
+## sync-bin.sh 統合
 
-`bin/wez` を [scripts/sync/sync-bin.sh](../../scripts/sync/sync-bin.sh) 経由で `~/bin/` にシンボリックリンクし、パスなしで `wez discover` を実行可能にする予定（Phase 1 ステップ 1-5）。
+`~/bin/wez` として PATH 配置済み（[`scripts/sync/sync-bin.sh`](../../scripts/sync/sync-bin.sh) 経由のシンボリックリンク）。`so-compare` / `arena-compare` と同じパターン。
+
+```bash
+./scripts/sync.sh bin   # ~/bin/wez を作成・更新
+wez discover            # パスなしで実行可能
+```

--- a/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
+++ b/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
@@ -50,9 +50,9 @@ use_when:
 
 | ID | 検証項目 | 状態 | 結果 | 根拠 |
 |----|---------|------|------|------|
-| B-1 | Stage 1: Agent mode で plan MD 作成 + peer-ai-review | SKIPPED | - | Phase 1 は Issue 駆動で進行。Stage 分離フローの本格検証は Phase 2 以降 |
-| B-2 | Stage 2: 確定プランを Plan mode に変換して実装 | SKIPPED | - | 同上 |
-| B-3 | Stage 3: episode + ADR + 本ファイル更新 + キックオフ突合 | SKIPPED | - | 同上 |
+| B-1 | Stage 1: Agent mode で plan MD 作成 + peer-ai-review | スキップ | - | Phase 1 は Issue 駆動で進行。Stage 分離フローの本格検証は Phase 2 以降 |
+| B-2 | Stage 2: 確定プランを Plan mode に変換して実装 | スキップ | - | 同上 |
+| B-3 | Stage 3: episode + ADR + 本ファイル更新 + キックオフ突合 | スキップ | - | 同上 |
 | B-4 | plan と episode の分離が運用で守られたか | 実施済み | PARTIAL | plans/ と episodes/ の分離は維持。ただし Stage 順序の厳格運用ではない |
 | B-5 | 実装後 `so-compare.sh` gate + `shellcheck` 前提のレビュー | 実施済み | PASSED | Issue #31, [E2E エピソード](episodes/2026-05-13-phase1-e2e.md) §3。Codex+Claude 2者合意、medium 2件修正済み |
 

--- a/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
+++ b/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
@@ -50,10 +50,10 @@ use_when:
 
 | ID | 検証項目 | 状態 | 結果 | 根拠 |
 |----|---------|------|------|------|
-| B-1 | Stage 1: Agent mode で plan MD 作成 + peer-ai-review | 未実施 | - | [CONVENTIONS.md](../CONVENTIONS.md) |
-| B-2 | Stage 2: 確定プランを Plan mode に変換して実装 | 未実施 | - | 同上 |
-| B-3 | Stage 3: episode + ADR + 本ファイル更新 + キックオフ突合 | 未実施 | - | 同上 |
-| B-4 | plan と episode の分離が運用で守られたか | 未実施 | - | 同上 |
+| B-1 | Stage 1: Agent mode で plan MD 作成 + peer-ai-review | SKIPPED | - | Phase 1 は Issue 駆動で進行。Stage 分離フローの本格検証は Phase 2 以降 |
+| B-2 | Stage 2: 確定プランを Plan mode に変換して実装 | SKIPPED | - | 同上 |
+| B-3 | Stage 3: episode + ADR + 本ファイル更新 + キックオフ突合 | SKIPPED | - | 同上 |
+| B-4 | plan と episode の分離が運用で守られたか | 実施済み | PARTIAL | plans/ と episodes/ の分離は維持。ただし Stage 順序の厳格運用ではない |
 | B-5 | 実装後 `so-compare.sh` gate + `shellcheck` 前提のレビュー | 実施済み | PASSED | Issue #31, [E2E エピソード](episodes/2026-05-13-phase1-e2e.md) §3。Codex+Claude 2者合意、medium 2件修正済み |
 
 ---

--- a/scripts/sync/sync-bin.sh
+++ b/scripts/sync/sync-bin.sh
@@ -8,9 +8,10 @@
 #   ./scripts/sync/sync-bin.sh
 #
 # Description:
-#   so-compare.sh, arena-compare.sh 等のスクリプトを
+#   so-compare.sh, arena-compare.sh, wez 等のスクリプトを
 #   ~/bin/ にシンボリックリンクとして配置します。
-#   リンク名は拡張子なし（so-compare, arena-compare）になります。
+#   リンク名は拡張子なし（so-compare, arena-compare）または
+#   元のファイル名のまま（wez）になります。
 #
 #   既にシンボリックリンクでないファイルが存在する場合はスキップします。
 #
@@ -41,10 +42,11 @@ usage() {
 
 [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
 
-CMD_NAMES=("so-compare" "arena-compare")
+CMD_NAMES=("so-compare" "arena-compare" "wez")
 CMD_SOURCES=(
     "${REPO_ROOT}/scripts/so-compare.sh"
     "${REPO_ROOT}/projects/arena-compare/arena-compare.sh"
+    "${REPO_ROOT}/projects/wezterm-ai-mode/bin/wez"
 )
 
 main() {


### PR DESCRIPTION
## 目的

`wez` CLI を `~/bin/` に sync 可能にし、Phase 1 完了に伴う各ドキュメントを最終状態に更新する。

## 変更内容

- `scripts/sync/sync-bin.sh` に `wez` エントリ追加（`so-compare` / `arena-compare` と同パターン）
- `CLAUDE.md` に `wez` の使い方ブロックとアーキテクチャ図への追記
- `projects/wezterm-ai-mode/README.md` を Phase 1 完了に更新（3ツール横断 E2E 検証済み、既知制約、sync-bin.sh 統合完了）
- `projects/README.md` の wezterm-ai-mode セクションに機能一覧と PATH 配置を反映
- `VERIFICATION_MATRIX.md` の B-1〜B-3 を SKIPPED、B-4 を PARTIAL に更新（Phase 1 は Issue 駆動で進行した事実の記録）

## 検証

- `./scripts/sync.sh bin` で `~/bin/wez` へのシンボリックリンク作成を確認
- `wez version` / `wez discover` が symlink 経由で正常動作
- `shellcheck scripts/sync/sync-bin.sh` — 問題なし

## 影響範囲

- `scripts/sync/sync-bin.sh`
- `CLAUDE.md`
- `projects/README.md`
- `projects/wezterm-ai-mode/README.md`
- `projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md`

Refs #32
