### PR TITLE
feat(orchestration-engine): Step 4-2 パース・状態管理（設計〜実装・検証）

### DIFF
--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# oe — orchestration-engine エントリポイント
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_DIR="${PROJECT_DIR}/lib"
+export PROJECT_DIR
+
+# source lib/*.sh
+# shellcheck source=../lib/constants.sh
+source "${LIB_DIR}/constants.sh"
+# shellcheck source=../lib/envelope.sh
+source "${LIB_DIR}/envelope.sh"
+# shellcheck source=../lib/spawn.sh
+source "${LIB_DIR}/spawn.sh"
+# shellcheck source=../lib/capture.sh
+source "${LIB_DIR}/capture.sh"
+# shellcheck source=../lib/monitor.sh
+source "${LIB_DIR}/monitor.sh"
+# shellcheck source=../lib/audit.sh
+source "${LIB_DIR}/audit.sh"
+# shellcheck source=../lib/cleanup.sh
+source "${LIB_DIR}/cleanup.sh"
+
+export OE_CURRENT_SESSION_ID=""
+trap oe_cleanup EXIT INT TERM
+
+oe_generate_session_id() {
+  local ts
+  local rand
+  # 26 文字: 先頭 14 は数字（ULID 時刻部相当）、残り 12 は Crockford base32（I/L/O/U 除外）
+  ts="$(date -u +%Y%m%d%H%M%S)"
+  rand="$(LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z' </dev/urandom | head -c 12)"
+  printf '%s%s\n' "$ts" "$rand"
+}
+
+oe_main() {
+  # 3) state/audit ディレクトリ準備
+  mkdir -p "${OE_STATE_DIR}" "${OE_AUDIT_DIR}"
+
+  # 4) セッションID確定
+  OE_CURRENT_SESSION_ID="$(oe_generate_session_id)"
+
+  # E2E タスク説明（未指定時は既定値）
+  local task_description="${*:-Run orchestration task}"
+  local pane_id
+
+  # 5) spawn 準備 → envelope 生成 → send
+  oe_spawn_prepare_pane
+  pane_id="$OE_SPAWN_PANE_ID"
+  oe_envelope_create "$OE_CURRENT_SESSION_ID" "$pane_id" "$task_description" "$PROJECT_DIR" "$OE_CB_TIMEOUT"
+  oe_spawn_send "$OE_CURRENT_SESSION_ID" "$pane_id" "$OE_ENVELOPE_PATH"
+
+  # 6) monitor loop
+  local monitor_rc
+  if oe_monitor_loop "$OE_CURRENT_SESSION_ID" "$pane_id"; then
+    monitor_rc=0
+  else
+    monitor_rc=$?
+  fi
+
+  # monitor が INT/TERM trap を解除するため、EXIT 経路の cleanup を再確保
+  trap oe_cleanup EXIT INT TERM
+
+  # 7) monitor 戻り値を尊重
+  return "$monitor_rc"
+}
+
+oe_main "$@"

--- a/projects/orchestration-engine/docs/episodes/2026-05-15-episode-step-4-2-phase-e-integration-validation.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-15-episode-step-4-2-phase-e-integration-validation.md
@@ -32,7 +32,7 @@
 6. ⚠️ Audit log 7 種イベント JSONL 出力  
    - 根拠コマンド: `bash ./tests/test_audit.sh`, `bash ./tests/test_monitor.sh`, `bash ./tests/test_e2e_smoke.sh`  
    - 根拠ファイル: `lib/audit.sh`, `lib/monitor.sh`, `lib/cleanup.sh`, `lib/spawn.sh`  
-   - 観測: `session_start/state_change/circuit_breaker_triggered/cleanup/session_end` は実出力確認済み。`interrupt/human_input` は呼び出し実装・検証が未追加
+   - 観測: `session_start/state_change/interrupt/circuit_breaker_triggered/cleanup/session_end` は実出力確認済み。`human_input` は呼び出し実装・検証が未追加
 
 7. ✅ trap EXIT でペイン kill + 一時ファイル削除  
    - 根拠コマンド: `bash ./tests/test_cleanup.sh`, `bash ./tests/test_e2e_smoke.sh`  
@@ -59,7 +59,7 @@ bash ./tests/test_e2e_smoke.sh
 
 ## 未達・懸念
 
-- 完了条件 6 の「7 種イベント実出力」は未達。`interrupt` と `human_input` の emit 経路（および検証）を追加すると完全充足になる。
+- 完了条件 6 の「7 種イベント実出力」は一部未達。`human_input` の emit 経路（および検証）を追加すると完全充足になる。
 
 ## 追記: Phase D ハードニング (2026-05-15)
 
@@ -72,3 +72,4 @@ so-compare レビューの指摘を受け、Phase D / E の結線に関する以
 - `spawn.sh` を2段階API（`prepare_pane` と `send`）に分割（`pane_id` 依存解消）
 - `capture.sh` で `\r` と ANSI エスケープを除去する前処理を追加
 - 監査ログ `payload` が JSON Object であることを `jq` で事前検証
+- `interrupt` イベント: `monitor.sh` が SIGINT/SIGTERM 検知時に `payload.method` を付与して emit

--- a/projects/orchestration-engine/docs/episodes/2026-05-15-episode-step-4-2-phase-e-integration-validation.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-15-episode-step-4-2-phase-e-integration-validation.md
@@ -1,0 +1,74 @@
+# Step 4-2 Phase E 統合検証（STOP E）
+
+実施日: 2026-05-15
+
+## 完了条件 8 項目チェック
+
+1. ✅ `bin/oe` が envelope を受け取りサブエージェントを spawn できる  
+   - 根拠コマンド: `bash ./tests/test_e2e_smoke.sh`  
+   - 根拠ファイル: `bin/oe`, `lib/envelope.sh`, `lib/spawn.sh`  
+   - 観測: `send.log` に `Read /tmp/oe-<session>-envelope.json and execute the task` を記録し、`session_start` を監査ログへ出力
+
+2. ✅ `@@OE_EXIT:{code}` 検出と 6 値分類  
+   - 根拠コマンド: `bash ./tests/test_capture.sh`, `bash ./tests/test_monitor.sh`, `bash ./tests/test_e2e_smoke.sh`  
+   - 根拠ファイル: `lib/capture.sh`, `lib/monitor.sh`  
+   - 観測: EXIT マーカー検出、`success/partial/retryable_failure/blocked/timeout/protocol_error` 分類を検証
+
+3. ✅ 2s ポーリングで管理ペイン巡回  
+   - 根拠コマンド: `bash ./tests/test_monitor.sh`  
+   - 根拠ファイル: `lib/monitor.sh`, `lib/constants.sh`  
+   - 観測: `OE_POLL_INTERVAL=2` の `while` ループで全管理ペインを巡回し、完了ペインを除外
+
+4. ✅ CB 違反時に `circuit_breaker_triggered` を emit して停止  
+   - 根拠コマンド: `bash ./tests/test_monitor.sh`  
+   - 根拠ファイル: `lib/monitor.sh`, `lib/audit.sh`  
+   - 観測: `timeout/max_turns/max_panes` の 3 条件で emit + kill + 終了を検証
+
+5. ✅ KVS に完了状態を atomic write  
+   - 根拠コマンド: `bash ./tests/test_kvs.sh`, `bash ./tests/test_e2e_smoke.sh`  
+   - 根拠ファイル: `lib/capture.sh`  
+   - 観測: `state/{session_id}.state.json` 生成、隠し tmp ファイル経由の `mv -f` で更新
+
+6. ⚠️ Audit log 7 種イベント JSONL 出力  
+   - 根拠コマンド: `bash ./tests/test_audit.sh`, `bash ./tests/test_monitor.sh`, `bash ./tests/test_e2e_smoke.sh`  
+   - 根拠ファイル: `lib/audit.sh`, `lib/monitor.sh`, `lib/cleanup.sh`, `lib/spawn.sh`  
+   - 観測: `session_start/state_change/circuit_breaker_triggered/cleanup/session_end` は実出力確認済み。`interrupt/human_input` は呼び出し実装・検証が未追加
+
+7. ✅ trap EXIT でペイン kill + 一時ファイル削除  
+   - 根拠コマンド: `bash ./tests/test_cleanup.sh`, `bash ./tests/test_e2e_smoke.sh`  
+   - 根拠ファイル: `lib/cleanup.sh`, `bin/oe`  
+   - 観測: `trap oe_cleanup EXIT INT TERM` により kill と `/tmp/oe-{session_id}-*` 掃除、`cleanup` 監査記録を確認
+
+8. ✅ shellcheck pass  
+   - 根拠コマンド: `shellcheck ./bin/oe ./lib/*.sh ./tests/*.sh`  
+   - 根拠ファイル: `bin/oe`, `lib/*.sh`, `tests/*.sh`  
+   - 観測: エラー/警告とも 0（実行済み）
+
+## 実行コマンド
+
+```bash
+shellcheck ./bin/oe ./lib/*.sh ./tests/*.sh
+bash ./tests/test_capture.sh
+bash ./tests/test_monitor.sh
+bash ./tests/test_envelope.sh
+bash ./tests/test_audit.sh
+bash ./tests/test_kvs.sh
+bash ./tests/test_cleanup.sh
+bash ./tests/test_e2e_smoke.sh
+```
+
+## 未達・懸念
+
+- 完了条件 6 の「7 種イベント実出力」は未達。`interrupt` と `human_input` の emit 経路（および検証）を追加すると完全充足になる。
+
+## 追記: Phase D ハードニング (2026-05-15)
+
+so-compare レビューの指摘を受け、Phase D / E の結線に関する以下の修正（ハードニング）を実施した上で、全テストをパスさせた。
+
+- `session_id` を ULID 文字集合（Crockford base32）に正規化
+- `session_start` イベントの `state` を `null` に固定
+- `cleanup` イベントの payload に `killed_pane_ids` を追加
+- `monitor.sh` 終了後に `bin/oe` で `trap oe_cleanup EXIT INT TERM` を再設定
+- `spawn.sh` を2段階API（`prepare_pane` と `send`）に分割（`pane_id` 依存解消）
+- `capture.sh` で `\r` と ANSI エスケープを除去する前処理を追加
+- 監査ログ `payload` が JSON Object であることを `jq` で事前検証

