### PR TITLE
feat(orchestration-engine): Step 4-3 検証ゲート v1 実装 (Phase A-E + so-compare 反映 + 蒸留)

### DIFF
--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -30,10 +30,16 @@ trap oe_cleanup EXIT INT TERM
 
 oe_generate_session_id() {
   local ts
+  local raw
   local rand
   # 26 文字: 先頭 14 は数字（ULID 時刻部相当）、残り 12 は Crockford base32（I/L/O/U 除外）
+  #
+  # Copilot #4 反映: tr の出力を head -c で早期 close すると tr に SIGPIPE が飛び、
+  # set -o pipefail 環境下で assignment が失敗する。固定バイト数を先に読んでから tr で
+  # filter する形に変更 (パイプの早期 close を回避)。
   ts="$(date -u +%Y%m%d%H%M%S)"
-  rand="$(LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z' </dev/urandom | head -c 12)"
+  raw="$(LC_ALL=C head -c 4096 /dev/urandom | LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z')"
+  rand="${raw:0:12}"
   printf '%s%s\n' "$ts" "$rand"
 }
 

--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -16,10 +16,12 @@ source "${LIB_DIR}/envelope.sh"
 source "${LIB_DIR}/spawn.sh"
 # shellcheck source=../lib/capture.sh
 source "${LIB_DIR}/capture.sh"
-# shellcheck source=../lib/monitor.sh
-source "${LIB_DIR}/monitor.sh"
 # shellcheck source=../lib/audit.sh
 source "${LIB_DIR}/audit.sh"
+# shellcheck source=../lib/verify.sh
+source "${LIB_DIR}/verify.sh"
+# shellcheck source=../lib/monitor.sh
+source "${LIB_DIR}/monitor.sh"
 # shellcheck source=../lib/cleanup.sh
 source "${LIB_DIR}/cleanup.sh"
 
@@ -63,7 +65,12 @@ oe_main() {
   # monitor が INT/TERM trap を解除するため、EXIT 経路の cleanup を再確保
   trap oe_cleanup EXIT INT TERM
 
-  # 7) monitor 戻り値を尊重
+  # 7) Step 4-3 Phase E: 検証フェーズ (CB / interrupt 発動時はスキップ)
+  if [[ "$monitor_rc" -eq 0 ]]; then
+    oe_verify_run_phase "$OE_CURRENT_SESSION_ID" "$pane_id"
+  fi
+
+  # 8) monitor 戻り値を尊重 (検証フェーズの結果は KVS / audit に記録、engine 自体は停止しない)
   return "$monitor_rc"
 }
 