--- a/projects/orchestration-engine/docs/plans/2026-05-14-kickoff-step-4-2-parse-and-state-management.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-14-kickoff-step-4-2-parse-and-state-management.md
@@ -67,7 +67,7 @@ tags: [orchestration, mvp, step-4-2, kickoff, parse, state-management, marker, m
 
 - [#19](https://github.com/stlwolf/ai-development-hub/issues/19) — Epic 親、Phase 4 ステップ管理
 - [#84](https://github.com/stlwolf/ai-development-hub/issues/84) — Step 4-1 サブ Issue（closed、[PR #85](https://github.com/stlwolf/ai-development-hub/pull/85)）
-- 4-2 用サブ Issue — 本 KickOff 作成後に別途作成
+- [#87](https://github.com/stlwolf/ai-development-hub/issues/87) — Step 4-2 サブ Issue（本 KickOff の観測層）
 
 ## スコープ
 
@@ -279,7 +279,7 @@ flowchart TD
 
 - [#19](https://github.com/stlwolf/ai-development-hub/issues/19) — Epic 親、Phase 4 ステップ管理
 - [#84](https://github.com/stlwolf/ai-development-hub/issues/84) — Step 4-1 サブ Issue（closed）
-- 4-2 用サブ Issue — 本 KickOff 作成後に別途作成
+- [#87](https://github.com/stlwolf/ai-development-hub/issues/87) — Step 4-2 サブ Issue（本 KickOff の観測層）
 
 ### 並行・合流候補
 

--- a/projects/orchestration-engine/docs/plans/2026-05-14-plan-step-4-2-parse-and-state-management.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-14-plan-step-4-2-parse-and-state-management.md
@@ -1,0 +1,440 @@
+---
+id: "01KRK33W3E7KKQZRSTB22G5KB0"
+title: "orchestration-engine Step 4-2 成果物パース + 状態管理 Plan"
+date: 2026-05-14
+type: plan
+status: draft
+related:
+  - type: derived_from
+    ref: "projects/orchestration-engine/docs/plans/2026-05-14-kickoff-step-4-2-parse-and-state-management.md"
+    reason: "変換元 KickOff。kickoff-to-plan SKILL に従い本 Plan を生成"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/19"
+    reason: "Epic #19 Phase 4 MVP 実装の Step 4-2（観測層・親 Epic）"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/87"
+    reason: "Step 4-2 観測層サブ Issue"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-05-14-discussion-parse-and-state-management.md"
+    reason: "Step 4-2 Discussion（Q1〜Q7 質問駆動設計の合意記録、KickOff の入力）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-13-kickoff-step-4-1-envelope-and-dispatcher.md"
+    reason: "Step 4-1 KickOff（15 DI、エンベロープ + ディスパッチャ骨格。本 Step の前提）"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/85"
+    reason: "Step 4-1 成果物 PR（schemas 5件、ADR 3件、episodes 13件、validate-envelope.sh）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-05-13-discussion-engine-scope-and-goals.md"
+    reason: "Step 4-0 Discussion（15 論点・3 UC・arena 反映済み、全体スコープの正本）"
+tags: [orchestration, mvp, step-4-2, plan, parse, state-management, marker, monitor-loop, audit-log]
+---
+
+# Step 4-2: 成果物パース + 状態管理 — Plan
+
+> 本 Plan は [KickOff](2026-05-14-kickoff-step-4-2-parse-and-state-management.md) を `kickoff-to-plan` SKILL に従い変換したもの。KickOff の 7 Decision Items（DI-1〜DI-7）を 5 Phase に配置し、各 DI を実装 TODO として展開する。Phase 構造は KickOff §DI 依存関係の推奨実装順に準拠。
+
+## 変換上の判断メモ
+
+> KickOff は Discussion Q1〜Q7 合意をもとに DI-1〜DI-7 を定義した構造。Step 4-1（設計主軸）と異なり、全 DI が実装コーディングを伴う。以下の判断で変換した。
+
+1. **DI → Phase 変換**: KickOff §DI 依存関係の推奨実装順 Phase A〜E をそのまま Plan の Phase 構造に採用。各 Phase 内で該当 DI を実装 TODO として展開
+2. **cleanup.sh の Phase 配置**: cleanup.sh は KickOff 上で独立 DI を持たないが、DI-2（一時ファイル削除）、DI-5（cleanup イベント）、DI-7（ファイルレイアウト）、完了条件 7 に跨る要素。Phase D（出力）に配置した理由: `oe_audit_emit()`（DI-5）を利用するため、DI-5 実装後でなければ cleanup イベント記録が完成しない
+3. **Open Questions の配置**: KickOff §Open Questions の「実装中に判断する事項」4 項目を、関連する Phase の冒頭に「確定タスク」として配置。「スコープ外だが次ステップに影響する事項」3 項目は §スコープ外 に転記
+4. **per-Phase 検証サイクル**: KickOff §次アクション の「実装 → shellcheck → 単体動作確認 → Episode 記録」サイクルを各 Phase に配置
+5. **GATE/STOP 配置**: ユーザー指示により Phase A/B/D に GATE、Phase C/E に STOP（HG）を配置。KickOff には明示的な STOP/GATE 指示がないため、これはユーザー指定の追加構造
+6. **DI-3 と capture.sh の Phase 分割**: DI-3 の定数定義・`oe_capture_scan()`・`oe_capture_classify()` は Phase B（Step 3）で実装。DI-4 の `monitor.sh` は Phase C（Step 5）で実装し、capture.sh の関数を呼び出す。KickOff 原文では `capture.sh` が DI-3 と DI-6 の両方に関連するが、依存グラフの `DI-3 → DI-4` パスに従い Phase B で基本関数を実装し、DI-6 の `oe_capture_write_kvs()` は Phase D で追加する
+7. **完了条件の展開**: 8 項目それぞれにサブ条件（箇条書き）があるため、サブ条件を検証 TODO の説明に含めて展開
+
+## Context
+
+### 前提（KickOff で確定済み）
+
+- Step 4-1（[PR #85](https://github.com/stlwolf/ai-development-hub/pull/85)）でエンベロープスキーマ・失敗分類・監査ログスキーマ・exit code マッピング・セッション状態 KVS スキーマ・`validate-envelope.sh` が確定済み
+- Step 4-0 Discussion の 15 論点のうち、4-2 に直結する実装論点を `question-driven-design` で 7 問に絞り込み、全問合意済み（[Discussion](../discussions/2026-05-14-discussion-parse-and-state-management.md) status: closed）
+- Step 4-2 の主題: `@@OE_EXIT:{code}` マーカーの検出・パース、ポーリングベースの監視ループ、G4 6 値への分類、KVS / 監査ログへの書き込みを Bash 関数ライブラリとして実装
+- 観測層 Issue [#87](https://github.com/stlwolf/ai-development-hub/issues/87) は作成済み（read-only、進捗トラッキング先）
+
+### 実行モデルの前提（so-compare レビューで明確化）
+
+- **MVP は one-shot モード**: AI CLI を `--prompt` / `-p` / `-q` フラグ付きで one-shot 実行。REPL（対話モード）は 4-2 スコープ外
+- **`wez pane send` で送るのは shell コマンド 1 行**: envelope JSON を直接送るのではなく、AI CLI コマンド + マーカー emit を `;` チェインで構成した 1 行を送る（`wez pane send` は改行を拒否するため）
+- **マーカー emit 主体はシェル**: AI CLI 終了後に shell の `;` で `printf '@@OE_EXIT:%d' $?` を実行。AI 本人にマーカー出力を依頼するのではない
+- **envelope 参照はファイルパス**: `wez pane send` で送る 1 行コマンド内で envelope ファイルパスを AI CLI に渡す（例: `cursor --prompt 'Read /tmp/oe-XXX.json and execute the task'`）
+- **画面キャプチャがプロトコル**: `wez pane capture` による画面状態の観測が、one-shot でも REPL でも共通の基盤。REPL 対応時にアーキテクチャ変更は不要（マーカー種別の分岐追加のみ）
+
+### 設計入力
+
+- KickOff: [`docs/plans/2026-05-14-kickoff-step-4-2-parse-and-state-management.md`](2026-05-14-kickoff-step-4-2-parse-and-state-management.md)
+- Discussion: [`docs/discussions/2026-05-14-discussion-parse-and-state-management.md`](../discussions/2026-05-14-discussion-parse-and-state-management.md)
+- DI 依存関係グラフ: KickOff §DI 依存関係（Mermaid `flowchart`）を参照
+
+### 駆動層入力（4-1 成果物）
+
+| 成果物 | パス | 本 Step での利用 |
+|--------|------|----------------|
+| Envelope Schema | `schemas/envelope.schema.json` | `lib/envelope.sh` が一時ファイル生成時に参照 |
+| Failure Taxonomy | `schemas/failure-taxonomy.schema.json` | `lib/capture.sh` の 6 値判定の正本 |
+| Exit Code Mapping | `schemas/exit-code-mapping.schema.json` | `lib/capture.sh` の exit code → 6 値変換ルール |
+| Audit Log Schema | `schemas/audit-log.schema.json` | `lib/audit.sh` の emit フォーマット |
+| Session State KVS | `schemas/session-state.schema.json` | `lib/capture.sh` の KVS 書き込みフォーマット |
+| validate-envelope.sh | `scripts/validate-envelope.sh` | `lib/envelope.sh` から呼び出し（変更なし） |
+| Exit Code Mapping（※4-2 で更新あり） | `schemas/exit-code-mapping.schema.json` | auxiliary_signals の pattern を `@@OE_BLOCKED` に統一（Phase B Step 3 で更新） |
+| ADR: Cleanup Strategy | `docs/decisions/2026-05-14-decision-cleanup-strategy.md` | `lib/cleanup.sh` の設計根拠 |
+| ADR: Permission Separation | `docs/decisions/2026-05-14-decision-permission-separation-mvp.md` | MVP 権限境界の前提 |
+| ADR: #20 Phase Convergence | `docs/decisions/2026-05-14-decision-issue-20-phase-convergence.md` | 中間層（wez CLI）との合流方針 |
+
+### 観測層 Issue（Read-only）
+
+- [#19](https://github.com/stlwolf/ai-development-hub/issues/19) — Epic 親、Phase 4 ステップ管理
+- [#84](https://github.com/stlwolf/ai-development-hub/issues/84) — Step 4-1 サブ Issue（closed、[PR #85](https://github.com/stlwolf/ai-development-hub/pull/85)）
+- [#87](https://github.com/stlwolf/ai-development-hub/issues/87) — Step 4-2 サブ Issue（本 Plan の観測層）
+
+### スコープ外（本 Plan では扱わない）
+
+KickOff §スコープ外:
+
+- `@@OE_OUTPUT:path` マーカー（将来拡張）
+- `--verbose` フラグ（`polling_snapshot` / `validation_failure` 記録）
+- dashboard API / TUI 表示（4-3 以降）
+- UC-2 並列協調の ownership 宣言・コンフリクト検出（4-3 以降）
+- UC-3 人間俯瞰の `wez notify` 統合（4-3 以降）
+- UC-3 REPL モード対応（対話型 AI セッションの中間状態検出・re-inject。画面キャプチャ基盤は共通だがマーカープロトコルの拡張が必要）
+- サブエージェント側への OE 固有ロジック注入（Q6 でディスパッチャ一元化を選択済み）
+- ハング検出の高度化（出力増分差分による停止検知。MVP は CB タイムアウトで代替）
+
+KickOff §Open Questions（スコープ外だが次ステップに影響する事項）:
+
+- `--verbose` フラグ: `polling_snapshot` / `validation_failure` の記録制御。4-3 以降のスコープ
+- UC-2 並列協調の ownership 宣言: `session-state.schema.json` への `ownership` フィールド追加。4-3 以降
+- UC-3 `wez notify` 統合: `human_input` 検出時の自動通知。4-3 以降
+
+---
+
+## Phase A: 基盤（DI-7 + DI-1）
+
+### Open Question 確定: `audit/` と `state/` のベースディレクトリ
+
+- [ ] `audit/` と `state/` のベースディレクトリを確定: `bin/oe` の CWD 相対 vs 環境変数 `OE_DATA_DIR` 指定
+- [ ] 確定結果を `lib/constants.sh` のパス定義に反映
+
+### Step 1: DI-7 — ファイルレイアウト構築
+
+- [ ] ディレクトリ構造を作成:
+
+```
+projects/orchestration-engine/
+├── bin/
+│   └── oe                    # エントリポイント（source lib/*.sh → main 呼び出し）
+├── lib/
+│   ├── constants.sh          # @@OE_ プレフィックス、SLO 5s、CB 閾値、KVS/audit パス
+│   ├── envelope.sh           # oe_envelope_create（inject は spawn.sh に統合）
+│   ├── spawn.sh              # oe_spawn（wez pane split + send + session_start emit）
+│   ├── capture.sh            # oe_capture_scan / oe_capture_classify / oe_capture_write_kvs
+│   ├── monitor.sh            # oe_monitor_loop（2s poll + CB + audit 統合）
+│   ├── audit.sh              # oe_audit_emit（JSONL 追記）
+│   └── cleanup.sh            # oe_cleanup（trap handler: pane kill + /tmp 削除）
+├── state/                    # KVS 出力先（{session_id}.state.json）
+├── audit/                    # 監査ログ出力先（{session_id}.jsonl）
+├── scripts/
+│   └── validate-envelope.sh  # 既存（4-1 成果物、変更なし）
+└── schemas/                  # 既存（4-1 成果物、変更なし）
+```
+
+- [ ] 命名規約確認: 関数名は `oe_` プレフィックス（C 昇格時のネームスペース準備）
+- [ ] `state/` と `audit/` は `bin/oe` 起動時に `mkdir -p` で自動作成する設計を `bin/oe` スケルトンに組み込み
+
+### Step 2: DI-1 — `bin/oe` エントリポイント + `constants.sh` + `lib/` スケルトン
+
+- [ ] `bin/oe` の shebang: `#!/usr/bin/env bash`
+- [ ] `lib/` の各ファイルは関数定義のみ（直接実行不可、`source` 専用）— 各 `.sh` にスケルトン関数を配置
+- [ ] `LIB_DIR` は `bin/oe` からの相対パス（`$(cd "$(dirname "$0")/../lib" && pwd)`）で解決
+- [ ] 将来 C（サブコマンド CLI）へ昇格する際: `bin/oe spawn` → `lib/spawn.sh::oe_spawn()` のルーティング追加で対応可能な構造にする
+- [ ] `lib/constants.sh` に以下を定義:
+  - CB 閾値: `OE_CB_TIMEOUT=1800`（秒）/ `OE_CB_MAX_TURNS=10` / `OE_CB_MAX_PANES=5`
+  - SLO: `OE_SLO_DETECT_SEC=5`
+  - ポーリング間隔: `OE_POLL_INTERVAL=2`
+  - KVS / audit パス（Open Question 確定結果を反映）
+
+### Phase A 検証サイクル
+
+- [ ] shellcheck: `bin/oe` + `lib/constants.sh` で shellcheck 実行、エラーゼロ確認
+- [ ] 単体動作確認: `bin/oe` が `source lib/constants.sh` を正常に読み込み、定数が参照可能であること
+- [ ] Episode 記録: Phase A の実装判断・発見事項を `docs/episodes/` に記録
+
+## GATE: Phase A 基盤確認
+
+- [ ] `bin/oe` が `lib/` の全スケルトンを `source` で読み込み、エラーなく実行開始できる
+- [ ] `lib/constants.sh` にマーカープレフィックス・CB 閾値・SLO・パス定義が含まれている
+- [ ] `audit/` と `state/` のベースディレクトリが確定し `constants.sh` に反映されている
+- [ ] shellcheck エラーゼロ
+
+---
+
+## Phase B: 入力（DI-2 + DI-3）
+
+### Open Question 確定: `@@OE_EXIT:{code}` の具体フォーマット
+
+- [ ] `@@OE_EXIT:{code}` の改行位置、前後の区切り文字を確定（`capture.sh` の正規表現設計の前提）
+- [ ] 確定結果を `lib/constants.sh` の `OE_EXIT_MARKER_RE` に反映
+
+### Step 3: DI-3 — マーカー規約 + キャプチャ関数（`constants.sh` 追加 + `capture.sh`）
+
+- [ ] `lib/constants.sh` にマーカー定義を追加:
+  - `OE_MARKER_PREFIX="@@OE_"`
+  - `OE_EXIT_MARKER_RE='^@@OE_EXIT:([0-9]{1,3})$'`（行頭・行末アンカー付き）
+  - 将来マーカー種別の予約（コメントで意図記載、MVP では未使用）: `@@OE_STATUS:{state}` / `@@OE_READY` / `@@OE_OUTPUT:{path}` / `@@OE_BLOCKED:{reason}`
+- [ ] `lib/capture.sh::oe_capture_scan()` 実装 — `wez pane capture` の出力を正規表現でスキャンし、**マーカー種別（marker_type）と値（value）の組**を返す（MVP は `EXIT` 種別のみ処理。REPL 拡張時に `STATUS` / `READY` 等の分岐を追加可能な構造）
+- [ ] 検出フロー実装: capture 出力 → `grep -E '^@@OE_EXIT:[0-9]{1,3}$' | tail -n 1` → exit code 抽出 → `oe_capture_classify()` で 6 値判定（行頭・行末アンカー + 最後の一致のみ採用で偽陽性を回避）
+- [ ] `oe_capture_classify()` 実装 — 6 値判定ロジック（`exit-code-mapping.schema.json` 準拠）:
+  - `0` → `success`
+  - `1` → `partial`
+  - `2` → `retryable_failure`（auxiliary signal `@@OE_BLOCKED` 検出時は `blocked` に上書き）
+  - `124` → `timeout`（Bash timeout コマンド由来）
+  - タイマー超過（CB） → `timeout`
+  - マーカーなし + プロセス停止 → `protocol_error`
+- [ ] `exit-code-mapping.schema.json` の `auxiliary_signals.end_marker_blocked.pattern` を `===STATE: blocked===` から `@@OE_BLOCKED` に更新（`@@OE_` 体系に統一）
+
+### Step 4: DI-2 — エンベロープ注入 + spawn（`envelope.sh` + `spawn.sh`）
+
+- [ ] `lib/envelope.sh::oe_envelope_create()` 実装 — envelope JSON 生成 → 一時ファイル書き出し → `validate-envelope.sh` 呼び出し
+- [ ] `lib/envelope.sh::oe_envelope_inject()` は不要（envelope JSON を直接送らない）。代わりに `oe_spawn()` 内で envelope ファイルパスを AI CLI コマンドに埋め込む
+- [ ] 一時ファイルのライフサイクル: `oe_envelope_create()` で生成、`lib/cleanup.sh` で削除
+- [ ] パス規約: `/tmp/oe-{session_id}-envelope.json`（`session_id` は ULID 26 文字）
+- [ ] `lib/spawn.sh::oe_spawn()` 実装 — `wez pane split` で新ペイン作成 → AI CLI コマンド + マーカー emit を `;` チェインで 1 行構成 → `wez pane send` で送信 → `session_start` emit
+  - 送信コマンド例: `cursor --prompt 'Read /tmp/oe-{session_id}-envelope.json and execute the task' ; printf '\n@@OE_EXIT:%d\n' $?`
+  - AI CLI 種別（cursor / claude / codex）は envelope の `constraints` または環境変数で指定
+  - 前提: ペインシェルは bash/zsh 互換（`$?` で直前の exit code を取得）。fish 等の非互換シェルは 4-3 以降で対応
+
+### Phase B 検証サイクル
+
+- [ ] shellcheck: `lib/capture.sh` + `lib/envelope.sh` + `lib/spawn.sh` で shellcheck 実行、エラーゼロ確認
+- [ ] 単体動作確認: `oe_capture_scan()` がテスト文字列から `@@OE_EXIT:{code}` を検出し、`oe_capture_classify()` が正しい 6 値を返すこと
+- [ ] Episode 記録: Phase B の実装判断・発見事項を `docs/episodes/` に記録
+
+## GATE: Phase B 入力系確認
+
+- [ ] `@@OE_EXIT:{code}` の具体フォーマットが確定し `constants.sh` に反映されている
+- [ ] `oe_capture_scan()` + `oe_capture_classify()` がマーカー検出 → 6 値分類を正しく実行できる
+- [ ] `oe_envelope_create()` が `/tmp/oe-{session_id}-envelope.json` を生成し `validate-envelope.sh` で検証 pass する
+- [ ] `oe_spawn()` が `wez pane split` + `wez pane send` でサブエージェントを起動できる
+- [ ] shellcheck エラーゼロ
+
+---
+
+## Phase C: コア（DI-4）
+
+### Open Question 確定: `wez pane capture --lines` + `blocked` 判定
+
+- [ ] `wez pane capture` の `--lines` オプション値を確定: 末尾何行をスキャンするか（実測して確定）
+- [ ] `blocked` 状態の判定ヒューリスティクスを確定: マーカーなし + プロセス存在 + 出力停止の組み合わせ条件
+- [ ] 確定結果を `lib/capture.sh` の `oe_capture_scan()` と `oe_capture_classify()` に反映
+
+### Step 5: DI-4 — 監視ループ（`monitor.sh`）
+
+- [ ] `lib/monitor.sh::oe_monitor_loop()` — メインループ関数を実装
+- [ ] 管理ペイン追跡: Bash 配列 `OE_MANAGED_PANES` で spawn 済みペイン ID を保持（ファイル registry は作らない。ADR cleanup-strategy と整合）
+- [ ] 完了済みペイン除外: Bash 配列 `OE_DONE_PANES` で完了検出済みペインを保持し、以後の監視対象から除外（マーカー再検出を防止）
+- [ ] 前回 state 保持: `declare -A OE_LAST_STATE` 連想配列でペインごとの直前 state を保持。差分検出で `state_change` を emit
+- [ ] ループ 1 サイクルの処理順を実装:
+  1. `OE_MANAGED_PANES` から `OE_DONE_PANES` を除外した未完了リストを取得
+  2. 各ペインに対し `oe_capture_scan()` 呼び出し → `marker_type` + `value` を取得
+  3. `case $marker_type` で分岐（MVP は `EXIT` のみ実装、将来 `STATUS` / `READY` 等を追加可能な switch 構造）
+  4. `EXIT` 検出時: `oe_capture_classify()` → 状態変化チェック（`OE_LAST_STATE` と比較）→ `state_change` emit（状態が変わった場合）→ `session_end` emit（この順序で必ず 2 イベント出力）→ KVS 書き込み → `OE_DONE_PANES` に追加
+  5. CB チェック: 経過時間 / ターン数 / ペイン数を `constants.sh` の閾値と比較
+  6. CB 違反時: `circuit_breaker_triggered` emit → 管理ペイン kill → ループ終了
+  7. `sleep 2`
+- [ ] ループ終了条件を実装: 全ペイン完了（`OE_DONE_PANES` = `OE_MANAGED_PANES`）or CB 発動 or SIGINT/SIGTERM 受信
+
+### Phase C 検証サイクル
+
+- [ ] shellcheck: `lib/monitor.sh` で shellcheck 実行、エラーゼロ確認
+- [ ] 単体動作確認: `oe_monitor_loop()` がテストペインに対し 2s 間隔でキャプチャ → マーカー検出 → ループ終了のフローを完走すること（`oe_audit_emit()` / `oe_capture_write_kvs()` は Phase A Step 2 で配置したスケルトン関数を呼び出す状態。audit/KVS の実出力検証は Phase D 以降）
+- [ ] Episode 記録: Phase C の実装判断・発見事項を `docs/episodes/` に記録
+
+## STOP: Phase C コアロジック確認 — ユーザーにコアロジック（監視ループ + キャプチャ + 6 値分類）の動作結果を報告し、Phase D 着手の承認を待つ
+
+---
+
+## Phase D: 出力（DI-5 + DI-6）+ cleanup
+
+### Step 6: DI-5 — Audit log（`audit.sh`）
+
+- [ ] `lib/audit.sh::oe_audit_emit()` 実装 — JSONL 1 行を `audit/{session_id}.jsonl` に追記
+- [ ] フォーマット: `audit-log.schema.json` 準拠（`ts / session_id / pane_id / event_type / state / payload`）
+- [ ] `ts` は `date -u +"%Y-%m-%dT%H:%M:%S+00:00"` で UTC 固定
+- [ ] 各 emit 呼び出し元を実装:
+  - `session_start`: `lib/spawn.sh`（envelope 注入完了後）
+  - `state_change`: `lib/monitor.sh`（マーカー検出時）
+  - `interrupt`: `lib/monitor.sh`（SIGINT / TTY inject 実行時）
+  - `human_input`: `lib/monitor.sh`（人間入力検出時、UC-3）
+  - `circuit_breaker_triggered`: `lib/monitor.sh`（CB 発動時）
+  - `cleanup`: `lib/cleanup.sh`（trap ハンドラ実行時）
+  - `session_end`: `lib/monitor.sh`（ペイン完了・最終状態確定時）
+
+### Step 7: DI-6 — KVS 書き込み（`capture.sh` 追加）
+
+- [ ] `lib/capture.sh::oe_capture_write_kvs()` 実装 — `session-state.schema.json` 準拠の JSON を atomic write
+- [ ] Atomic write 実装: `jq` で JSON 生成 → `{kvs_dir}/.{session_id}.state.json.$$` に書き出し → 同一ディレクトリ内で `mv -f` により rename（cross-FS 回避で POSIX rename atomicity を保証）
+- [ ] 書き込みタイミング: `@@OE_EXIT:{code}` マーカー検出後、6 値分類完了時に 1 回だけ書き込み
+- [ ] KVS ディレクトリ: `state/`（`bin/oe` 起動時に `mkdir -p` で確保）
+- [ ] 書き込み内容: `session_id`, `pane_id`, `state`（6 値）, `last_updated`（ISO 8601）, `outputs[]`（空配列、`@@OE_OUTPUT` 未実装のため）, `blockers[]`（`blocked` 時のみ非空）
+
+### Step 8: クリーンアップ（`cleanup.sh`）
+
+> 前提: ADR cleanup-strategy（[`docs/decisions/2026-05-14-decision-cleanup-strategy.md`](../decisions/2026-05-14-decision-cleanup-strategy.md)）の設計に準拠
+
+- [ ] `lib/cleanup.sh::oe_cleanup()` 実装 — trap handler 関数
+- [ ] 二重実行ガード: 冒頭で `[[ -n "${OE_CLEANUP_DONE:-}" ]] && return; OE_CLEANUP_DONE=1` + trap 解除
+- [ ] `bin/oe` 内で `trap oe_cleanup EXIT INT TERM` を設定（INT/TERM → EXIT の二重発火をガードで吸収）
+- [ ] 管理下ペインの `wez pane kill` 処理（`|| true` で失敗を吸収、wez 無応答時にハングしない）
+- [ ] `/tmp/oe-{session_id}-*` の一時ファイル削除（DI-2 envelope 一時ファイル含む）
+- [ ] `cleanup` イベントを `oe_audit_emit()` で audit log に記録（emit 失敗も非致命扱い）
+
+### Phase D 検証サイクル
+
+- [ ] shellcheck: `lib/audit.sh` + `lib/cleanup.sh` + `lib/capture.sh`（追加分）で shellcheck 実行、エラーゼロ確認
+- [ ] 単体動作確認: `oe_audit_emit()` が `audit-log.schema.json` 準拠の JSONL を出力し、`oe_capture_write_kvs()` が `session-state.schema.json` 準拠の JSON を atomic write すること
+- [ ] Episode 記録: Phase D の実装判断・発見事項を `docs/episodes/` に記録
+
+## GATE: Phase D 出力系確認
+
+- [ ] `oe_audit_emit()` が 7 種のイベントを `audit-log.schema.json` 準拠の JSONL で出力できる
+- [ ] `oe_capture_write_kvs()` が `session-state.schema.json` 準拠の JSON を atomic write できる
+- [ ] `oe_cleanup()` が管理ペイン kill + 一時ファイル削除 + `cleanup` イベント emit を実行できる
+- [ ] shellcheck エラーゼロ
+
+---
+
+## Phase E: 統合
+
+### Step 9: `bin/oe` メインフロー結線
+
+- [ ] `bin/oe` のメインフロー実装: `source lib/*.sh` → `trap` 設定 → `mkdir -p` → envelope 生成 → spawn → monitor loop → cleanup
+- [ ] エンドツーエンドフローの結線確認: 各 `lib/` 関数がメインフローから正しく呼び出されること
+
+### Step 10: shellcheck 全スクリプト pass
+
+- [ ] `bin/oe` + `lib/*.sh`（7 ファイル）で `shellcheck` 実行、全ファイルエラーゼロ
+- [ ] `shellcheck` 警告（warning）も可能な限り解消
+
+### Phase E 検証サイクル
+
+- [ ] 統合動作確認: `bin/oe` がエンドツーエンドでエンベロープ生成 → spawn → 監視 → 完了検出 → KVS 書き込み → audit log → cleanup のフローを完走すること
+- [ ] Episode 記録: Phase E の実装判断・統合時の発見事項を `docs/episodes/` に記録
+
+## STOP: Phase E 統合完了 — ユーザーに統合結果を報告し、最終検証への移行を確認
+
+---
+
+## 最終検証
+
+> KickOff §完了条件 8 項目との照合。
+
+- [ ] `bin/oe` が envelope を受け取りサブエージェントを spawn できる
+  - `lib/envelope.sh` が `/tmp/oe-{session_id}-envelope.json` を生成し `validate-envelope.sh` で検証 pass
+  - `lib/spawn.sh` が `wez pane split` + `wez pane send` でサブエージェントを起動
+  - `lib/audit.sh` が `session_start` イベントを emit
+- [ ] `@@OE_EXIT:{code}` マーカーで終了を検出し 6 値に分類できる
+  - `lib/capture.sh` が `wez pane capture` 出力からマーカーを正規表現でスキャン
+  - exit code → `failure-taxonomy.schema.json` の 6 値へ正しく分類
+- [ ] ポーリングループが 2s 間隔で全管理ペインを巡回する
+  - `lib/monitor.sh` が単一 `while` ループで管理ペインリストを順次処理
+  - SLO 5s 以内に状態変化を検知（5 ペイン巡回で約 380ms + 2s sleep）
+- [ ] CB（1800s / 10 turns / 5 panes）違反時に `circuit_breaker_triggered` を emit して停止する
+  - `lib/monitor.sh` がループ内で経過時間 / ターン数 / ペイン数を `constants.sh` 閾値と比較
+  - 違反検出時: `oe_audit_emit circuit_breaker_triggered` → 管理ペイン kill → ループ終了
+- [ ] KVS（`{session_id}.state.json`）に完了状態を atomic write する
+  - `lib/capture.sh` が `session-state.schema.json` 準拠の JSON を生成
+  - `state/` 配下の隠しファイルへの書き出し → 同一ディレクトリ内 `mv -f` による atomic rename
+- [ ] Audit log に 7 種のイベントを JSONL で出力する
+  - `audit-log.schema.json` 準拠の各フィールド（`ts / session_id / pane_id / event_type / state / payload`）
+  - 7 種: `session_start / state_change / interrupt / human_input / circuit_breaker_triggered / cleanup / session_end`
+- [ ] trap EXIT で管理ペイン kill + 一時ファイル削除が動作する
+  - `lib/cleanup.sh` が `trap oe_cleanup EXIT INT TERM` を設定
+  - 管理下ペインの `wez pane kill` + `/tmp/oe-{session_id}-*` の削除
+  - `cleanup` イベントを audit log に記録
+- [ ] shellcheck で全スクリプトが pass する
+  - `bin/oe` + `lib/*.sh`（7 ファイル）で `shellcheck` エラーゼロ
+
+## 関連
+
+- 変換元 KickOff: [`2026-05-14-kickoff-step-4-2-parse-and-state-management.md`](2026-05-14-kickoff-step-4-2-parse-and-state-management.md)
+- Parent Epic: [#19](https://github.com/stlwolf/ai-development-hub/issues/19)
+- 観測層サブ Issue: [#87](https://github.com/stlwolf/ai-development-hub/issues/87)
+- Step 4-1 成果物: [PR #85](https://github.com/stlwolf/ai-development-hub/pull/85)（[#84](https://github.com/stlwolf/ai-development-hub/issues/84) closed）
+- Step 4-2 Discussion: [`2026-05-14-discussion-parse-and-state-management.md`](../discussions/2026-05-14-discussion-parse-and-state-management.md)
+- Step 4-0 Discussion: [`2026-05-13-discussion-engine-scope-and-goals.md`](../discussions/2026-05-13-discussion-engine-scope-and-goals.md)
+- Step 4-1 KickOff: [`2026-05-13-kickoff-step-4-1-envelope-and-dispatcher.md`](2026-05-13-kickoff-step-4-1-envelope-and-dispatcher.md)
+- wez CLI（Phase 1 完了）: [#20](https://github.com/stlwolf/ai-development-hub/issues/20)
+
+## Review 履歴
+
+### Plan Review (2026-05-14)
+
+**Status:** Approved
+
+**Reviewer:** adversarial-review SKILL（kickoff-to-plan 変換後の品質チェック）
+
+**完全性チェック数値:**
+
+| 突合項目 | KickOff | Plan | 結果 |
+|---------|---------|------|------|
+| 完了条件チェックボックス数 → 最終検証 TODO 数 | 8件 | 8件 | ✅ |
+| DI 数 → Step 数（DI 対応分） | 7件 | 7件（Step 1〜7） | ✅ |
+| STOP 指示数 → STOP TODO 数 | 0件（KickOff なし） | 2件（ユーザー指定） | ✅（判断メモ §5） |
+| GATE 指示数 → GATE TODO 数 | 0件（KickOff なし） | 3件（ユーザー指定） | ✅（判断メモ §5） |
+| Open Questions（実装中）数 → 確定タスク TODO 数 | 4件 | 4件（Phase A: 1, B: 1, C: 2） | ✅ |
+| スコープ外項目数 → スコープ外記載数 | 9件（6+3） | 9件（6+3） | ✅ |
+| 「〜等」「〜など」省略 | — | 0件 | ✅ |
+| GATE が独立 TODO 項目 | — | 3件全て独立 | ✅ |
+
+**検証結果:**
+
+| 観点 | 結果 |
+|------|------|
+| Completeness | DI-1〜DI-7 が全て Step に割り当て済み。完了条件 8 項目が最終検証に完全展開。Open Questions 4 件が関連 Phase 冒頭に配置。スコープ外 9 件が Context に記載。cleanup.sh は独立 DI を持たないが Step 8 として正当に配置（判断メモ §2） |
+| Consistency | Mermaid 依存グラフの全 8 矢印が Phase/Step 順序と整合。DI-7(Step1)→DI-1(Step2)→DI-4(Step5), DI-3(Step3)→DI-4(Step5), DI-2/SPAWN(Step4)→DI-4(Step5), DI-4(Step5)→DI-5(Step6)/DI-6(Step7), DI-3(Step3)→DI-6(Step7) の全依存パスが保持されている |
+| Clarity | 各 Step が DI と 1:1 対応し、関数名・ファイルパス・正規表現・6 値マッピングが KickOff 原文のまま保持。Gate/Stop 基準は具体的かつ検証可能 |
+| Scope | bin/oe + lib/ 7 ファイルの実装に収まっている。スコープ外項目（@@OE_OUTPUT, --verbose, dashboard, UC-2/UC-3, wez notify）は扱っていない |
+| YAGNI | cleanup.sh（Step 8）は多 DI + 完了条件 7 からの正当な導出。per-Phase 検証サイクルは KickOff §次アクションからの忠実な変換。不要な追加なし |
+
+**ユーザー指定 6 観点の照合:**
+
+1. **DI 展開の完全性**: DI-1→Step 2, DI-2→Step 4, DI-3→Step 3, DI-4→Step 5, DI-5→Step 6, DI-6→Step 7, DI-7→Step 1。全 7 DI カバー
+2. **完了条件カバレッジ**: 8 項目が最終検証にサブ条件含め完全展開。KickOff 原文と一致
+3. **Gate 配置**: Phase A/B/D に GATE、Phase C/E に STOP（HG）。ユーザー指定どおり
+4. **依存関係 → ステップ順序**: 全 8 依存矢印が Phase 順序で保持。直列パス DI-3→DI-4→DI-5/DI-6 が Phase B→C→D に正確にマッピング
+5. **Open Questions 配置**: audit/state ディレクトリ→Phase A、@@OE_EXIT フォーマット→Phase B、--lines/blocked→Phase C。全て関連 Phase の冒頭に配置
+6. **スコープ外の明示**: KickOff §スコープ外 6 件 + Open Questions §スコープ外 3 件 = 計 9 件が Context §スコープ外に転記
+
+**Recommendations（advisory, do not block approval）:**
+
+- Phase C Step 5 の監視ループ実装において、`oe_audit_emit()` と `oe_capture_write_kvs()` は Phase D まで stub（Phase A Step 2 で作成したスケルトン関数）のまま呼び出される。Phase C 検証サイクルの「単体動作確認」は stub 呼び出し状態でのフロー完走確認を意味し、audit/KVS の実出力検証は Phase D GATE 以降となる。この暗黙の前提は Step 2 の「各 .sh にスケルトン関数を配置」から読み取れるが、Phase C の検証サイクル説明に「audit/KVS は Phase D 実装後に実出力を検証」と付記すると実装者の混乱を防げる
+
+### so-compare Review (2026-05-14)
+
+**Reviewer:** Codex + Claude（`so-compare`）
+
+**結果:** 9 件の指摘、うち議論不要 6 件を即時反映、設計議論 3 件を解決後に反映。
+
+**即時反映（C3/C4/C6/C7/C8/C9）:**
+
+- C3: KVS atomic write を `/tmp/` → `state/` から同一ディレクトリ内 rename に変更（cross-FS 回避）
+- C4: trap ハンドラに二重実行ガード（`OE_CLEANUP_DONE` フラグ）追加
+- C6: マーカー正規表現に行頭・行末アンカー追加（`^...$`）
+- C7: 完了済みペイン除外フラグ（`OE_DONE_PANES`）を monitor ループに追加
+- C8: 前回 state 保持（`declare -A OE_LAST_STATE`）を monitor ループに追加
+- C9: 「registry から」の表現を「Bash 配列 `OE_MANAGED_PANES`」に修正（ADR と整合）
+
+**設計議論後に反映（C1/C2/C5）:**
+
+- C1: `wez pane send` 改行制約 → envelope JSON を直接送らず、ファイルパス参照を shell コマンド 1 行で送る方式に明確化。`oe_envelope_inject()` 不要に
+- C2: `@@OE_EXIT` emit 主体 → AI CLI は one-shot（`--prompt`）実行、shell `;` チェインでマーカー emit。REPL 前提は誤解（文書の曖昧さが原因）
+- C5: `===STATE: blocked===` → `@@OE_BLOCKED` に統一（`exit-code-mapping.schema.json` 更新タスクを Phase B に追加）
+
+**追加の設計判断（REPL 拡張パス）:**
+
+- `oe_capture_scan()` を「マーカー種別 + 値」の構造を返す設計に変更（MVP は EXIT のみ）
+- monitor ループを `case $marker_type` switch 構造に変更
+- `constants.sh` に将来マーカー種別（`@@OE_STATUS` / `@@OE_READY` / `@@OE_OUTPUT` / `@@OE_BLOCKED`）を予約定義
+- スコープ外に UC-3 REPL 対応・ハング検出の高度化を明記

--- a/projects/orchestration-engine/lib/audit.sh
+++ b/projects/orchestration-engine/lib/audit.sh
@@ -28,7 +28,7 @@ oe_audit_emit() {
   fi
 
   if [[ -n "$payload_json" ]]; then
-    if ! echo "$payload_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    if ! printf '%s\n' "$payload_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
       echo "oe_audit_emit: invalid payload (must be JSON object)" >&2
       return 1
     fi

--- a/projects/orchestration-engine/lib/audit.sh
+++ b/projects/orchestration-engine/lib/audit.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+# audit.sh — 監査ログ JSONL 追記（source 専用）
+
+oe_audit_emit() {
+  local event_type="${1:-}"
+  local session_id="${2:-}"
+  local pane_id="${3:-}"
+  local state="${4:-}"
+  local payload_json="${5:-}"
+
+  local ts
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
+
+  local out_file="${OE_AUDIT_DIR}/${session_id}.jsonl"
+  local state_json
+  local payload_arg
+  local oe_valid_state_re='^(success|partial|retryable_failure|blocked|protocol_error|timeout)$'
+
+  if [[ -n "$state" ]]; then
+    if [[ "$state" =~ $oe_valid_state_re ]]; then
+      state_json="$(jq -cn --arg value "$state" '$value')"
+    else
+      echo "oe_audit_emit: invalid state '${state}', coercing to null" >&2
+      state_json="null"
+    fi
+  else
+    state_json="null"
+  fi
+
+  if [[ -n "$payload_json" ]]; then
+    if ! echo "$payload_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+      echo "oe_audit_emit: invalid payload (must be JSON object)" >&2
+      return 1
+    fi
+    payload_arg="$payload_json"
+  else
+    payload_arg='{}'
+  fi
+
+  jq -cn \
+    --arg ts "$ts" \
+    --arg event_type "$event_type" \
+    --arg session_id "$session_id" \
+    --argjson pane_id "$pane_id" \
+    --argjson state "$state_json" \
+    --argjson payload "$payload_arg" \
+    '{ts:$ts,event_type:$event_type,session_id:$session_id,pane_id:$pane_id,state:$state,payload:$payload}' \
+    >> "$out_file"
+  return 0
+}

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -1,0 +1,109 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# capture.sh — 成果物キャプチャ・分類・KVS 書き込み（source 専用）
+
+# グローバル変数: oe_capture_scan() の戻り値
+OE_SCAN_MARKER_TYPE=""
+OE_SCAN_VALUE=""
+OE_SCAN_BLOCKED="false"
+
+# グローバル変数: oe_capture_classify() の戻り値
+OE_CLASSIFY_STATE=""
+
+# oe_capture_scan — pane 出力からマーカーをスキャンし種別と値を返す
+#
+# 引数: pane_id（WezTerm ペイン ID）
+# 戻り値: OE_SCAN_MARKER_TYPE / OE_SCAN_VALUE に設定
+#   マーカー未検出時は両方空文字
+oe_capture_scan() {
+  local pane_id="$1"
+
+  OE_SCAN_MARKER_TYPE=""
+  OE_SCAN_VALUE=""
+  OE_SCAN_BLOCKED="false"
+
+  local captured
+  captured="$(wez pane capture "$pane_id" --lines 50 2>/dev/null)" || return 0
+
+  local normalized
+  normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g')"
+
+  _oe_capture_scan_parse "$normalized"
+}
+
+# _oe_capture_scan_parse — capture 出力文字列をパースする内部関数
+# テスト容易性のために wez 呼び出しと分離
+_oe_capture_scan_parse() {
+  local input="$1"
+
+  OE_SCAN_MARKER_TYPE=""
+  OE_SCAN_VALUE=""
+  OE_SCAN_BLOCKED="false"
+
+  local line
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^@@OE_BLOCKED($|:.*$) ]]; then
+      OE_SCAN_BLOCKED="true"
+    fi
+
+    if [[ "$line" =~ $OE_EXIT_MARKER_RE ]]; then
+      OE_SCAN_MARKER_TYPE="EXIT"
+      OE_SCAN_VALUE="${BASH_REMATCH[1]}"
+    fi
+  done <<< "$input"
+}
+
+# oe_capture_classify — exit code を failure-taxonomy 6 値に分類
+#
+# 引数: exit_code（整数）, [blocked_flag]（"true" の場合 blocked 上書き）
+# 戻り値: OE_CLASSIFY_STATE に 6 値文字列を設定
+oe_capture_classify() {
+  local exit_code="$1"
+  local blocked_flag="${2:-}"
+
+  OE_CLASSIFY_STATE=""
+
+  case "$exit_code" in
+    0)   OE_CLASSIFY_STATE="success" ;;
+    1)   OE_CLASSIFY_STATE="partial" ;;
+    2)
+      if [[ "$blocked_flag" == "true" ]]; then
+        OE_CLASSIFY_STATE="blocked"
+      else
+        OE_CLASSIFY_STATE="retryable_failure"
+      fi
+      ;;
+    124) OE_CLASSIFY_STATE="timeout" ;;
+    *)   OE_CLASSIFY_STATE="protocol_error" ;;
+  esac
+}
+
+oe_capture_write_kvs() {
+  local session_id="${1:-}"
+  local pane_id="${2:-}"
+  local state="${3:-}"
+  : "$session_id" "$pane_id" "$state"
+
+  local last_updated
+  last_updated="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
+
+  local blockers='[]'
+  if [[ "$state" == "blocked" ]]; then
+    blockers='["@@OE_BLOCKED"]'
+  fi
+
+  local state_file="${OE_STATE_DIR}/${session_id}.state.json"
+  local tmp_file="${OE_STATE_DIR}/.${session_id}.state.json.$$"
+
+  jq -n \
+    --arg session_id "$session_id" \
+    --argjson pane_id "$pane_id" \
+    --arg state "$state" \
+    --arg last_updated "$last_updated" \
+    --argjson blockers "$blockers" \
+    '{session_id:$session_id,pane_id:$pane_id,state:$state,last_updated:$last_updated,outputs:[],blockers:$blockers}' \
+    > "$tmp_file"
+
+  mv -f "$tmp_file" "$state_file"
+  return 0
+}

--- a/projects/orchestration-engine/lib/cleanup.sh
+++ b/projects/orchestration-engine/lib/cleanup.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+# cleanup.sh — trap ハンドラ: ペイン削除 + /tmp 削除（source 専用）
+
+oe_cleanup() {
+  [[ -n "${OE_CLEANUP_DONE:-}" ]] && return 0
+  OE_CLEANUP_DONE=1
+
+  trap - EXIT INT TERM
+
+  local killed_json='[]'
+  if [[ ${#OE_MANAGED_PANES[@]} -gt 0 ]]; then
+    local pane_id
+    local ids_lines=""
+    for pane_id in "${OE_MANAGED_PANES[@]}"; do
+      [[ -n "$pane_id" ]] || continue
+      ids_lines+="${pane_id}"$'\n'
+      wez pane kill "$pane_id" 2>/dev/null || true
+    done
+    killed_json="$(printf '%s' "$ids_lines" | jq -R -s 'split("\n") | map(select(length>0) | tonumber)')"
+  fi
+
+  local payload_json
+  payload_json="$(jq -cn --argjson ids "$killed_json" '{killed_pane_ids:$ids}')"
+
+  local session_id="${OE_CURRENT_SESSION_ID:-}"
+  if [[ -n "$session_id" ]]; then
+    local tmp_path
+    for tmp_path in /tmp/oe-"$session_id"-*; do
+      [[ -e "$tmp_path" ]] || continue
+      rm -f "$tmp_path" 2>/dev/null || true
+    done
+    oe_audit_emit "cleanup" "$session_id" 0 "" "$payload_json" || true
+  fi
+
+  return 0
+}

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# constants.sh — OE グローバル定数定義（source 専用）
+
+# マーカープレフィックス
+OE_MARKER_PREFIX="@@OE_"
+
+# EXIT マーカー正規表現（行頭・行末アンカー付き）
+OE_EXIT_MARKER_RE='^@@OE_EXIT:([0-9]{1,3})$'
+
+# 将来マーカー種別の予約（MVP では未使用）:
+#   @@OE_STATUS:{state}  — 進捗状態の報告
+#   @@OE_READY           — サブエージェント準備完了
+#   @@OE_OUTPUT:{path}   — 成果物パスの通知
+#   @@OE_BLOCKED:{reason} — ブロック理由の報告
+
+# サーキットブレーカー閾値
+OE_CB_TIMEOUT=1800
+OE_CB_MAX_TURNS=10
+OE_CB_MAX_PANES=5
+
+# SLO: マーカー検出目標（秒）
+OE_SLO_DETECT_SEC=5
+
+# ポーリング間隔（秒）
+OE_POLL_INTERVAL=2
+
+# KVS パス（OE_DATA_DIR でオーバーライド可能、デフォルトはプロジェクトルート相対）
+OE_STATE_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/state"
+
+# 監査ログパス
+OE_AUDIT_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/audit"

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -25,6 +25,9 @@ OE_SLO_DETECT_SEC=5
 # ポーリング間隔（秒）
 OE_POLL_INTERVAL=2
 
+# wez pane split --wait-ready のタイムアウト（秒）。ADR-003 に準拠。
+OE_SPAWN_WAIT_READY_SEC="${OE_SPAWN_WAIT_READY_SEC:-10}"
+
 # KVS パス（OE_DATA_DIR でオーバーライド可能、デフォルトはプロジェクトルート相対）
 OE_STATE_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/state"
 

--- a/projects/orchestration-engine/lib/envelope.sh
+++ b/projects/orchestration-engine/lib/envelope.sh
@@ -1,0 +1,58 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# envelope.sh — エンベロープ生成（source 専用）
+
+# グローバル変数: oe_envelope_create() の戻り値
+OE_ENVELOPE_PATH=""
+
+# oe_envelope_create — エンベロープ JSON を生成し validate-envelope.sh で検証
+#
+# 引数: session_id, pane_id, task_description, output_dir, timeout_seconds
+# 戻り値: OE_ENVELOPE_PATH に生成ファイルパスを設定
+# 検証失敗時は exit 1（set -e による自動終了）
+oe_envelope_create() {
+  local session_id="$1"
+  local pane_id="$2"
+  local task_description="$3"
+  local output_dir="$4"
+  local timeout_seconds="$5"
+
+  OE_ENVELOPE_PATH=""
+
+  local envelope_path="/tmp/oe-${session_id}-envelope.json"
+
+  jq -n \
+    --arg sid "$session_id" \
+    --argjson pid "$pane_id" \
+    --arg desc "$task_description" \
+    --arg odir "$output_dir" \
+    --argjson timeout "$timeout_seconds" \
+    --argjson max_panes "$OE_CB_MAX_PANES" \
+    '{
+      session_id: $sid,
+      pane_id: $pid,
+      task: {
+        description: $desc,
+        output_dir: $odir,
+        exit_conditions: {
+          marker: "@@OE_EXIT",
+          timeout_seconds: $timeout
+        },
+        read_docs: [],
+        use_skills: []
+      },
+      context: {
+        parent_session_id: null,
+        related_issues: [],
+        shared_kvs_path: null
+      },
+      constraints: {
+        max_panes: $max_panes,
+        state_vocabulary: ["spawn","ready","progress","done","blocked"]
+      }
+    }' > "$envelope_path"
+
+  "${PROJECT_DIR}/scripts/validate-envelope.sh" "$envelope_path"
+
+  OE_ENVELOPE_PATH="$envelope_path"
+}

--- a/projects/orchestration-engine/lib/monitor.sh
+++ b/projects/orchestration-engine/lib/monitor.sh
@@ -80,7 +80,7 @@ oe_monitor_loop() {
   trap '_OE_MONITOR_INTERRUPTED=1; _OE_INTERRUPT_METHOD=SIGTERM' TERM
 
   local turn=0
-  SECONDS=0
+  local start_seconds=$SECONDS
 
   while true; do
     if [[ $_OE_MONITOR_INTERRUPTED -ne 0 ]]; then
@@ -130,8 +130,8 @@ oe_monitor_loop() {
       esac
     done
 
-    # CB: 経過時間
-    if [[ $SECONDS -ge $OE_CB_TIMEOUT ]]; then
+    # CB: 経過時間（呼び出し元の SECONDS を壊さないようローカル起点との差分で判定）
+    if [[ $((SECONDS - start_seconds)) -ge $OE_CB_TIMEOUT ]]; then
       cb_payload='{"reason":"timeout"}'
       oe_audit_emit "circuit_breaker_triggered" "$session_id" 0 "" "$cb_payload"
       _oe_monitor_kill_all_panes

--- a/projects/orchestration-engine/lib/monitor.sh
+++ b/projects/orchestration-engine/lib/monitor.sh
@@ -8,14 +8,47 @@ OE_MANAGED_PANES=()
 # 完了済みペイン（マーカー検出済み、監視対象から除外）
 OE_DONE_PANES=()
 
-# 前回 state 保持（Bash 4+ 必須: declare -A）
-declare -A OE_LAST_STATE
+# 前回 state 保持（Bash 3.2 互換: ペイン ID と state を平行配列で保持）
+_OE_LAST_STATE_PANES=()
+_OE_LAST_STATE_VALS=()
 
 # シグナル受信フラグ（trap ハンドラ用グローバル）
 _OE_MONITOR_INTERRUPTED=0
 
 # SIGINT / SIGTERM 区別（trap から設定、interrupt 監査の payload.method に使用）
 _OE_INTERRUPT_METHOD=""
+
+_oe_monitor_last_state_clear() {
+  _OE_LAST_STATE_PANES=()
+  _OE_LAST_STATE_VALS=()
+}
+
+# 戻り値: 0 で stdout に state（改行なし）、未登録は 1
+_oe_monitor_last_state_get() {
+  local pane_id="$1"
+  local i
+  for (( i = 0; i < ${#_OE_LAST_STATE_PANES[@]}; i++ )); do
+    if [[ "${_OE_LAST_STATE_PANES[i]}" == "$pane_id" ]]; then
+      printf '%s' "${_OE_LAST_STATE_VALS[i]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_oe_monitor_last_state_set() {
+  local pane_id="$1"
+  local state="$2"
+  local i
+  for (( i = 0; i < ${#_OE_LAST_STATE_PANES[@]}; i++ )); do
+    if [[ "${_OE_LAST_STATE_PANES[i]}" == "$pane_id" ]]; then
+      _OE_LAST_STATE_VALS[i]="$state"
+      return 0
+    fi
+  done
+  _OE_LAST_STATE_PANES+=("$pane_id")
+  _OE_LAST_STATE_VALS+=("$state")
+}
 
 # oe_monitor_loop — メインポーリングループ
 #
@@ -29,7 +62,7 @@ oe_monitor_loop() {
 
   OE_MANAGED_PANES=("$@")
   OE_DONE_PANES=()
-  OE_LAST_STATE=()
+  _oe_monitor_last_state_clear
   _OE_MONITOR_INTERRUPTED=0
   _OE_INTERRUPT_METHOD=""
 
@@ -80,8 +113,10 @@ oe_monitor_loop() {
           oe_capture_classify "$OE_SCAN_VALUE" "$OE_SCAN_BLOCKED"
 
           # 状態変化時に state_change → session_end の順で emit
-          if [[ "${OE_LAST_STATE[$pane_id]:-}" != "$OE_CLASSIFY_STATE" ]]; then
-            OE_LAST_STATE[$pane_id]="$OE_CLASSIFY_STATE"
+          local _prev_ls
+          _prev_ls="$(_oe_monitor_last_state_get "$pane_id" 2>/dev/null || true)"
+          if [[ "$_prev_ls" != "$OE_CLASSIFY_STATE" ]]; then
+            _oe_monitor_last_state_set "$pane_id" "$OE_CLASSIFY_STATE"
             oe_audit_emit "state_change" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
           fi
 

--- a/projects/orchestration-engine/lib/monitor.sh
+++ b/projects/orchestration-engine/lib/monitor.sh
@@ -14,6 +14,9 @@ declare -A OE_LAST_STATE
 # シグナル受信フラグ（trap ハンドラ用グローバル）
 _OE_MONITOR_INTERRUPTED=0
 
+# SIGINT / SIGTERM 区別（trap から設定、interrupt 監査の payload.method に使用）
+_OE_INTERRUPT_METHOD=""
+
 # oe_monitor_loop — メインポーリングループ
 #
 # 引数: session_id pane_id1 [pane_id2 ...]
@@ -28,6 +31,7 @@ oe_monitor_loop() {
   OE_DONE_PANES=()
   OE_LAST_STATE=()
   _OE_MONITOR_INTERRUPTED=0
+  _OE_INTERRUPT_METHOD=""
 
   local cb_payload
 
@@ -39,13 +43,17 @@ oe_monitor_loop() {
     return 1
   fi
 
-  trap '_OE_MONITOR_INTERRUPTED=1' INT TERM
+  trap '_OE_MONITOR_INTERRUPTED=1; _OE_INTERRUPT_METHOD=SIGINT' INT
+  trap '_OE_MONITOR_INTERRUPTED=1; _OE_INTERRUPT_METHOD=SIGTERM' TERM
 
   local turn=0
   SECONDS=0
 
   while true; do
     if [[ $_OE_MONITOR_INTERRUPTED -ne 0 ]]; then
+      local intr_payload
+      intr_payload="$(jq -cn --arg m "${_OE_INTERRUPT_METHOD:-SIGINT}" '{method:$m}')"
+      oe_audit_emit "interrupt" "$session_id" 0 "" "$intr_payload" || true
       monitor_rc=130
       break
     fi

--- a/projects/orchestration-engine/lib/monitor.sh
+++ b/projects/orchestration-engine/lib/monitor.sh
@@ -1,0 +1,135 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# monitor.sh — ポーリングループ + サーキットブレーカー（source 専用）
+
+# 管理ペイン追跡（spawn 済みペイン ID）
+OE_MANAGED_PANES=()
+
+# 完了済みペイン（マーカー検出済み、監視対象から除外）
+OE_DONE_PANES=()
+
+# 前回 state 保持（Bash 4+ 必須: declare -A）
+declare -A OE_LAST_STATE
+
+# シグナル受信フラグ（trap ハンドラ用グローバル）
+_OE_MONITOR_INTERRUPTED=0
+
+# oe_monitor_loop — メインポーリングループ
+#
+# 引数: session_id pane_id1 [pane_id2 ...]
+# 終了条件: 全ペイン完了 / CB 発動 / SIGINT・SIGTERM 受信
+oe_monitor_loop() {
+  local session_id="$1"
+  shift
+
+  local monitor_rc=0
+
+  OE_MANAGED_PANES=("$@")
+  OE_DONE_PANES=()
+  OE_LAST_STATE=()
+  _OE_MONITOR_INTERRUPTED=0
+
+  local cb_payload
+
+  # CB: ペイン数チェック（初回のみ）
+  if [[ ${#OE_MANAGED_PANES[@]} -gt $OE_CB_MAX_PANES ]]; then
+    cb_payload='{"reason":"max_panes"}'
+    oe_audit_emit "circuit_breaker_triggered" "$session_id" 0 "" "$cb_payload"
+    _oe_monitor_kill_all_panes
+    return 1
+  fi
+
+  trap '_OE_MONITOR_INTERRUPTED=1' INT TERM
+
+  local turn=0
+  SECONDS=0
+
+  while true; do
+    if [[ $_OE_MONITOR_INTERRUPTED -ne 0 ]]; then
+      monitor_rc=130
+      break
+    fi
+
+    # 未完了ペインリスト取得
+    local pending=()
+    local pane_id
+    for pane_id in "${OE_MANAGED_PANES[@]}"; do
+      if ! _oe_monitor_is_done "$pane_id"; then
+        pending+=("$pane_id")
+      fi
+    done
+
+    if [[ ${#pending[@]} -eq 0 ]]; then
+      break
+    fi
+
+    # 各ペインスキャン + マーカー処理
+    for pane_id in "${pending[@]}"; do
+      oe_capture_scan "$pane_id"
+
+      case "$OE_SCAN_MARKER_TYPE" in
+        EXIT)
+          oe_capture_classify "$OE_SCAN_VALUE" "$OE_SCAN_BLOCKED"
+
+          # 状態変化時に state_change → session_end の順で emit
+          if [[ "${OE_LAST_STATE[$pane_id]:-}" != "$OE_CLASSIFY_STATE" ]]; then
+            OE_LAST_STATE[$pane_id]="$OE_CLASSIFY_STATE"
+            oe_audit_emit "state_change" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
+          fi
+
+          oe_audit_emit "session_end" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
+          oe_capture_write_kvs "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
+          OE_DONE_PANES+=("$pane_id")
+          ;;
+        # 将来: STATUS / READY / OUTPUT / BLOCKED を追加
+        *)
+          ;;
+      esac
+    done
+
+    # CB: 経過時間
+    if [[ $SECONDS -ge $OE_CB_TIMEOUT ]]; then
+      cb_payload='{"reason":"timeout"}'
+      oe_audit_emit "circuit_breaker_triggered" "$session_id" 0 "" "$cb_payload"
+      _oe_monitor_kill_all_panes
+      monitor_rc=1
+      break
+    fi
+
+    # CB: ターン数
+    (( turn++ )) || true
+    if [[ $turn -ge $OE_CB_MAX_TURNS ]]; then
+      cb_payload='{"reason":"max_turns"}'
+      oe_audit_emit "circuit_breaker_triggered" "$session_id" 0 "" "$cb_payload"
+      _oe_monitor_kill_all_panes
+      monitor_rc=1
+      break
+    fi
+
+    sleep "$OE_POLL_INTERVAL"
+  done
+
+  trap - INT TERM
+  return "$monitor_rc"
+}
+
+# _oe_monitor_is_done — ペインが OE_DONE_PANES に含まれるか判定
+_oe_monitor_is_done() {
+  local target="$1"
+  [[ ${#OE_DONE_PANES[@]} -eq 0 ]] && return 1
+  local done_id
+  for done_id in "${OE_DONE_PANES[@]}"; do
+    if [[ "$done_id" == "$target" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# _oe_monitor_kill_all_panes — 全管理ペインを wez pane kill で終了
+_oe_monitor_kill_all_panes() {
+  local pane_id
+  for pane_id in "${OE_MANAGED_PANES[@]}"; do
+    wez pane kill "$pane_id" 2>/dev/null || true
+  done
+}

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -8,7 +8,8 @@ OE_SPAWN_PANE_ID=""
 # oe_spawn_prepare_pane — 新ペインを作成し OE_SPAWN_PANE_ID に保存
 oe_spawn_prepare_pane() {
   OE_SPAWN_PANE_ID=""
-  OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent 30)"
+  # --wait-ready: 新ペインが入力受付可能になるまで待機（tmux auto-attach 等のタイミング問題の緩和）
+  OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent 30 --wait-ready --timeout "$OE_SPAWN_WAIT_READY_SEC")"
 }
 
 # oe_spawn_send — 既存ペインに AI CLI コマンド + マーカー emit を送信

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -1,0 +1,43 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# spawn.sh — ペイン生成 + セッション開始（source 専用）
+
+# グローバル変数: oe_spawn() の戻り値
+OE_SPAWN_PANE_ID=""
+
+# oe_spawn_prepare_pane — 新ペインを作成し OE_SPAWN_PANE_ID に保存
+oe_spawn_prepare_pane() {
+  OE_SPAWN_PANE_ID=""
+  OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent 30)"
+}
+
+# oe_spawn_send — 既存ペインに AI CLI コマンド + マーカー emit を送信
+#
+# 引数: session_id, pane_id, envelope_path, [ai_cli]（デフォルト: "cursor"）
+oe_spawn_send() {
+  local session_id="$1"
+  local pane_id="$2"
+  local envelope_path="$3"
+  local ai_cli="${4:-cursor}"
+
+  local cli_command
+  cli_command="${ai_cli} --prompt 'Read ${envelope_path} and execute the task' ; printf '\\n@@OE_EXIT:%d\\n' \$?"
+
+  wez pane send "$pane_id" "$cli_command"
+
+  # session_start の state は audit schema（failure-taxonomy）と整合するため null
+  oe_audit_emit "session_start" "$session_id" "$pane_id" "" "{}"
+}
+
+# oe_spawn — 後方互換ラッパー（prepare → send）
+#
+# 引数: session_id, envelope_path, [ai_cli]（デフォルト: "cursor"）
+# 戻り値: OE_SPAWN_PANE_ID にペイン ID を設定
+oe_spawn() {
+  local session_id="$1"
+  local envelope_path="$2"
+  local ai_cli="${3:-cursor}"
+
+  oe_spawn_prepare_pane
+  oe_spawn_send "$session_id" "$OE_SPAWN_PANE_ID" "$envelope_path" "$ai_cli"
+}

--- a/projects/orchestration-engine/schemas/exit-code-mapping.schema.json
+++ b/projects/orchestration-engine/schemas/exit-code-mapping.schema.json
@@ -111,7 +111,7 @@
     "auxiliary_signals": {
       "end_marker_blocked": {
         "method": "end_marker_scan",
-        "pattern": "===STATE: blocked==="
+        "pattern": "@@OE_BLOCKED"
       }
     }
   }

--- a/projects/orchestration-engine/tests/test_audit.sh
+++ b/projects/orchestration-engine/tests/test_audit.sh
@@ -52,6 +52,11 @@ assert_eq "line2 state value" "success" "$(jq -r 'select(.event_type=="session_e
 assert_eq "line2 pane_id type number" "number" "$(jq -r 'select(.event_type=="session_end") | (.pane_id|type)' "$audit_file")"
 assert_eq "line2 payload inserted" "ok" "$(jq -r 'select(.event_type=="session_end") | .payload.note' "$audit_file")"
 
+oe_audit_emit "interrupt" "$session_id" 0 "" '{"method":"SIGINT"}'
+assert_eq "jsonl line count after interrupt" "3" "$(wc -l < "$audit_file" | tr -d ' ')"
+assert_eq "interrupt line state null" "null" "$(jq -r 'select(.event_type=="interrupt") | (.state|tostring)' "$audit_file")"
+assert_eq "interrupt payload method" "SIGINT" "$(jq -r 'select(.event_type=="interrupt") | .payload.method' "$audit_file")"
+
 echo ""
 echo "=== invalid payload rejected ==="
 if oe_audit_emit "session_end" "$session_id" 0 "success" '[]' 2>/dev/null; then

--- a/projects/orchestration-engine/tests/test_audit.sh
+++ b/projects/orchestration-engine/tests/test_audit.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_audit.sh — audit.sh のユニットテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+_TMP_DIR="${SCRIPT_DIR}/.tmp_test_audit_$$"
+mkdir -p "$_TMP_DIR/audit"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+OE_DATA_DIR="$_TMP_DIR"
+export OE_DATA_DIR
+
+# shellcheck source=../lib/constants.sh
+source "${PROJECT_DIR}/lib/constants.sh"
+# shellcheck source=../lib/audit.sh
+source "${PROJECT_DIR}/lib/audit.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+echo "=== oe_audit_emit ==="
+
+session_id="S01TEST"
+audit_file="${OE_AUDIT_DIR}/${session_id}.jsonl"
+
+oe_audit_emit "state_change" "$session_id" 7 "" ""
+oe_audit_emit "session_end" "$session_id" 0 "success" '{"exit_code":0,"note":"ok"}'
+
+assert_eq "audit file exists" "true" "$( [[ -f "$audit_file" ]] && echo true || echo false )"
+assert_eq "jsonl line count" "2" "$(wc -l < "$audit_file" | tr -d ' ')"
+
+assert_eq "line1 state is null" "null" "$(jq -r 'select(.event_type=="state_change") | (.state|tostring)' "$audit_file")"
+assert_eq "line1 payload default" "{}" "$(jq -c 'select(.event_type=="state_change") | .payload' "$audit_file")"
+assert_eq "line2 state value" "success" "$(jq -r 'select(.event_type=="session_end") | .state' "$audit_file")"
+assert_eq "line2 pane_id type number" "number" "$(jq -r 'select(.event_type=="session_end") | (.pane_id|type)' "$audit_file")"
+assert_eq "line2 payload inserted" "ok" "$(jq -r 'select(.event_type=="session_end") | .payload.note' "$audit_file")"
+
+echo ""
+echo "=== invalid payload rejected ==="
+if oe_audit_emit "session_end" "$session_id" 0 "success" '[]' 2>/dev/null; then
+  assert_eq "invalid payload should fail" "should_fail" "passed"
+else
+  assert_eq "invalid payload rejected" "true" "true"
+fi
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_capture.sh — capture.sh のユニットテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+# constants.sh をロード
+# shellcheck source=../lib/constants.sh
+source "${PROJECT_DIR}/lib/constants.sh"
+
+# capture.sh をロード
+# shellcheck source=../lib/capture.sh
+source "${PROJECT_DIR}/lib/capture.sh"
+
+# wez コマンドのモック
+wez() {
+  # "pane capture <pane_id>" の場合にモック出力を返す
+  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+    echo "$_MOCK_WEZ_OUTPUT"
+    return 0
+  fi
+  return 1
+}
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+# --- _oe_capture_scan_parse テスト ---
+echo "=== _oe_capture_scan_parse ==="
+
+echo "-- EXIT マーカーあり (exit code 0) --"
+_oe_capture_scan_parse "some output
+@@OE_EXIT:0
+trailing line"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "0" "$OE_SCAN_VALUE"
+assert_eq "blocked_flag" "false" "$OE_SCAN_BLOCKED"
+
+echo "-- EXIT マーカーあり (exit code 1) --"
+_oe_capture_scan_parse "@@OE_EXIT:1"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "1" "$OE_SCAN_VALUE"
+
+echo "-- EXIT マーカーあり (exit code 124) --"
+_oe_capture_scan_parse "line1
+line2
+@@OE_EXIT:124"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "124" "$OE_SCAN_VALUE"
+
+echo "-- EXIT マーカーあり (3 桁 exit code 255) --"
+_oe_capture_scan_parse "@@OE_EXIT:255"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "255" "$OE_SCAN_VALUE"
+
+echo "-- 複数マーカー → 最後の 1 つを採用 --"
+_oe_capture_scan_parse "@@OE_EXIT:1
+some middle output
+@@OE_EXIT:0"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "0" "$OE_SCAN_VALUE"
+
+echo "-- マーカーなし --"
+_oe_capture_scan_parse "no markers here
+just normal output"
+assert_eq "marker_type" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "" "$OE_SCAN_VALUE"
+assert_eq "blocked_flag" "false" "$OE_SCAN_BLOCKED"
+
+echo "-- 空文字列 --"
+_oe_capture_scan_parse ""
+assert_eq "marker_type" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "" "$OE_SCAN_VALUE"
+
+echo "-- 行途中のマーカーは無視（行頭アンカー） --"
+_oe_capture_scan_parse "prefix @@OE_EXIT:0 suffix"
+assert_eq "marker_type" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "" "$OE_SCAN_VALUE"
+
+echo "-- 4 桁 exit code は無視（1-3 桁のみ） --"
+_oe_capture_scan_parse "@@OE_EXIT:1234"
+assert_eq "marker_type" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "" "$OE_SCAN_VALUE"
+
+echo "-- 値なし @@OE_EXIT: は不一致 --"
+_oe_capture_scan_parse "@@OE_EXIT:"
+assert_eq "marker_type" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "" "$OE_SCAN_VALUE"
+
+echo "-- @@OE_BLOCKED 検出 --"
+_oe_capture_scan_parse "log line
+@@OE_BLOCKED
+@@OE_EXIT:2"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "2" "$OE_SCAN_VALUE"
+assert_eq "blocked_flag" "true" "$OE_SCAN_BLOCKED"
+
+# --- oe_capture_scan テスト（wez モック経由） ---
+echo ""
+echo "=== oe_capture_scan (wez mock) ==="
+
+echo "-- wez モック出力から EXIT マーカー検出 --"
+_MOCK_WEZ_OUTPUT="task output
+@@OE_EXIT:2
+done"
+oe_capture_scan "42"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "2" "$OE_SCAN_VALUE"
+assert_eq "blocked_flag" "false" "$OE_SCAN_BLOCKED"
+
+echo "-- wez モック出力にマーカーなし --"
+_MOCK_WEZ_OUTPUT="just normal output"
+oe_capture_scan "42"
+assert_eq "marker_type" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "" "$OE_SCAN_VALUE"
+assert_eq "blocked_flag" "false" "$OE_SCAN_BLOCKED"
+
+echo "-- CR 付きマーカーを正規化して検出 --"
+_MOCK_WEZ_OUTPUT=$'line\r\n@@OE_EXIT:0\r\n'
+oe_capture_scan "42"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "0" "$OE_SCAN_VALUE"
+
+echo "-- ANSI 付きマーカーを正規化して検出 --"
+_MOCK_WEZ_OUTPUT=$'\033[32m@@OE_EXIT:1\033[0m'
+oe_capture_scan "42"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "1" "$OE_SCAN_VALUE"
+
+# --- oe_capture_classify テスト ---
+echo ""
+echo "=== oe_capture_classify ==="
+
+echo "-- exit_code=0 → success --"
+oe_capture_classify 0
+assert_eq "state" "success" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=1 → partial --"
+oe_capture_classify 1
+assert_eq "state" "partial" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=2 → retryable_failure --"
+oe_capture_classify 2
+assert_eq "state" "retryable_failure" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=2 + blocked_flag=true → blocked --"
+oe_capture_classify 2 "true"
+assert_eq "state" "blocked" "$OE_CLASSIFY_STATE"
+
+echo "-- scan blocked_flag と classify の連携 --"
+_oe_capture_scan_parse "@@OE_BLOCKED:needs-human
+@@OE_EXIT:2"
+oe_capture_classify "$OE_SCAN_VALUE" "$OE_SCAN_BLOCKED"
+assert_eq "state" "blocked" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=2 + blocked_flag=false → retryable_failure --"
+oe_capture_classify 2 "false"
+assert_eq "state" "retryable_failure" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=124 → timeout --"
+oe_capture_classify 124
+assert_eq "state" "timeout" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=3 → protocol_error --"
+oe_capture_classify 3
+assert_eq "state" "protocol_error" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=255 → protocol_error --"
+oe_capture_classify 255
+assert_eq "state" "protocol_error" "$OE_CLASSIFY_STATE"
+
+echo "-- exit_code=42 → protocol_error --"
+oe_capture_classify 42
+assert_eq "state" "protocol_error" "$OE_CLASSIFY_STATE"
+
+# --- サマリ ---
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_cleanup.sh
+++ b/projects/orchestration-engine/tests/test_cleanup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+set -euo pipefail
+
+# test_cleanup.sh — cleanup.sh のユニットテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+# shellcheck source=../lib/cleanup.sh
+source "${PROJECT_DIR}/lib/cleanup.sh"
+
+PASS=0
+FAIL=0
+
+_MOCK_KILL_CALLS=()
+_MOCK_AUDIT_CALLS=0
+_MOCK_LAST_CLEANUP_PAYLOAD=""
+
+wez() {
+  if [[ "${1:-}" == "pane" && "${2:-}" == "kill" ]]; then
+    _MOCK_KILL_CALLS+=("${3:-}")
+    return 0
+  fi
+  return 1
+}
+
+oe_audit_emit() {
+  (( _MOCK_AUDIT_CALLS++ )) || true
+  if [[ "${1:-}" == "cleanup" ]]; then
+    _MOCK_LAST_CLEANUP_PAYLOAD="${5:-}"
+  fi
+  return 0
+}
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+echo "=== oe_cleanup empty panes ==="
+OE_MANAGED_PANES=()
+OE_CURRENT_SESSION_ID="EMPTYKILL"
+OE_CLEANUP_DONE=""
+_MOCK_KILL_CALLS=()
+_MOCK_AUDIT_CALLS=0
+_MOCK_LAST_CLEANUP_PAYLOAD=""
+
+oe_cleanup
+
+assert_eq "no kill when panes empty" "0" "${#_MOCK_KILL_CALLS[@]}"
+assert_eq "cleanup audit once" "1" "$_MOCK_AUDIT_CALLS"
+assert_eq "cleanup payload killed_pane_ids empty" "[]" "$(echo "$_MOCK_LAST_CLEANUP_PAYLOAD" | jq -c '.killed_pane_ids')"
+
+echo ""
+echo "=== oe_cleanup ==="
+
+_MOCK_KILL_CALLS=()
+_MOCK_AUDIT_CALLS=0
+_MOCK_LAST_CLEANUP_PAYLOAD=""
+
+OE_MANAGED_PANES=("101" "102")
+OE_CURRENT_SESSION_ID="TESTCLEAN"
+OE_CLEANUP_DONE=""
+
+tmp_target_1="/tmp/oe-${OE_CURRENT_SESSION_ID}-one.txt"
+tmp_target_2="/tmp/oe-${OE_CURRENT_SESSION_ID}-two.txt"
+tmp_keep="/tmp/oe-NOT-MATCH-keep.txt"
+echo "x" > "$tmp_target_1"
+echo "x" > "$tmp_target_2"
+echo "x" > "$tmp_keep"
+
+cleanup_files() {
+  rm -f "$tmp_target_1" "$tmp_target_2" "$tmp_keep"
+}
+trap cleanup_files EXIT
+
+oe_cleanup
+
+assert_eq "kill called twice" "2" "${#_MOCK_KILL_CALLS[@]}"
+assert_eq "first killed pane" "101" "${_MOCK_KILL_CALLS[0]}"
+assert_eq "second killed pane" "102" "${_MOCK_KILL_CALLS[1]}"
+assert_eq "session tmp removed #1" "false" "$( [[ -e "$tmp_target_1" ]] && echo true || echo false )"
+assert_eq "session tmp removed #2" "false" "$( [[ -e "$tmp_target_2" ]] && echo true || echo false )"
+assert_eq "non-session tmp kept" "true" "$( [[ -e "$tmp_keep" ]] && echo true || echo false )"
+assert_eq "audit called once" "1" "$_MOCK_AUDIT_CALLS"
+assert_eq "cleanup payload killed_pane_ids" "[101,102]" "$(echo "$_MOCK_LAST_CLEANUP_PAYLOAD" | jq -c '.killed_pane_ids')"
+
+oe_cleanup
+
+assert_eq "double run guard kill unchanged" "2" "${#_MOCK_KILL_CALLS[@]}"
+assert_eq "double run guard audit unchanged" "1" "$_MOCK_AUDIT_CALLS"
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -34,6 +34,20 @@ set -euo pipefail
 log_dir="${OE_MOCK_LOG_DIR:?}"
 
 if [[ "${1:-}" == "pane" && "${2:-}" == "split" ]]; then
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bottom|--right|--left|--top|--wait-ready|--json) shift ;;
+      --percent|--timeout|--pane-id|--cwd)
+        [[ $# -ge 2 ]] || exit 1
+        shift 2
+        ;;
+      *)
+        echo "unexpected wez split option: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
   echo "777"
   exit 0
 fi

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_e2e_smoke.sh — bin/oe の最小 E2E スモークテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+_TMP_DIR="${SCRIPT_DIR}/.tmp_test_e2e_smoke_$$"
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/logs" "$_TMP_DIR/data"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+cat > "${_TMP_DIR}/bin/wez" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir="${OE_MOCK_LOG_DIR:?}"
+
+if [[ "${1:-}" == "pane" && "${2:-}" == "split" ]]; then
+  echo "777"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pane" && "${2:-}" == "send" ]]; then
+  pane_id="${3:-}"
+  payload="${4:-}"
+  printf '%s|%s\n' "$pane_id" "$payload" >> "${log_dir}/send.log"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+  pane_id="${3:-}"
+  count_file="${log_dir}/capture_count_${pane_id}"
+  current=0
+  [[ -f "$count_file" ]] && current=$(<"$count_file")
+  current=$(( current + 1 ))
+  echo "$current" > "$count_file"
+  printf 'mock output\n@@OE_EXIT:0\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "pane" && "${2:-}" == "kill" ]]; then
+  pane_id="${3:-}"
+  printf '%s\n' "$pane_id" >> "${log_dir}/kill.log"
+  exit 0
+fi
+
+echo "unexpected wez call: $*" >&2
+exit 1
+EOF
+chmod +x "${_TMP_DIR}/bin/wez"
+
+export PATH="${_TMP_DIR}/bin:${PATH}"
+export OE_MOCK_LOG_DIR="${_TMP_DIR}/logs"
+export OE_DATA_DIR="${_TMP_DIR}/data"
+
+echo "=== bin/oe E2E smoke ==="
+bash "${PROJECT_DIR}/bin/oe" "E2E smoke task"
+
+state_file="$(echo "${OE_DATA_DIR}"/state/*.state.json)"
+audit_file="$(echo "${OE_DATA_DIR}"/audit/*.jsonl)"
+session_id="$(basename "$state_file" .state.json)"
+
+assert_eq "state file exists" "true" "$( [[ -f "$state_file" ]] && echo true || echo false )"
+assert_eq "audit file exists" "true" "$( [[ -f "$audit_file" ]] && echo true || echo false )"
+assert_eq "state.session_id" "$session_id" "$(jq -r '.session_id' "$state_file")"
+assert_eq "session_id matches ULID alphabet pattern" "true" "$( [[ "$session_id" =~ ^[0-9A-HJKMNP-TV-Z]{26}$ ]] && echo true || echo false )"
+assert_eq "state.state" "success" "$(jq -r '.state' "$state_file")"
+assert_eq "capture called once" "1" "$(cat "${OE_MOCK_LOG_DIR}/capture_count_777")"
+assert_eq "cleanup kill called" "777" "$(cat "${OE_MOCK_LOG_DIR}/kill.log")"
+
+assert_eq "session_start emitted" "1" \
+  "$(jq -r 'select(.event_type=="session_start") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "session_start state null" "null" "$(jq -r 'select(.event_type=="session_start") | .state' "$audit_file")"
+assert_eq "session_end emitted" "1" \
+  "$(jq -r 'select(.event_type=="session_end") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "state_change emitted" "1" \
+  "$(jq -r 'select(.event_type=="state_change" and .state=="success") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "cleanup emitted" "1" \
+  "$(jq -r 'select(.event_type=="cleanup") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "cleanup payload has killed_pane_ids" "777" "$(jq -r 'select(.event_type=="cleanup") | .payload.killed_pane_ids[0]' "$audit_file")"
+assert_eq "envelope path used in send" "1" \
+  "$(awk -v sid="$session_id" 'index($0,"/tmp/oe-" sid "-envelope.json"){found=1} END{print found+0}' "${OE_MOCK_LOG_DIR}/send.log")"
+assert_eq "spawn send executed" "1" \
+  "$(awk -v sid="$session_id" 'index($0,"Read /tmp/oe-" sid "-envelope.json and execute the task"){found=1} END{print found+0}' "${OE_MOCK_LOG_DIR}/send.log")"
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_envelope.sh
+++ b/projects/orchestration-engine/tests/test_envelope.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_envelope.sh — envelope.sh のユニットテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+# constants.sh をロード
+# shellcheck source=../lib/constants.sh
+source "${PROJECT_DIR}/lib/constants.sh"
+
+# envelope.sh をロード
+# shellcheck source=../lib/envelope.sh
+source "${PROJECT_DIR}/lib/envelope.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+cleanup() {
+  rm -f /tmp/oe-TEST_SESSION_01-envelope.json
+  rm -f /tmp/oe-TEST_SESSION_02-envelope.json
+}
+trap cleanup EXIT
+
+# --- oe_envelope_create テスト ---
+echo "=== oe_envelope_create ==="
+
+echo "-- 正常な envelope 生成 + validate-envelope.sh pass --"
+oe_envelope_create "TEST_SESSION_01" 42 "Test task description" "./output" 300
+assert_eq "OE_ENVELOPE_PATH set" "/tmp/oe-TEST_SESSION_01-envelope.json" "$OE_ENVELOPE_PATH"
+assert_eq "file exists" "true" "$( [[ -f "$OE_ENVELOPE_PATH" ]] && echo true || echo false )"
+
+echo "-- JSON フィールド検証 --"
+JSON="$OE_ENVELOPE_PATH"
+
+assert_eq "session_id" "TEST_SESSION_01" "$(jq -r '.session_id' "$JSON")"
+assert_eq "pane_id" "42" "$(jq -r '.pane_id' "$JSON")"
+assert_eq "task.description" "Test task description" "$(jq -r '.task.description' "$JSON")"
+assert_eq "task.output_dir" "./output" "$(jq -r '.task.output_dir' "$JSON")"
+assert_eq "task.exit_conditions.marker" "@@OE_EXIT" "$(jq -r '.task.exit_conditions.marker' "$JSON")"
+assert_eq "task.exit_conditions.timeout_seconds" "300" "$(jq -r '.task.exit_conditions.timeout_seconds' "$JSON")"
+assert_eq "task.read_docs" "[]" "$(jq -c '.task.read_docs' "$JSON")"
+assert_eq "task.use_skills" "[]" "$(jq -c '.task.use_skills' "$JSON")"
+assert_eq "context.parent_session_id" "null" "$(jq -r '.context.parent_session_id' "$JSON")"
+assert_eq "context.related_issues" "[]" "$(jq -c '.context.related_issues' "$JSON")"
+assert_eq "context.shared_kvs_path" "null" "$(jq -r '.context.shared_kvs_path' "$JSON")"
+assert_eq "constraints.max_panes" "$OE_CB_MAX_PANES" "$(jq -r '.constraints.max_panes' "$JSON")"
+
+VOCAB="$(jq -c '.constraints.state_vocabulary | sort' "$JSON")"
+assert_eq "constraints.state_vocabulary" '["blocked","done","progress","ready","spawn"]' "$VOCAB"
+
+echo ""
+echo "-- 異なるパラメータでの生成 --"
+oe_envelope_create "TEST_SESSION_02" 99 "Another task" "/tmp/out" 1800
+assert_eq "OE_ENVELOPE_PATH set" "/tmp/oe-TEST_SESSION_02-envelope.json" "$OE_ENVELOPE_PATH"
+
+JSON2="$OE_ENVELOPE_PATH"
+assert_eq "session_id" "TEST_SESSION_02" "$(jq -r '.session_id' "$JSON2")"
+assert_eq "pane_id" "99" "$(jq -r '.pane_id' "$JSON2")"
+assert_eq "timeout_seconds" "1800" "$(jq -r '.task.exit_conditions.timeout_seconds' "$JSON2")"
+
+echo ""
+echo "-- validate-envelope.sh 単体検証 --"
+VALIDATE_RESULT="$("${PROJECT_DIR}/scripts/validate-envelope.sh" "$JSON2" 2>&1)" || true
+assert_eq "validate passes" "OK: $JSON2" "$VALIDATE_RESULT"
+
+# --- サマリ ---
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_kvs.sh
+++ b/projects/orchestration-engine/tests/test_kvs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_kvs.sh — capture.sh の KVS 書き込みテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+_TMP_DIR="${SCRIPT_DIR}/.tmp_test_kvs_$$"
+mkdir -p "$_TMP_DIR/state"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+OE_DATA_DIR="$_TMP_DIR"
+export OE_DATA_DIR
+
+# shellcheck source=../lib/constants.sh
+source "${PROJECT_DIR}/lib/constants.sh"
+# shellcheck source=../lib/capture.sh
+source "${PROJECT_DIR}/lib/capture.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+echo "=== oe_capture_write_kvs ==="
+
+session_id="S02TEST"
+state_file="${OE_STATE_DIR}/${session_id}.state.json"
+
+oe_capture_write_kvs "$session_id" 12 "blocked"
+
+assert_eq "state file exists" "true" "$( [[ -f "$state_file" ]] && echo true || echo false )"
+assert_eq "session_id" "$session_id" "$(jq -r '.session_id' "$state_file")"
+assert_eq "pane_id" "12" "$(jq -r '.pane_id' "$state_file")"
+assert_eq "state blocked" "blocked" "$(jq -r '.state' "$state_file")"
+assert_eq "outputs empty array" "[]" "$(jq -c '.outputs' "$state_file")"
+assert_eq "blockers for blocked" '["@@OE_BLOCKED"]' "$(jq -c '.blockers' "$state_file")"
+assert_eq "last_updated present" "true" "$(jq -r '.last_updated | length > 0' "$state_file")"
+
+oe_capture_write_kvs "$session_id" 12 "success"
+
+assert_eq "state success overwrite" "success" "$(jq -r '.state' "$state_file")"
+assert_eq "blockers for non-blocked" "[]" "$(jq -c '.blockers' "$state_file")"
+
+if compgen -G "${OE_STATE_DIR}/.${session_id}.state.json.*" > /dev/null; then
+  echo "  FAIL: temp file leftover"
+  (( FAIL++ )) || true
+else
+  echo "  PASS: no temp file leftover"
+  (( PASS++ )) || true
+fi
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_monitor.sh
+++ b/projects/orchestration-engine/tests/test_monitor.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+set -euo pipefail
+
+# test_monitor.sh — monitor.sh のユニットテスト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+# constants.sh をロード
+# shellcheck source=../lib/constants.sh
+source "${PROJECT_DIR}/lib/constants.sh"
+
+# capture.sh をロード（oe_capture_scan / oe_capture_classify）
+# shellcheck source=../lib/capture.sh
+source "${PROJECT_DIR}/lib/capture.sh"
+
+# audit.sh をロード（stub）
+# shellcheck source=../lib/audit.sh
+source "${PROJECT_DIR}/lib/audit.sh"
+
+# cleanup.sh をロード（stub）
+# shellcheck source=../lib/cleanup.sh
+source "${PROJECT_DIR}/lib/cleanup.sh"
+
+# monitor.sh をロード
+# shellcheck source=../lib/monitor.sh
+source "${PROJECT_DIR}/lib/monitor.sh"
+
+# --- モック ---
+
+_MOCK_TMPDIR="${SCRIPT_DIR}/.tmp_test_monitor_$$"
+mkdir -p "$_MOCK_TMPDIR"
+trap 'rm -rf "$_MOCK_TMPDIR"' EXIT
+
+declare -A _MOCK_CAPTURE_OUTPUT
+_MOCK_KILL_CALLS=()
+
+# wez モック（capture count はサブシェル対応のためファイルベース）
+wez() {
+  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+    local pane_id="${3:-}"
+    local count_file="${_MOCK_TMPDIR}/capture_${pane_id}"
+    local current=0
+    [[ -f "$count_file" ]] && current=$(<"$count_file")
+    echo $(( current + 1 )) > "$count_file"
+    echo "${_MOCK_CAPTURE_OUTPUT[$pane_id]:-}"
+    return 0
+  fi
+  if [[ "${1:-}" == "pane" && "${2:-}" == "kill" ]]; then
+    _MOCK_KILL_CALLS+=("${3:-}")
+    return 0
+  fi
+  return 1
+}
+
+mock_capture_count() {
+  local pane_id="$1"
+  local count_file="${_MOCK_TMPDIR}/capture_${pane_id}"
+  if [[ -f "$count_file" ]]; then
+    cat "$count_file"
+  else
+    echo "0"
+  fi
+}
+
+# sleep モック（即座に返す）
+sleep() { :; }
+
+# audit_emit トラッカー
+_MOCK_AUDIT_CALLS=()
+oe_audit_emit() {
+  _MOCK_AUDIT_CALLS+=("$1|$2|$3|${4:-}|${5:-}")
+}
+
+# cleanup トラッカー
+_MOCK_CLEANUP_CALLED=0
+oe_cleanup() {
+  _MOCK_CLEANUP_CALLED=1
+}
+
+# KVS write トラッカー
+_MOCK_KVS_WRITE_COUNT=0
+_MOCK_KVS_LAST_ARGS=""
+oe_capture_write_kvs() {
+  _MOCK_KVS_LAST_ARGS="${1:-}|${2:-}|${3:-}"
+  (( _MOCK_KVS_WRITE_COUNT++ )) || true
+}
+
+# --- モックリセット ---
+
+reset_mocks() {
+  _MOCK_CAPTURE_OUTPUT=()
+  _MOCK_KILL_CALLS=()
+  _MOCK_AUDIT_CALLS=()
+  _MOCK_CLEANUP_CALLED=0
+  _MOCK_KVS_WRITE_COUNT=0
+  _MOCK_KVS_LAST_ARGS=""
+  _OE_MONITOR_INTERRUPTED=0
+  OE_CB_TIMEOUT=1800
+  OE_CB_MAX_TURNS=10
+  OE_CB_MAX_PANES=5
+  OE_POLL_INTERVAL=2
+  rm -f "${_MOCK_TMPDIR}"/capture_* 2>/dev/null || true
+}
+
+# --- アサーション ---
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local needle="$2"
+  shift 2
+  local haystack=("$@")
+  local item
+  for item in "${haystack[@]}"; do
+    if [[ "$item" == "$needle" ]]; then
+      echo "  PASS: $label"
+      (( PASS++ )) || true
+      return 0
+    fi
+  done
+  echo "  FAIL: $label (needle='$needle' not found in [${haystack[*]}])"
+  (( FAIL++ )) || true
+}
+
+# --- テスト a: 単一ペイン EXIT:0 → ループ終了 ---
+
+echo "=== Test a: 単一ペイン EXIT:0 → ループ終了 ==="
+reset_mocks
+_MOCK_CAPTURE_OUTPUT[p1]="task output
+@@OE_EXIT:0
+done"
+
+oe_monitor_loop "sess-a" "p1"
+
+assert_eq "OE_DONE_PANES count" "1" "${#OE_DONE_PANES[@]}"
+assert_eq "OE_DONE_PANES[0]" "p1" "${OE_DONE_PANES[0]}"
+assert_eq "OE_LAST_STATE[p1]" "success" "${OE_LAST_STATE[p1]}"
+assert_eq "capture count for p1" "1" "$(mock_capture_count p1)"
+assert_eq "KVS write count" "1" "$_MOCK_KVS_WRITE_COUNT"
+assert_eq "KVS args include session/pane/state" "sess-a|p1|success" "$_MOCK_KVS_LAST_ARGS"
+assert_contains "state_change emitted" "state_change|sess-a|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
+assert_contains "session_end emitted" "session_end|sess-a|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
+assert_eq "no kill calls" "0" "${#_MOCK_KILL_CALLS[@]}"
+assert_eq "cleanup not called in monitor" "0" "$_MOCK_CLEANUP_CALLED"
+
+# --- テスト b: CB タイムアウト発動 ---
+
+echo ""
+echo "=== Test b: CB タイムアウト発動 ==="
+reset_mocks
+OE_CB_TIMEOUT=0
+_MOCK_CAPTURE_OUTPUT[p1]="no markers here"
+
+oe_monitor_loop "sess-b" "p1" || true
+
+assert_eq "OE_DONE_PANES count" "0" "${#OE_DONE_PANES[@]}"
+assert_contains "circuit_breaker_triggered" \
+  'circuit_breaker_triggered|sess-b|0||{"reason":"timeout"}' \
+  "${_MOCK_AUDIT_CALLS[@]}"
+assert_eq "kill called for p1" "1" "${#_MOCK_KILL_CALLS[@]}"
+assert_eq "killed pane" "p1" "${_MOCK_KILL_CALLS[0]}"
+
+# --- テスト c: 複数ペイン — 1 つ完了 + 残り未完了 ---
+
+echo ""
+echo "=== Test c: 複数ペイン — 1 完了 + 1 未完了 ==="
+reset_mocks
+OE_CB_MAX_TURNS=3
+_MOCK_CAPTURE_OUTPUT[p1]="@@OE_EXIT:0"
+_MOCK_CAPTURE_OUTPUT[p2]="still running"
+
+oe_monitor_loop "sess-c" "p1" "p2" || true
+
+assert_eq "OE_DONE_PANES count" "1" "${#OE_DONE_PANES[@]}"
+assert_eq "OE_DONE_PANES[0]" "p1" "${OE_DONE_PANES[0]}"
+assert_eq "p1 capture count" "1" "$(mock_capture_count p1)"
+assert_eq "p2 capture count" "3" "$(mock_capture_count p2)"
+assert_contains "state_change for p1" "state_change|sess-c|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
+assert_contains "session_end for p1" "session_end|sess-c|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
+assert_contains "CB max_turns" \
+  'circuit_breaker_triggered|sess-c|0||{"reason":"max_turns"}' \
+  "${_MOCK_AUDIT_CALLS[@]}"
+assert_eq "kill count" "2" "${#_MOCK_KILL_CALLS[@]}"
+
+# --- テスト d: マーカーなし → ループ継続（max_turns で終了） ---
+
+echo ""
+echo "=== Test d: マーカーなし → ループ継続 ==="
+reset_mocks
+OE_CB_MAX_TURNS=3
+_MOCK_CAPTURE_OUTPUT[p1]="just normal output"
+
+oe_monitor_loop "sess-d" "p1" || true
+
+assert_eq "OE_DONE_PANES count" "0" "${#OE_DONE_PANES[@]}"
+assert_eq "p1 capture count" "3" "$(mock_capture_count p1)"
+assert_contains "CB max_turns" \
+  'circuit_breaker_triggered|sess-d|0||{"reason":"max_turns"}' \
+  "${_MOCK_AUDIT_CALLS[@]}"
+
+# --- テスト e: CB ペイン数超過 ---
+
+echo ""
+echo "=== Test e: CB ペイン数超過 ==="
+reset_mocks
+OE_CB_MAX_PANES=2
+
+oe_monitor_loop "sess-e" "p1" "p2" "p3" || true
+
+assert_contains "CB pane_count_exceeded" \
+  'circuit_breaker_triggered|sess-e|0||{"reason":"max_panes"}' \
+  "${_MOCK_AUDIT_CALLS[@]}"
+assert_eq "kill count" "3" "${#_MOCK_KILL_CALLS[@]}"
+
+# --- テスト f: trap 復元 ---
+echo ""
+echo "=== Test f: trap 復元 ==="
+reset_mocks
+_MOCK_CAPTURE_OUTPUT[p1]="@@OE_EXIT:0"
+
+oe_monitor_loop "sess-f" "p1"
+
+assert_eq "INT trap cleared" "" "$(trap -p INT)"
+assert_eq "TERM trap cleared" "" "$(trap -p TERM)"
+
+# --- サマリ ---
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_monitor.sh
+++ b/projects/orchestration-engine/tests/test_monitor.sh
@@ -153,7 +153,7 @@ oe_monitor_loop "sess-a" "p1"
 
 assert_eq "OE_DONE_PANES count" "1" "${#OE_DONE_PANES[@]}"
 assert_eq "OE_DONE_PANES[0]" "p1" "${OE_DONE_PANES[0]}"
-assert_eq "OE_LAST_STATE[p1]" "success" "${OE_LAST_STATE[p1]}"
+assert_eq "OE_LAST_STATE[p1]" "success" "$(_oe_monitor_last_state_get p1 || true)"
 assert_eq "capture count for p1" "1" "$(mock_capture_count p1)"
 assert_eq "KVS write count" "1" "$_MOCK_KVS_WRITE_COUNT"
 assert_eq "KVS args include session/pane/state" "sess-a|p1|success" "$_MOCK_KVS_LAST_ARGS"

--- a/projects/orchestration-engine/tests/test_monitor.sh
+++ b/projects/orchestration-engine/tests/test_monitor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2317
 set -euo pipefail
 
 # test_monitor.sh — monitor.sh のユニットテスト
@@ -98,6 +98,7 @@ reset_mocks() {
   _MOCK_KVS_WRITE_COUNT=0
   _MOCK_KVS_LAST_ARGS=""
   _OE_MONITOR_INTERRUPTED=0
+  _OE_INTERRUPT_METHOD=""
   OE_CB_TIMEOUT=1800
   OE_CB_MAX_TURNS=10
   OE_CB_MAX_PANES=5
@@ -229,6 +230,33 @@ assert_contains "CB pane_count_exceeded" \
   'circuit_breaker_triggered|sess-e|0||{"reason":"max_panes"}' \
   "${_MOCK_AUDIT_CALLS[@]}"
 assert_eq "kill count" "3" "${#_MOCK_KILL_CALLS[@]}"
+
+# --- テスト g: interrupt（SIGINT 経路）---
+echo ""
+echo "=== Test g: interrupt (SIGINT) ==="
+reset_mocks
+_MOCK_CAPTURE_OUTPUT[p1]="running without marker"
+OE_CB_MAX_TURNS=100
+_OE_MONITOR_SLEEP_INT_PHASE=0
+sleep() {
+  if [[ $_OE_MONITOR_SLEEP_INT_PHASE -eq 0 ]]; then
+    _OE_MONITOR_SLEEP_INT_PHASE=1
+    return 0
+  fi
+  _OE_MONITOR_INTERRUPTED=1
+  _OE_INTERRUPT_METHOD=SIGINT
+  return 0
+}
+
+int_rc=0
+oe_monitor_loop "sess-int" "p1" || int_rc=$?
+
+assert_eq "interrupt exit code 130" "130" "$int_rc"
+assert_contains "interrupt audit emitted" \
+  'interrupt|sess-int|0||{"method":"SIGINT"}' \
+  "${_MOCK_AUDIT_CALLS[@]}"
+
+sleep() { :; }
 
 # --- テスト f: trap 復元 ---
 echo ""


### PR DESCRIPTION
## 背景

Step 4-1（PR #85）完了後、Step 4-2「成果物パース + 状態管理」の一連作業（設計・計画、Phase A〜E の実装・テスト、各種レビュー反映）を本 PR にまとめています。

question-driven-design で 7 つの設計論点（スクリプト構成、envelope 注入、マーカー規約、監視ループ、audit log、KVS 書き込み、ファイルレイアウト）を合意し、Discussion → KickOff → Plan の distillation pipeline を実行しました。

その後、Phase A〜E の全機能を実装し、`so-compare` レビューに基づくハードニングを実施しました。

## 変更内容

### 設計・計画ドキュメント
- Discussion: Q1〜Q7 の質問駆動設計の合意記録（status: closed）
- KickOff: DI-1〜DI-7 の実装スコープ・依存関係・完了条件 8 項目
- Plan: Phase A〜E の 10 Step + 3 GATE + 2 STOP 構成

### 実装・テスト（Phase A〜E）
- `bin/oe`: エントリポイント、セッション生成、メイン結線
- `lib/constants.sh`: グローバル定数定義
- `lib/envelope.sh`: エンベロープJSON生成
- `lib/spawn.sh`: ペイン生成 + コマンド送信
- `lib/capture.sh`: マーカー検出、分類、KVS書込
- `lib/monitor.sh`: ポーリング、CB、状態追跡
- `lib/audit.sh`: 監査ログ JSONL 追記
- `lib/cleanup.sh`: 終了時の安全なクリーンアップ
- `tests/*`: ユニットテストと E2E スモークテスト（全てパス）

### so-compare レビュー（実装後ハードニング）
- `session_id` を ULID 文字集合（Crockford base32）に正規化
- `session_start` イベントの `state` を `null` に固定
- `cleanup` イベントの payload に `killed_pane_ids` を追加
- `monitor.sh` 終了後に `bin/oe` で `trap oe_cleanup EXIT INT TERM` を再設定
- `spawn.sh` を2段階APIに分割（`pane_id` 依存解消）
- `capture.sh` で `\r` と ANSI エスケープを除去する前処理を追加
- 監査ログ `payload` が JSON Object であることを `jq` で事前検証

### Copilot / Codex レビュー反映（追記）
- Copilot: `3245710` — SIGINT/SIGTERM 時に `interrupt` 監査イベントを emit（`method` で区別）
- Copilot: `ed2e8ef` — `monitor.sh` で `SECONDS` をゼロリセットしないタイムアウト計算、`audit.sh` の payload 検証を `printf '%s\n'` 経由に変更
- Codex: `bdee880` — Bash 3.2 互換の last-state 保持、`wez pane split` に `--wait-ready` / `--timeout`（`OE_SPAWN_WAIT_READY_SEC`）

## 成果物

- `docs/discussions/2026-05-14-discussion-parse-and-state-management.md`
- `docs/plans/2026-05-14-kickoff-step-4-2-parse-and-state-management.md`
- `docs/plans/2026-05-14-plan-step-4-2-parse-and-state-management.md`
- `docs/episodes/2026-05-15-episode-step-4-2-phase-e-integration-validation.md`
- `bin/`, `lib/`, `tests/`, `state/`, `audit/` 以下の各種ファイル

## 残課題・未達事項
- `audit` イベントの `human_input` の emit 経路および検証が未追加です。

Refs #87
Refs #19