--- a/projects/orchestration-engine/docs/decisions/2026-05-16-decision-verification-gate-design.md
+++ b/projects/orchestration-engine/docs/decisions/2026-05-16-decision-verification-gate-design.md
@@ -1,0 +1,243 @@
+---
+id: "01KRQA3H7XP50TZXHEGYJYVXTR"
+title: "Step 4-3: 検証ゲート v1 アーキテクチャ — Compliance Review only + 疎結合 skill 統合 + pane-keyed KVS"
+date: 2026-05-16
+type: decision
+status: accepted
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/19"
+    reason: "Epic #19 Phase 4 MVP"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/89"
+    reason: "Step 4-3 観測層サブ Issue"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-05-15-discussion-step-4-3-verification-gate.md"
+    reason: "QDD で 7 Q closed、本 ADR の決定根拠の正本"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-15-kickoff-step-4-3-verification-gate.md"
+    reason: "DI-1〜DI-7 (Step 4-3 ローカル番号) を確定した KickOff"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-15-plan-step-4-3-verification-gate.md"
+    reason: "Plan + so-compare 初回レビュー F1-F8 反映済み"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-05-16-episode-step-4-3-implementation.md"
+    reason: "実装 + so-compare 実装段階レビュー + F-SO-1〜12 反映の実行記録"
+  - type: depends_on
+    ref: "DI-13"
+    reason: "MVP 権限分離方針 (Step 4-1)。本決定は検証 agent の権限境界に依存"
+  - type: depends_on
+    ref: "DI-14"
+    reason: "クリーンアップ戦略 (Step 4-1)。本決定は検証ペインを OE_VERIFY_MANAGED_PANES として cleanup に統合"
+tags: [orchestration, mvp, step-4-3, decision, verification-gate, adversarial-review, skill-integration]
+---
+
+# Step 4-3: 検証ゲート v1 アーキテクチャ — Compliance Review only + 疎結合 skill 統合 + pane-keyed KVS
+
+## コンテキスト
+
+Step 4-2 ([PR #88](https://github.com/stlwolf/ai-development-hub/pull/88)) で `bin/oe` + `lib/*.sh` の駆動エンジンが完成した。サブエージェントの spawn、マーカー検出、KVS 書き込み、監査ログ、クリーンアップが動作する状態。
+
+Step 4-3 の主題は **「サブエージェントの出力を別エージェントが adversarial review する仕組み」** (KickOff §「主題」)。これは MVP の核心機能の 1 つだが、設計判断の自由度が大きく、以下の論点を解く必要があった:
+
+- 検証はいつ・どこで実行するか? (発火タイミング、起動方式)
+- 検証 agent には何を渡すか? (要件、完了報告、変更ファイル)
+- 検証結果の表現と保存先は? (語彙、KVS / audit log)
+- 不合格時のフローは? (リトライ、エスカレーション、記録のみ)
+- 既存の `canonical/skills/adversarial-review` skill との統合方針は?
+
+加えて、本 Step は **ツール間引き継ぎ (Cursor → Claude Code)** の dogfood ケースでもあり、駆動層ドキュメントだけで作業継続できるかの検証も兼ねていた。
+
+## 検討した選択肢 (Discussion Q1〜Q7、KickOff DI-1〜DI-7、Plan F1〜F8、so-compare F-SO-1〜12)
+
+主要な分岐点と検討した代替案:
+
+### Q1/DI-1: 検証モードのスコープ
+
+- A. Plan Review のみ (kickoff-to-plan 直後のドキュメント品質チェック)
+- **B. Compliance Review のみ** ← 採用
+- C. 両方
+
+### Q2/DI-2: 発火タイミング
+
+- A. 各タスク完了ごと (per-pane)
+- **B. 全タスク完了後 (end-of-session)** ← 採用 + Q2 追加決定でセッション内 fail 率を記録
+- C. ハイブリッド (envelope で指定)
+
+### Q3/DI-3: 検証 agent 起動方法
+
+- **A. 新ペイン spawn (`lib/spawn.sh` 再利用)** ← 採用
+- B. 既存ペイン再利用
+- C. 同期外部コマンド
+
+### Q4/DI-4: プロンプト構成
+
+- A. envelope の `task.description` のみ
+- **B. envelope + audit ログ + KVS の 3 ソース統合** ← 採用
+- C. 自由フォーマット
+
+### Q5/DI-5: 検証結果の表現と保存
+
+- A. 既存 6 値 (`partial`) に集約
+- **B'. KVS スキーマを最小拡張 (`verification` map + `verification_summary`)** ← 採用、Plan F5 で **pane-keyed map** に確定
+- C. audit ログのみ
+
+### Q6/DI-6: 不合格時のフロー
+
+- **A. 記録のみ + `wez notify` で完了通知** ← 採用
+- B. 自動リトライ
+- C. 人間エスカレーション
+
+### Q7/DI-7: skill 統合方針
+
+- A. engine に skill prompt を埋め込み
+- **B. envelope の `use_skills` で指定 (疎結合)** ← 採用
+- C. skill 側に engine 用 entry 追加
+
+加えて、出力パース方式は (i) skill 出力に明示マーカーをバックポート / (ii) 既存テキストを正規表現抽出 / **(iii) engine が envelope で `@@OE_VERIFY:{result}` を要求** の 3 案から **(iii)** を採用 (既存 `@@OE_EXIT:{code}` パターンと整合)。
+
+## 決定
+
+検証ゲート v1 を以下のアーキテクチャで実装する:
+
+### 1. 動作モード
+
+**Compliance Review only** (skill `adversarial-review` の Compliance Review モード)。Plan Review は engine 統合せず、必要時は人間が skill を単独起動する。
+
+### 2. 発火タイミング
+
+`oe_monitor_loop` 終了後 (全 `OE_DONE_PANES` 完了時のみ、CB / interrupt 時はスキップ) に **end-of-session** で発火。逐次 (per-target-pane) に検証 agent を spawn し、検証完了後にセッション集計を行う。
+
+### 3. 検証エージェント起動
+
+- `lib/verify.sh:oe_verify_run_phase()` 内の **独立ポーリングループ** (F1 反映) で実行
+- 通常ペイン管理配列 (`OE_MANAGED_PANES` / `OE_DONE_PANES`) と分離した **`OE_VERIFY_MANAGED_PANES` / `OE_VERIFY_DONE_PANES`** を使用 (F2 反映、意味の衝突回避)
+- 検証 agent ペインは `lib/spawn.sh:oe_spawn_prepare_pane` を再利用して新規生成
+- AI CLI は `OE_VERIFY_AI_CLI` 環境変数 (デフォルト `cursor`) で選択可能 (F-SO-6 反映)
+
+### 4. プロンプト構成 (engine の責務 = 構造化入力の抽出のみ)
+
+`oe_verify_envelope_create()` が検証 envelope を生成し、以下を `task.read_docs` に含める:
+
+1. `canonical/skills/adversarial-review/SKILL.md` (skill 本文)
+2. 被検証 envelope (`/tmp/oe-{target_session_id}-envelope.json`)
+3. 監査ログ (`audit/{target_session_id}.jsonl`)
+4. KVS (`state/{target_session_id}.state.json`)
+5. 構造化された 3 入力ファイル (`/tmp/oe-{reviewer_session_id}-verify-inputs.md`、`oe_verify_prompt_build` が生成)
+
+`task.use_skills: ["adversarial-review"]` で skill を疎結合指定 (F4 反映、engine に skill prompt の static copy を持たない)。`task.description` には **skill 出力 → `@@OE_VERIFY` マッピング** を明示 (F-SO-1 反映):
+
+- Spec Compliant (critical issue なし) → `@@OE_VERIFY:pass`
+- Issues Found + Critical → `@@OE_VERIFY:fail`
+- Spec Compliant + 非自明な Recommendations / 軽微 Issues → `@@OE_VERIFY:warn`
+
+### 5. マーカー検出 (二値保持)
+
+`lib/capture.sh:_oe_capture_scan_parse` を **`OE_SCAN_EXIT_CODE` + `OE_SCAN_VERIFY_RESULT` の二値保持** (F3 反映) に拡張。`@@OE_VERIFY:` と shell が後置する `@@OE_EXIT:` が同一 capture に並ぶ前提で、両方を独立に保持する。
+
+検証ペインは verbose 出力を扱うため、`oe_capture_scan` に optional `lines` 引数を追加し検証ループから `200` を渡す (F-SO-4 反映)。
+
+### 6. 結果の永続化
+
+`schemas/session-state.schema.json` を以下のように拡張 (DI-5 / F5 / F-SO-2):
+
+```json
+{
+  "verification": {
+    "<target_pane_id>": {
+      "result": "pass" | "fail" | "warn",
+      "reviewer_session_id": "<ULID>",
+      "reviewer_pane_id": "<int>",
+      "issues_count": <int>,
+      "marker_raw": "@@OE_VERIFY:<result>",
+      "completed_at": "<ISO 8601>",
+      "exit_code": <int>  // F-SO-2: 非 0 の場合のみ記録 (protocol error)
+    }
+  },
+  "verification_summary": {
+    "total": <int>,
+    "passed": <int>,
+    "failed": <int>,
+    "warned": <int>,
+    "fail_rate": <number>,
+    "protocol_errors": <int>  // F-SO-12: exit_code != 0 のエントリ数
+  }
+}
+```
+
+`schemas/audit-log.schema.json` に 3 イベント追加:
+
+- `verification_started` — Phase B (`oe_verify_spawn`) で emit (F6 反映)
+- `verification_completed` — Phase D (`oe_verify_emit_completed`) で emit (F6 反映)
+- `verification_protocol_error` — F-SO-2 反映、`@@OE_VERIFY:` 検出時に `OE_SCAN_EXIT_CODE` が非 0 だった場合に追加 emit
+
+### 7. 不合格時のフロー
+
+不合格 (result=fail) でも engine は停止しない。CB / interrupt が発動しなかった場合のみ `cleanup.sh` 末尾で `wez notify "orchestration-engine session complete"` を呼び、本文に `session_id={} verification: pass={} fail={} warn={} fail_rate={}` を展開する (DI-6 + Q2 追加決定: fail 率を実運用データとして記録)。
+
+### 8. スコープ外 (派生課題として記録)
+
+以下は本 Step では対応せず、派生 Issue または後続 Step に委ねる:
+
+- **AI CLI 起動オプションの実 CLI 整合** ([#91](https://github.com/stlwolf/ai-development-hub/issues/91), Step 4-4 着手前必須)
+- **変更ファイル検出の per-pane 化 + 完了報告の充実** ([#92](https://github.com/stlwolf/ai-development-hub/issues/92), Step 4-5 候補)
+- **reviewer 一時ファイル掃除 + nonce マーカー偽陽性対策** ([#93](https://github.com/stlwolf/ai-development-hub/issues/93), MVP 後拡張)
+- **per-pane 発火への昇格、自動リトライ、人間エスカレーション** (Step 4-4 / 4-5 の運用フィードバックで判断)
+- **`human_input` audit イベント** (必要時に追加)
+
+## 根拠
+
+### 設計判断の主軸
+
+- **engine の責務を「駆動 + 構造化入力の組み立て」に純粋化**: skill 規約 (Compliance Review プロンプト) と engine プロトコル (`@@OE_VERIFY:` マーカー) を分離し、skill 改訂時の追従不要を実現。skill が orchestration 統合前提で使われる頻度が増えても、engine 側に skill 内容を抱えない設計に
+- **既存資産の最大再利用**: Step 4-2 の `lib/spawn.sh` / `oe_capture_scan` / `oe_audit_emit` / `oe_cleanup` をそのまま再利用、新規実装は `lib/verify.sh` に集約。設計の手戻りリスクを最小化
+- **observability ファースト**: fail 率の構造化記録 (Q2 追加決定) と verification_protocol_error (F-SO-2) で、実運用での問題検出を早期に可能に。MVP の単一 UC でも、Step 4-4 / 4-5 のフィードバックフェーズで意思決定に使えるデータを残す
+- **mock では検出できない実 agent 失敗モードを認識**: so-compare 実装段階レビュー (F-SO-1, F-SO-7) が指摘した「CLI 不整合」「マッピング欠落」は wez 完全 mock テストでは絶対に出ない。Step 4-4 で実 CLI 1 種を必ず通すという運用前ゲートを #91 で明示化
+
+### Compliance Review のみ採用の理由 (DI-1)
+
+- engine の主用途は「サブエージェントを駆動して成果物を得る」こと。Plan Review は人間が `kickoff-to-plan` 直後に手動起動する性質が強く、engine 統合の価値が薄い
+- Plan Review 統合は将来 Step (4-5 以降) で必要性が見えれば追加可能なパスを残す
+
+### pane-keyed map の理由 (DI-5 / F5)
+
+- 単一オブジェクトでは複数 target pane の per-pane 結果を保持できない
+- Q2 で確定した「セッション内 fail 率を記録」要件には複数 pane を扱える構造が必須
+- `additionalProperties` パターンで JSON Schema との整合性を維持
+
+### `use_skills` 疎結合の理由 (DI-7 / F4)
+
+- envelope schema には Step 4-1 段階で `task.use_skills` フィールドが存在し、Step 4-2 で実装ペインに渡している実績がある
+- skill prompt の static copy を engine に持たない設計により、skill の改訂が engine 側のリリースサイクルから独立する
+- skill が orchestration 前提で使われるなら、skill 側の改修方針も将来 engine 統合に揃えてよい (派生課題、Step 4-4 以降で判断)
+
+## 結果 / トレードオフ
+
+### 得たもの
+
+- **設計の手戻り防止**: Plan 段階の so-compare (F1〜F8) で構造的な見落としを潰し、実装段階の so-compare (F-SO-1〜12) で実装詳細の見落としを潰す 2 段階レビュー体制
+- **疎結合**: skill / engine / 検証 agent の 3 者責務境界が明確 — skill は規約を持ち、engine は構造化入力を組み、検証 agent は両方を読んで判定
+- **テスト網羅性**: 8 テストスイート 293 assertions PASS (mock 経由)、shellcheck クリーン、validator で schema 整合性確保
+- **dogfood 成功**: ツール間引き継ぎ (Cursor → Claude Code) で駆動層ドキュメントだけで作業継続できることを実証
+
+### トレードオフ
+
+- **mock の限界**: 実 agent での動作確認は Step 4-4 待ち。本 Step 単独では「マージ可だが、実 agent 動作未検証」という前提を明示しないと現場で混乱しうる。Episode と本 ADR、および [#91](https://github.com/stlwolf/ai-development-hub/issues/91) で明示化
+- **scope creep の抑制と spec change の境界**: KickOff §「スコープ外」で「スキーマ変更は 4-5」と明記していたが、Q5 で `verification` / `verification_summary` の最小拡張を含めると user 確認で緩和。今後の Step でも、スコープ外条件は実装上の必要性で **明示的緩和** の意思決定を残すパターンを確立した
+- **`MARKER_TYPE=VERIFY` の後方互換コスト**: 将来 monitor.sh が `case "$OE_SCAN_MARKER_TYPE"` に VERIFY を追加すると誤動作する。コメント明示 (F-SO-5) で対処したが、コードレベルの enforcement (`assert` 等) はしていない。技術的負債として認識
+- **CLI ハードコード残存**: `OE_VERIFY_AI_CLI` env var で選択可能化したが、デフォルト `cursor` のままで実 CLI 起動オプションが不整合 ([#91](https://github.com/stlwolf/ai-development-hub/issues/91))。Step 4-4 着手前に必ず潰す
+
+### 観測したリスク (将来発火する可能性あり)
+
+- **`@@OE_VERIFY:` 偽陽性**: 検証 agent が応答テキスト中で `@@OE_VERIFY:pass` を単独行で引用した場合に誤検出 ([#93](https://github.com/stlwolf/ai-development-hub/issues/93))
+- **検証ペイン capture の `--lines` 不足**: 200 行に拡張したが、verbose な review 出力が押し出されるケースは依然ある。`@@OE_VERIFY` 直後に shell が `@@OE_EXIT` を後置する間に他出力が紛れ込むリスク
+- **長期運用での `/tmp` 蓄積**: cleanup.sh が reviewer 一時ファイルを掃除しないため、macOS の `/tmp` が再起動まで膨張 ([#93](https://github.com/stlwolf/ai-development-hub/issues/93))
+
+## 参照
+
+- 駆動層ドキュメント: [Discussion](../discussions/2026-05-15-discussion-step-4-3-verification-gate.md) / [KickOff](../plans/2026-05-15-kickoff-step-4-3-verification-gate.md) / [Plan](../plans/2026-05-15-plan-step-4-3-verification-gate.md)
+- 実装エピソード: [`2026-05-16-episode-step-4-3-implementation.md`](../episodes/2026-05-16-episode-step-4-3-implementation.md)
+- Step 4-3 全成果物 PR: [#90](https://github.com/stlwolf/ai-development-hub/pull/90)
+- 派生 Issue: [#91](https://github.com/stlwolf/ai-development-hub/issues/91) / [#92](https://github.com/stlwolf/ai-development-hub/issues/92) / [#93](https://github.com/stlwolf/ai-development-hub/issues/93)
+- 関連 ADR: [DI-13 権限分離](2026-05-14-decision-permission-separation-mvp.md) / [DI-14 クリーンアップ戦略](2026-05-14-decision-cleanup-strategy.md)
+- 関連 skill: [adversarial-review](../../../../canonical/skills/adversarial-review/SKILL.md) (本決定が `use_skills` 経由で参照)

--- a/projects/orchestration-engine/docs/decisions/2026-05-16-decision-verification-gate-design.md
+++ b/projects/orchestration-engine/docs/decisions/2026-05-16-decision-verification-gate-design.md
@@ -160,7 +160,8 @@ Step 4-3 の主題は **「サブエージェントの出力を別エージェ�
     "failed": <int>,
     "warned": <int>,
     "fail_rate": <number>,
-    "protocol_errors": <int>  // F-SO-12: exit_code != 0 のエントリ数
+    "protocol_errors": <int>,  // F-SO-12: verification entry の exit_code != 0 件数
+    "timeouts": <int>          // iter2 #3252519565: verification entry を残せなかった件数 (CB timeout + exit_without_verify_marker)
   }
 }
 ```
@@ -169,11 +170,11 @@ Step 4-3 の主題は **「サブエージェントの出力を別エージェ�
 
 - `verification_started` — Phase B (`oe_verify_spawn`) で emit (F6 反映)
 - `verification_completed` — Phase D (`oe_verify_emit_completed`) で emit (F6 反映)
-- `verification_protocol_error` — F-SO-2 反映、`@@OE_VERIFY:` 検出時に `OE_SCAN_EXIT_CODE` が非 0 だった場合に追加 emit
+- `verification_protocol_error` — F-SO-2 反映、2 ケースをカバー: (1) `@@OE_VERIFY:` 検出時に `OE_SCAN_EXIT_CODE` が非 0、(2) `@@OE_EXIT` が見えたが `@@OE_VERIFY` 未 emit (`exit_without_verify_marker`)
 
 ### 7. 不合格時のフロー
 
-不合格 (result=fail) でも engine は停止しない。CB / interrupt が発動しなかった場合のみ `cleanup.sh` 末尾で `wez notify "orchestration-engine session complete"` を呼び、本文に `session_id={} verification: pass={} fail={} warn={} fail_rate={}` を展開する (DI-6 + Q2 追加決定: fail 率を実運用データとして記録)。
+不合格 (result=fail) でも engine は停止しない。CB / interrupt が発動しなかった場合のみ `cleanup.sh` 末尾で `wez notify "orchestration-engine session complete"` を呼び、本文に `session_id={} verification: pass={} fail={} warn={} fail_rate={} protocol_errors={} timeouts={}` を展開する (DI-6 + Q2 追加決定: fail 率を実運用データとして記録、iter2 #3252519569 反映: protocol_errors / timeouts を notify に含めて誤った成功通知を防ぐ)。
 
 ### 8. スコープ外 (派生課題として記録)
 

--- a/projects/orchestration-engine/docs/episodes/2026-05-16-episode-step-4-3-implementation.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-16-episode-step-4-3-implementation.md
@@ -1,0 +1,263 @@
+---
+id: "01KRQA3H7WK03Y6TGN5ZZZBZG7"
+title: "Step 4-3 検証ゲート v1 実装エピソード (元実装 + so-compare レビュー反映)"
+date: 2026-05-16
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/19"
+    reason: "Epic #19 Phase 4 MVP 実装の Step 4-3"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/89"
+    reason: "Step 4-3 観測層 Issue (本エピソードの主スコープ)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-05-15-discussion-step-4-3-verification-gate.md"
+    reason: "Step 4-3 Discussion (QDD 全 7 Q closed)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-15-kickoff-step-4-3-verification-gate.md"
+    reason: "Step 4-3 KickOff (status: confirmed)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-15-plan-step-4-3-verification-gate.md"
+    reason: "Step 4-3 Plan (5 Phase 構成、so-compare 初回レビュー F1-F8 反映済み)"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/90"
+    reason: "Step 4-3 全成果物の PR (本エピソードの記録対象)"
+  - type: source_material
+    ref: "canonical/skills/adversarial-review/SKILL.md"
+    reason: "Compliance Review プロンプト規約 (engine が use_skills 経由で参照)"
+  - type: derived
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/91"
+    reason: "F-SO-7 派生 Issue: Step 4-4 着手前必須の AI CLI 起動オプション修正"
+  - type: derived
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/92"
+    reason: "F-SO-8/9 派生 Issue: Step 4-5 候補の変更ファイル検出 + 完了報告充実"
+  - type: derived
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/93"
+    reason: "F-SO-10/11 派生 Issue: MVP 後拡張候補の一時ファイル掃除 + nonce マーカー"
+tags: [orchestration, mvp, step-4-3, episode, implementation, so-compare, adversarial-review]
+---
+
+# Step 4-3 検証ゲート v1 実装エピソード
+
+> Plan ([`2026-05-15-plan-step-4-3-verification-gate.md`](../plans/2026-05-15-plan-step-4-3-verification-gate.md)) に従って 5 Phase で実装を行い、完了後に `so-compare` (Codex + Claude) で実装レビューを実施した記録。本エピソードは **(A) 元実装フェーズの記録**、**(B) so-compare レビュー結果**、**(C) F-SO 修正反映後の実装記録** を明確に分離して残す。
+
+## 概要
+
+| フェーズ | 期間 | 主な成果物 |
+|----------|------|-----------|
+| (A) 元実装 (Phase A〜E) | 2026-05-15 22:51 〜 2026-05-16 02:43 (JST) | `lib/verify.sh` 新規 + schema 拡張 + capture/cleanup/bin/oe/test_e2e_smoke 更新、8 テストスイート 280 assertions |
+| (B) so-compare 実装レビュー | 2026-05-16 02:52 〜 02:58 (JST) | Codex (133s) + Claude (344s) 並列、Critical 一致 3 件 + 高 Concern 多数 |
+| (C) F-SO 修正反映 | 2026-05-16 03:00 〜 03:29 (JST) | F-SO-1〜6 + F-SO-12 を 1 コミット (`4a05fe8`)、test_verify 85 → 98、全 293 assertions |
+| (D) 派生 Issue 起票 | 2026-05-16 (本エピソード作成時) | [#91](https://github.com/stlwolf/ai-development-hub/issues/91) / [#92](https://github.com/stlwolf/ai-development-hub/issues/92) / [#93](https://github.com/stlwolf/ai-development-hub/issues/93) |
+
+---
+
+## (A) 元実装フェーズ — Phase A〜E
+
+KickOff §進め方 + Plan §Phase 構造に従い 5 Phase で実装した。Plan の F1〜F8 (so-compare 初回レビュー、Plan ドキュメント段階) は実装着手前に反映済み。
+
+### Phase A — スキーマ拡張 + validator (DI-5) — `d6d258a`
+
+- `schemas/session-state.schema.json`: `verification` を **pane-keyed map** (target_pane_id をキー) として追加、`verification_summary` (集計) を追加。両方 optional
+- `schemas/audit-log.schema.json`: event_type に `verification_started` / `verification_completed` を追加
+- `scripts/validate-session-state.sh` 新規: jq ベース validator (必須フィールド + 型 + ULID パターン + verification map の構造 + summary 数値範囲)
+- `tests/test_kvs.sh`: legacy KVS / 拡張 KVS / 不正値の 3 ケース追加 (10 → 13 assertions)
+
+**設計判断:**
+- `verification` を単一オブジェクトではなく pane-keyed map にしたのは Plan F5 反映 (so-compare 初回レビューで Codex 指摘) で確定済み。実装段階で再確認済み
+- `validate-session-state.sh` は `validate-envelope.sh` をひな型にして対称性を維持
+
+### Phase B — 検証 envelope 生成 + spawn (DI-3 + DI-7(a)) — `da4866a`
+
+- `lib/verify.sh` 新規: `oe_verify_envelope_create()` + `oe_verify_spawn()`
+- envelope の `task.use_skills: [adversarial-review]` で疎結合 (Plan F4 反映: engine に skill prompt の static copy を持たない)
+- `task.exit_conditions.marker: "@@OE_VERIFY"` で engine プロトコルを envelope で指定
+- `verification_started` audit イベントは `oe_verify_spawn` 内で emit (Plan F6: emit 責務を Phase B に固定)
+- `tests/test_verify.sh` 新規 (32 assertions): wez モック経由で envelope 構造 + spawn フロー + audit emit を検証
+
+### Phase C — プロンプト構築 (DI-4) — `8baab8e`
+
+- `oe_verify_prompt_build()`: envelope の `task.description` + audit JSONL の最後の `state_change` + KVS の `outputs[]` から構造化マークダウン (3 セクション) を生成、`OE_VERIFY_PROMPT_PATH` でエクスポート
+- `oe_verify_envelope_create` に optional 6 引数目 `verify_prompt_path` を追加し、指定時に `task.read_docs` の 5 件目として注入 (Phase B 既存テスト後方互換)
+- `oe_verify_spawn` を `prompt_build` → `envelope_create (with prompt)` の順に統合
+- `outputs[]` が空の場合 `git diff --name-only` フォールバック (Plan F7 反映: MVP では常に git パスが選ばれる旨を明示)
+- test_verify.sh 拡張 (32 → 53 assertions): プロンプト構築 + フォールバック + envelope read_docs 5 件版
+
+### Phase D — マーカーパース + KVS 書き込み + 集計 (DI-7(b) + DI-5(書き込み)) — `db2f9a1`
+
+- `lib/constants.sh`: `OE_VERIFY_MARKER_RE='^@@OE_VERIFY:(pass|fail|warn)$'` を追加
+- `lib/capture.sh`: 戻り値を二値保持 (`OE_SCAN_EXIT_CODE` + `OE_SCAN_VERIFY_RESULT`、Plan F3 反映) に拡張、既存 `OE_SCAN_MARKER_TYPE` / `OE_SCAN_VALUE` は後方互換
+- `lib/verify.sh`: `oe_verify_write_kvs()` (pane-keyed map で per-pane 書き込み) + `oe_verify_summary_update()` (jq 集計 + awk fail_rate 3 桁丸め) + `oe_verify_emit_completed()` (Phase D 責務、Plan F6 反映)
+- `tests/test_capture.sh` 拡張: VERIFY パース 22 ケース (pass/fail/warn / 不正値 / 行頭アンカー / VERIFY+EXIT 同時検出) → 45 → 67 assertions
+- `tests/test_verify.sh` 拡張: KVS pane-keyed 書き込み + 集計 + emit_completed + F6 責務分離 → 53 → 85 assertions
+
+### Phase E — 発火統合 + 通知 + E2E (DI-2 + DI-6) — `5c402fc`
+
+- `lib/constants.sh`: `OE_VERIFY_MANAGED_PANES` / `OE_VERIFY_DONE_PANES` (Plan F2 反映: OE_MANAGED_PANES と分離) + `OE_VERIFY_PHASE_COMPLETED` フラグ
+- `lib/verify.sh`: `_oe_verify_generate_session_id` (ULID 形式 reviewer_session_id 生成) + `oe_verify_run_phase()` (独立ポーリングループ、Plan F1 反映: monitor.sh の責務範囲を膨らませない)
+- `bin/oe`: oe_monitor_loop 成功時のみ `oe_verify_run_phase` を呼ぶ (CB 発動時はスキップ)
+- `lib/cleanup.sh`: OE_VERIFY_MANAGED_PANES も kill 対象、`OE_VERIFY_PHASE_COMPLETED=1` のとき `wez notify` で完了通知 (DI-6)
+- `tests/test_e2e_smoke.sh` 拡張: wez モックを連番化 (target 777 / reviewer 888)、検証フェーズを含む 1 サイクル完走を確認 → 15 → 40 assertions
+
+### Phase E 完了時点の統計
+
+- 全 8 テストスイート 280 assertions PASS、shellcheck クリーン
+- KickOff §完了条件 8 項目すべて mock 経由で達成
+- 設計判断は Plan F1〜F8 反映方針に沿って着地
+
+---
+
+## (B) so-compare 実装レビュー (Codex + Claude 並列)
+
+Phase E 完走後、user 提案 + 私の同意で **so-compare** (Codex + Claude 並列) を実施した。前回 (Plan ドキュメント段階) の so-compare で F1〜F8 を反映済みのため、**今回は実装段階の "前提条件" と "設計判断"** にスコープを絞ったプロンプトで実施。
+
+### プロンプト設計
+
+`/tmp/so_impl_review_prompt.txt` (永続化なし、`tmp/so-20260516-025239/prompt.txt` に保存) に以下を明示:
+
+- 品質観点 (Bash 3.2 互換性の細部、命名、コード重複、shellcheck 警告等) はスコープ外、MVP のため
+- **「前提条件」レビュー観点 (6 点)**: AI CLI prompt 最小性、skill path 解決、VERIFY/EXIT 同時検出、CB タイムアウト、shared_kvs_path 意味、F3 後方互換
+- **「設計判断」レビュー観点**: 含む 6 観点の critical 部分
+- **「ゼロベース観点での見落とし発見」**: 私が flag していない設計判断・前提条件で「これは見落としではないか」と感じる点をすべて列挙してほしい
+
+### 結果概要
+
+| Reviewer | 経過 | 出力サイズ | 判定 |
+|----------|------|-----------|------|
+| Codex | 133s | 9613 bytes | **Critical** — 設計の小さな手戻りが必要 |
+| Claude | 344s | 15716 bytes | **Concern (条件付き)** — 設計判断レベルの手戻り不要、運用前ゲート 3 点必須 |
+
+両者一致の **Critical 3 点**:
+
+1. **AI CLI prompt の最小性**: `${ai_cli} --prompt` が実 CLI (`claude -p`, `codex -p`) と不整合。実 agent では起動エラー → silent failure
+2. **`@@OE_VERIFY:` 検出時の `@@OE_EXIT:` 軽視**: F3 二値保持を実装したのに `oe_verify_run_phase` 内ループで EXIT_CODE をチェックしていない。`exit_code=124` (timeout) や `exit_code=1` (failure) が並んでも verify_result を盲信する設計欠落
+3. **`Spec Compliant / Issues Found` → `@@OE_VERIFY:pass/fail/warn` マッピングが engine から検証 agent に伝達されない**: Discussion Q5 で決めたマッピングが task.description にも skill にも書かれていない
+
+両者一致の **Concern 多数**:
+
+- `context.shared_kvs_path` を target session の state ファイル (file path) に設定しているが、envelope schema の本来の意図 (UC-2 並列協調用ディレクトリパス) と乖離
+- `oe_verify_run_phase` から `ai_cli` が伝播されない (cursor ハードコード) - Plan §「未解決の細部」項目 1 の未実装
+- `MARKER_TYPE=VERIFY` (後方互換用) を将来 monitor.sh が誤って case で扱うリスク → コメントで明示すべき
+- 検証ペインの `wez pane capture --lines 50` で verbose な review 出力が枠外に流れる可能性
+- `task.description` で skill 規約を再記述する冗長性 (F4 と矛盾)
+
+### so-compare 結果ファイル
+
+- `tmp/so-20260516-025239/codex-stdout.txt`
+- `tmp/so-20260516-025239/claude-stdout.txt`
+- `tmp/so-20260516-025239/prompt.txt`
+
+(gitignore 対象、ローカル参照のみ)
+
+---
+
+## (C) F-SO 修正反映後の実装 — `4a05fe8`
+
+so-compare 結果を user と分類した結果、以下の振り分けで対応:
+
+- **本 PR で対応 (A グループ)**: F-SO-1, 2, 3, 4, 5, 6 + F-SO-12 (F-SO-2 の延長)
+- **派生 Issue 化 (B グループ)**: F-SO-7 (Step 4-4 必須) / F-SO-8, 9 (Step 4-5 候補) / F-SO-10, 11 (MVP 後拡張)
+
+### A グループ 7 件の修正内容
+
+| ID | 対応 | 影響箇所 |
+|----|------|----------|
+| **F-SO-1** | task.description に skill 出力 → @@OE_VERIFY マッピング明示 (`Spec Compliant → pass` / `Issues Found+Critical → fail` / `Spec Compliant+advisory → warn`) | `lib/verify.sh:oe_verify_envelope_create` |
+| **F-SO-2** | `OE_SCAN_EXIT_CODE` 非 0 のとき `verification_protocol_error` 監査 + KVS に `exit_code` 併記 | `lib/verify.sh:oe_verify_run_phase`、`oe_verify_write_kvs` (8 引数化)、`schemas/session-state.schema.json` (exit_code optional)、`schemas/audit-log.schema.json` (新 event type) |
+| **F-SO-3** | `context.shared_kvs_path` を `null` に (envelope schema 意図と整合)、KVS パスは `read_docs` のみで参照 | `lib/verify.sh:oe_verify_envelope_create` |
+| **F-SO-4** | `oe_capture_scan` に optional `lines` 引数 (デフォルト 50、検証ペインから 200 を渡す) | `lib/capture.sh:oe_capture_scan`、`lib/verify.sh:oe_verify_run_phase` |
+| **F-SO-5** | `capture.sh` コメントで `MARKER_TYPE=VERIFY` は検証専用、monitor.sh の case に追加しない旨を明示 | `lib/capture.sh:_oe_capture_scan_parse` (コメントのみ) |
+| **F-SO-6** | `OE_VERIFY_AI_CLI` 環境変数で検証 agent CLI 選択可能化 | `lib/verify.sh:oe_verify_run_phase`、`oe_verify_spawn` (5 引数目に伝播) |
+| **F-SO-12** | `oe_verify_summary_update` で `protocol_errors` を集計 (exit_code != 0 のエントリ数) | `lib/verify.sh:oe_verify_summary_update`、`schemas/session-state.schema.json` (protocol_errors optional)、`scripts/validate-session-state.sh` |
+
+### テスト追加
+
+- F-SO-1: task.description 内の `Spec Compliant` / `Issues Found` / `@@OE_VERIFY:pass|fail|warn` 各キーワード検証 (5 assertions)
+- F-SO-2: exit_code 記録 + 未指定時の欠落 + protocol_errors 集計 + validate-session-state.sh PASS (5 assertions)
+- F-SO-3: `context.shared_kvs_path = null` (1 assertion、既存「includes target session_id」を置き換え)
+- F-SO-4: `oe_capture_scan "888"` / `oe_capture_scan "888" 200` で `wez --lines` の値が変わる (2 assertions、subshell 内記録が消える bug を file 経由で回避)
+
+test_verify.sh: 85 → 98 assertions、全 PASS。全テストスイート 293 assertions PASS (回帰なし)。
+
+### F-SO 修正後の判定見込み (再 so-compare せず、Plan の Review 履歴セクション流儀)
+
+| 観点 | Codex 初回 | Claude 初回 | 修正後の見込み |
+|------|-----------|-------------|---------------|
+| (1) AI CLI prompt | Critical | Critical | **派生 Issue #91** で Step 4-4 着手前に対応 (本 PR スコープ外) |
+| (2) skill path 解決 | Concern | Concern | MVP 許容、運用昇格時に再評価 |
+| (3) VERIFY/EXIT 同時検出 | Critical | Concern | **F-SO-2 で解決** (Approved 見込み) |
+| (4) CB タイムアウト | Concern | Approved (条件付き) | MVP 許容、`OE_VERIFY_AI_CLI` の hook で将来チューニング可 |
+| (5) shared_kvs_path | Concern | Concern | **F-SO-3 で解決** (null に修正) |
+| (6) MARKER_TYPE=VERIFY 後方互換 | Concern | Concern | **F-SO-5 で解決** (コメント明示) |
+
+ゼロベース観点で発見された Critical:
+
+- **A. `Spec Compliant / Issues Found` → `pass/fail/warn` マッピング欠落** → **F-SO-1 で解決**
+- **B. AI CLI 命令が実 CLI 仕様と不整合** → **派生 Issue #91 で Step 4-4 着手前に対応**
+
+---
+
+## (D) 派生 Issue 起票 + Step 4-3 ロードマップ反映
+
+A グループ修正後に 3 派生 Issue を起票:
+
+| Issue | 内容 | スコープ | sub-issue of #19 |
+|-------|------|---------|------|
+| [#91](https://github.com/stlwolf/ai-development-hub/issues/91) | F-SO-7: AI CLI 起動オプションを実 CLI 仕様 (`claude -p` / `codex -p`) に修正 | **Step 4-4 着手前必須** | ✅ |
+| [#92](https://github.com/stlwolf/ai-development-hub/issues/92) | F-SO-8/9: 変更ファイル検出 per-pane 化 + 完了報告内容の充実 | **Step 4-5 候補** | ✅ |
+| [#93](https://github.com/stlwolf/ai-development-hub/issues/93) | F-SO-10/11: reviewer 一時ファイル掃除 + nonce 付きマーカー偽陽性対策 | **MVP 後拡張候補** | ❌ (Refs のみ) |
+
+これにより、本 PR を merge する時点で **「実 agent 動作可能性に懸念がある箇所」** が #91 として明示的にスケジュール化され、Step 4-4 KickOff の前提インプットとなる。
+
+---
+
+## 教訓 / 学び
+
+### 1. mock テストの限界 — 「mock では通るが実 agent では動かない」失敗モード
+
+Step 4-3 の E2E スモークは wez 完全 mock で 40 assertions が PASS する。しかし so-compare が指摘した「AI CLI 起動オプションが実 CLI と不整合」「skill load → マーカー emit の連鎖が agent good behavior に依存」は mock では検出できない。**MVP 段階で実 CLI 1 種で実 agent を 1 サイクル動かす E2E を別経路で持つ**ことが、本来 Step 4-2 / 4-3 のどこかで必要だった (現状は Step 4-4 でようやく対応予定)。
+
+### 2. 2 段階 so-compare (Plan ドキュメント段階 → 実装段階) の有効性
+
+Plan ドキュメント段階の so-compare (F1〜F8) は「設計の手戻り防止」に効いた。実装段階の so-compare (F-SO-1〜12) は「設計判断と実装の乖離」「ドキュメントで言及されたが実装で漏れた事項」「ゼロベースで見落とした暗黙の前提」を洗い出すのに効いた。**各段階で焦点が異なる**ため、両方やる価値がある。
+
+### 3. ゼロベース観点指示の有効性
+
+so-compare プロンプトで「私が flag していない設計判断・前提条件で『見落としではないか』と感じる点をすべて列挙してください」と明示したことで、私が認識していなかった **Critical: skill 出力 → @@OE_VERIFY マッピング欠落** が両者から指摘された。**reviewer に独自の批判視点を許容するプロンプト設計**が、見落とし発見の鍵。
+
+### 4. F1〜F8 (Plan 段階) と F-SO-1〜12 (実装段階) の独立性
+
+Plan 段階で確定した修正方針 (F4: skill prompt static copy 撤回 / F5: pane-keyed map / F6: emit 責務分離) は実装で踏襲できた。しかし新たに発見された Critical (F-SO-1, 2, 3) は **Plan 段階では見えなかった実装詳細**に起因する。**Plan レビュー → 実装レビューの 2 段階体制**は今後も維持する。
+
+### 5. ツール間引き継ぎ (Cursor → Claude Code) の dogfood 結果
+
+本 Step は KickOff (Cursor で起草) → Claude Code で継続作業の最初のケース。**駆動層ドキュメント (Discussion / KickOff / Plan) だけで Claude Code が継続できる**ことが実証された (実装中の追加情報要求は 1 件のみ = adversarial-review skill 内容の確認)。orchestration-engine の dogfood として有効性が確認された。
+
+---
+
+## 残課題 (本 PR 後)
+
+### 直近 (Step 4-4 着手前必須)
+
+- [#91](https://github.com/stlwolf/ai-development-hub/issues/91) AI CLI 起動オプションを実 CLI 仕様に修正
+- Step 4-4 のスコープ確定 (E2E 実 agent 1 サイクル完走を Discussion → KickOff → Plan で定義)
+
+### Step 4-5 候補
+
+- [#92](https://github.com/stlwolf/ai-development-hub/issues/92) 変更ファイル検出 per-pane 化 + 完了報告内容の充実
+- architecture-sketch.md の更新 (Step 4-3 で確定した検証ゲート設計を反映)
+
+### MVP 後拡張候補
+
+- [#93](https://github.com/stlwolf/ai-development-hub/issues/93) reviewer 一時ファイル掃除 + nonce 付きマーカー偽陽性対策
+
+---
+
+## 参照
+
+- 駆動層ドキュメント: [Discussion](../discussions/2026-05-15-discussion-step-4-3-verification-gate.md) / [KickOff](../plans/2026-05-15-kickoff-step-4-3-verification-gate.md) / [Plan](../plans/2026-05-15-plan-step-4-3-verification-gate.md)
+- ADR (本エピソードから蒸留): [`2026-05-16-decision-verification-gate-design.md`](../decisions/2026-05-16-decision-verification-gate-design.md)
+- so-compare 結果: `tmp/so-20260516-025239/` (ローカル参照)
+- 派生 Issue: [#91](https://github.com/stlwolf/ai-development-hub/issues/91) / [#92](https://github.com/stlwolf/ai-development-hub/issues/92) / [#93](https://github.com/stlwolf/ai-development-hub/issues/93)
+- 関連スキル: [adversarial-review](../../../../canonical/skills/adversarial-review/SKILL.md) / [kickoff-to-plan](../../../../canonical/skills/kickoff-to-plan/SKILL.md) / [so-compare](../../../../canonical/skills/so-compare/SKILL.md)

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -7,6 +7,11 @@ OE_SCAN_MARKER_TYPE=""
 OE_SCAN_VALUE=""
 OE_SCAN_BLOCKED="false"
 
+# Step 4-3 F3: 二値保持 — @@OE_EXIT: と @@OE_VERIFY: の同時検出に対応
+# (検証 agent の出力では shell が @@OE_EXIT:{code} を後置するため両方が並ぶ)
+OE_SCAN_EXIT_CODE=""
+OE_SCAN_VERIFY_RESULT=""
+
 # グローバル変数: oe_capture_classify() の戻り値
 OE_CLASSIFY_STATE=""
 
@@ -21,6 +26,8 @@ oe_capture_scan() {
   OE_SCAN_MARKER_TYPE=""
   OE_SCAN_VALUE=""
   OE_SCAN_BLOCKED="false"
+  OE_SCAN_EXIT_CODE=""
+  OE_SCAN_VERIFY_RESULT=""
 
   local captured
   captured="$(wez pane capture "$pane_id" --lines 50 2>/dev/null)" || return 0
@@ -33,12 +40,22 @@ oe_capture_scan() {
 
 # _oe_capture_scan_parse — capture 出力文字列をパースする内部関数
 # テスト容易性のために wez 呼び出しと分離
+#
+# Step 4-3 F3: 二値保持
+#   OE_SCAN_EXIT_CODE         @@OE_EXIT:{1-3 桁} 検出時の値
+#   OE_SCAN_VERIFY_RESULT     @@OE_VERIFY:(pass|fail|warn) 検出時の値
+#   OE_SCAN_MARKER_TYPE/VALUE 後方互換のため残す:
+#     - EXIT 検出時 → MARKER_TYPE=EXIT, VALUE=exit_code (従来通り)
+#     - VERIFY のみ検出時 → MARKER_TYPE=VERIFY, VALUE=verify_result
+#     - 両方検出時 → MARKER_TYPE=EXIT (既存 monitor.sh への影響最小化、verify.sh は新変数を直接参照)
 _oe_capture_scan_parse() {
   local input="$1"
 
   OE_SCAN_MARKER_TYPE=""
   OE_SCAN_VALUE=""
   OE_SCAN_BLOCKED="false"
+  OE_SCAN_EXIT_CODE=""
+  OE_SCAN_VERIFY_RESULT=""
 
   local line
   while IFS= read -r line; do
@@ -47,10 +64,22 @@ _oe_capture_scan_parse() {
     fi
 
     if [[ "$line" =~ $OE_EXIT_MARKER_RE ]]; then
-      OE_SCAN_MARKER_TYPE="EXIT"
-      OE_SCAN_VALUE="${BASH_REMATCH[1]}"
+      OE_SCAN_EXIT_CODE="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ "$line" =~ $OE_VERIFY_MARKER_RE ]]; then
+      OE_SCAN_VERIFY_RESULT="${BASH_REMATCH[1]}"
     fi
   done <<< "$input"
+
+  # 後方互換: MARKER_TYPE / VALUE を設定
+  if [[ -n "$OE_SCAN_EXIT_CODE" ]]; then
+    OE_SCAN_MARKER_TYPE="EXIT"
+    OE_SCAN_VALUE="$OE_SCAN_EXIT_CODE"
+  elif [[ -n "$OE_SCAN_VERIFY_RESULT" ]]; then
+    OE_SCAN_MARKER_TYPE="VERIFY"
+    OE_SCAN_VALUE="$OE_SCAN_VERIFY_RESULT"
+  fi
 }
 
 # oe_capture_classify — exit code を failure-taxonomy 6 値に分類

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -22,6 +22,7 @@ OE_CLASSIFY_STATE=""
 #   マーカー未検出時は両方空文字
 oe_capture_scan() {
   local pane_id="$1"
+  local lines="${2:-50}"  # F-SO-4: 検証ペインなど verbose 出力を扱うケースでは呼び出し側が 200 を渡す
 
   OE_SCAN_MARKER_TYPE=""
   OE_SCAN_VALUE=""
@@ -30,7 +31,7 @@ oe_capture_scan() {
   OE_SCAN_VERIFY_RESULT=""
 
   local captured
-  captured="$(wez pane capture "$pane_id" --lines 50 2>/dev/null)" || return 0
+  captured="$(wez pane capture "$pane_id" --lines "$lines" 2>/dev/null)" || return 0
 
   local normalized
   normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g')"
@@ -73,6 +74,11 @@ _oe_capture_scan_parse() {
   done <<< "$input"
 
   # 後方互換: MARKER_TYPE / VALUE を設定
+  #
+  # 重要 (F-SO-5): MARKER_TYPE="VERIFY" は **検証専用ループ (oe_verify_run_phase) からのみ参照される
+  # 後方互換の内部値**。monitor.sh の case "$OE_SCAN_MARKER_TYPE" に "VERIFY)" 分岐を**追加してはならない**。
+  # 通常 agent ペインで偶発的に @@OE_VERIFY: が出現した場合、誤動作の原因になる。
+  # 検証側は OE_SCAN_VERIFY_RESULT を直接参照する設計 (lib/verify.sh:oe_verify_run_phase)。
   if [[ -n "$OE_SCAN_EXIT_CODE" ]]; then
     OE_SCAN_MARKER_TYPE="EXIT"
     OE_SCAN_VALUE="$OE_SCAN_EXIT_CODE"

--- a/projects/orchestration-engine/lib/cleanup.sh
+++ b/projects/orchestration-engine/lib/cleanup.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# cleanup.sh — trap ハンドラ: ペイン削除 + /tmp 削除（source 専用）
+# cleanup.sh — trap ハンドラ: ペイン削除 + /tmp 削除 + wez notify（source 専用）
 
 oe_cleanup() {
   [[ -n "${OE_CLEANUP_DONE:-}" ]] && return 0
@@ -7,11 +7,25 @@ oe_cleanup() {
 
   trap - EXIT INT TERM
 
-  local killed_json='[]'
+  # 防御的初期化: 未宣言でも安全に動作するよう (test_cleanup.sh のように
+  # constants.sh を source せず cleanup.sh 単独で source されるケースに備える)
+  declare -p OE_MANAGED_PANES >/dev/null 2>&1 || OE_MANAGED_PANES=()
+  declare -p OE_VERIFY_MANAGED_PANES >/dev/null 2>&1 || OE_VERIFY_MANAGED_PANES=()
+
+  # 通常ペイン + 検証ペイン (OE_VERIFY_MANAGED_PANES) の両方を kill 対象に
+  local all_panes=()
   if [[ ${#OE_MANAGED_PANES[@]} -gt 0 ]]; then
+    all_panes+=("${OE_MANAGED_PANES[@]}")
+  fi
+  if [[ ${#OE_VERIFY_MANAGED_PANES[@]} -gt 0 ]]; then
+    all_panes+=("${OE_VERIFY_MANAGED_PANES[@]}")
+  fi
+
+  local killed_json='[]'
+  if [[ ${#all_panes[@]} -gt 0 ]]; then
     local pane_id
     local ids_lines=""
-    for pane_id in "${OE_MANAGED_PANES[@]}"; do
+    for pane_id in "${all_panes[@]}"; do
       [[ -n "$pane_id" ]] || continue
       ids_lines+="${pane_id}"$'\n'
       wez pane kill "$pane_id" 2>/dev/null || true
@@ -29,7 +43,37 @@ oe_cleanup() {
       [[ -e "$tmp_path" ]] || continue
       rm -f "$tmp_path" 2>/dev/null || true
     done
+
+    # 検証 agent の一時ファイル (reviewer_session_id 起点) も削除
+    local reviewer_pane
+    for reviewer_pane in "${OE_VERIFY_MANAGED_PANES[@]}"; do
+      # reviewer ファイルは reviewer_session_id ベース。pane_id では特定できないため
+      # /tmp/oe-*-verify-{envelope.json,inputs.md} を一括掃除する想定だが、
+      # 他セッションの一時ファイルに影響を出さないよう、ここではセッション内で
+      # 生成された reviewer envelope/inputs は OS の /tmp 自動掃除に任せる。
+      : "$reviewer_pane"
+    done
+
     oe_audit_emit "cleanup" "$session_id" 0 "" "$payload_json" || true
+
+    # DI-6: 検証フェーズ完走時は wez notify で完了通知 (CB / interrupt 時はスキップ)
+    # KVS から verification_summary を読み、本文に展開
+    if [[ "${OE_VERIFY_PHASE_COMPLETED:-0}" -eq 1 ]]; then
+      local state_file="${OE_STATE_DIR}/${session_id}.state.json"
+      local notify_body
+      if [[ -f "$state_file" ]] && jq -e '.verification_summary' "$state_file" >/dev/null 2>&1; then
+        local s_pass s_fail s_warn s_rate
+        s_pass="$(jq -r '.verification_summary.passed' "$state_file")"
+        s_fail="$(jq -r '.verification_summary.failed' "$state_file")"
+        s_warn="$(jq -r '.verification_summary.warned' "$state_file")"
+        s_rate="$(jq -r '.verification_summary.fail_rate' "$state_file")"
+        notify_body="session_id=${session_id}, verification: pass=${s_pass}, fail=${s_fail}, warn=${s_warn}, fail_rate=${s_rate}"
+      else
+        notify_body="session_id=${session_id} (no verification_summary)"
+      fi
+      # best-effort: notify 失敗は engine 終了に影響させない
+      wez notify "orchestration-engine session complete" "$notify_body" 2>/dev/null || true
+    fi
   fi
 
   return 0

--- a/projects/orchestration-engine/lib/cleanup.sh
+++ b/projects/orchestration-engine/lib/cleanup.sh
@@ -56,18 +56,24 @@ oe_cleanup() {
 
     oe_audit_emit "cleanup" "$session_id" 0 "" "$payload_json" || true
 
-    # DI-6: 検証フェーズ完走時は wez notify で完了通知 (CB / interrupt 時はスキップ)
-    # KVS から verification_summary を読み、本文に展開
+    # DI-6: 検証フェーズが走った場合は wez notify で完了通知
+    # (monitor の CB / interrupt で検証フェーズに到達しなかった場合は OE_VERIFY_PHASE_COMPLETED=0 のままスキップ)
+    #
+    # Copilot #2 反映: OE_VERIFY_PHASE_COMPLETED=1 は「検証フェーズが走った」事実を示す。
+    #                   timeouts / protocol_errors は notify 本文で別途明示する。
+    # Copilot #8 反映: protocol_errors + timeouts を notify 本文に含めることで誤った成功通知を防ぐ。
     if [[ "${OE_VERIFY_PHASE_COMPLETED:-0}" -eq 1 ]]; then
       local state_file="${OE_STATE_DIR}/${session_id}.state.json"
       local notify_body
       if [[ -f "$state_file" ]] && jq -e '.verification_summary' "$state_file" >/dev/null 2>&1; then
-        local s_pass s_fail s_warn s_rate
+        local s_pass s_fail s_warn s_rate s_protocol s_timeouts
         s_pass="$(jq -r '.verification_summary.passed' "$state_file")"
         s_fail="$(jq -r '.verification_summary.failed' "$state_file")"
         s_warn="$(jq -r '.verification_summary.warned' "$state_file")"
         s_rate="$(jq -r '.verification_summary.fail_rate' "$state_file")"
-        notify_body="session_id=${session_id}, verification: pass=${s_pass}, fail=${s_fail}, warn=${s_warn}, fail_rate=${s_rate}"
+        s_protocol="$(jq -r '.verification_summary.protocol_errors // 0' "$state_file")"
+        s_timeouts="$(jq -r '.verification_summary.timeouts // 0' "$state_file")"
+        notify_body="session_id=${session_id}, verification: pass=${s_pass}, fail=${s_fail}, warn=${s_warn}, fail_rate=${s_rate}, protocol_errors=${s_protocol}, timeouts=${s_timeouts}"
       else
         notify_body="session_id=${session_id} (no verification_summary)"
       fi

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -36,3 +36,10 @@ OE_STATE_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/state"
 
 # 監査ログパス
 OE_AUDIT_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/audit"
+
+# Step 4-3 Phase E: 検証ペイン管理用配列 (F2: 通常ペイン OE_MANAGED_PANES / OE_DONE_PANES と分離)
+OE_VERIFY_MANAGED_PANES=()
+OE_VERIFY_DONE_PANES=()
+
+# Step 4-3 Phase E: 検証フェーズ完走フラグ (cleanup の wez notify 発火条件、CB 発動時は未設定のまま)
+OE_VERIFY_PHASE_COMPLETED=0

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -8,6 +8,9 @@ OE_MARKER_PREFIX="@@OE_"
 # EXIT マーカー正規表現（行頭・行末アンカー付き）
 OE_EXIT_MARKER_RE='^@@OE_EXIT:([0-9]{1,3})$'
 
+# VERIFY マーカー正規表現 (Step 4-3 検証ゲート v1、行頭・行末アンカー付き)
+OE_VERIFY_MARKER_RE='^@@OE_VERIFY:(pass|fail|warn)$'
+
 # 将来マーカー種別の予約（MVP では未使用）:
 #   @@OE_STATUS:{state}  — 進捗状態の報告
 #   @@OE_READY           — サブエージェント準備完了

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -1,0 +1,147 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# verify.sh — Step 4-3 検証ゲート v1 関数群（source 専用）
+#
+# 責務:
+#   - 検証用 envelope の生成（adversarial-review skill を use_skills + read_docs で疎結合指定）
+#   - 検証 agent ペインの spawn と verification_started イベント emit
+#   - Phase C で oe_verify_prompt_build を追加（3 入力の構造化抽出）
+#   - Phase D で @@OE_VERIFY: パース + KVS pane-keyed map 書き込み + verification_completed emit を追加
+#   - Phase E で oe_verify_run_phase の独立ループを追加
+#
+# 設計方針 (Plan F4 / DI-7):
+#   engine は skill prompt の static copy を持たない。検証 agent が envelope の
+#   use_skills: ["adversarial-review"] と read_docs から skill を読み、Compliance Review を実行する。
+
+# グローバル変数: oe_verify_envelope_create / oe_verify_spawn の戻り値
+OE_VERIFY_ENVELOPE_PATH=""
+OE_VERIFY_PANE_ID=""
+
+# oe_verify_envelope_create — 検証用 envelope を生成し validate-envelope.sh で検証
+#
+# 引数:
+#   reviewer_session_id   検証 agent のセッション ID (ULID)
+#   reviewer_pane_id      検証 agent が起動するペイン ID (oe_spawn_prepare_pane の出力)
+#   target_pane_id        被検証ペイン ID
+#   target_session_id     被検証セッション ID (= bin/oe メインの session_id)
+#   target_envelope_path  被検証ペインの envelope JSON のパス
+#
+# 戻り値: OE_VERIFY_ENVELOPE_PATH に生成ファイルパスを設定
+# 検証失敗時は exit 1 (set -e による自動終了)
+oe_verify_envelope_create() {
+  local reviewer_session_id="$1"
+  local reviewer_pane_id="$2"
+  local target_pane_id="$3"
+  local target_session_id="$4"
+  local target_envelope_path="$5"
+
+  OE_VERIFY_ENVELOPE_PATH=""
+
+  local envelope_path="/tmp/oe-${reviewer_session_id}-verify-envelope.json"
+
+  # skill のパス: PROJECT_DIR からの相対で canonical/skills/adversarial-review/SKILL.md
+  # (リポジトリルートは PROJECT_DIR の親の親)
+  local repo_root
+  repo_root="$(cd "${PROJECT_DIR}/../.." && pwd)"
+  local skill_path="${repo_root}/canonical/skills/adversarial-review/SKILL.md"
+  local audit_path="${OE_AUDIT_DIR}/${target_session_id}.jsonl"
+  local kvs_path="${OE_STATE_DIR}/${target_session_id}.state.json"
+
+  # task.description は検証指示の概要のみ。skill prompt 本文は engine に持たない (F4)
+  local task_desc
+  task_desc="Compliance Review per the adversarial-review skill. Read the inputs in read_docs and emit one of: @@OE_VERIFY:pass / @@OE_VERIFY:fail / @@OE_VERIFY:warn on a new line based on your conclusion before exit."
+
+  jq -n \
+    --arg sid "$reviewer_session_id" \
+    --argjson pid "$reviewer_pane_id" \
+    --arg desc "$task_desc" \
+    --arg odir "$PROJECT_DIR" \
+    --argjson timeout "$OE_CB_TIMEOUT" \
+    --arg skill "$skill_path" \
+    --arg tenv "$target_envelope_path" \
+    --arg taudit "$audit_path" \
+    --arg tkvs "$kvs_path" \
+    --arg parent "$target_session_id" \
+    --argjson max_panes "$OE_CB_MAX_PANES" \
+    '{
+      session_id: $sid,
+      pane_id: $pid,
+      task: {
+        description: $desc,
+        output_dir: $odir,
+        exit_conditions: {
+          marker: "@@OE_VERIFY",
+          timeout_seconds: $timeout
+        },
+        read_docs: [$skill, $tenv, $taudit, $tkvs],
+        use_skills: ["adversarial-review"]
+      },
+      context: {
+        parent_session_id: $parent,
+        related_issues: [],
+        shared_kvs_path: $tkvs
+      },
+      constraints: {
+        max_panes: $max_panes,
+        state_vocabulary: ["spawn","ready","progress","done","blocked"]
+      }
+    }' > "$envelope_path"
+
+  "${PROJECT_DIR}/scripts/validate-envelope.sh" "$envelope_path" >/dev/null
+
+  OE_VERIFY_ENVELOPE_PATH="$envelope_path"
+}
+
+# oe_verify_spawn — 検証 agent ペインを準備 + envelope 生成 + 送信 + verification_started emit
+#
+# 引数:
+#   reviewer_session_id   検証 agent のセッション ID (ULID)
+#   target_pane_id        被検証ペイン ID
+#   target_session_id     被検証セッション ID
+#   target_envelope_path  被検証ペインの envelope JSON のパス
+#   [ai_cli]              使用する AI CLI (デフォルト: "cursor")
+#
+# 戻り値:
+#   OE_VERIFY_PANE_ID         検証 agent ペイン ID
+#   OE_VERIFY_ENVELOPE_PATH   検証用 envelope パス
+oe_verify_spawn() {
+  local reviewer_session_id="$1"
+  local target_pane_id="$2"
+  local target_session_id="$3"
+  local target_envelope_path="$4"
+  local ai_cli="${5:-cursor}"
+
+  OE_VERIFY_PANE_ID=""
+
+  # 検証 agent 用ペインを準備 (Step 4-2 の lib/spawn.sh を再利用)
+  oe_spawn_prepare_pane
+  local reviewer_pane_id="$OE_SPAWN_PANE_ID"
+
+  oe_verify_envelope_create \
+    "$reviewer_session_id" \
+    "$reviewer_pane_id" \
+    "$target_pane_id" \
+    "$target_session_id" \
+    "$target_envelope_path"
+
+  # 送信コマンド: ai_cli に envelope を読ませる + 末尾で shell が @@OE_EXIT を emit
+  # 検証 agent 自身は task.description / skill の指示に従って @@OE_VERIFY:{result} を出力する。
+  # 二値 (@@OE_VERIFY + @@OE_EXIT) の同時検出は Phase D F3 の二値保持で対応する。
+  local cli_command
+  cli_command="${ai_cli} --prompt 'Read ${OE_VERIFY_ENVELOPE_PATH} and execute the task' ; printf '\\n@@OE_EXIT:%d\\n' \$?"
+
+  wez pane send "$reviewer_pane_id" "$cli_command"
+
+  # verification_started イベントを target session の audit log に emit (F6: emit は Phase B のみ)
+  local payload
+  payload="$(jq -cn \
+    --argjson tpid "$target_pane_id" \
+    --arg tsid "$target_session_id" \
+    --argjson rpid "$reviewer_pane_id" \
+    --arg rsid "$reviewer_session_id" \
+    '{target_pane_id: $tpid, target_session_id: $tsid, reviewer_pane_id: $rpid, reviewer_session_id: $rsid}')"
+
+  oe_audit_emit "verification_started" "$target_session_id" "$target_pane_id" "" "$payload"
+
+  OE_VERIFY_PANE_ID="$reviewer_pane_id"
+}

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -13,18 +13,21 @@
 #   engine は skill prompt の static copy を持たない。検証 agent が envelope の
 #   use_skills: ["adversarial-review"] と read_docs から skill を読み、Compliance Review を実行する。
 
-# グローバル変数: oe_verify_envelope_create / oe_verify_spawn の戻り値
+# グローバル変数: oe_verify_envelope_create / oe_verify_spawn / oe_verify_prompt_build の戻り値
 OE_VERIFY_ENVELOPE_PATH=""
 OE_VERIFY_PANE_ID=""
+OE_VERIFY_PROMPT_PATH=""
 
 # oe_verify_envelope_create — 検証用 envelope を生成し validate-envelope.sh で検証
 #
 # 引数:
-#   reviewer_session_id   検証 agent のセッション ID (ULID)
-#   reviewer_pane_id      検証 agent が起動するペイン ID (oe_spawn_prepare_pane の出力)
-#   target_pane_id        被検証ペイン ID
-#   target_session_id     被検証セッション ID (= bin/oe メインの session_id)
-#   target_envelope_path  被検証ペインの envelope JSON のパス
+#   reviewer_session_id    検証 agent のセッション ID (ULID)
+#   reviewer_pane_id       検証 agent が起動するペイン ID (oe_spawn_prepare_pane の出力)
+#   target_pane_id         被検証ペイン ID
+#   target_session_id      被検証セッション ID (= bin/oe メインの session_id)
+#   target_envelope_path   被検証ペインの envelope JSON のパス
+#   [verify_prompt_path]   Phase C で oe_verify_prompt_build が生成した 3 入力ファイル (optional)
+#                          指定時は read_docs に 5 件目として追加 (Phase B 後方互換)
 #
 # 戻り値: OE_VERIFY_ENVELOPE_PATH に生成ファイルパスを設定
 # 検証失敗時は exit 1 (set -e による自動終了)
@@ -34,6 +37,7 @@ oe_verify_envelope_create() {
   local target_pane_id="$3"
   local target_session_id="$4"
   local target_envelope_path="$5"
+  local verify_prompt_path="${6:-}"
 
   OE_VERIFY_ENVELOPE_PATH=""
 
@@ -51,15 +55,32 @@ oe_verify_envelope_create() {
   local task_desc
   task_desc="Compliance Review per the adversarial-review skill. Read the inputs in read_docs and emit one of: @@OE_VERIFY:pass / @@OE_VERIFY:fail / @@OE_VERIFY:warn on a new line based on your conclusion before exit."
 
+  # read_docs 配列を構築 (verify_prompt_path が指定されたら 5 件目に追加)
+  local read_docs_json
+  if [[ -n "$verify_prompt_path" ]]; then
+    read_docs_json="$(jq -cn \
+      --arg skill "$skill_path" \
+      --arg tenv "$target_envelope_path" \
+      --arg taudit "$audit_path" \
+      --arg tkvs "$kvs_path" \
+      --arg tprompt "$verify_prompt_path" \
+      '[$skill, $tenv, $taudit, $tkvs, $tprompt]')"
+  else
+    read_docs_json="$(jq -cn \
+      --arg skill "$skill_path" \
+      --arg tenv "$target_envelope_path" \
+      --arg taudit "$audit_path" \
+      --arg tkvs "$kvs_path" \
+      '[$skill, $tenv, $taudit, $tkvs]')"
+  fi
+
   jq -n \
     --arg sid "$reviewer_session_id" \
     --argjson pid "$reviewer_pane_id" \
     --arg desc "$task_desc" \
     --arg odir "$PROJECT_DIR" \
     --argjson timeout "$OE_CB_TIMEOUT" \
-    --arg skill "$skill_path" \
-    --arg tenv "$target_envelope_path" \
-    --arg taudit "$audit_path" \
+    --argjson read_docs "$read_docs_json" \
     --arg tkvs "$kvs_path" \
     --arg parent "$target_session_id" \
     --argjson max_panes "$OE_CB_MAX_PANES" \
@@ -73,7 +94,7 @@ oe_verify_envelope_create() {
           marker: "@@OE_VERIFY",
           timeout_seconds: $timeout
         },
-        read_docs: [$skill, $tenv, $taudit, $tkvs],
+        read_docs: $read_docs,
         use_skills: ["adversarial-review"]
       },
       context: {
@@ -92,7 +113,91 @@ oe_verify_envelope_create() {
   OE_VERIFY_ENVELOPE_PATH="$envelope_path"
 }
 
-# oe_verify_spawn — 検証 agent ペインを準備 + envelope 生成 + 送信 + verification_started emit
+# oe_verify_prompt_build — Compliance Review に渡す 3 入力 (要件・完了報告・変更ファイル) を
+# envelope / audit JSONL / KVS から抽出し、構造化マークダウンとして書き出す。
+#
+# 引数:
+#   reviewer_session_id   検証 agent のセッション ID (出力ファイル名に使用)
+#   target_pane_id        被検証ペイン ID (未使用、将来拡張用、API 安定化のため引数として保持)
+#   target_session_id     被検証セッション ID (audit / KVS パスの解決に使用)
+#   target_envelope_path  被検証ペインの envelope JSON のパス
+#
+# 戻り値: OE_VERIFY_PROMPT_PATH に生成ファイルパスを設定
+#
+# F4: engine は skill prompt 本文を組み立てない。3 入力の構造化抽出のみ。
+#     検証 agent が use_skills + read_docs で skill を読んで自分でプロンプトを組み立てる。
+# F7: outputs[] は MVP では常に空配列のため、git diff --name-only パスが常時選択される。
+#     outputs[] の書き込み拡張は本 Step スコープ外。
+oe_verify_prompt_build() {
+  local reviewer_session_id="$1"
+  # shellcheck disable=SC2034  # API 安定化のため引数として保持 (将来 per-pane 拡張で使用予定)
+  local target_pane_id="$2"
+  local target_session_id="$3"
+  local target_envelope_path="$4"
+
+  OE_VERIFY_PROMPT_PATH=""
+
+  local prompt_path="/tmp/oe-${reviewer_session_id}-verify-inputs.md"
+  local audit_path="${OE_AUDIT_DIR}/${target_session_id}.jsonl"
+  local kvs_path="${OE_STATE_DIR}/${target_session_id}.state.json"
+
+  # 要件: target envelope の task.description (envelope は事前に存在する前提)
+  local task_description
+  if [[ -f "$target_envelope_path" ]]; then
+    task_description="$(jq -r '.task.description // "(no description)"' "$target_envelope_path")"
+  else
+    task_description="(target envelope not found: $target_envelope_path)"
+  fi
+
+  # 完了報告: audit JSONL から最後の state_change イベントを抽出
+  local last_state_change
+  if [[ -f "$audit_path" ]]; then
+    last_state_change="$(jq -s 'map(select(.event_type == "state_change")) | last // null' "$audit_path")"
+    if [[ "$last_state_change" == "null" ]]; then
+      last_state_change="(no state_change events recorded in audit log)"
+    fi
+  else
+    last_state_change="(audit log not found: $audit_path)"
+  fi
+
+  # 変更ファイル: KVS の outputs[] を優先、空なら git diff --name-only にフォールバック (F7)
+  local changed_files_block
+  local outputs_count=0
+  if [[ -f "$kvs_path" ]]; then
+    outputs_count="$(jq '(.outputs // []) | length' "$kvs_path")"
+  fi
+
+  if [[ "$outputs_count" -gt 0 ]]; then
+    changed_files_block="$(jq -r '.outputs[] | "- " + .' "$kvs_path")"
+  else
+    # フォールバック: git diff --name-only (MVP では常にこちらが選択される)
+    local git_output
+    if git_output="$(git diff --name-only 2>/dev/null)" && [[ -n "$git_output" ]]; then
+      changed_files_block="$(printf '%s\n' "$git_output" | awk 'NF { print "- " $0 }')"
+    else
+      changed_files_block="(no changes detected from KVS outputs[] or git diff)"
+    fi
+  fi
+
+  # 構造化マークダウンとして書き出し
+  {
+    printf '# Compliance Review Inputs\n\n'
+    printf 'reviewer_session_id: %s\n' "$reviewer_session_id"
+    printf 'target_session_id: %s\n' "$target_session_id"
+    printf 'target_pane_id: %s\n\n' "$target_pane_id"
+    printf '## 要件 (Task description)\n\n'
+    printf '%s\n\n' "$task_description"
+    printf '## 完了報告 (Latest state_change event)\n\n'
+    # shellcheck disable=SC2016  # backticks in single quotes are literal Markdown fences here
+    printf '```json\n%s\n```\n\n' "$last_state_change"
+    printf '## 変更ファイル (Changed files)\n\n'
+    printf '%s\n' "$changed_files_block"
+  } > "$prompt_path"
+
+  OE_VERIFY_PROMPT_PATH="$prompt_path"
+}
+
+# oe_verify_spawn — 検証 agent ペインを準備 + プロンプト構築 + envelope 生成 + 送信 + verification_started emit
 #
 # 引数:
 #   reviewer_session_id   検証 agent のセッション ID (ULID)
@@ -104,6 +209,7 @@ oe_verify_envelope_create() {
 # 戻り値:
 #   OE_VERIFY_PANE_ID         検証 agent ペイン ID
 #   OE_VERIFY_ENVELOPE_PATH   検証用 envelope パス
+#   OE_VERIFY_PROMPT_PATH     構築されたプロンプト (3 入力) ファイルパス
 oe_verify_spawn() {
   local reviewer_session_id="$1"
   local target_pane_id="$2"
@@ -117,12 +223,21 @@ oe_verify_spawn() {
   oe_spawn_prepare_pane
   local reviewer_pane_id="$OE_SPAWN_PANE_ID"
 
+  # Phase C: プロンプト (3 入力の構造化抽出) を先に構築
+  oe_verify_prompt_build \
+    "$reviewer_session_id" \
+    "$target_pane_id" \
+    "$target_session_id" \
+    "$target_envelope_path"
+
+  # envelope 生成 (read_docs に OE_VERIFY_PROMPT_PATH を含む 5 件)
   oe_verify_envelope_create \
     "$reviewer_session_id" \
     "$reviewer_pane_id" \
     "$target_pane_id" \
     "$target_session_id" \
-    "$target_envelope_path"
+    "$target_envelope_path" \
+    "$OE_VERIFY_PROMPT_PATH"
 
   # 送信コマンド: ai_cli に envelope を読ませる + 末尾で shell が @@OE_EXIT を emit
   # 検証 agent 自身は task.description / skill の指示に従って @@OE_VERIFY:{result} を出力する。

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -260,3 +260,137 @@ oe_verify_spawn() {
 
   OE_VERIFY_PANE_ID="$reviewer_pane_id"
 }
+
+# oe_verify_write_kvs — Step 4-3 Phase D: 検証結果を KVS の verification (pane-keyed map) に書き込む
+#
+# 引数:
+#   target_session_id     被検証セッション ID
+#   target_pane_id        被検証ペイン ID (verification map のキー)
+#   reviewer_session_id   検証 agent セッション ID
+#   reviewer_pane_id      検証 agent ペイン ID
+#   result                "pass" | "fail" | "warn" (@@OE_VERIFY: の値)
+#   [issues_count]        skill 出力からの問題件数 (デフォルト 0)
+#   [marker_raw]          捕捉したマーカー原文 (デフォルト "@@OE_VERIFY:{result}")
+#
+# F5 反映: pane-keyed map で書き込む。既存 verification map に他 pane エントリがあれば維持する。
+# atomic rename パターン (Step 4-2 oe_capture_write_kvs と同様)。
+oe_verify_write_kvs() {
+  local target_session_id="$1"
+  local target_pane_id="$2"
+  local reviewer_session_id="$3"
+  local reviewer_pane_id="$4"
+  local result="$5"
+  local issues_count="${6:-0}"
+  local marker_raw="${7:-@@OE_VERIFY:${result}}"
+
+  local state_file="${OE_STATE_DIR}/${target_session_id}.state.json"
+  local tmp_file="${OE_STATE_DIR}/.${target_session_id}.state.json.$$"
+
+  if [[ ! -f "$state_file" ]]; then
+    echo "oe_verify_write_kvs: state file not found: $state_file" >&2
+    return 1
+  fi
+
+  local completed_at
+  completed_at="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
+
+  # verification.{target_pane_id} を更新 (既存 map は維持)
+  jq \
+    --arg pid "$target_pane_id" \
+    --arg result "$result" \
+    --arg rsid "$reviewer_session_id" \
+    --argjson rpid "$reviewer_pane_id" \
+    --argjson issues "$issues_count" \
+    --arg marker_raw "$marker_raw" \
+    --arg completed_at "$completed_at" \
+    '.verification = ((.verification // {}) | .[$pid] = {
+       result: $result,
+       reviewer_session_id: $rsid,
+       reviewer_pane_id: $rpid,
+       issues_count: $issues,
+       marker_raw: $marker_raw,
+       completed_at: $completed_at
+     })' \
+    "$state_file" > "$tmp_file"
+
+  mv -f "$tmp_file" "$state_file"
+  return 0
+}
+
+# oe_verify_summary_update — KVS の verification map を集計し verification_summary に書き込む
+#
+# 引数: target_session_id
+#
+# total = verification map のキー数
+# passed/failed/warned = 各 result 値の件数
+# fail_rate = failed / total を awk で 3 桁丸め (Bash 3.2 整数演算回避)
+oe_verify_summary_update() {
+  local target_session_id="$1"
+
+  local state_file="${OE_STATE_DIR}/${target_session_id}.state.json"
+  local tmp_file="${OE_STATE_DIR}/.${target_session_id}.state.json.$$"
+
+  if [[ ! -f "$state_file" ]]; then
+    echo "oe_verify_summary_update: state file not found: $state_file" >&2
+    return 1
+  fi
+
+  local total passed failed warned
+  total="$(jq '(.verification // {}) | length' "$state_file")"
+  passed="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "pass")) | length' "$state_file")"
+  failed="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "fail")) | length' "$state_file")"
+  warned="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "warn")) | length' "$state_file")"
+
+  local fail_rate
+  if [[ "$total" -gt 0 ]]; then
+    fail_rate="$(awk -v f="$failed" -v t="$total" 'BEGIN{ printf "%.3f", f/t }')"
+  else
+    fail_rate="0.000"
+  fi
+
+  jq \
+    --argjson total "$total" \
+    --argjson passed "$passed" \
+    --argjson failed "$failed" \
+    --argjson warned "$warned" \
+    --argjson fail_rate "$fail_rate" \
+    '.verification_summary = {
+       total: $total,
+       passed: $passed,
+       failed: $failed,
+       warned: $warned,
+       fail_rate: $fail_rate
+     }' \
+    "$state_file" > "$tmp_file"
+
+  mv -f "$tmp_file" "$state_file"
+  return 0
+}
+
+# oe_verify_emit_completed — verification_completed イベントを target session の audit log に emit
+#
+# 引数:
+#   target_session_id     被検証セッション ID
+#   target_pane_id        被検証ペイン ID
+#   result                "pass" | "fail" | "warn"
+#   [issues_count]        問題件数 (デフォルト 0)
+#   [marker_raw]          捕捉したマーカー原文 (デフォルト "@@OE_VERIFY:{result}")
+#
+# F6: verification_started は Phase B (oe_verify_spawn) のみ、本関数は completed のみ emit
+oe_verify_emit_completed() {
+  local target_session_id="$1"
+  local target_pane_id="$2"
+  local result="$3"
+  local issues_count="${4:-0}"
+  local marker_raw="${5:-@@OE_VERIFY:${result}}"
+
+  local payload
+  payload="$(jq -cn \
+    --argjson tpid "$target_pane_id" \
+    --arg result "$result" \
+    --argjson issues "$issues_count" \
+    --arg marker_raw "$marker_raw" \
+    '{target_pane_id: $tpid, result: $result, issues_count: $issues, marker_raw: $marker_raw}')"
+
+  oe_audit_emit "verification_completed" "$target_session_id" "$target_pane_id" "" "$payload"
+}

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -394,3 +394,98 @@ oe_verify_emit_completed() {
 
   oe_audit_emit "verification_completed" "$target_session_id" "$target_pane_id" "" "$payload"
 }
+
+# _oe_verify_generate_session_id — 検証 agent 用の ULID 形式セッション ID を生成
+# (bin/oe の oe_generate_session_id と同フォーマット: 14 桁数字 + 12 桁 Crockford base32)
+_oe_verify_generate_session_id() {
+  local ts rand
+  ts="$(date -u +%Y%m%d%H%M%S)"
+  rand="$(LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z' </dev/urandom | head -c 12)"
+  printf '%s%s\n' "$ts" "$rand"
+}
+
+# oe_verify_run_phase — Step 4-3 Phase E: end-of-session 発火の検証フェーズ
+#
+# 引数: target_session_id target_pane_id1 [target_pane_id2 ...]
+#
+# 各 target pane に対して以下を順次実行 (MVP は逐次):
+#   1. reviewer_session_id を生成
+#   2. oe_verify_spawn → 検証 agent ペイン起動 + verification_started emit
+#   3. 独立ポーリングループ: OE_POLL_INTERVAL 間隔で reviewer pane を scan
+#      OE_SCAN_VERIFY_RESULT (Phase D F3 二値保持) を検出するまで待機
+#   4. 検出時: oe_verify_write_kvs + oe_verify_emit_completed
+#   5. CB タイムアウト (OE_CB_TIMEOUT) 超過時は当該検証スキップ
+#
+# 完了後: oe_verify_summary_update でセッション集計
+# OE_VERIFY_PHASE_COMPLETED=1 をセット (cleanup の wez notify 発火条件)
+#
+# F1: monitor.sh の責務範囲を膨らませない (独立ループ)
+# F2: OE_VERIFY_MANAGED_PANES / OE_VERIFY_DONE_PANES は通常ペイン配列と別物
+oe_verify_run_phase() {
+  local target_session_id="$1"
+  shift
+
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
+
+  local target_envelope_path="/tmp/oe-${target_session_id}-envelope.json"
+
+  local target_pane_id
+  for target_pane_id in "$@"; do
+    local reviewer_session_id
+    reviewer_session_id="$(_oe_verify_generate_session_id)"
+
+    oe_verify_spawn \
+      "$reviewer_session_id" \
+      "$target_pane_id" \
+      "$target_session_id" \
+      "$target_envelope_path"
+
+    local reviewer_pane_id="$OE_VERIFY_PANE_ID"
+    OE_VERIFY_MANAGED_PANES+=("$reviewer_pane_id")
+
+    # 独立ポーリングループ
+    local start_seconds=$SECONDS
+    local verified=0
+    while true; do
+      sleep "$OE_POLL_INTERVAL"
+      oe_capture_scan "$reviewer_pane_id"
+
+      if [[ -n "$OE_SCAN_VERIFY_RESULT" ]]; then
+        oe_verify_write_kvs \
+          "$target_session_id" \
+          "$target_pane_id" \
+          "$reviewer_session_id" \
+          "$reviewer_pane_id" \
+          "$OE_SCAN_VERIFY_RESULT" \
+          0 \
+          "@@OE_VERIFY:${OE_SCAN_VERIFY_RESULT}"
+        oe_verify_emit_completed \
+          "$target_session_id" \
+          "$target_pane_id" \
+          "$OE_SCAN_VERIFY_RESULT" \
+          0 \
+          "@@OE_VERIFY:${OE_SCAN_VERIFY_RESULT}"
+        OE_VERIFY_DONE_PANES+=("$reviewer_pane_id")
+        verified=1
+        break
+      fi
+
+      # CB: タイムアウト
+      if [[ $((SECONDS - start_seconds)) -ge $OE_CB_TIMEOUT ]]; then
+        local cb_payload
+        cb_payload="$(jq -cn --argjson tpid "$target_pane_id" \
+          '{reason:"verification_timeout", target_pane_id:$tpid}')"
+        oe_audit_emit "circuit_breaker_triggered" "$target_session_id" "$target_pane_id" "" "$cb_payload" || true
+        break
+      fi
+    done
+
+    # verified は将来の拡張 (リトライ判断) で参照する想定 — 現状は debug 用に保持
+    : "$verified"
+  done
+
+  oe_verify_summary_update "$target_session_id"
+  OE_VERIFY_PHASE_COMPLETED=1
+}

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -51,9 +51,18 @@ oe_verify_envelope_create() {
   local audit_path="${OE_AUDIT_DIR}/${target_session_id}.jsonl"
   local kvs_path="${OE_STATE_DIR}/${target_session_id}.state.json"
 
-  # task.description は検証指示の概要のみ。skill prompt 本文は engine に持たない (F4)
+  # task.description: 検証指示の概要 + skill 出力 → @@OE_VERIFY マッピング (F-SO-1)
+  # skill prompt 本文は engine に持たない (F4)。skill 規約 (Spec Compliant / Issues Found) と
+  # engine プロトコル (@@OE_VERIFY:pass/fail/warn) の対応を明示しないと検証 agent ごとに揺れる。
   local task_desc
-  task_desc="Compliance Review per the adversarial-review skill. Read the inputs in read_docs and emit one of: @@OE_VERIFY:pass / @@OE_VERIFY:fail / @@OE_VERIFY:warn on a new line based on your conclusion before exit."
+  task_desc="Compliance Review per the adversarial-review skill listed in task.use_skills. Read task.read_docs in order (skill, target envelope, audit JSONL, KVS, verify-inputs) and execute the review.
+
+Emit exactly one of the following on a new line at the very end, immediately before exiting:
+- @@OE_VERIFY:pass — when the skill report concludes \"Status: Spec Compliant\" with no critical issues (advisory recommendations are acceptable for pass)
+- @@OE_VERIFY:fail — when the skill report concludes \"Status: Issues Found\" with one or more critical issues (Missing requirements / Extra unneeded work / Misunderstandings that affect functionality)
+- @@OE_VERIFY:warn — when the skill report concludes \"Status: Spec Compliant\" but the Recommendations section is non-trivial, or when issues are observed but are minor / advisory / non-blocking
+
+The marker must be on its own line, no surrounding spaces, exact case. The shell will append @@OE_EXIT:0 automatically."
 
   # read_docs 配列を構築 (verify_prompt_path が指定されたら 5 件目に追加)
   local read_docs_json
@@ -81,7 +90,6 @@ oe_verify_envelope_create() {
     --arg odir "$PROJECT_DIR" \
     --argjson timeout "$OE_CB_TIMEOUT" \
     --argjson read_docs "$read_docs_json" \
-    --arg tkvs "$kvs_path" \
     --arg parent "$target_session_id" \
     --argjson max_panes "$OE_CB_MAX_PANES" \
     '{
@@ -100,7 +108,7 @@ oe_verify_envelope_create() {
       context: {
         parent_session_id: $parent,
         related_issues: [],
-        shared_kvs_path: $tkvs
+        shared_kvs_path: null
       },
       constraints: {
         max_panes: $max_panes,
@@ -271,6 +279,7 @@ oe_verify_spawn() {
 #   result                "pass" | "fail" | "warn" (@@OE_VERIFY: の値)
 #   [issues_count]        skill 出力からの問題件数 (デフォルト 0)
 #   [marker_raw]          捕捉したマーカー原文 (デフォルト "@@OE_VERIFY:{result}")
+#   [exit_code]           F-SO-2: 検証 agent の exit_code が非 0 のとき指定。空文字は省略扱い
 #
 # F5 反映: pane-keyed map で書き込む。既存 verification map に他 pane エントリがあれば維持する。
 # atomic rename パターン (Step 4-2 oe_capture_write_kvs と同様)。
@@ -282,6 +291,7 @@ oe_verify_write_kvs() {
   local result="$5"
   local issues_count="${6:-0}"
   local marker_raw="${7:-@@OE_VERIFY:${result}}"
+  local exit_code="${8:-}"
 
   local state_file="${OE_STATE_DIR}/${target_session_id}.state.json"
   local tmp_file="${OE_STATE_DIR}/.${target_session_id}.state.json.$$"
@@ -295,23 +305,46 @@ oe_verify_write_kvs() {
   completed_at="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
 
   # verification.{target_pane_id} を更新 (既存 map は維持)
-  jq \
-    --arg pid "$target_pane_id" \
-    --arg result "$result" \
-    --arg rsid "$reviewer_session_id" \
-    --argjson rpid "$reviewer_pane_id" \
-    --argjson issues "$issues_count" \
-    --arg marker_raw "$marker_raw" \
-    --arg completed_at "$completed_at" \
-    '.verification = ((.verification // {}) | .[$pid] = {
-       result: $result,
-       reviewer_session_id: $rsid,
-       reviewer_pane_id: $rpid,
-       issues_count: $issues,
-       marker_raw: $marker_raw,
-       completed_at: $completed_at
-     })' \
-    "$state_file" > "$tmp_file"
+  # F-SO-2: exit_code が指定された場合のみ exit_code フィールドを含める
+  if [[ -n "$exit_code" ]]; then
+    jq \
+      --arg pid "$target_pane_id" \
+      --arg result "$result" \
+      --arg rsid "$reviewer_session_id" \
+      --argjson rpid "$reviewer_pane_id" \
+      --argjson issues "$issues_count" \
+      --arg marker_raw "$marker_raw" \
+      --arg completed_at "$completed_at" \
+      --argjson exit_code "$exit_code" \
+      '.verification = ((.verification // {}) | .[$pid] = {
+         result: $result,
+         reviewer_session_id: $rsid,
+         reviewer_pane_id: $rpid,
+         issues_count: $issues,
+         marker_raw: $marker_raw,
+         completed_at: $completed_at,
+         exit_code: $exit_code
+       })' \
+      "$state_file" > "$tmp_file"
+  else
+    jq \
+      --arg pid "$target_pane_id" \
+      --arg result "$result" \
+      --arg rsid "$reviewer_session_id" \
+      --argjson rpid "$reviewer_pane_id" \
+      --argjson issues "$issues_count" \
+      --arg marker_raw "$marker_raw" \
+      --arg completed_at "$completed_at" \
+      '.verification = ((.verification // {}) | .[$pid] = {
+         result: $result,
+         reviewer_session_id: $rsid,
+         reviewer_pane_id: $rpid,
+         issues_count: $issues,
+         marker_raw: $marker_raw,
+         completed_at: $completed_at
+       })' \
+      "$state_file" > "$tmp_file"
+  fi
 
   mv -f "$tmp_file" "$state_file"
   return 0
@@ -335,11 +368,13 @@ oe_verify_summary_update() {
     return 1
   fi
 
-  local total passed failed warned
+  local total passed failed warned protocol_errors
   total="$(jq '(.verification // {}) | length' "$state_file")"
   passed="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "pass")) | length' "$state_file")"
   failed="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "fail")) | length' "$state_file")"
   warned="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "warn")) | length' "$state_file")"
+  # F-SO-2/12: exit_code が non-zero として記録されたエントリ数
+  protocol_errors="$(jq '(.verification // {}) | to_entries | map(select(.value.exit_code != null and .value.exit_code != 0)) | length' "$state_file")"
 
   local fail_rate
   if [[ "$total" -gt 0 ]]; then
@@ -354,12 +389,14 @@ oe_verify_summary_update() {
     --argjson failed "$failed" \
     --argjson warned "$warned" \
     --argjson fail_rate "$fail_rate" \
+    --argjson protocol_errors "$protocol_errors" \
     '.verification_summary = {
        total: $total,
        passed: $passed,
        failed: $failed,
        warned: $warned,
-       fail_rate: $fail_rate
+       fail_rate: $fail_rate,
+       protocol_errors: $protocol_errors
      }' \
     "$state_file" > "$tmp_file"
 
@@ -421,9 +458,16 @@ _oe_verify_generate_session_id() {
 #
 # F1: monitor.sh の責務範囲を膨らませない (独立ループ)
 # F2: OE_VERIFY_MANAGED_PANES / OE_VERIFY_DONE_PANES は通常ペイン配列と別物
+# F-SO-2: OE_SCAN_EXIT_CODE 非 0 のとき verification_protocol_error 監査 + KVS に exit_code 併記
+# F-SO-4: 検証ペインは verbose 出力のため oe_capture_scan に lines=200 を渡す
+# F-SO-6: ai_cli (デフォルト cursor) を引数で受け取り oe_verify_spawn に伝播
 oe_verify_run_phase() {
   local target_session_id="$1"
   shift
+
+  # 末尾オプション: ai_cli (位置引数ではなく環境変数 OE_VERIFY_AI_CLI で渡す設計、
+  # 後方互換維持のため位置引数化はしない)
+  local ai_cli="${OE_VERIFY_AI_CLI:-cursor}"
 
   if [[ $# -eq 0 ]]; then
     return 0
@@ -440,19 +484,34 @@ oe_verify_run_phase() {
       "$reviewer_session_id" \
       "$target_pane_id" \
       "$target_session_id" \
-      "$target_envelope_path"
+      "$target_envelope_path" \
+      "$ai_cli"
 
     local reviewer_pane_id="$OE_VERIFY_PANE_ID"
     OE_VERIFY_MANAGED_PANES+=("$reviewer_pane_id")
 
-    # 独立ポーリングループ
+    # 独立ポーリングループ (検証ペインは verbose 出力対策で lines=200)
     local start_seconds=$SECONDS
     local verified=0
     while true; do
       sleep "$OE_POLL_INTERVAL"
-      oe_capture_scan "$reviewer_pane_id"
+      oe_capture_scan "$reviewer_pane_id" 200
 
       if [[ -n "$OE_SCAN_VERIFY_RESULT" ]]; then
+        # F-SO-2: exit_code が非 0 ならプロトコルエラー監査 + KVS に exit_code 併記
+        local exit_code_field=""
+        if [[ -n "$OE_SCAN_EXIT_CODE" && "$OE_SCAN_EXIT_CODE" != "0" ]]; then
+          exit_code_field="$OE_SCAN_EXIT_CODE"
+          local protocol_payload
+          protocol_payload="$(jq -cn \
+            --argjson tpid "$target_pane_id" \
+            --arg result "$OE_SCAN_VERIFY_RESULT" \
+            --argjson exit_code "$OE_SCAN_EXIT_CODE" \
+            --arg marker_raw "@@OE_VERIFY:${OE_SCAN_VERIFY_RESULT}" \
+            '{target_pane_id: $tpid, verify_result: $result, exit_code: $exit_code, marker_raw: $marker_raw}')"
+          oe_audit_emit "verification_protocol_error" "$target_session_id" "$target_pane_id" "" "$protocol_payload" || true
+        fi
+
         oe_verify_write_kvs \
           "$target_session_id" \
           "$target_pane_id" \
@@ -460,7 +519,8 @@ oe_verify_run_phase() {
           "$reviewer_pane_id" \
           "$OE_SCAN_VERIFY_RESULT" \
           0 \
-          "@@OE_VERIFY:${OE_SCAN_VERIFY_RESULT}"
+          "@@OE_VERIFY:${OE_SCAN_VERIFY_RESULT}" \
+          "$exit_code_field"
         oe_verify_emit_completed \
           "$target_session_id" \
           "$target_pane_id" \

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -183,8 +183,10 @@ oe_verify_prompt_build() {
     changed_files_block="$(jq -r '.outputs[] | "- " + .' "$kvs_path")"
   else
     # フォールバック: git diff --name-only (MVP では常にこちらが選択される)
+    # iter2 #3252519559 反映: PROJECT_DIR で git を実行することで、caller の CWD に依存しない安定した
+    # 結果を得る。target task の実際の output_dir に紐づけるのは派生 Issue #92 のスコープ。
     local git_output
-    if git_output="$(git diff --name-only 2>/dev/null)" && [[ -n "$git_output" ]]; then
+    if git_output="$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null)" && [[ -n "$git_output" ]]; then
       changed_files_block="$(printf '%s\n' "$git_output" | awk 'NF { print "- " $0 }')"
     else
       changed_files_block="(no changes detected from KVS outputs[] or git diff)"
@@ -569,9 +571,10 @@ oe_verify_run_phase() {
         break
       fi
 
-      # Copilot #1 反映: @@OE_EXIT は見えたが @@OE_VERIFY が出ていない → protocol error として早期 break
-      # (例: CLI 起動エラーで shell が @@OE_EXIT:1 を後置するケース。CB timeout 待ちは無駄)
-      if [[ -z "$OE_SCAN_VERIFY_RESULT" && -n "$OE_SCAN_EXIT_CODE" && "$OE_SCAN_EXIT_CODE" != "0" ]]; then
+      # Copilot #1 反映 + iter2 #3252519542: @@OE_EXIT は見えたが @@OE_VERIFY が出ていない → protocol error として早期 break
+      # exit_code が 0 でも (reviewer が正常終了したが marker emit を忘れた) protocol 違反とする。
+      # 30 分の CB timeout 待ちを避け、即座に protocol error として記録する。
+      if [[ -z "$OE_SCAN_VERIFY_RESULT" && -n "$OE_SCAN_EXIT_CODE" ]]; then
         local protocol_payload
         protocol_payload="$(jq -cn \
           --argjson tpid "$target_pane_id" \

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -157,12 +157,16 @@ oe_verify_prompt_build() {
     task_description="(target envelope not found: $target_envelope_path)"
   fi
 
-  # 完了報告: audit JSONL から最後の state_change イベントを抽出
+  # 完了報告: audit JSONL から target_pane_id の最後の state_change イベントを抽出
+  # Copilot #3 反映: 全セッションの最後の state_change ではなく、target_pane_id でフィルタする
+  # (oe_verify_run_phase は複数 target pane を順次扱うため、混線を避ける)
   local last_state_change
   if [[ -f "$audit_path" ]]; then
-    last_state_change="$(jq -s 'map(select(.event_type == "state_change")) | last // null' "$audit_path")"
+    last_state_change="$(jq -s --argjson pid "$target_pane_id" \
+      'map(select(.event_type == "state_change" and .pane_id == $pid)) | last // null' \
+      "$audit_path")"
     if [[ "$last_state_change" == "null" ]]; then
-      last_state_change="(no state_change events recorded in audit log)"
+      last_state_change="(no state_change events recorded for target_pane_id=${target_pane_id} in audit log)"
     fi
   else
     last_state_change="(audit log not found: $audit_path)"
@@ -230,6 +234,11 @@ oe_verify_spawn() {
   # 検証 agent 用ペインを準備 (Step 4-2 の lib/spawn.sh を再利用)
   oe_spawn_prepare_pane
   local reviewer_pane_id="$OE_SPAWN_PANE_ID"
+
+  # Copilot #5 反映: prepare_pane 直後に OE_VERIFY_MANAGED_PANES に追加。
+  # 以降の envelope 生成 / send / audit emit のいずれかで失敗しても、cleanup.sh が
+  # 確実にこの reviewer pane を kill できるようにする (orphan pane 防止)。
+  OE_VERIFY_MANAGED_PANES+=("$reviewer_pane_id")
 
   # Phase C: プロンプト (3 入力の構造化抽出) を先に構築
   oe_verify_prompt_build \
@@ -368,13 +377,16 @@ oe_verify_summary_update() {
     return 1
   fi
 
-  local total passed failed warned protocol_errors
+  local total passed failed warned protocol_errors timeouts
   total="$(jq '(.verification // {}) | length' "$state_file")"
   passed="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "pass")) | length' "$state_file")"
   failed="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "fail")) | length' "$state_file")"
   warned="$(jq '(.verification // {}) | to_entries | map(select(.value.result == "warn")) | length' "$state_file")"
   # F-SO-2/12: exit_code が non-zero として記録されたエントリ数
   protocol_errors="$(jq '(.verification // {}) | to_entries | map(select(.value.exit_code != null and .value.exit_code != 0)) | length' "$state_file")"
+  # Copilot #2 反映: timeout / exit_without_verify_marker で verification entry を残せなかった件数
+  # (oe_verify_run_phase が OE_VERIFY_TIMEOUTS_LOCAL でカウント)
+  timeouts="${OE_VERIFY_TIMEOUTS_LOCAL:-0}"
 
   local fail_rate
   if [[ "$total" -gt 0 ]]; then
@@ -390,13 +402,15 @@ oe_verify_summary_update() {
     --argjson warned "$warned" \
     --argjson fail_rate "$fail_rate" \
     --argjson protocol_errors "$protocol_errors" \
+    --argjson timeouts "$timeouts" \
     '.verification_summary = {
        total: $total,
        passed: $passed,
        failed: $failed,
        warned: $warned,
        fail_rate: $fail_rate,
-       protocol_errors: $protocol_errors
+       protocol_errors: $protocol_errors,
+       timeouts: $timeouts
      }' \
     "$state_file" > "$tmp_file"
 
@@ -434,10 +448,17 @@ oe_verify_emit_completed() {
 
 # _oe_verify_generate_session_id — 検証 agent 用の ULID 形式セッション ID を生成
 # (bin/oe の oe_generate_session_id と同フォーマット: 14 桁数字 + 12 桁 Crockford base32)
+#
+# Copilot #4 反映: tr の出力を head -c で早期 close すると tr に SIGPIPE が飛び、
+# set -o pipefail 環境下で assignment が失敗する。/dev/urandom から固定バイト数を先に
+# 読んでから tr で filter する形に変更 (パイプの早期 close を回避)。
 _oe_verify_generate_session_id() {
-  local ts rand
+  local ts raw rand
   ts="$(date -u +%Y%m%d%H%M%S)"
-  rand="$(LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z' </dev/urandom | head -c 12)"
+  # 4096 バイト読めば Crockford base32 alphabet (32/256 = 12.5%) で期待 ~512 valid 文字、
+  # 12 文字必要なので統計的に十分なマージン
+  raw="$(LC_ALL=C head -c 4096 /dev/urandom | LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z')"
+  rand="${raw:0:12}"
   printf '%s%s\n' "$ts" "$rand"
 }
 
@@ -461,6 +482,14 @@ _oe_verify_generate_session_id() {
 # F-SO-2: OE_SCAN_EXIT_CODE 非 0 のとき verification_protocol_error 監査 + KVS に exit_code 併記
 # F-SO-4: 検証ペインは verbose 出力のため oe_capture_scan に lines=200 を渡す
 # F-SO-6: ai_cli (デフォルト cursor) を引数で受け取り oe_verify_spawn に伝播
+#
+# Codex P2 + Copilot 反映:
+#   - 記録は @@OE_VERIFY と @@OE_EXIT の **両方** が見えた時点で行う (timing window で
+#     片方しか見えていない状態の record を避ける)
+#   - @@OE_EXIT が先に見えて @@OE_VERIFY が出ない場合は protocol error として早期 break
+#   - timeout / protocol-only error の件数を local counter で追跡し、summary に timeouts として記録
+#   - OE_VERIFY_PHASE_COMPLETED は「検証フェーズが走った」事実を示すフラグであり、
+#     timeouts / protocol_errors の有無は notify 本文で別途表現する (cleanup.sh の wez notify)
 oe_verify_run_phase() {
   local target_session_id="$1"
   shift
@@ -475,6 +504,10 @@ oe_verify_run_phase() {
 
   local target_envelope_path="/tmp/oe-${target_session_id}-envelope.json"
 
+  # local counter: 本フェーズで発生した timeout 件数 (verify_result も emit されなかった pane)
+  # summary に timeouts として記録するため OE_VERIFY_TIMEOUTS_LOCAL を export
+  local timeouts_local=0
+
   local target_pane_id
   for target_pane_id in "$@"; do
     local reviewer_session_id
@@ -488,19 +521,23 @@ oe_verify_run_phase() {
       "$ai_cli"
 
     local reviewer_pane_id="$OE_VERIFY_PANE_ID"
-    OE_VERIFY_MANAGED_PANES+=("$reviewer_pane_id")
+    # 注: oe_verify_spawn は内部で OE_VERIFY_MANAGED_PANES に append 済み
+    # (Copilot #5 反映: prepare_pane 直後に登録、途中失敗時の cleanup 取り逃しを防ぐ)
 
     # 独立ポーリングループ (検証ペインは verbose 出力対策で lines=200)
     local start_seconds=$SECONDS
-    local verified=0
+    local resolved=0
     while true; do
       sleep "$OE_POLL_INTERVAL"
       oe_capture_scan "$reviewer_pane_id" 200
 
-      if [[ -n "$OE_SCAN_VERIFY_RESULT" ]]; then
+      # Codex P2: @@OE_VERIFY と @@OE_EXIT の **両方** が見えるまで待つ
+      # 片方しか見えていない状態で記録すると、agent が後で非 0 終了した場合に
+      # exit_code を取り逃して protocol error が隠蔽される
+      if [[ -n "$OE_SCAN_VERIFY_RESULT" && -n "$OE_SCAN_EXIT_CODE" ]]; then
         # F-SO-2: exit_code が非 0 ならプロトコルエラー監査 + KVS に exit_code 併記
         local exit_code_field=""
-        if [[ -n "$OE_SCAN_EXIT_CODE" && "$OE_SCAN_EXIT_CODE" != "0" ]]; then
+        if [[ "$OE_SCAN_EXIT_CODE" != "0" ]]; then
           exit_code_field="$OE_SCAN_EXIT_CODE"
           local protocol_payload
           protocol_payload="$(jq -cn \
@@ -528,7 +565,22 @@ oe_verify_run_phase() {
           0 \
           "@@OE_VERIFY:${OE_SCAN_VERIFY_RESULT}"
         OE_VERIFY_DONE_PANES+=("$reviewer_pane_id")
-        verified=1
+        resolved=1
+        break
+      fi
+
+      # Copilot #1 反映: @@OE_EXIT は見えたが @@OE_VERIFY が出ていない → protocol error として早期 break
+      # (例: CLI 起動エラーで shell が @@OE_EXIT:1 を後置するケース。CB timeout 待ちは無駄)
+      if [[ -z "$OE_SCAN_VERIFY_RESULT" && -n "$OE_SCAN_EXIT_CODE" && "$OE_SCAN_EXIT_CODE" != "0" ]]; then
+        local protocol_payload
+        protocol_payload="$(jq -cn \
+          --argjson tpid "$target_pane_id" \
+          --argjson exit_code "$OE_SCAN_EXIT_CODE" \
+          '{target_pane_id: $tpid, exit_code: $exit_code, reason: "exit_without_verify_marker"}')"
+        oe_audit_emit "verification_protocol_error" "$target_session_id" "$target_pane_id" "" "$protocol_payload" || true
+        # verification 結果が無いまま break。verification entry は書かない (timeouts と同様の扱い)
+        timeouts_local=$((timeouts_local + 1))
+        resolved=1
         break
       fi
 
@@ -538,14 +590,17 @@ oe_verify_run_phase() {
         cb_payload="$(jq -cn --argjson tpid "$target_pane_id" \
           '{reason:"verification_timeout", target_pane_id:$tpid}')"
         oe_audit_emit "circuit_breaker_triggered" "$target_session_id" "$target_pane_id" "" "$cb_payload" || true
+        timeouts_local=$((timeouts_local + 1))
         break
       fi
     done
 
-    # verified は将来の拡張 (リトライ判断) で参照する想定 — 現状は debug 用に保持
-    : "$verified"
+    # resolved は将来の拡張 (リトライ判断) で参照する想定 — 現状は debug 用に保持
+    : "$resolved"
   done
 
+  # timeout / exit_without_verify_marker 件数を summary_update に渡すため export
+  export OE_VERIFY_TIMEOUTS_LOCAL="$timeouts_local"
   oe_verify_summary_update "$target_session_id"
   OE_VERIFY_PHASE_COMPLETED=1
 }

--- a/projects/orchestration-engine/schemas/audit-log.schema.json
+++ b/projects/orchestration-engine/schemas/audit-log.schema.json
@@ -36,7 +36,8 @@
         "cleanup",
         "session_end",
         "verification_started",
-        "verification_completed"
+        "verification_completed",
+        "verification_protocol_error"
       ]
     },
     "state": {
@@ -147,6 +148,14 @@
       },
       "then": {
         "description": "Step 4-3: 検証結果確定時。payload に target_pane_id, result (pass/fail/warn), issues_count, marker_raw を含む。"
+      }
+    },
+    {
+      "if": {
+        "properties": { "event_type": { "const": "verification_protocol_error" } }
+      },
+      "then": {
+        "description": "F-SO-2 (Step 4-3): 検証 agent が @@OE_VERIFY を emit したが exit_code が non-zero だった場合に追加で emit。payload に target_pane_id, verify_result, exit_code, marker_raw を含む。verification_completed も並行して emit される (verify_result 自体は KVS に書き込まれるが、exit_code が付記される)。"
       }
     }
   ]

--- a/projects/orchestration-engine/schemas/audit-log.schema.json
+++ b/projects/orchestration-engine/schemas/audit-log.schema.json
@@ -155,7 +155,7 @@
         "properties": { "event_type": { "const": "verification_protocol_error" } }
       },
       "then": {
-        "description": "F-SO-2 (Step 4-3): 検証 agent が @@OE_VERIFY を emit したが exit_code が non-zero だった場合に追加で emit。payload に target_pane_id, verify_result, exit_code, marker_raw を含む。verification_completed も並行して emit される (verify_result 自体は KVS に書き込まれるが、exit_code が付記される)。"
+        "description": "F-SO-2 + iter2 #3252519572 (Step 4-3): 検証 agent の protocol 違反時に emit。2 ケースをカバー: (1) @@OE_VERIFY が emit されたが exit_code が non-zero — payload に target_pane_id, verify_result, exit_code, marker_raw を含む。verification_completed も並行 emit される (verify_result は KVS に書き込まれるが exit_code が付記される)。(2) @@OE_EXIT が emit されたが @@OE_VERIFY が未 emit (exit_without_verify_marker) — payload に target_pane_id, exit_code, reason: 'exit_without_verify_marker' を含む。verification_completed は emit されず、verification map にエントリは残らない (verification_summary.timeouts に計上される)。"
       }
     }
   ]

--- a/projects/orchestration-engine/schemas/audit-log.schema.json
+++ b/projects/orchestration-engine/schemas/audit-log.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/stlwolf/ai-development-hub/schemas/audit-log.schema.json",
   "title": "Audit Log Entry",
-  "description": "監査ログ JSON Lines の 1 行分のスキーマ。ディスパッチャが audit/${session_id}.jsonl に追記する。1 セッション 1 ファイル、1 行 1 イベント。session_start → state_change* → session_end の時系列から 1 サイクルの流れを再構成可能。Step 4-3 で verification_started / verification_completed の 2 イベントを追加（検証ゲート v1）。",
+  "description": "監査ログ JSON Lines の 1 行分のスキーマ。ディスパッチャが audit/${session_id}.jsonl に追記する。1 セッション 1 ファイル、1 行 1 イベント。session_start → state_change* → session_end の時系列から 1 サイクルの流れを再構成可能。Step 4-3 で verification_started / verification_completed / verification_protocol_error の 3 イベントを追加（検証ゲート v1）。",
   "type": "object",
   "required": ["ts", "session_id", "pane_id", "event_type"],
   "properties": {

--- a/projects/orchestration-engine/schemas/audit-log.schema.json
+++ b/projects/orchestration-engine/schemas/audit-log.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/stlwolf/ai-development-hub/schemas/audit-log.schema.json",
   "title": "Audit Log Entry",
-  "description": "監査ログ JSON Lines の 1 行分のスキーマ。ディスパッチャが audit/${session_id}.jsonl に追記する。1 セッション 1 ファイル、1 行 1 イベント。session_start → state_change* → session_end の時系列から 1 サイクルの流れを再構成可能。",
+  "description": "監査ログ JSON Lines の 1 行分のスキーマ。ディスパッチャが audit/${session_id}.jsonl に追記する。1 セッション 1 ファイル、1 行 1 イベント。session_start → state_change* → session_end の時系列から 1 サイクルの流れを再構成可能。Step 4-3 で verification_started / verification_completed の 2 イベントを追加（検証ゲート v1）。",
   "type": "object",
   "required": ["ts", "session_id", "pane_id", "event_type"],
   "properties": {
@@ -34,7 +34,9 @@
         "circuit_breaker_triggered",
         "validation_failure",
         "cleanup",
-        "session_end"
+        "session_end",
+        "verification_started",
+        "verification_completed"
       ]
     },
     "state": {
@@ -129,6 +131,22 @@
       "then": {
         "required": ["state"],
         "description": "セッション終了。state に最終 exit_state を記録。"
+      }
+    },
+    {
+      "if": {
+        "properties": { "event_type": { "const": "verification_started" } }
+      },
+      "then": {
+        "description": "Step 4-3: 検証 agent spawn 時。payload に target_pane_id, target_session_id, reviewer_pane_id, reviewer_session_id を含む。"
+      }
+    },
+    {
+      "if": {
+        "properties": { "event_type": { "const": "verification_completed" } }
+      },
+      "then": {
+        "description": "Step 4-3: 検証結果確定時。payload に target_pane_id, result (pass/fail/warn), issues_count, marker_raw を含む。"
       }
     }
   ]

--- a/projects/orchestration-engine/schemas/session-state.schema.json
+++ b/projects/orchestration-engine/schemas/session-state.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/stlwolf/ai-development-hub/schemas/session-state.schema.json",
   "title": "Session State (File-based KVS)",
-  "description": "UC-2 ファイルベース KVS の最小契約。各セッションが {session_id}.state.json として自身の状態を書き出し、親エージェントが読む。ロック戦略は atomic rename（mv は POSIX で atomic）。注: 本 KVS はセッション完了時にのみ書き込む。実行中の状態（spawn/ready/progress 等）は wez pane capture のマーカースキャンで取得する（so-compare レビュー episode 参照）。",
+  "description": "UC-2 ファイルベース KVS の最小契約。各セッションが {session_id}.state.json として自身の状態を書き出し、親エージェントが読む。ロック戦略は atomic rename（mv は POSIX で atomic）。注: 本 KVS はセッション完了時にのみ書き込む。実行中の状態（spawn/ready/progress 等）は wez pane capture のマーカースキャンで取得する（so-compare レビュー episode 参照）。Step 4-3 で verification / verification_summary を追加（検証ゲート v1、optional）。",
   "type": "object",
   "required": ["session_id", "pane_id", "state", "last_updated"],
   "properties": {
@@ -44,6 +44,80 @@
       "items": { "type": "string" },
       "description": "ブロッカーの自由記述一覧",
       "default": []
+    },
+    "verification": {
+      "type": "object",
+      "description": "Step 4-3 検証ゲート v1: target_pane_id をキーとする per-pane の検証結果 map。検証フェーズ実行後に書き込まれる（optional）。複数 target pane がある場合は各ペイン分のエントリを持つ。",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["result", "reviewer_session_id", "reviewer_pane_id", "completed_at"],
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "検証結果（@@OE_VERIFY: マーカー値）",
+            "enum": ["pass", "fail", "warn"]
+          },
+          "reviewer_session_id": {
+            "type": "string",
+            "description": "検証 agent のセッション ID（ULID）",
+            "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+          },
+          "reviewer_pane_id": {
+            "type": "integer",
+            "description": "検証 agent のペイン ID",
+            "minimum": 0
+          },
+          "issues_count": {
+            "type": "integer",
+            "description": "検証で検出された問題件数（skill の Compliance Review 出力から抽出）",
+            "minimum": 0,
+            "default": 0
+          },
+          "marker_raw": {
+            "type": "string",
+            "description": "捕捉した @@OE_VERIFY:{value} の原文",
+            "pattern": "^@@OE_VERIFY:(pass|fail|warn)$"
+          },
+          "completed_at": {
+            "type": "string",
+            "description": "検証完了時刻（ISO 8601）",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "verification_summary": {
+      "type": "object",
+      "description": "Step 4-3 検証ゲート v1: セッション全体の検証結果集計。verification map から engine が導出（optional）。Q2「fail 率を実運用データとして記録」要件に対応。",
+      "required": ["total", "passed", "failed", "warned", "fail_rate"],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "description": "検証実行件数（verification map のキー数）",
+          "minimum": 0
+        },
+        "passed": {
+          "type": "integer",
+          "description": "result=pass の件数",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "description": "result=fail の件数",
+          "minimum": 0
+        },
+        "warned": {
+          "type": "integer",
+          "description": "result=warn の件数",
+          "minimum": 0
+        },
+        "fail_rate": {
+          "type": "number",
+          "description": "failed / total の値。total=0 の場合は 0。小数 3 桁に丸める",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
     }
   }
 }

--- a/projects/orchestration-engine/schemas/session-state.schema.json
+++ b/projects/orchestration-engine/schemas/session-state.schema.json
@@ -47,49 +47,52 @@
     },
     "verification": {
       "type": "object",
-      "description": "Step 4-3 検証ゲート v1: target_pane_id をキーとする per-pane の検証結果 map。検証フェーズ実行後に書き込まれる（optional）。複数 target pane がある場合は各ペイン分のエントリを持つ。",
-      "additionalProperties": {
-        "type": "object",
-        "required": ["result", "reviewer_session_id", "reviewer_pane_id", "completed_at"],
-        "properties": {
-          "result": {
-            "type": "string",
-            "description": "検証結果（@@OE_VERIFY: マーカー値）",
-            "enum": ["pass", "fail", "warn"]
-          },
-          "reviewer_session_id": {
-            "type": "string",
-            "description": "検証 agent のセッション ID（ULID）",
-            "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
-          },
-          "reviewer_pane_id": {
-            "type": "integer",
-            "description": "検証 agent のペイン ID",
-            "minimum": 0
-          },
-          "issues_count": {
-            "type": "integer",
-            "description": "検証で検出された問題件数（skill の Compliance Review 出力から抽出）",
-            "minimum": 0,
-            "default": 0
-          },
-          "marker_raw": {
-            "type": "string",
-            "description": "捕捉した @@OE_VERIFY:{value} の原文",
-            "pattern": "^@@OE_VERIFY:(pass|fail|warn)$"
-          },
-          "completed_at": {
-            "type": "string",
-            "description": "検証完了時刻（ISO 8601）",
-            "format": "date-time"
-          },
-          "exit_code": {
-            "type": "integer",
-            "description": "F-SO-2: 検証 agent の exit_code が non-zero だった場合に記録される (protocol error 検出用)。0 または欠落時は正常完了。",
-            "minimum": 0
+      "description": "Step 4-3 検証ゲート v1: target_pane_id をキーとする per-pane の検証結果 map。検証フェーズ実行後に書き込まれる（optional）。複数 target pane がある場合は各ペイン分のエントリを持つ。Copilot #7 反映: キーは pane_id (非負整数の文字列形式) のみを許容する。",
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "object",
+          "required": ["result", "reviewer_session_id", "reviewer_pane_id", "completed_at"],
+          "properties": {
+            "result": {
+              "type": "string",
+              "description": "検証結果（@@OE_VERIFY: マーカー値）",
+              "enum": ["pass", "fail", "warn"]
+            },
+            "reviewer_session_id": {
+              "type": "string",
+              "description": "検証 agent のセッション ID（ULID）",
+              "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+            },
+            "reviewer_pane_id": {
+              "type": "integer",
+              "description": "検証 agent のペイン ID",
+              "minimum": 0
+            },
+            "issues_count": {
+              "type": "integer",
+              "description": "検証で検出された問題件数（skill の Compliance Review 出力から抽出予定）。MVP では常に 0 (派生 Issue #92 で skill 出力からの抽出を実装予定)。",
+              "minimum": 0,
+              "default": 0
+            },
+            "marker_raw": {
+              "type": "string",
+              "description": "捕捉した @@OE_VERIFY:{value} の原文",
+              "pattern": "^@@OE_VERIFY:(pass|fail|warn)$"
+            },
+            "completed_at": {
+              "type": "string",
+              "description": "検証完了時刻（ISO 8601）",
+              "format": "date-time"
+            },
+            "exit_code": {
+              "type": "integer",
+              "description": "F-SO-2: 検証 agent の exit_code が non-zero だった場合に記録される (protocol error 検出用)。0 または欠落時は正常完了。",
+              "minimum": 0
+            }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "verification_summary": {
       "type": "object",
@@ -125,6 +128,11 @@
         "protocol_errors": {
           "type": "integer",
           "description": "F-SO-2/12: 検証 agent の exit_code が non-zero として記録されたエントリ数 (verification[*].exit_code が 0 以外)。protocol error の総数。",
+          "minimum": 0
+        },
+        "timeouts": {
+          "type": "integer",
+          "description": "Copilot #2 反映: verification CB timeout で verification entry を残せなかった件数 + @@OE_EXIT のみ見えて @@OE_VERIFY が emit されなかった件数 (exit_without_verify_marker)。total には含まれない。",
           "minimum": 0
         }
       }

--- a/projects/orchestration-engine/schemas/session-state.schema.json
+++ b/projects/orchestration-engine/schemas/session-state.schema.json
@@ -82,6 +82,11 @@
             "type": "string",
             "description": "検証完了時刻（ISO 8601）",
             "format": "date-time"
+          },
+          "exit_code": {
+            "type": "integer",
+            "description": "F-SO-2: 検証 agent の exit_code が non-zero だった場合に記録される (protocol error 検出用)。0 または欠落時は正常完了。",
+            "minimum": 0
           }
         }
       }
@@ -116,6 +121,11 @@
           "description": "failed / total の値。total=0 の場合は 0。小数 3 桁に丸める",
           "minimum": 0,
           "maximum": 1
+        },
+        "protocol_errors": {
+          "type": "integer",
+          "description": "F-SO-2/12: 検証 agent の exit_code が non-zero として記録されたエントリ数 (verification[*].exit_code が 0 以外)。protocol error の総数。",
+          "minimum": 0
         }
       }
     }

--- a/projects/orchestration-engine/scripts/validate-session-state.sh
+++ b/projects/orchestration-engine/scripts/validate-session-state.sh
@@ -65,12 +65,16 @@ jq -e '.session_id | type == "string"' "$TARGET" >/dev/null 2>&1 \
   || fail "session_id must be string"
 jq -e '.session_id | test("^[0-9A-HJKMNP-TV-Z]{26}$")' "$TARGET" >/dev/null 2>&1 \
   || fail "session_id must match ULID pattern"
-jq -e '.pane_id | type == "number"' "$TARGET" >/dev/null 2>&1 \
-  || fail "pane_id must be number"
+# iter2 #3252519552 反映: pane_id は非負整数 (JSON number だけでなく、整数 + 非負)
+jq -e '.pane_id | type == "number" and . >= 0 and (. - (. | floor) == 0)' "$TARGET" >/dev/null 2>&1 \
+  || fail "pane_id must be non-negative integer"
 jq -e '.state | type == "string"' "$TARGET" >/dev/null 2>&1 \
   || fail "state must be string"
 jq -e '.last_updated | type == "string"' "$TARGET" >/dev/null 2>&1 \
   || fail "last_updated must be string"
+# iter2 #3252519582 反映: last_updated を ISO 8601 date-time pattern で検証
+jq -e '.last_updated | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$")' "$TARGET" >/dev/null 2>&1 \
+  || fail "last_updated must match ISO 8601 date-time pattern"
 
 log "checking state enum..."
 VALID_STATES='["success","partial","retryable_failure","blocked","protocol_error","timeout"]'
@@ -80,13 +84,18 @@ jq -e --argjson valid "$VALID_STATES" \
   || fail "state must be one of: success, partial, retryable_failure, blocked, protocol_error, timeout"
 
 log "checking optional outputs / blockers arrays..."
+# iter2 #3252519576 反映: 配列の各要素も string であることを検証
 if jq -e 'has("outputs")' "$TARGET" >/dev/null 2>&1; then
   jq -e '.outputs | type == "array"' "$TARGET" >/dev/null 2>&1 \
     || fail "outputs must be array"
+  jq -e '(.outputs // []) | all(type == "string")' "$TARGET" >/dev/null 2>&1 \
+    || fail "outputs elements must all be strings"
 fi
 if jq -e 'has("blockers")' "$TARGET" >/dev/null 2>&1; then
   jq -e '.blockers | type == "array"' "$TARGET" >/dev/null 2>&1 \
     || fail "blockers must be array"
+  jq -e '(.blockers // []) | all(type == "string")' "$TARGET" >/dev/null 2>&1 \
+    || fail "blockers elements must all be strings"
 fi
 
 log "checking optional verification map (Step 4-3)..."
@@ -125,10 +134,17 @@ if jq -e 'has("verification")' "$TARGET" >/dev/null 2>&1; then
       "$TARGET" >/dev/null 2>&1 \
       || fail "verification.$pane_key.reviewer_session_id must match ULID pattern"
 
+    # iter2 #3252519556 反映: reviewer_pane_id は非負整数 (JSON number だけでなく、整数 + 非負)
     jq -e --arg k "$pane_key" \
-      '.verification[$k].reviewer_pane_id | type == "number"' \
+      '.verification[$k].reviewer_pane_id | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
       "$TARGET" >/dev/null 2>&1 \
-      || fail "verification.$pane_key.reviewer_pane_id must be number"
+      || fail "verification.$pane_key.reviewer_pane_id must be non-negative integer"
+
+    # iter2 #3252519582 反映: completed_at は ISO 8601 date-time
+    jq -e --arg k "$pane_key" \
+      '.verification[$k].completed_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$")' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification.$pane_key.completed_at must match ISO 8601 date-time pattern"
 
     # marker_raw は optional だが、ある場合はパターン検証
     if jq -e --arg k "$pane_key" '.verification[$k] | has("marker_raw")' \

--- a/projects/orchestration-engine/scripts/validate-session-state.sh
+++ b/projects/orchestration-engine/scripts/validate-session-state.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-session-state.sh — Session State KVS JSON の schema 検証（jq ベース）
+#
+# 使用例:
+#   ./scripts/validate-session-state.sh path/to/{session_id}.state.json
+#   ./scripts/validate-session-state.sh path/to/state.json --verbose
+#
+# Exit codes:
+#   0 = valid
+#   1 = invalid (検証エラー)
+#   2 = file not found / jq not found
+#
+# Step 4-3 で追加。session-state.schema.json の主要制約（必須フィールド・型・enum・
+# verification map / verification_summary の構造）を jq で検証する。
+# validate-envelope.sh の構造を踏襲。
+
+VERBOSE=0
+if [[ "${2:-}" == "--verbose" ]]; then
+  VERBOSE=1
+fi
+
+log() {
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    echo "[validate-state] $*" >&2
+  fi
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is not installed" >&2
+  exit 2
+fi
+
+TARGET="${1:-}"
+if [[ -z "$TARGET" ]]; then
+  echo "Usage: $0 <session-state.json> [--verbose]" >&2
+  exit 2
+fi
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "ERROR: file not found: $TARGET" >&2
+  exit 2
+fi
+
+if ! jq empty "$TARGET" 2>/dev/null; then
+  fail "invalid JSON: $TARGET"
+fi
+
+log "checking required top-level fields..."
+REQUIRED_TOP=("session_id" "pane_id" "state" "last_updated")
+for field in "${REQUIRED_TOP[@]}"; do
+  if ! jq -e --arg f "$field" 'has($f)' "$TARGET" >/dev/null 2>&1; then
+    fail "missing required field: $field"
+  fi
+done
+
+log "checking field types..."
+jq -e '.session_id | type == "string"' "$TARGET" >/dev/null 2>&1 \
+  || fail "session_id must be string"
+jq -e '.session_id | test("^[0-9A-HJKMNP-TV-Z]{26}$")' "$TARGET" >/dev/null 2>&1 \
+  || fail "session_id must match ULID pattern"
+jq -e '.pane_id | type == "number"' "$TARGET" >/dev/null 2>&1 \
+  || fail "pane_id must be number"
+jq -e '.state | type == "string"' "$TARGET" >/dev/null 2>&1 \
+  || fail "state must be string"
+jq -e '.last_updated | type == "string"' "$TARGET" >/dev/null 2>&1 \
+  || fail "last_updated must be string"
+
+log "checking state enum..."
+VALID_STATES='["success","partial","retryable_failure","blocked","protocol_error","timeout"]'
+jq -e --argjson valid "$VALID_STATES" \
+  '.state as $s | $valid | index($s) != null' \
+  "$TARGET" >/dev/null 2>&1 \
+  || fail "state must be one of: success, partial, retryable_failure, blocked, protocol_error, timeout"
+
+log "checking optional outputs / blockers arrays..."
+if jq -e 'has("outputs")' "$TARGET" >/dev/null 2>&1; then
+  jq -e '.outputs | type == "array"' "$TARGET" >/dev/null 2>&1 \
+    || fail "outputs must be array"
+fi
+if jq -e 'has("blockers")' "$TARGET" >/dev/null 2>&1; then
+  jq -e '.blockers | type == "array"' "$TARGET" >/dev/null 2>&1 \
+    || fail "blockers must be array"
+fi
+
+log "checking optional verification map (Step 4-3)..."
+if jq -e 'has("verification")' "$TARGET" >/dev/null 2>&1; then
+  jq -e '.verification | type == "object"' "$TARGET" >/dev/null 2>&1 \
+    || fail "verification must be object (pane-keyed map)"
+
+  VALID_RESULTS='["pass","fail","warn"]'
+  # 各 pane キーのオブジェクトを検証
+  while IFS= read -r pane_key; do
+    log "  checking verification.$pane_key ..."
+    jq -e --arg k "$pane_key" '.verification[$k] | type == "object"' "$TARGET" >/dev/null 2>&1 \
+      || fail "verification.$pane_key must be object"
+
+    REQUIRED_V=("result" "reviewer_session_id" "reviewer_pane_id" "completed_at")
+    for field in "${REQUIRED_V[@]}"; do
+      if ! jq -e --arg k "$pane_key" --arg f "$field" \
+        '.verification[$k] | has($f)' "$TARGET" >/dev/null 2>&1; then
+        fail "missing verification.$pane_key.$field"
+      fi
+    done
+
+    jq -e --arg k "$pane_key" --argjson valid "$VALID_RESULTS" \
+      '.verification[$k].result as $r | $valid | index($r) != null' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification.$pane_key.result must be pass/fail/warn"
+
+    jq -e --arg k "$pane_key" \
+      '.verification[$k].reviewer_session_id | test("^[0-9A-HJKMNP-TV-Z]{26}$")' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification.$pane_key.reviewer_session_id must match ULID pattern"
+
+    jq -e --arg k "$pane_key" \
+      '.verification[$k].reviewer_pane_id | type == "number"' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification.$pane_key.reviewer_pane_id must be number"
+
+    # marker_raw は optional だが、ある場合はパターン検証
+    if jq -e --arg k "$pane_key" '.verification[$k] | has("marker_raw")' \
+      "$TARGET" >/dev/null 2>&1; then
+      jq -e --arg k "$pane_key" \
+        '.verification[$k].marker_raw | test("^@@OE_VERIFY:(pass|fail|warn)$")' \
+        "$TARGET" >/dev/null 2>&1 \
+        || fail "verification.$pane_key.marker_raw must match @@OE_VERIFY:(pass|fail|warn)"
+    fi
+  done < <(jq -r '.verification | keys[]' "$TARGET")
+fi
+
+log "checking optional verification_summary (Step 4-3)..."
+if jq -e 'has("verification_summary")' "$TARGET" >/dev/null 2>&1; then
+  jq -e '.verification_summary | type == "object"' "$TARGET" >/dev/null 2>&1 \
+    || fail "verification_summary must be object"
+
+  REQUIRED_VS=("total" "passed" "failed" "warned" "fail_rate")
+  for field in "${REQUIRED_VS[@]}"; do
+    if ! jq -e --arg f "$field" '.verification_summary | has($f)' \
+      "$TARGET" >/dev/null 2>&1; then
+      fail "missing verification_summary.$field"
+    fi
+  done
+
+  for field in total passed failed warned; do
+    jq -e --arg f "$field" \
+      '.verification_summary[$f] | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification_summary.$field must be non-negative integer"
+  done
+
+  jq -e \
+    '.verification_summary.fail_rate | type == "number" and . >= 0 and . <= 1' \
+    "$TARGET" >/dev/null 2>&1 \
+    || fail "verification_summary.fail_rate must be number in [0, 1]"
+fi
+
+echo "OK: $TARGET"
+exit 0

--- a/projects/orchestration-engine/scripts/validate-session-state.sh
+++ b/projects/orchestration-engine/scripts/validate-session-state.sh
@@ -98,6 +98,12 @@ if jq -e 'has("verification")' "$TARGET" >/dev/null 2>&1; then
   # 各 pane キーのオブジェクトを検証
   while IFS= read -r pane_key; do
     log "  checking verification.$pane_key ..."
+
+    # Copilot #7 反映: キーは pane_id 形式 (非負整数の文字列) のみ許容
+    if [[ ! "$pane_key" =~ ^[0-9]+$ ]]; then
+      fail "verification key '$pane_key' must match ^[0-9]+$ (target_pane_id integer string)"
+    fi
+
     jq -e --arg k "$pane_key" '.verification[$k] | type == "object"' "$TARGET" >/dev/null 2>&1 \
       || fail "verification.$pane_key must be object"
 
@@ -141,6 +147,15 @@ if jq -e 'has("verification")' "$TARGET" >/dev/null 2>&1; then
         "$TARGET" >/dev/null 2>&1 \
         || fail "verification.$pane_key.exit_code must be non-negative integer"
     fi
+
+    # Copilot #10 反映: issues_count は optional、ある場合は非負整数
+    if jq -e --arg k "$pane_key" '.verification[$k] | has("issues_count")' \
+      "$TARGET" >/dev/null 2>&1; then
+      jq -e --arg k "$pane_key" \
+        '.verification[$k].issues_count | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
+        "$TARGET" >/dev/null 2>&1 \
+        || fail "verification.$pane_key.issues_count must be non-negative integer"
+    fi
   done < <(jq -r '.verification | keys[]' "$TARGET")
 fi
 
@@ -175,6 +190,14 @@ if jq -e 'has("verification_summary")' "$TARGET" >/dev/null 2>&1; then
       '.verification_summary.protocol_errors | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
       "$TARGET" >/dev/null 2>&1 \
       || fail "verification_summary.protocol_errors must be non-negative integer"
+  fi
+
+  # Copilot #2 反映: timeouts は optional、ある場合は非負整数
+  if jq -e '.verification_summary | has("timeouts")' "$TARGET" >/dev/null 2>&1; then
+    jq -e \
+      '.verification_summary.timeouts | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification_summary.timeouts must be non-negative integer"
   fi
 fi
 

--- a/projects/orchestration-engine/scripts/validate-session-state.sh
+++ b/projects/orchestration-engine/scripts/validate-session-state.sh
@@ -132,6 +132,15 @@ if jq -e 'has("verification")' "$TARGET" >/dev/null 2>&1; then
         "$TARGET" >/dev/null 2>&1 \
         || fail "verification.$pane_key.marker_raw must match @@OE_VERIFY:(pass|fail|warn)"
     fi
+
+    # F-SO-2: exit_code は optional、ある場合は非負整数
+    if jq -e --arg k "$pane_key" '.verification[$k] | has("exit_code")' \
+      "$TARGET" >/dev/null 2>&1; then
+      jq -e --arg k "$pane_key" \
+        '.verification[$k].exit_code | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
+        "$TARGET" >/dev/null 2>&1 \
+        || fail "verification.$pane_key.exit_code must be non-negative integer"
+    fi
   done < <(jq -r '.verification | keys[]' "$TARGET")
 fi
 
@@ -159,6 +168,14 @@ if jq -e 'has("verification_summary")' "$TARGET" >/dev/null 2>&1; then
     '.verification_summary.fail_rate | type == "number" and . >= 0 and . <= 1' \
     "$TARGET" >/dev/null 2>&1 \
     || fail "verification_summary.fail_rate must be number in [0, 1]"
+
+  # F-SO-2: protocol_errors は optional、ある場合は非負整数
+  if jq -e '.verification_summary | has("protocol_errors")' "$TARGET" >/dev/null 2>&1; then
+    jq -e \
+      '.verification_summary.protocol_errors | type == "number" and . >= 0 and (. - (. | floor) == 0)' \
+      "$TARGET" >/dev/null 2>&1 \
+      || fail "verification_summary.protocol_errors must be non-negative integer"
+  fi
 fi
 
 echo "OK: $TARGET"

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -111,6 +111,65 @@ assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
 assert_eq "value" "2" "$OE_SCAN_VALUE"
 assert_eq "blocked_flag" "true" "$OE_SCAN_BLOCKED"
 
+# --- Step 4-3 F3: @@OE_VERIFY: 検出と二値保持 ---
+echo ""
+echo "=== _oe_capture_scan_parse — @@OE_VERIFY: (Step 4-3 F3) ==="
+
+echo "-- VERIFY のみ (pass) --"
+_oe_capture_scan_parse "review output
+@@OE_VERIFY:pass"
+assert_eq "verify_result" "pass" "$OE_SCAN_VERIFY_RESULT"
+assert_eq "exit_code (空)" "" "$OE_SCAN_EXIT_CODE"
+assert_eq "marker_type (VERIFY 単独 → VERIFY)" "VERIFY" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (VERIFY 単独 → pass)" "pass" "$OE_SCAN_VALUE"
+
+echo "-- VERIFY のみ (fail) --"
+_oe_capture_scan_parse "@@OE_VERIFY:fail"
+assert_eq "verify_result" "fail" "$OE_SCAN_VERIFY_RESULT"
+assert_eq "marker_type" "VERIFY" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "fail" "$OE_SCAN_VALUE"
+
+echo "-- VERIFY のみ (warn) --"
+_oe_capture_scan_parse "@@OE_VERIFY:warn"
+assert_eq "verify_result" "warn" "$OE_SCAN_VERIFY_RESULT"
+
+echo "-- VERIFY 不正値 → 無視 --"
+_oe_capture_scan_parse "@@OE_VERIFY:invalid"
+assert_eq "verify_result (不正値)" "" "$OE_SCAN_VERIFY_RESULT"
+assert_eq "exit_code (不正値)" "" "$OE_SCAN_EXIT_CODE"
+assert_eq "marker_type (不正値)" "" "$OE_SCAN_MARKER_TYPE"
+
+echo "-- VERIFY 値なし @@OE_VERIFY: は無視 --"
+_oe_capture_scan_parse "@@OE_VERIFY:"
+assert_eq "verify_result (値なし)" "" "$OE_SCAN_VERIFY_RESULT"
+
+echo "-- 行途中の VERIFY マーカーは無視 (行頭アンカー) --"
+_oe_capture_scan_parse "prefix @@OE_VERIFY:pass suffix"
+assert_eq "verify_result (行途中)" "" "$OE_SCAN_VERIFY_RESULT"
+
+echo "-- VERIFY + EXIT 両方検出 (二値保持) --"
+_oe_capture_scan_parse "task output
+@@OE_VERIFY:pass
+@@OE_EXIT:0"
+assert_eq "verify_result (両方検出)" "pass" "$OE_SCAN_VERIFY_RESULT"
+assert_eq "exit_code (両方検出)" "0" "$OE_SCAN_EXIT_CODE"
+assert_eq "marker_type (両方 → EXIT 優先で後方互換)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (両方 → exit_code)" "0" "$OE_SCAN_VALUE"
+
+echo "-- VERIFY + EXIT 両方検出 (fail + 0) --"
+_oe_capture_scan_parse "@@OE_VERIFY:fail
+@@OE_EXIT:0"
+assert_eq "verify_result (fail)" "fail" "$OE_SCAN_VERIFY_RESULT"
+assert_eq "exit_code (0)" "0" "$OE_SCAN_EXIT_CODE"
+assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value" "0" "$OE_SCAN_VALUE"
+
+echo "-- 複数 VERIFY → 最後の 1 つを採用 --"
+_oe_capture_scan_parse "@@OE_VERIFY:pass
+middle output
+@@OE_VERIFY:fail"
+assert_eq "verify_result (最後)" "fail" "$OE_SCAN_VERIFY_RESULT"
+
 # --- oe_capture_scan テスト（wez モック経由） ---
 echo ""
 echo "=== oe_capture_scan (wez mock) ==="

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -48,7 +48,14 @@ if [[ "${1:-}" == "pane" && "${2:-}" == "split" ]]; then
         ;;
     esac
   done
-  echo "777"
+  # 連番 split: 1 回目 = 777 (target)、2 回目 = 888 (reviewer)
+  count_file="${log_dir}/split_count"
+  current=777
+  [[ -f "$count_file" ]] && current=$(<"$count_file")
+  echo "$current" > "${log_dir}/split_last"
+  next=$(( current + 111 ))
+  echo "$next" > "$count_file"
+  echo "$current"
   exit 0
 fi
 
@@ -66,13 +73,25 @@ if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
   [[ -f "$count_file" ]] && current=$(<"$count_file")
   current=$(( current + 1 ))
   echo "$current" > "$count_file"
-  printf 'mock output\n@@OE_EXIT:0\n'
+  # reviewer pane (888) は @@OE_VERIFY:pass + @@OE_EXIT:0、それ以外は @@OE_EXIT:0 のみ
+  if [[ "$pane_id" == "888" ]]; then
+    printf 'review output\n@@OE_VERIFY:pass\n@@OE_EXIT:0\n'
+  else
+    printf 'mock output\n@@OE_EXIT:0\n'
+  fi
   exit 0
 fi
 
 if [[ "${1:-}" == "pane" && "${2:-}" == "kill" ]]; then
   pane_id="${3:-}"
   printf '%s\n' "$pane_id" >> "${log_dir}/kill.log"
+  exit 0
+fi
+
+if [[ "${1:-}" == "notify" ]]; then
+  title="${2:-}"
+  body="${3:-}"
+  printf '%s|%s\n' "$title" "$body" >> "${log_dir}/notify.log"
   exit 0
 fi
 
@@ -97,8 +116,8 @@ assert_eq "audit file exists" "true" "$( [[ -f "$audit_file" ]] && echo true || 
 assert_eq "state.session_id" "$session_id" "$(jq -r '.session_id' "$state_file")"
 assert_eq "session_id matches ULID alphabet pattern" "true" "$( [[ "$session_id" =~ ^[0-9A-HJKMNP-TV-Z]{26}$ ]] && echo true || echo false )"
 assert_eq "state.state" "success" "$(jq -r '.state' "$state_file")"
-assert_eq "capture called once" "1" "$(cat "${OE_MOCK_LOG_DIR}/capture_count_777")"
-assert_eq "cleanup kill called" "777" "$(cat "${OE_MOCK_LOG_DIR}/kill.log")"
+assert_eq "capture target pane (777) called at least once" "true" \
+  "$( [[ -f "${OE_MOCK_LOG_DIR}/capture_count_777" && "$(cat "${OE_MOCK_LOG_DIR}/capture_count_777")" -ge 1 ]] && echo true || echo false )"
 
 assert_eq "session_start emitted" "1" \
   "$(jq -r 'select(.event_type=="session_start") | 1' "$audit_file" | wc -l | tr -d ' ')"
@@ -109,11 +128,82 @@ assert_eq "state_change emitted" "1" \
   "$(jq -r 'select(.event_type=="state_change" and .state=="success") | 1' "$audit_file" | wc -l | tr -d ' ')"
 assert_eq "cleanup emitted" "1" \
   "$(jq -r 'select(.event_type=="cleanup") | 1' "$audit_file" | wc -l | tr -d ' ')"
-assert_eq "cleanup payload has killed_pane_ids" "777" "$(jq -r 'select(.event_type=="cleanup") | .payload.killed_pane_ids[0]' "$audit_file")"
 assert_eq "envelope path used in send" "1" \
   "$(awk -v sid="$session_id" 'index($0,"/tmp/oe-" sid "-envelope.json"){found=1} END{print found+0}' "${OE_MOCK_LOG_DIR}/send.log")"
 assert_eq "spawn send executed" "1" \
   "$(awk -v sid="$session_id" 'index($0,"Read /tmp/oe-" sid "-envelope.json and execute the task"){found=1} END{print found+0}' "${OE_MOCK_LOG_DIR}/send.log")"
+
+# ---- Step 4-3 Phase E: 検証フェーズが 1 サイクルに含まれる ----
+echo ""
+echo "=== Step 4-3 Phase E: 検証フェーズ完走 ==="
+
+# 検証 agent ペイン (888) が spawn された
+assert_eq "reviewer pane (888) split" "true" \
+  "$( [[ -f "${OE_MOCK_LOG_DIR}/capture_count_888" ]] && echo true || echo false )"
+
+# 検証用 envelope/inputs が send.log に展開される (target=777, reviewer=888)
+assert_eq "reviewer pane に verify envelope を send" "true" \
+  "$(awk -F'|' '$1=="888" && index($2, "verify-envelope.json"){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
+
+# verification_started イベントが emit される (target session の audit log)
+assert_eq "verification_started 1 件" "1" \
+  "$(jq -r 'select(.event_type=="verification_started") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "verification_started.payload.target_pane_id" "777" \
+  "$(jq -r 'select(.event_type=="verification_started") | .payload.target_pane_id' "$audit_file")"
+assert_eq "verification_started.payload.reviewer_pane_id" "888" \
+  "$(jq -r 'select(.event_type=="verification_started") | .payload.reviewer_pane_id' "$audit_file")"
+
+# verification_completed イベントが emit される (Phase D)
+assert_eq "verification_completed 1 件" "1" \
+  "$(jq -r 'select(.event_type=="verification_completed") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "verification_completed.payload.result" "pass" \
+  "$(jq -r 'select(.event_type=="verification_completed") | .payload.result' "$audit_file")"
+assert_eq "verification_completed.payload.marker_raw" "@@OE_VERIFY:pass" \
+  "$(jq -r 'select(.event_type=="verification_completed") | .payload.marker_raw' "$audit_file")"
+
+# KVS に verification (pane-keyed map) が書かれる
+assert_eq "verification map 件数" "1" "$(jq '.verification | length' "$state_file")"
+assert_eq "verification.777.result" "pass" "$(jq -r '.verification."777".result' "$state_file")"
+assert_eq "verification.777.reviewer_pane_id" "888" "$(jq -r '.verification."777".reviewer_pane_id' "$state_file")"
+assert_eq "verification.777.completed_at 存在" "true" \
+  "$(jq -r '.verification."777".completed_at | length > 0' "$state_file")"
+
+# verification_summary が集計される (1 件 pass / fail_rate = 0.000)
+assert_eq "verification_summary.total" "1" "$(jq -r '.verification_summary.total' "$state_file")"
+assert_eq "verification_summary.passed" "1" "$(jq -r '.verification_summary.passed' "$state_file")"
+assert_eq "verification_summary.failed" "0" "$(jq -r '.verification_summary.failed' "$state_file")"
+assert_eq "verification_summary.fail_rate" "0.000" "$(jq -r '.verification_summary.fail_rate' "$state_file")"
+
+# KVS が validate-session-state.sh で PASS
+if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$state_file" > /dev/null 2>&1; then
+  echo "  PASS: validate-session-state.sh"
+  (( PASS++ )) || true
+else
+  echo "  FAIL: validate-session-state.sh"
+  "${PROJECT_DIR}/scripts/validate-session-state.sh" "$state_file" 2>&1 | sed 's/^/    /'
+  (( FAIL++ )) || true
+fi
+
+# cleanup で target + reviewer 両ペインが kill される
+assert_eq "kill.log にエントリ 2 件" "2" "$(wc -l < "${OE_MOCK_LOG_DIR}/kill.log" | tr -d ' ')"
+assert_eq "kill.log に 777" "true" \
+  "$(grep -qx 777 "${OE_MOCK_LOG_DIR}/kill.log" && echo true || echo false)"
+assert_eq "kill.log に 888" "true" \
+  "$(grep -qx 888 "${OE_MOCK_LOG_DIR}/kill.log" && echo true || echo false)"
+assert_eq "cleanup payload killed_pane_ids に target + reviewer" "[777,888]" \
+  "$(jq -c 'select(.event_type=="cleanup") | .payload.killed_pane_ids' "$audit_file")"
+
+# DI-6: wez notify が呼ばれる (検証完走時)
+assert_eq "notify.log 存在" "true" "$( [[ -f "${OE_MOCK_LOG_DIR}/notify.log" ]] && echo true || echo false )"
+assert_eq "notify 1 件" "1" "$(wc -l < "${OE_MOCK_LOG_DIR}/notify.log" | tr -d ' ')"
+assert_eq "notify タイトル" "orchestration-engine session complete" \
+  "$(awk -F'|' 'NR==1{print $1}' "${OE_MOCK_LOG_DIR}/notify.log")"
+assert_eq "notify 本文に session_id" "true" \
+  "$(awk -F'|' -v sid="$session_id" 'NR==1 && index($2, sid){f=1} END{print (f+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/notify.log")"
+assert_eq "notify 本文に pass=1" "true" \
+  "$(awk -F'|' 'NR==1 && index($2, "pass=1"){f=1} END{print (f+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/notify.log")"
+assert_eq "notify 本文に fail_rate=0.000" "true" \
+  "$(awk -F'|' 'NR==1 && index($2, "fail_rate=0.000"){f=1} END{print (f+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/notify.log")"
 
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -205,6 +205,16 @@ assert_eq "notify 本文に pass=1" "true" \
 assert_eq "notify 本文に fail_rate=0.000" "true" \
   "$(awk -F'|' 'NR==1 && index($2, "fail_rate=0.000"){f=1} END{print (f+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/notify.log")"
 
+# Copilot #8 + #2: notify 本文に protocol_errors / timeouts が含まれる (誤った成功通知の防止)
+assert_eq "notify 本文に protocol_errors=0" "true" \
+  "$(awk -F'|' 'NR==1 && index($2, "protocol_errors=0"){f=1} END{print (f+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/notify.log")"
+assert_eq "notify 本文に timeouts=0" "true" \
+  "$(awk -F'|' 'NR==1 && index($2, "timeouts=0"){f=1} END{print (f+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/notify.log")"
+
+# Copilot #2: verification_summary に timeouts フィールドが追加される
+assert_eq "verification_summary.timeouts = 0 (正常完了時)" "0" \
+  "$(jq -r '.verification_summary.timeouts' "$state_file")"
+
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
 if [[ "$FAIL" -gt 0 ]]; then

--- a/projects/orchestration-engine/tests/test_kvs.sh
+++ b/projects/orchestration-engine/tests/test_kvs.sh
@@ -63,6 +63,105 @@ else
   (( PASS++ )) || true
 fi
 
+# ---- Step 4-3 Phase A: validate-session-state.sh の後方互換テスト ----
+# 既存の oe_capture_write_kvs 出力（verification フィールド無し）が新 validator で PASS する
+# = Step 4-2 で生成された state ファイルへの破壊的変更が起きていないことを保証する
+
+echo ""
+echo "=== validate-session-state.sh 後方互換 (Step 4-3 Phase A) ==="
+
+# ULID 形式の session_id を使った最小有効ケース（既存 capture.sh の出力相当）
+ulid_session_id="01KRMYHMET73WDE32JXD1TZ0A4"
+ulid_state_file="${OE_STATE_DIR}/${ulid_session_id}.state.json"
+
+oe_capture_write_kvs "$ulid_session_id" 5 "success"
+
+if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$ulid_state_file" > /dev/null 2>&1; then
+  echo "  PASS: legacy KVS (verification なし) が validator で PASS"
+  (( PASS++ )) || true
+else
+  echo "  FAIL: legacy KVS の validator が失敗"
+  "${PROJECT_DIR}/scripts/validate-session-state.sh" "$ulid_state_file" 2>&1 | sed 's/^/    /'
+  (( FAIL++ )) || true
+fi
+
+# verification + verification_summary を後付けで含めた KVS も validator で PASS する
+echo ""
+echo "=== validate-session-state.sh 拡張フィールド (Step 4-3 Phase A) ==="
+
+extended_state_file="${OE_STATE_DIR}/${ulid_session_id}.extended.state.json"
+cat > "$extended_state_file" <<'JSON'
+{
+  "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
+  "pane_id": 5,
+  "state": "success",
+  "last_updated": "2026-05-15T12:34:56Z",
+  "outputs": [],
+  "blockers": [],
+  "verification": {
+    "12": {
+      "result": "pass",
+      "reviewer_session_id": "01KRMYHMETZZZZZZZZZZZZZZZZ",
+      "reviewer_pane_id": 99,
+      "issues_count": 0,
+      "marker_raw": "@@OE_VERIFY:pass",
+      "completed_at": "2026-05-15T12:35:00Z"
+    },
+    "13": {
+      "result": "fail",
+      "reviewer_session_id": "01KRMYHMETZZZZZZZZZZZZZZZY",
+      "reviewer_pane_id": 100,
+      "issues_count": 3,
+      "marker_raw": "@@OE_VERIFY:fail",
+      "completed_at": "2026-05-15T12:36:00Z"
+    }
+  },
+  "verification_summary": {
+    "total": 2,
+    "passed": 1,
+    "failed": 1,
+    "warned": 0,
+    "fail_rate": 0.5
+  }
+}
+JSON
+
+if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$extended_state_file" > /dev/null 2>&1; then
+  echo "  PASS: 拡張 KVS (verification + verification_summary) が validator で PASS"
+  (( PASS++ )) || true
+else
+  echo "  FAIL: 拡張 KVS の validator が失敗"
+  "${PROJECT_DIR}/scripts/validate-session-state.sh" "$extended_state_file" 2>&1 | sed 's/^/    /'
+  (( FAIL++ )) || true
+fi
+
+# 不正値で FAIL することを確認
+bad_state_file="${OE_STATE_DIR}/${ulid_session_id}.bad.state.json"
+cat > "$bad_state_file" <<'JSON'
+{
+  "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
+  "pane_id": 5,
+  "state": "success",
+  "last_updated": "2026-05-15T12:34:56Z",
+  "verification": {
+    "12": {
+      "result": "invalid_value",
+      "reviewer_session_id": "01KRMYHMETZZZZZZZZZZZZZZZZ",
+      "reviewer_pane_id": 99,
+      "completed_at": "2026-05-15T12:35:00Z"
+    }
+  }
+}
+JSON
+
+if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$bad_state_file" > /dev/null 2>&1; then
+  echo "  FAIL: 不正な verification.result が validator で誤って PASS"
+  (( FAIL++ )) || true
+else
+  echo "  PASS: 不正な verification.result が validator で FAIL を返す"
+  (( PASS++ )) || true
+fi
+
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
 if [[ "$FAIL" -gt 0 ]]; then

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -14,7 +14,7 @@ export PROJECT_DIR
 
 _TMP_DIR="${SCRIPT_DIR}/.tmp_test_verify_$$"
 mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/logs" "$_TMP_DIR/data/state" "$_TMP_DIR/data/audit"
-trap 'rm -rf "$_TMP_DIR"; rm -f /tmp/oe-RTEST_REVIEWER_01-verify-envelope.json /tmp/oe-RTEST_REVIEWER_02-verify-envelope.json' EXIT
+trap 'rm -rf "$_TMP_DIR"; rm -f /tmp/oe-RTEST_REVIEWER_01-verify-envelope.json /tmp/oe-RTEST_REVIEWER_02-verify-envelope.json /tmp/oe-RTEST_SPAWN_REVIEWER_01-verify-envelope.json /tmp/oe-RTEST_SPAWN_REVIEWER_01-verify-inputs.md /tmp/oe-RTEST_PROMPT_01-verify-inputs.md /tmp/oe-RTEST_PROMPT_02-verify-inputs.md /tmp/oe-RTEST_PROMPT_GIT-verify-inputs.md /tmp/oe-RTEST_ENV_WITH_PROMPT-verify-envelope.json' EXIT
 
 PASS=0
 FAIL=0
@@ -31,6 +31,21 @@ assert_eq() {
     (( FAIL++ )) || true
   fi
 }
+
+# --- git モック (Phase C: outputs[] 空 → git diff フォールバックの検証用) ---
+# OE_MOCK_GIT_FILES が設定されていればそれを返し、未設定なら空文字列を返す
+cat > "${_TMP_DIR}/bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "diff" && "${2:-}" == "--name-only" ]]; then
+  if [[ -n "${OE_MOCK_GIT_FILES:-}" ]]; then
+    printf '%s\n' "${OE_MOCK_GIT_FILES}"
+  fi
+  exit 0
+fi
+# git diff 以外の git は素通り (実 git を使う)
+exec /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git "$@"
+EOF
+chmod +x "${_TMP_DIR}/bin/git"
 
 # --- wez モック: split / send を記録 ---
 cat > "${_TMP_DIR}/bin/wez" <<'EOF'
@@ -199,6 +214,126 @@ assert_eq "payload.reviewer_pane_id" "888" \
   "$(jq -r 'select(.event_type=="verification_started") | .payload.reviewer_pane_id' "$target_audit")"
 assert_eq "payload.reviewer_session_id" "$reviewer_session_id_for_spawn" \
   "$(jq -r 'select(.event_type=="verification_started") | .payload.reviewer_session_id' "$target_audit")"
+
+# ---- Phase C: oe_verify_prompt_build (3 入力の構造化抽出) ----
+echo ""
+echo "=== oe_verify_prompt_build (Phase C) ==="
+
+# 既に oe_verify_spawn 経由で target session の audit log に verification_started イベントが
+# 書かれている。Phase C 用に state_change イベントを追記:
+oe_audit_emit "state_change" "$target_session_id" "$target_pane_id" "success" '{"from":"progress","to":"success"}'
+
+# Case 1: KVS に outputs[] が複数あるケース (git フォールバックは呼ばれない)
+target_kvs_file="${OE_STATE_DIR}/${target_session_id}.state.json"
+cat > "$target_kvs_file" <<'JSON'
+{
+  "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
+  "pane_id": 42,
+  "state": "success",
+  "last_updated": "2026-05-15T12:34:56Z",
+  "outputs": ["src/foo.sh", "tests/test_foo.sh"],
+  "blockers": []
+}
+JSON
+
+echo "-- Case 1: KVS の outputs[] を使用 --"
+oe_verify_prompt_build "RTEST_PROMPT_01" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+
+assert_eq "OE_VERIFY_PROMPT_PATH set" "/tmp/oe-RTEST_PROMPT_01-verify-inputs.md" "$OE_VERIFY_PROMPT_PATH"
+assert_eq "prompt file exists" "true" "$( [[ -f "$OE_VERIFY_PROMPT_PATH" ]] && echo true || echo false )"
+
+assert_eq "section: 要件" "true" "$(grep -q '^## 要件' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "section: 完了報告" "true" "$(grep -q '^## 完了報告' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "section: 変更ファイル" "true" "$(grep -q '^## 変更ファイル' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+
+assert_eq "要件 = target.task.description" "true" \
+  "$(grep -q 'Target task description' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "完了報告に state_change イベント" "true" \
+  "$(grep -qE '"event_type": ?"state_change"' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "変更ファイルに outputs[0]" "true" \
+  "$(grep -q '^- src/foo.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "変更ファイルに outputs[1]" "true" \
+  "$(grep -q '^- tests/test_foo.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+
+# Case 2: KVS の outputs[] が空 → git diff フォールバック (git mock 経由)
+echo ""
+echo "-- Case 2: outputs[] 空 → git diff --name-only フォールバック --"
+
+cat > "$target_kvs_file" <<'JSON'
+{
+  "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
+  "pane_id": 42,
+  "state": "success",
+  "last_updated": "2026-05-15T12:34:56Z",
+  "outputs": [],
+  "blockers": []
+}
+JSON
+
+export OE_MOCK_GIT_FILES="lib/changed.sh
+tests/test_changed.sh"
+oe_verify_prompt_build "RTEST_PROMPT_GIT" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+unset OE_MOCK_GIT_FILES
+
+assert_eq "prompt path (git fallback)" "/tmp/oe-RTEST_PROMPT_GIT-verify-inputs.md" "$OE_VERIFY_PROMPT_PATH"
+assert_eq "git fallback: lib/changed.sh" "true" \
+  "$(grep -q '^- lib/changed.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "git fallback: tests/test_changed.sh" "true" \
+  "$(grep -q '^- tests/test_changed.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+assert_eq "git fallback: outputs[0] (src/foo.sh) は含まない" "false" \
+  "$(grep -q '^- src/foo.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+
+# Case 3: outputs[] 空 + git 出力も空 → "(no changes detected ...)" プレースホルダ
+echo ""
+echo "-- Case 3: outputs[] 空 + git 空 → プレースホルダ --"
+
+unset OE_MOCK_GIT_FILES
+oe_verify_prompt_build "RTEST_PROMPT_02" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+assert_eq "プレースホルダ表示" "true" \
+  "$(grep -q 'no changes detected' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+
+# ---- Phase C: oe_verify_envelope_create に prompt path を渡すと read_docs に 5 件目が追加される ----
+echo ""
+echo "=== oe_verify_envelope_create + verify_prompt_path (Phase C) ==="
+
+oe_verify_envelope_create \
+  "RTEST_ENV_WITH_PROMPT" \
+  900 \
+  "$target_pane_id" \
+  "$target_session_id" \
+  "$target_envelope_path" \
+  "$OE_VERIFY_PROMPT_PATH"
+
+JSON_WP="$OE_VERIFY_ENVELOPE_PATH"
+assert_eq "read_docs 件数 (prompt 含む)" "5" "$(jq '.task.read_docs | length' "$JSON_WP")"
+assert_eq "read_docs[4] = prompt path" "$OE_VERIFY_PROMPT_PATH" "$(jq -r '.task.read_docs[4]' "$JSON_WP")"
+assert_eq "read_docs[0] = skill path (5 件版)" "true" \
+  "$(jq -r '.task.read_docs[0] | endswith("canonical/skills/adversarial-review/SKILL.md")' "$JSON_WP")"
+
+# ---- Phase C: oe_verify_spawn が prompt_build → envelope (5 件 read_docs) を経由 ----
+echo ""
+echo "=== oe_verify_spawn が prompt_build を内部呼び出しする (Phase C) ==="
+
+# spawn を再実行 (前回の split mock state を更新)
+echo "888" > "${OE_MOCK_LOG_DIR}/split_count"
+rm -f "${OE_MOCK_LOG_DIR}/send.log"
+
+reviewer_spawn_c="RTEST_SPAWN_PHASE_C"
+oe_verify_spawn \
+  "$reviewer_spawn_c" \
+  "$target_pane_id" \
+  "$target_session_id" \
+  "$target_envelope_path"
+
+assert_eq "OE_VERIFY_PROMPT_PATH set after spawn" "/tmp/oe-${reviewer_spawn_c}-verify-inputs.md" "$OE_VERIFY_PROMPT_PATH"
+assert_eq "spawn-generated prompt file exists" "true" "$( [[ -f "$OE_VERIFY_PROMPT_PATH" ]] && echo true || echo false )"
+assert_eq "spawn-generated envelope read_docs 5 件" "5" \
+  "$(jq '.task.read_docs | length' "$OE_VERIFY_ENVELOPE_PATH")"
+assert_eq "spawn-generated envelope read_docs[4] = prompt" "$OE_VERIFY_PROMPT_PATH" \
+  "$(jq -r '.task.read_docs[4]' "$OE_VERIFY_ENVELOPE_PATH")"
+
+# クリーンアップ追加
+rm -f "/tmp/oe-${reviewer_spawn_c}-verify-envelope.json" "/tmp/oe-${reviewer_spawn_c}-verify-inputs.md"
 
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -142,8 +142,10 @@ assert_eq "task.exit_conditions.marker" "@@OE_VERIFY" "$(jq -r '.task.exit_condi
 assert_eq "task.exit_conditions.timeout_seconds" "$OE_CB_TIMEOUT" "$(jq -r '.task.exit_conditions.timeout_seconds' "$JSON")"
 assert_eq "task.use_skills" '["adversarial-review"]' "$(jq -c '.task.use_skills' "$JSON")"
 assert_eq "context.parent_session_id" "$target_session_id" "$(jq -r '.context.parent_session_id' "$JSON")"
-assert_eq "context.shared_kvs_path includes target session_id" "true" \
-  "$(jq -r --arg sid "$target_session_id" '.context.shared_kvs_path | endswith($sid + ".state.json")' "$JSON")"
+# F-SO-3: shared_kvs_path は null (schema 意図 = UC-2 並列協調用ディレクトリパス と乖離するため)
+# KVS パスは read_docs 経由で参照する
+assert_eq "context.shared_kvs_path = null (F-SO-3)" "null" \
+  "$(jq -r '.context.shared_kvs_path' "$JSON")"
 
 echo "-- task.read_docs に skill / 被検証 envelope / audit / KVS が含まれる --"
 assert_eq "read_docs 件数" "4" "$(jq '.task.read_docs | length' "$JSON")"
@@ -158,6 +160,18 @@ assert_eq "read_docs[3] = KVS state" "true" \
 echo "-- task.description に @@OE_VERIFY 指示が含まれる --"
 assert_eq "description references @@OE_VERIFY" "true" \
   "$(jq -r '.task.description | test("@@OE_VERIFY")' "$JSON")"
+
+# F-SO-1: skill 出力 → @@OE_VERIFY マッピング (Spec Compliant→pass / Issues Found→fail / advisory→warn) 明示
+assert_eq "F-SO-1: description に Spec Compliant マッピング" "true" \
+  "$(jq -r '.task.description | test("Spec Compliant")' "$JSON")"
+assert_eq "F-SO-1: description に Issues Found マッピング" "true" \
+  "$(jq -r '.task.description | test("Issues Found")' "$JSON")"
+assert_eq "F-SO-1: description に @@OE_VERIFY:pass" "true" \
+  "$(jq -r '.task.description | test("@@OE_VERIFY:pass")' "$JSON")"
+assert_eq "F-SO-1: description に @@OE_VERIFY:fail" "true" \
+  "$(jq -r '.task.description | test("@@OE_VERIFY:fail")' "$JSON")"
+assert_eq "F-SO-1: description に @@OE_VERIFY:warn" "true" \
+  "$(jq -r '.task.description | test("@@OE_VERIFY:warn")' "$JSON")"
 
 echo ""
 echo "-- 異なる reviewer_session_id で再生成 --"
@@ -466,6 +480,91 @@ echo "-- F6: verification_started は本 Phase D で emit されない --"
 echo "   (Phase B 初回 oe_verify_spawn + Phase C 再 oe_verify_spawn の 2 件のみ、Phase D は emit しない)"
 assert_eq "verification_started 件数 (Phase B + Phase C spawn の 2 件)" "2" \
   "$(jq -r 'select(.event_type=="verification_started") | 1' "$target_audit_file" | wc -l | tr -d ' ')"
+
+# ---- F-SO-2: exit_code 非 0 のとき verification_protocol_error + KVS に exit_code 併記 ----
+echo ""
+echo "=== F-SO-2: protocol error 経路 (exit_code != 0) ==="
+
+# 新しい target session を別途用意 (既存の集計と分離)
+proto_session="01KRSTERR00000000000000001"
+oe_capture_write_kvs "$proto_session" 60 "success"
+
+# exit_code=1 のケース: write_kvs に 8 引数目を渡す
+oe_verify_write_kvs \
+  "$proto_session" \
+  60 \
+  "01KRMYHMETZZZZZZZZZZZZZZZV" \
+  300 \
+  "pass" \
+  0 \
+  "@@OE_VERIFY:pass" \
+  1
+
+proto_state_file="${OE_STATE_DIR}/${proto_session}.state.json"
+assert_eq "F-SO-2: verification.60.exit_code 記録" "1" "$(jq -r '.verification."60".exit_code' "$proto_state_file")"
+assert_eq "F-SO-2: result は記録される (pass)" "pass" "$(jq -r '.verification."60".result' "$proto_state_file")"
+
+# exit_code=0 / 未指定なら exit_code フィールドは無い
+oe_verify_write_kvs \
+  "$proto_session" \
+  61 \
+  "01KRMYHMETZZZZZZZZZZZZZZZS" \
+  301 \
+  "pass" \
+  0 \
+  "@@OE_VERIFY:pass"
+assert_eq "F-SO-2: exit_code 未指定なら欠落" "false" \
+  "$(jq -r '.verification."61" | has("exit_code")' "$proto_state_file")"
+
+# summary に protocol_errors が記録される
+oe_verify_summary_update "$proto_session"
+assert_eq "F-SO-2: verification_summary.protocol_errors=1" "1" \
+  "$(jq -r '.verification_summary.protocol_errors' "$proto_state_file")"
+assert_eq "F-SO-2: total=2 (両エントリ集計対象)" "2" \
+  "$(jq -r '.verification_summary.total' "$proto_state_file")"
+
+# validate-session-state.sh で PASS (exit_code 拡張 + protocol_errors 拡張)
+if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$proto_state_file" > /dev/null 2>&1; then
+  echo "  PASS: F-SO-2: validate-session-state.sh で拡張 KVS が PASS"
+  (( PASS++ )) || true
+else
+  echo "  FAIL: F-SO-2: validate-session-state.sh で拡張 KVS が FAIL"
+  "${PROJECT_DIR}/scripts/validate-session-state.sh" "$proto_state_file" 2>&1 | sed 's/^/    /'
+  (( FAIL++ )) || true
+fi
+
+# ---- F-SO-4: oe_capture_scan の 2 引数目 (lines) 動作 ----
+echo ""
+echo "=== F-SO-4: oe_capture_scan の lines 引数 ==="
+
+# capture.sh が直接 source されていないので import
+# shellcheck source=../lib/capture.sh
+source "${PROJECT_DIR}/lib/capture.sh"
+
+# capture が wez を適切な --lines で呼ぶことを確認するため、wez モックを差し替える。
+# oe_capture_scan は wez を $(...) subshell 内で呼ぶため、変数記録は失われる。
+# ファイル経由で記録する。
+_F_SO_4_log="${_TMP_DIR}/f_so_4_lines.log"
+: > "$_F_SO_4_log"
+# shellcheck disable=SC2317  # wez は関数として PATH より優先される (function takes precedence)
+wez() {
+  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+    # arg3 = pane_id, arg4 = --lines, arg5 = lines value
+    printf '%s\n' "${5:-}" >> "$_F_SO_4_log"
+    echo "@@OE_EXIT:0"
+    return 0
+  fi
+  return 1
+}
+export -f wez
+
+oe_capture_scan "888"  # デフォルト lines=50
+assert_eq "F-SO-4: デフォルト lines=50" "50" "$(tail -1 "$_F_SO_4_log")"
+
+oe_capture_scan "888" 200  # 検証ペイン用 lines=200
+assert_eq "F-SO-4: lines=200 を渡せる" "200" "$(tail -1 "$_F_SO_4_log")"
+
+unset -f wez
 
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -36,7 +36,15 @@ assert_eq() {
 # OE_MOCK_GIT_FILES が設定されていればそれを返し、未設定なら空文字列を返す
 cat > "${_TMP_DIR}/bin/git" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "diff" && "${2:-}" == "--name-only" ]]; then
+# iter2 #3252519559 反映: verify.sh は `git -C "$PROJECT_DIR" diff --name-only` 形式で呼ぶようになった。
+# 先頭の -C <dir> を skip して subcommand を判定する。
+args=("$@")
+i=0
+# -C <path> を skip
+if [[ "${args[0]:-}" == "-C" && -n "${args[1]:-}" ]]; then
+  i=2
+fi
+if [[ "${args[i]:-}" == "diff" && "${args[$((i+1))]:-}" == "--name-only" ]]; then
   if [[ -n "${OE_MOCK_GIT_FILES:-}" ]]; then
     printf '%s\n' "${OE_MOCK_GIT_FILES}"
   fi

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -335,6 +335,138 @@ assert_eq "spawn-generated envelope read_docs[4] = prompt" "$OE_VERIFY_PROMPT_PA
 # クリーンアップ追加
 rm -f "/tmp/oe-${reviewer_spawn_c}-verify-envelope.json" "/tmp/oe-${reviewer_spawn_c}-verify-inputs.md"
 
+# ---- Phase D Step 9-10: KVS pane-keyed map 書き込み + summary 集計 + audit emit ----
+echo ""
+echo "=== oe_verify_write_kvs / oe_verify_summary_update / oe_verify_emit_completed (Phase D) ==="
+
+# Phase D テスト用に target KVS を初期化 (oe_capture_write_kvs 経由で legacy 形式)
+# shellcheck source=../lib/capture.sh
+source "${PROJECT_DIR}/lib/capture.sh"
+oe_capture_write_kvs "$target_session_id" "$target_pane_id" "success"
+
+echo "-- Pane 42 の検証結果を書き込み (pass) --"
+oe_verify_write_kvs \
+  "$target_session_id" \
+  "$target_pane_id" \
+  "01KRMYHMETZZZZZZZZZZZZZZZZ" \
+  101 \
+  "pass" \
+  0 \
+  "@@OE_VERIFY:pass"
+
+state_file="${OE_STATE_DIR}/${target_session_id}.state.json"
+assert_eq "state file 維持" "true" "$( [[ -f "$state_file" ]] && echo true || echo false )"
+assert_eq "verification.42.result" "pass" "$(jq -r '.verification."42".result' "$state_file")"
+assert_eq "verification.42.reviewer_session_id" "01KRMYHMETZZZZZZZZZZZZZZZZ" \
+  "$(jq -r '.verification."42".reviewer_session_id' "$state_file")"
+assert_eq "verification.42.reviewer_pane_id" "101" \
+  "$(jq -r '.verification."42".reviewer_pane_id' "$state_file")"
+assert_eq "verification.42.issues_count" "0" \
+  "$(jq -r '.verification."42".issues_count' "$state_file")"
+assert_eq "verification.42.marker_raw" "@@OE_VERIFY:pass" \
+  "$(jq -r '.verification."42".marker_raw' "$state_file")"
+assert_eq "verification.42.completed_at 存在" "true" \
+  "$(jq -r '.verification."42".completed_at | length > 0' "$state_file")"
+
+echo "-- 既存 state ({session_id, pane_id, state, ...}) は維持 --"
+assert_eq "session_id 維持" "$target_session_id" "$(jq -r '.session_id' "$state_file")"
+assert_eq "state 維持" "success" "$(jq -r '.state' "$state_file")"
+
+echo "-- Pane 43 の検証結果を追加書き込み (fail, issues=3) --"
+oe_verify_write_kvs \
+  "$target_session_id" \
+  43 \
+  "01KRMYHMETZZZZZZZZZZZZZZZY" \
+  102 \
+  "fail" \
+  3 \
+  "@@OE_VERIFY:fail"
+
+assert_eq "verification map 件数" "2" "$(jq '.verification | length' "$state_file")"
+assert_eq "verification.42 維持 (上書きなし)" "pass" "$(jq -r '.verification."42".result' "$state_file")"
+assert_eq "verification.43.result" "fail" "$(jq -r '.verification."43".result' "$state_file")"
+assert_eq "verification.43.issues_count" "3" "$(jq -r '.verification."43".issues_count' "$state_file")"
+
+echo "-- Pane 44 を warn で追加書き込み --"
+oe_verify_write_kvs \
+  "$target_session_id" \
+  44 \
+  "01KRMYHMETZZZZZZZZZZZZZZZX" \
+  103 \
+  "warn" \
+  1 \
+  "@@OE_VERIFY:warn"
+
+assert_eq "verification map 件数 (3 pane)" "3" "$(jq '.verification | length' "$state_file")"
+
+echo ""
+echo "-- oe_verify_summary_update でセッション集計 --"
+oe_verify_summary_update "$target_session_id"
+
+assert_eq "verification_summary.total" "3" "$(jq -r '.verification_summary.total' "$state_file")"
+assert_eq "verification_summary.passed" "1" "$(jq -r '.verification_summary.passed' "$state_file")"
+assert_eq "verification_summary.failed" "1" "$(jq -r '.verification_summary.failed' "$state_file")"
+assert_eq "verification_summary.warned" "1" "$(jq -r '.verification_summary.warned' "$state_file")"
+assert_eq "verification_summary.fail_rate" "0.333" \
+  "$(jq -r '.verification_summary.fail_rate' "$state_file")"
+
+echo ""
+echo "-- 集計後の KVS が validate-session-state.sh で PASS --"
+if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$state_file" > /dev/null 2>&1; then
+  echo "  PASS: validate-session-state.sh"
+  (( PASS++ )) || true
+else
+  echo "  FAIL: validate-session-state.sh"
+  "${PROJECT_DIR}/scripts/validate-session-state.sh" "$state_file" 2>&1 | sed 's/^/    /'
+  (( FAIL++ )) || true
+fi
+
+echo ""
+echo "-- fail のみ (total=1, failed=1, fail_rate=1.000) のケース --"
+# 別 target session で完全 fail パターンを検証
+fail_session="01KRFAIL000000000000000001"
+oe_capture_write_kvs "$fail_session" 50 "success"
+oe_verify_write_kvs "$fail_session" 50 "01KRMYHMETZZZZZZZZZZZZZZZW" 200 "fail" 5 "@@OE_VERIFY:fail"
+oe_verify_summary_update "$fail_session"
+
+fail_state_file="${OE_STATE_DIR}/${fail_session}.state.json"
+assert_eq "fail-only total" "1" "$(jq -r '.verification_summary.total' "$fail_state_file")"
+assert_eq "fail-only failed" "1" "$(jq -r '.verification_summary.failed' "$fail_state_file")"
+assert_eq "fail-only fail_rate" "1.000" "$(jq -r '.verification_summary.fail_rate' "$fail_state_file")"
+
+echo ""
+echo "-- oe_verify_emit_completed が target audit log に追記 --"
+target_audit_file="${OE_AUDIT_DIR}/${target_session_id}.jsonl"
+oe_verify_emit_completed "$target_session_id" "$target_pane_id" "pass" 0 "@@OE_VERIFY:pass"
+oe_verify_emit_completed "$target_session_id" 43 "fail" 3 "@@OE_VERIFY:fail"
+
+assert_eq "verification_completed 件数" "2" \
+  "$(jq -r 'select(.event_type=="verification_completed") | 1' "$target_audit_file" | wc -l | tr -d ' ')"
+
+# 最初の verification_completed (pane 42, pass)
+assert_eq "verification_completed[0].pane_id" "$target_pane_id" \
+  "$(jq -s 'map(select(.event_type=="verification_completed")) | .[0].pane_id' "$target_audit_file")"
+assert_eq "verification_completed[0].payload.result" "pass" \
+  "$(jq -s -r 'map(select(.event_type=="verification_completed")) | .[0].payload.result' "$target_audit_file")"
+assert_eq "verification_completed[0].payload.issues_count" "0" \
+  "$(jq -s -r 'map(select(.event_type=="verification_completed")) | .[0].payload.issues_count' "$target_audit_file")"
+assert_eq "verification_completed[0].payload.marker_raw" "@@OE_VERIFY:pass" \
+  "$(jq -s -r 'map(select(.event_type=="verification_completed")) | .[0].payload.marker_raw' "$target_audit_file")"
+
+# 2 件目 (pane 43, fail, issues=3)
+assert_eq "verification_completed[1].pane_id" "43" \
+  "$(jq -s 'map(select(.event_type=="verification_completed")) | .[1].pane_id' "$target_audit_file")"
+assert_eq "verification_completed[1].payload.result" "fail" \
+  "$(jq -s -r 'map(select(.event_type=="verification_completed")) | .[1].payload.result' "$target_audit_file")"
+assert_eq "verification_completed[1].payload.issues_count" "3" \
+  "$(jq -s -r 'map(select(.event_type=="verification_completed")) | .[1].payload.issues_count' "$target_audit_file")"
+
+echo ""
+echo "-- F6: verification_started は本 Phase D で emit されない --"
+echo "   (Phase B 初回 oe_verify_spawn + Phase C 再 oe_verify_spawn の 2 件のみ、Phase D は emit しない)"
+assert_eq "verification_started 件数 (Phase B + Phase C spawn の 2 件)" "2" \
+  "$(jq -r 'select(.event_type=="verification_started") | 1' "$target_audit_file" | wc -l | tr -d ' ')"
+
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
 if [[ "$FAIL" -gt 0 ]]; then

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_verify.sh — Step 4-3 verify.sh のユニットテスト (Phase B)
+#
+# Phase B 対象:
+#   - oe_verify_envelope_create: 検証用 envelope の生成 + validate-envelope.sh PASS
+#   - oe_verify_spawn: wez モック経由のペイン準備 + 送信 + verification_started emit
+# Phase C/D で追加: oe_verify_prompt_build, KVS 書き込み, verification_completed emit
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+_TMP_DIR="${SCRIPT_DIR}/.tmp_test_verify_$$"
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/logs" "$_TMP_DIR/data/state" "$_TMP_DIR/data/audit"
+trap 'rm -rf "$_TMP_DIR"; rm -f /tmp/oe-RTEST_REVIEWER_01-verify-envelope.json /tmp/oe-RTEST_REVIEWER_02-verify-envelope.json' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+# --- wez モック: split / send を記録 ---
+cat > "${_TMP_DIR}/bin/wez" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir="${OE_MOCK_LOG_DIR:?}"
+
+if [[ "${1:-}" == "pane" && "${2:-}" == "split" ]]; then
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bottom|--right|--left|--top|--wait-ready|--json) shift ;;
+      --percent|--timeout|--pane-id|--cwd)
+        [[ $# -ge 2 ]] || exit 1
+        shift 2
+        ;;
+      *)
+        echo "unexpected wez split option: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+  # 連番ペイン ID (888, 889, ...) を返す
+  count_file="${log_dir}/split_count"
+  current=888
+  [[ -f "$count_file" ]] && current=$(<"$count_file")
+  echo "$current" > "$count_file"
+  next=$(( current + 1 ))
+  echo "$next" > "$count_file"
+  echo "$current"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pane" && "${2:-}" == "send" ]]; then
+  pane_id="${3:-}"
+  payload="${4:-}"
+  printf '%s|%s\n' "$pane_id" "$payload" >> "${log_dir}/send.log"
+  exit 0
+fi
+
+echo "unexpected wez call: $*" >&2
+exit 1
+EOF
+chmod +x "${_TMP_DIR}/bin/wez"
+
+export PATH="${_TMP_DIR}/bin:${PATH}"
+export OE_MOCK_LOG_DIR="${_TMP_DIR}/logs"
+export OE_DATA_DIR="${_TMP_DIR}/data"
+
+# constants.sh / audit.sh / envelope.sh / spawn.sh / verify.sh をロード
+# shellcheck source=../lib/constants.sh
+source "${PROJECT_DIR}/lib/constants.sh"
+# shellcheck source=../lib/audit.sh
+source "${PROJECT_DIR}/lib/audit.sh"
+# shellcheck source=../lib/envelope.sh
+source "${PROJECT_DIR}/lib/envelope.sh"
+# shellcheck source=../lib/spawn.sh
+source "${PROJECT_DIR}/lib/spawn.sh"
+# shellcheck source=../lib/verify.sh
+source "${PROJECT_DIR}/lib/verify.sh"
+
+# ---- oe_verify_envelope_create ----
+echo "=== oe_verify_envelope_create ==="
+
+# 被検証 envelope (target) を先に生成 (read_docs から参照される)
+target_session_id="01KRMYHMET73WDE32JXD1TZ0A4"
+target_pane_id=42
+target_envelope_path="/tmp/oe-${target_session_id}-envelope.json"
+oe_envelope_create "$target_session_id" "$target_pane_id" "Target task description" "./output" 300
+# oe_envelope_create が生成したファイルパスを target として使う
+target_envelope_path="$OE_ENVELOPE_PATH"
+
+reviewer_session_id="RTEST_REVIEWER_01"
+reviewer_pane_id=888
+
+echo "-- 検証用 envelope を生成 + validate-envelope.sh PASS --"
+oe_verify_envelope_create \
+  "$reviewer_session_id" \
+  "$reviewer_pane_id" \
+  "$target_pane_id" \
+  "$target_session_id" \
+  "$target_envelope_path"
+
+assert_eq "OE_VERIFY_ENVELOPE_PATH set" "/tmp/oe-${reviewer_session_id}-verify-envelope.json" "$OE_VERIFY_ENVELOPE_PATH"
+assert_eq "verify envelope file exists" "true" "$( [[ -f "$OE_VERIFY_ENVELOPE_PATH" ]] && echo true || echo false )"
+
+JSON="$OE_VERIFY_ENVELOPE_PATH"
+
+echo "-- envelope フィールド検証 --"
+assert_eq "session_id" "$reviewer_session_id" "$(jq -r '.session_id' "$JSON")"
+assert_eq "pane_id" "$reviewer_pane_id" "$(jq -r '.pane_id' "$JSON")"
+assert_eq "task.exit_conditions.marker" "@@OE_VERIFY" "$(jq -r '.task.exit_conditions.marker' "$JSON")"
+assert_eq "task.exit_conditions.timeout_seconds" "$OE_CB_TIMEOUT" "$(jq -r '.task.exit_conditions.timeout_seconds' "$JSON")"
+assert_eq "task.use_skills" '["adversarial-review"]' "$(jq -c '.task.use_skills' "$JSON")"
+assert_eq "context.parent_session_id" "$target_session_id" "$(jq -r '.context.parent_session_id' "$JSON")"
+assert_eq "context.shared_kvs_path includes target session_id" "true" \
+  "$(jq -r --arg sid "$target_session_id" '.context.shared_kvs_path | endswith($sid + ".state.json")' "$JSON")"
+
+echo "-- task.read_docs に skill / 被検証 envelope / audit / KVS が含まれる --"
+assert_eq "read_docs 件数" "4" "$(jq '.task.read_docs | length' "$JSON")"
+assert_eq "read_docs[0] = skill path" "true" \
+  "$(jq -r '.task.read_docs[0] | endswith("canonical/skills/adversarial-review/SKILL.md")' "$JSON")"
+assert_eq "read_docs[1] = target envelope" "$target_envelope_path" "$(jq -r '.task.read_docs[1]' "$JSON")"
+assert_eq "read_docs[2] = audit JSONL" "true" \
+  "$(jq -r --arg sid "$target_session_id" '.task.read_docs[2] | endswith($sid + ".jsonl")' "$JSON")"
+assert_eq "read_docs[3] = KVS state" "true" \
+  "$(jq -r --arg sid "$target_session_id" '.task.read_docs[3] | endswith($sid + ".state.json")' "$JSON")"
+
+echo "-- task.description に @@OE_VERIFY 指示が含まれる --"
+assert_eq "description references @@OE_VERIFY" "true" \
+  "$(jq -r '.task.description | test("@@OE_VERIFY")' "$JSON")"
+
+echo ""
+echo "-- 異なる reviewer_session_id で再生成 --"
+oe_verify_envelope_create \
+  "RTEST_REVIEWER_02" \
+  889 \
+  43 \
+  "$target_session_id" \
+  "$target_envelope_path"
+assert_eq "OE_VERIFY_ENVELOPE_PATH 更新" "/tmp/oe-RTEST_REVIEWER_02-verify-envelope.json" "$OE_VERIFY_ENVELOPE_PATH"
+assert_eq "session_id 更新" "RTEST_REVIEWER_02" "$(jq -r '.session_id' "$OE_VERIFY_ENVELOPE_PATH")"
+assert_eq "pane_id 更新" "889" "$(jq -r '.pane_id' "$OE_VERIFY_ENVELOPE_PATH")"
+
+# ---- oe_verify_spawn (wez モック経由) ----
+echo ""
+echo "=== oe_verify_spawn (wez mock) ==="
+
+# split mock が次に返す ID は 888
+echo "888" > "${OE_MOCK_LOG_DIR}/split_count"
+
+reviewer_session_id_for_spawn="RTEST_SPAWN_REVIEWER_01"
+oe_verify_spawn \
+  "$reviewer_session_id_for_spawn" \
+  "$target_pane_id" \
+  "$target_session_id" \
+  "$target_envelope_path"
+
+assert_eq "OE_VERIFY_PANE_ID set (mock の split で 888 を返した)" "888" "$OE_VERIFY_PANE_ID"
+assert_eq "OE_VERIFY_ENVELOPE_PATH (spawn 後)" "/tmp/oe-${reviewer_session_id_for_spawn}-verify-envelope.json" "$OE_VERIFY_ENVELOPE_PATH"
+
+echo "-- wez pane send 呼び出し記録 --"
+send_log="${OE_MOCK_LOG_DIR}/send.log"
+assert_eq "send.log にエントリ" "true" "$( [[ -s "$send_log" ]] && echo true || echo false )"
+assert_eq "send pane_id" "888" "$(awk -F'|' 'NR==1{print $1}' "$send_log")"
+assert_eq "send payload に verify envelope パス" "true" \
+  "$(awk -F'|' -v sid="$reviewer_session_id_for_spawn" 'index($0, "/tmp/oe-" sid "-verify-envelope.json"){found=1} END{print (found+0==1) ? "true" : "false"}' "$send_log")"
+assert_eq "send payload に @@OE_EXIT printf" "true" \
+  "$(awk -F'|' 'index($0, "@@OE_EXIT"){found=1} END{print (found+0==1) ? "true" : "false"}' "$send_log")"
+
+echo "-- verification_started audit emit (target session の audit log に追記) --"
+target_audit="${OE_AUDIT_DIR}/${target_session_id}.jsonl"
+assert_eq "audit file exists" "true" "$( [[ -f "$target_audit" ]] && echo true || echo false )"
+assert_eq "verification_started 1 件" "1" \
+  "$(jq -r 'select(.event_type=="verification_started") | 1' "$target_audit" | wc -l | tr -d ' ')"
+assert_eq "verification_started.pane_id = target_pane_id" "$target_pane_id" \
+  "$(jq -r 'select(.event_type=="verification_started") | .pane_id' "$target_audit")"
+assert_eq "verification_started.state = null" "null" \
+  "$(jq -r 'select(.event_type=="verification_started") | .state' "$target_audit")"
+assert_eq "payload.target_pane_id" "$target_pane_id" \
+  "$(jq -r 'select(.event_type=="verification_started") | .payload.target_pane_id' "$target_audit")"
+assert_eq "payload.target_session_id" "$target_session_id" \
+  "$(jq -r 'select(.event_type=="verification_started") | .payload.target_session_id' "$target_audit")"
+assert_eq "payload.reviewer_pane_id" "888" \
+  "$(jq -r 'select(.event_type=="verification_started") | .payload.reviewer_pane_id' "$target_audit")"
+assert_eq "payload.reviewer_session_id" "$reviewer_session_id_for_spawn" \
+  "$(jq -r 'select(.event_type=="verification_started") | .payload.reviewer_session_id' "$target_audit")"
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -211,6 +211,11 @@ assert_eq "send payload に verify envelope パス" "true" \
 assert_eq "send payload に @@OE_EXIT printf" "true" \
   "$(awk -F'|' 'index($0, "@@OE_EXIT"){found=1} END{print (found+0==1) ? "true" : "false"}' "$send_log")"
 
+# Copilot #5: prepare_pane 直後に OE_VERIFY_MANAGED_PANES に追加されている (orphan pane 防止)
+echo "-- Copilot #5: OE_VERIFY_MANAGED_PANES に reviewer pane が追加される --"
+assert_eq "OE_VERIFY_MANAGED_PANES に 888 が含まれる" "true" \
+  "$(printf '%s\n' "${OE_VERIFY_MANAGED_PANES[@]}" | grep -q '^888$' && echo true || echo false)"
+
 echo "-- verification_started audit emit (target session の audit log に追記) --"
 target_audit="${OE_AUDIT_DIR}/${target_session_id}.jsonl"
 assert_eq "audit file exists" "true" "$( [[ -f "$target_audit" ]] && echo true || echo false )"
@@ -305,6 +310,21 @@ unset OE_MOCK_GIT_FILES
 oe_verify_prompt_build "RTEST_PROMPT_02" "$target_pane_id" "$target_session_id" "$target_envelope_path"
 assert_eq "プレースホルダ表示" "true" \
   "$(grep -q 'no changes detected' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
+
+# Copilot #3 反映: state_change は target_pane_id でフィルタされる
+# 別 pane (99) の state_change イベントを混入させても、target (pane 42) の方が選ばれることを確認
+echo ""
+echo "-- Copilot #3: oe_verify_prompt_build は state_change を target_pane_id でフィルタ --"
+oe_audit_emit "state_change" "$target_session_id" 99 "partial" '{"from":"progress","to":"partial","note":"different pane"}'
+oe_verify_prompt_build "RTEST_PROMPT_FILTER" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+filter_prompt_path="$OE_VERIFY_PROMPT_PATH"
+
+assert_eq "Copilot #3: prompt に target pane_id=42 が含まれる" "true" \
+  "$(grep -q '"pane_id": 42' "$filter_prompt_path" && echo true || echo false)"
+assert_eq "Copilot #3: 別 pane 99 の state_change は混入しない" "false" \
+  "$(grep -q '"pane_id": 99' "$filter_prompt_path" && echo true || echo false)"
+
+rm -f "/tmp/oe-RTEST_PROMPT_FILTER-verify-inputs.md"
 
 # ---- Phase C: oe_verify_envelope_create に prompt path を渡すと read_docs に 5 件目が追加される ----
 echo ""


### PR DESCRIPTION
## Summary

[Epic #19](https://github.com/stlwolf/ai-development-hub/issues/19) Phase 4 MVP の **Step 4-3「検証ゲート v1」** の駆動層ドキュメントと実装。Compliance Review モードの検証ゲートを `lib/verify.sh` + schema 拡張で実装し、so-compare 2 段階レビュー (Plan 段階 + 実装段階) を経て確定した。

ツール間引き継ぎ (Cursor Agent → Claude Code) の dogfood ケースとしても機能した。駆動層ドキュメント (Discussion / KickOff / Plan) のみで Claude Code が継続作業できることを実証した。

## 蒸留チェーン (全段階完走)

| 段階 | ファイル | 状態 |
|------|---------|------|
| Discussion | `docs/discussions/2026-05-15-discussion-step-4-3-verification-gate.md` | closed (Q1〜Q7 合意) |
| KickOff | `docs/plans/2026-05-15-kickoff-step-4-3-verification-gate.md` | confirmed (DI-1〜DI-7 確定) |
| Plan | `docs/plans/2026-05-15-plan-step-4-3-verification-gate.md` | draft (F1-F8 反映済み、5 Phase 構成) |
| Implementation (Phase A〜E) | `lib/verify.sh` 他 | 5 commits (d6d258a 〜 5c402fc) |
| so-compare 実装レビュー | `tmp/so-20260516-025239/` (gitignore) | Codex (Critical) + Claude (Concern 条件付き) |
| F-SO 修正 | 1 commit (4a05fe8) | F-SO-1〜6 + F-SO-12 反映 |
| Episode | `docs/episodes/2026-05-16-episode-step-4-3-implementation.md` | stable (実装 + レビュー + 修正の分離記述) |
| ADR | `docs/decisions/2026-05-16-decision-verification-gate-design.md` | accepted (8 主要決定 + 根拠 + トレードオフ) |

## 主な設計判断 (DI-1〜DI-7)

- **DI-1**: 動作モード = Compliance Review のみ (Plan Review は engine 統合せず)
- **DI-2**: 発火タイミング = end-of-session + fail 率を実運用データとして記録
- **DI-3**: 検証 agent 起動 = 新ペイン spawn (`lib/spawn.sh` 再利用)
- **DI-4**: プロンプト構成 = envelope + audit + KVS の 3 ソース統合
- **DI-5**: 結果表現 = `verification` (pane-keyed map) + `verification_summary` で KVS スキーマ最小拡張
- **DI-6**: 不合格時 = 記録のみ + `wez notify` で完了通知
- **DI-7**: skill 統合 = envelope の `use_skills: [adversarial-review]` で疎結合 + `@@OE_VERIFY:{result}` マーカー

詳細は [Discussion](https://github.com/stlwolf/ai-development-hub/blob/feature/%2389_step-4-3-verification-gate-impl/projects/orchestration-engine/docs/discussions/2026-05-15-discussion-step-4-3-verification-gate.md) と [ADR](https://github.com/stlwolf/ai-development-hub/blob/feature/%2389_step-4-3-verification-gate-impl/projects/orchestration-engine/docs/decisions/2026-05-16-decision-verification-gate-design.md) 参照。

## 実装範囲

```
projects/orchestration-engine/
├── bin/oe                                 (M) oe_verify_run_phase 呼び出し統合
├── lib/
│   ├── constants.sh                       (M) OE_VERIFY_MARKER_RE / OE_VERIFY_MANAGED_PANES 等
│   ├── capture.sh                         (M) F3 二値保持 + F-SO-4/5 反映
│   ├── verify.sh                          (+) 新規 — 全検証ロジック集約 (envelope/spawn/prompt/write/summary/run_phase)
│   └── cleanup.sh                         (M) 検証ペイン kill + wez notify (DI-6)
├── schemas/
│   ├── session-state.schema.json          (M) verification + verification_summary 拡張 (F-SO-2 で exit_code / protocol_errors 追加)
│   └── audit-log.schema.json              (M) 3 event types 追加 (started/completed/protocol_error)
├── scripts/
│   └── validate-session-state.sh          (+) 新規 — schema 拡張対応 validator
├── tests/
│   ├── test_kvs.sh                        (M) validator 後方互換 + 拡張テスト 13 assertions
│   ├── test_capture.sh                    (M) VERIFY パース 22 ケース追加 (67 assertions)
│   ├── test_e2e_smoke.sh                  (M) 検証フェーズを含む 1 サイクル完走 (40 assertions)
│   └── test_verify.sh                     (+) 新規 — Phase B〜D + F-SO カバレッジ (98 assertions)
└── docs/
    ├── discussions/2026-05-15-discussion-step-4-3-verification-gate.md  (+)
    ├── plans/2026-05-15-kickoff-step-4-3-verification-gate.md           (M, status: confirmed)
    ├── plans/2026-05-15-plan-step-4-3-verification-gate.md              (+, F1-F8 反映済み)
    ├── episodes/2026-05-16-episode-step-4-3-implementation.md           (+)
    └── decisions/2026-05-16-decision-verification-gate-design.md        (+)
```

## テスト統計

**全 8 テストスイート 293 assertions PASS** (Step 4-2 完了時から +148):

| Suite | 件数 |
|-------|------|
| test_audit | 11 |
| test_capture | 67 (+22 VERIFY) |
| test_cleanup | 13 |
| test_e2e_smoke | 40 (+25 Phase E) |
| test_envelope | 20 |
| test_kvs | 13 (+3 validator) |
| test_monitor | 31 |
| **test_verify** | **98** (B 32 + C 21 + D 32 + F-SO 13) |

shellcheck クリーン。schemas は jq で構文チェック PASS、`validate-session-state.sh` で拡張 KVS が PASS。

## 2 段階 so-compare レビューの反映

| 段階 | レビュー対象 | 反映 | 結果 |
|------|-------------|------|------|
| Plan 段階 (PR #90 docs phase) | Discussion + KickOff + Plan | **F1-F8** | Plan 文書修正で解消、commit 47b101f |
| 実装段階 (本 PR の impl phase) | lib/verify.sh + 関連 schema/test | **F-SO-1〜6 + F-SO-12** | コード修正で解消、commit 4a05fe8 |

実装段階の so-compare で発見された Critical 一致点 3 件のうち 2 件は本 PR で解消、残り 1 件 (AI CLI 起動オプション不整合) は派生 Issue [#91](https://github.com/stlwolf/ai-development-hub/issues/91) として Step 4-4 着手前必須に分類した。

## Test plan

本 PR は **mock 経由テスト** で全機能の動作を検証している。実 agent での動作確認は Step 4-4 で実施 (派生 Issue [#91](https://github.com/stlwolf/ai-development-hub/issues/91) で AI CLI 起動オプション修正後)。

レビュー観点:

- [ ] 駆動層ドキュメントが Discussion → KickOff → Plan → Episode → ADR の蒸留チェーンを完走しているか
- [ ] DI-1〜DI-7 + F1〜F8 + F-SO-1〜12 が ADR / Episode で追跡可能か
- [ ] 検証ゲート v1 の 8 完了条件 (KickOff §完了条件) がすべて達成されているか
- [ ] schema 拡張 (session-state + audit-log) が `validate-session-state.sh` と整合しているか
- [ ] 全 8 テストスイートが PASS、shellcheck クリーン
- [ ] 派生 Issue 起票 ([#91](https://github.com/stlwolf/ai-development-hub/issues/91) / [#92](https://github.com/stlwolf/ai-development-hub/issues/92) / [#93](https://github.com/stlwolf/ai-development-hub/issues/93)) が Step 4-4 / Step 4-5 / MVP 後拡張のロードマップと整合しているか

## 派生 Issue (本 PR 後の運用)

| Issue | 内容 | スコープ |
|-------|------|---------|
| [#91](https://github.com/stlwolf/ai-development-hub/issues/91) | AI CLI 起動オプション (`claude -p` / `codex -p`) に修正 (F-SO-7) | **Step 4-4 着手前必須** (sub-issue of #19) |
| [#92](https://github.com/stlwolf/ai-development-hub/issues/92) | 変更ファイル検出 per-pane 化 + 完了報告内容の充実 (F-SO-8/9) | Step 4-5 候補 (sub-issue of #19) |
| [#93](https://github.com/stlwolf/ai-development-hub/issues/93) | reviewer 一時ファイル掃除 + nonce マーカー偽陽性対策 (F-SO-10/11) | MVP 後拡張 |

## 参照

- Parent Epic: [#19](https://github.com/stlwolf/ai-development-hub/issues/19)
- 観測層サブ Issue: [#89](https://github.com/stlwolf/ai-development-hub/issues/89)
- 前 Step: [#87](https://github.com/stlwolf/ai-development-hub/issues/87) Step 4-2 (closed, [PR #88](https://github.com/stlwolf/ai-development-hub/pull/88))
- `canonical/skills/adversarial-review/SKILL.md` — Compliance Review プロンプト規約 (engine が `use_skills` 経由で参照)

Refs #19 #89 #91 #92 #93
