### PR TITLE
feat(orchestration-engine): Step 4-4 E2E 検証 v1 実装 (実 agent 1 サイクル完走 + Phase C.5 viewport bug fix)

### DIFF
--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -51,13 +51,30 @@ oe_main() {
   OE_CURRENT_SESSION_ID="$(oe_generate_session_id)"
 
   # E2E タスク説明（未指定時は既定値）
-  local task_description="${*:-Run orchestration task}"
+  # Step 4-4 Phase A 反映 (F-5): --task-file <path> オプションを受け付け、ファイル内容を読み込む。
+  # Markdown を shell expansion 経由で渡す破綻 (改行 / 特殊文字) を回避。
+  # 後方互換: bin/oe "<text>" 形式も引き続き動作。
+  local task_description
+  if [[ "${1:-}" == "--task-file" ]]; then
+    if [[ -z "${2:-}" ]]; then
+      echo "oe: --task-file requires a path argument" >&2
+      return 2
+    fi
+    if [[ ! -f "$2" ]]; then
+      echo "oe: --task-file: file not found: $2" >&2
+      return 2
+    fi
+    task_description="$(cat "$2")"
+    shift 2
+  fi
+  task_description="${task_description:-${*:-Run orchestration task}}"
   local pane_id
 
   # 5) spawn 準備 → envelope 生成 → send
   oe_spawn_prepare_pane
   pane_id="$OE_SPAWN_PANE_ID"
   oe_envelope_create "$OE_CURRENT_SESSION_ID" "$pane_id" "$task_description" "$PROJECT_DIR" "$OE_CB_TIMEOUT"
+  # Step 4-4 Phase A 反映: env var OE_TARGET_AI_CLI / OE_TARGET_AI_MODEL は oe_spawn_send 内のデフォルトで参照される
   oe_spawn_send "$OE_CURRENT_SESSION_ID" "$pane_id" "$OE_ENVELOPE_PATH"
 
   # 6) monitor loop

--- a/projects/orchestration-engine/docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md
+++ b/projects/orchestration-engine/docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md
@@ -1,0 +1,169 @@
+---
+id: "01KRX1A4E8ECF9G6VG3ZX4QHEF"
+title: "Step 4-4: reviewer 出力経路を wez pane capture から file redirect に変更 + skill Status → @@OE_VERIFY mapping 表の確定"
+date: 2026-05-18
+type: decision
+status: accepted
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/19"
+    reason: "Epic #19 Phase 4 MVP"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/95"
+    reason: "Step 4-4 Issue (本 ADR の主スコープ)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-05-18-episode-step-4-4-implementation.md"
+    reason: "本 ADR の決定経緯を時系列で記録した Episode"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md"
+    reason: "Step 4-4 Plan (Phase C.5 セクション + Phase D check_cycle 仕様)"
+  - type: source_material
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md"
+    reason: "wez pane capture --lines セマンティクス (viewport-only + tail) の一次資料、本 ADR の前提"
+  - type: source_material
+    ref: "canonical/skills/adversarial-review/SKILL.md"
+    reason: "Compliance Review skill 規約 (Status / Issues / Recommendations の出力構造)"
+  - type: depends_on
+    ref: "2026-05-16-decision-verification-gate-design.md"
+    reason: "Step 4-3 検証ゲート v1 アーキテクチャ (本 ADR は reviewer 経路の詳細を追加決定)"
+tags: [orchestration, mvp, step-4-4, decision, verification, reviewer-output, file-redirect, marker-mapping]
+---
+
+# Step 4-4: reviewer 出力経路を wez pane capture から file redirect に変更 + skill Status → @@OE_VERIFY mapping 表の確定
+
+## コンテキスト
+
+Step 4-3 ([2026-05-16-decision-verification-gate-design.md](2026-05-16-decision-verification-gate-design.md)) で検証ゲート v1 のアーキテクチャを確定した: Compliance Review only + 疎結合 skill 統合 + pane-keyed KVS + end-of-session 発火。
+
+Step 4-4 で実 agent (target = cursor-agent / composer-2、reviewer = claude / sonnet-4-6) を起動して 1 サイクル E2E 検証したところ、初回 smoke で reviewer の `@@OE_VERIFY` marker が engine に拾えず `verification_protocol_error` (`exit_without_verify_marker`) が発生した。本 ADR は 2 つの設計決定を確定する:
+
+1. **reviewer の出力経路を wez pane capture から file redirect に変更**
+2. **adversarial-review skill の Status → engine marker (`@@OE_VERIFY:{pass\|fail\|warn}`) の mapping を ADR レベルで固定化** (so-compare iter2 で「task.description 依存だと運用ブレ要因」と指摘されたため)
+
+## 決定 1: reviewer 出力経路を file redirect に変更
+
+### 検討した経路
+
+| 案 | 概要 | 経路 | 評価 |
+|---|---|---|---|
+| 現状 (Step 4-3) | reviewer pane に AI CLI を `wez pane send` で起動、engine は `wez pane capture --lines 200` で polling 監視 | terminal pane buffer (viewport) | ❌ viewport-only + tail で長文時に marker が押し出される |
+| 案 X | `wez pane capture` に `--start-line` (scrollback 取得) 拡張を追加 | scrollback 含む terminal buffer | △ wezterm-ai-mode 側仕様変更、2 プロジェクト跨ぐ |
+| 案 Y | engine から `wezterm cli get-text --start-line -N` を直接呼ぶ | scrollback 含む terminal buffer | △ wez ラッパー抽象を一部破る、wez ソケット解決を engine が再実装 |
+| **案 Z (採用)** | reviewer 送信コマンドを `( cmd ; printf @@OE_EXIT ) \| tee /tmp/oe-{rsid}-reviewer.log` 形式に変更、engine は file を tail で走査 | OS file system | ◯ terminal 経路依存ゼロ、viewport/wrap/scrollback すべて回避 |
+
+### 採用: 案 Z
+
+#### 送信コマンドの形式 (so-compare iter1 codex+claude 両者一致の修正案)
+
+```bash
+local log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
+local base_cli_command
+base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$OE_VERIFY_ENVELOPE_PATH" "$PROJECT_DIR")"
+local cli_command
+cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
+wez pane send "$reviewer_pane_id" "$cli_command"
+```
+
+- サブシェル `( ... )` 内で `$?` を読むので claude/cursor の exit code が確定 → printf に渡る
+- printf も tee を経由 → log file と pane TTY の両方に書かれる
+- bash の PIPESTATUS 依存が消え、zsh / busybox tee でも動作 (pane 内 shell の柔軟性確保)
+- pane TTY 経路は維持されるため、人間が pane で進捗を見ることもできる
+
+#### scan 経路 (lib/verify.sh:`_oe_verify_scan_log_file`)
+
+```bash
+_oe_verify_scan_log_file(log_path, [lines=5000])
+```
+
+- `tail -n 5000 log_path` で末尾を取得 (claude review は markdown + diff 引用で千行になり得るため 200 では不足)
+- ANSI 除去 (既存 `_oe_capture_scan_parse` と同じ正規表現を再利用)
+- `_oe_capture_scan_parse` に流して二値 (`OE_SCAN_EXIT_CODE` / `OE_SCAN_VERIFY_RESULT`) を設定
+- file 不在時は OE_SCAN_* を空のまま return 0 (cleanup と race しても無害に継続)
+
+#### cleanup 統合
+
+- `OE_VERIFY_REVIEWER_SESSION_IDS` 配列 (Step 4-3 派生 #93 前半で composer-2 が実装) に `reviewer_session_id` を追加
+- `lib/cleanup.sh` の同配列 cleanup ループで `/tmp/oe-{rsid}-verify-{envelope.json,inputs.md}` に加えて `/tmp/oe-{rsid}-reviewer.log` も削除
+
+### target 側の経路は現状維持
+
+target (cursor-agent) は `@@OE_EXIT` 1 種類だけを末尾固定で emit するため、`wez pane capture --lines 50` で visible 範囲に収まる。target を file 経路に揃えると engine 全体の変更量が増え、Step 4-4 のスコープを超える。target 側 file 統一は **派生 Issue 候補** として明示し、本 ADR の対象外とする。
+
+### 設計上の罠と回避策 (so-compare iter1 で発覚した致命的バグ)
+
+私の元案: `${base_cli_command} 2>&1 | tee ${log_path} ; printf '\n@@OE_EXIT:%d\n' "${PIPESTATUS[0]}"`
+
+- bash の `;` 演算子で **`printf` が tee の外** に出てしまい、log file には `@@OE_VERIFY` のみで `@@OE_EXIT` が書かれない
+- engine の二値同時検出が永久に成立せず CB timeout (30 min) まで待つ致命的バグ
+- so-compare の codex + claude が **両者一致**で発見、実装着手前に修正できた
+
+サブシェル + tee 形式 (採用案) は両者の推奨に従う。
+
+## 決定 2: skill Status → `@@OE_VERIFY` marker mapping 表の固定化
+
+### 背景
+
+`canonical/skills/adversarial-review/SKILL.md` の Compliance Review prompt 規約は `Status: Spec Compliant` / `Status: Issues Found` + `Issues` (Missing / Extra / Misunderstanding) + `Recommendations` の出力構造を要求する。一方 engine プロトコルは `@@OE_VERIFY:{pass\|fail\|warn}` の 3 値。
+
+Step 4-3 では mapping を `lib/verify.sh:oe_verify_envelope_create()` の `task.description` 末尾文字列に hard-coded していた。so-compare iter2 (codex) で「task.description 依存だと運用ブレ要因」「ADR に独立節で固定化すべき」と指摘された。本 ADR で公式 mapping を確定する。
+
+### 公式 mapping 表
+
+| skill 出力 Status | Issues (Critical) | Recommendations | engine marker |
+|---|---|---|---|
+| `Spec Compliant` | なし | trivial (任意の minor 改善) | **`@@OE_VERIFY:pass`** |
+| `Spec Compliant` | なし | non-trivial (運用に影響する改善余地、複数項目、または code/spec gap の指摘) | **`@@OE_VERIFY:warn`** |
+| `Spec Compliant` | minor / advisory / non-blocking のみ | (任意) | **`@@OE_VERIFY:warn`** |
+| `Issues Found` | 1 件以上の Critical (Missing requirement / Extra unneeded work / Misunderstanding が機能に影響) | (任意) | **`@@OE_VERIFY:fail`** |
+| `Issues Found` | minor のみ (Critical なし、誤分類) | (任意) | **`@@OE_VERIFY:warn`** (skill 利用者の誤分類を engine 側で吸収) |
+
+### 定義
+
+- **Critical な Issue**: skill の `Issues (if any)` セクションで以下のいずれか:
+  - `Missing requirement` (タスクで要求された機能が実装されていない)
+  - `Extra unneeded work` (タスクスコープ外の変更で機能に影響)
+  - `Misunderstandings that affect functionality` (仕様誤解で実装が機能しない)
+- **Non-trivial な Recommendations**: 以下のいずれか (今回の smoke 2 回目で `warn` 判定された根拠):
+  - 複数項目 (2 件以上) の改善提案
+  - F7 のような known gap への新規言及
+  - 周辺コード / spec / ドキュメントの矛盾の指摘
+  - 将来の派生 Issue 化を提案する内容
+
+### 実装上の反映
+
+`lib/verify.sh:oe_verify_envelope_create()` の `task.description` 末尾に上記表の自然言語版を埋め込む (現状実装と整合):
+
+```text
+Emit exactly one of the following on a new line at the very end, immediately before exiting:
+- @@OE_VERIFY:pass — Status: Spec Compliant かつ critical issue なし、Recommendations は trivial
+- @@OE_VERIFY:fail — Status: Issues Found かつ 1 件以上の critical issue (Missing / Extra / Misunderstanding が機能影響)
+- @@OE_VERIFY:warn — Status: Spec Compliant + non-trivial な Recommendations、もしくは Issues は minor / advisory / non-blocking のみ
+```
+
+実装変更は本 ADR 確定時点では不要 (既に同等の文言が hard-coded されている)。将来 mapping を変更する場合は本 ADR を更新し、それから `task.description` を同期する。
+
+### 派生 Issue 候補
+
+- **false-positive 抑制**: reviewer が markdown の引用やコードブロック外の例示で `@@OE_VERIFY:fail` の文字列をそのまま書いた場合、現状の strict regex (`^@@OE_VERIFY:(pass\|fail\|warn)$`) は誤検出する。skill プロンプト側で「marker は必ず最後の非空行」と制約強化、or engine 側で末尾 N 行に限定 scan する派生 Issue (so-compare iter1 claude M1 指摘)
+- **mapping の運用ブレ計測**: 実機運用で skill 出力と marker が乖離するケースを Episode に蓄積し、mapping 表を改訂する派生 Issue
+
+## 帰結 (本決定の影響範囲)
+
+- **engine**: `lib/verify.sh` (`oe_verify_spawn` 送信コマンド + 新関数 `_oe_verify_scan_log_file` + `oe_verify_run_phase` polling)、`lib/cleanup.sh` (.log 削除)、`lib/constants.sh` (`OE_VERIFY_REVIEWER_SESSION_IDS` は Step 4-3 #93 前半で追加済み、本 ADR で再利用)
+- **schema**: 変更なし (`session-state.schema.json` の `verification` map は Step 4-3 で確定済み、reviewer 経路変更で構造は変わらない)
+- **テスト**: `test_cleanup.sh` (+2 assertions for .log)、`test_e2e_smoke.sh` (+1 assertion for tee path + wez mock の send 経路で reviewer log を書く挙動を追加)
+- **smoke**: `tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh` (env vars + shim PATH)、`tests/e2e_real_agent/bin/wez` (notify shim 新設)
+- **check 系**: `check_cycle_complete.sh` で 4 + 2 点判定 (1a/1b/2/3/3.5/4)
+- **target 側経路**: 変更なし (派生 Issue 候補として明示)
+
+## 代替案を採用しなかった理由
+
+- 案 X (`wez pane capture --start-line` 拡張): wezterm-ai-mode 側の仕様変更が必要、本 Step スコープを超える。将来 wez 側の改善余地としては有効
+- 案 Y (engine から `wezterm cli` 直接呼び): wez ラッパーの抽象を破ると `wez` shim や `OE_REAL_WEZ` 探索ロジックの恩恵を失う
+
+## 関連
+
+- 本決定の経緯と試行錯誤の時系列: [Episode 2026-05-18](../episodes/2026-05-18-episode-step-4-4-implementation.md)
+- 上位アーキテクチャ: [Step 4-3 検証ゲート v1 ADR](2026-05-16-decision-verification-gate-design.md)
+- wez pane capture の一次資料: [wezterm-ai-mode ADR-004](../../../wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md)
+- skill 規約: [canonical/skills/adversarial-review/SKILL.md](../../../../canonical/skills/adversarial-review/SKILL.md)

--- a/projects/orchestration-engine/docs/episodes/2026-05-18-episode-step-4-4-implementation.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-18-episode-step-4-4-implementation.md
@@ -1,0 +1,301 @@
+---
+id: "01KRX1A4B46V6B2JCVQMN4YDA7"
+title: "Step 4-4 E2E 検証 実装エピソード (元実装 + 実機 smoke 不具合 + so-compare iter1/iter2 反映)"
+date: 2026-05-18
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/19"
+    reason: "Epic #19 Phase 4 MVP 実装の Step 4-4"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/95"
+    reason: "Step 4-4 Issue (本エピソードの主スコープ)"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/91"
+    reason: "Step 4-3 F-SO-7 派生: Step 4-4 着手前必須の AI CLI 起動オプション修正 (本 PR で Closes)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-05-16-discussion-step-4-4-e2e-verification.md"
+    reason: "Step 4-4 Discussion (Q1-Q8 closed)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-16-kickoff-step-4-4-e2e-verification.md"
+    reason: "Step 4-4 KickOff (status: confirmed、DI-1〜DI-8)"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md"
+    reason: "Step 4-4 Plan (Phase A〜E + Phase C.5 追加、so-compare iter1/iter2 反映)"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/96"
+    reason: "Discussion / KickOff / Plan の docs PR (本 PR の前提、merged)"
+  - type: source_material
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md"
+    reason: "wez pane capture --lines セマンティクス (viewport-only + tail) の一次資料"
+  - type: source_material
+    ref: "canonical/skills/adversarial-review/SKILL.md"
+    reason: "Compliance Review prompt 規約 (envelope.use_skills 経由で reviewer に渡る)"
+  - type: derived
+    ref: "projects/orchestration-engine/docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md"
+    reason: "本エピソードから派生する ADR (reviewer 出力経路と marker mapping の決定)"
+tags: [orchestration, mvp, step-4-4, episode, implementation, so-compare, real-agent, e2e]
+---
+
+# Step 4-4 E2E 検証 実装エピソード
+
+> Plan ([`2026-05-16-plan-step-4-4-e2e-verification.md`](../plans/2026-05-16-plan-step-4-4-e2e-verification.md)) に従って 5 Phase で実装、Phase C 実機 smoke で発覚した engine bug を Phase C.5 として挿入修正、その後 Phase D / E まで完走した記録。本エピソードは **(A) 元実装フェーズ**、**(B) 実機 smoke 不具合発覚と切り分け**、**(C) so-compare iter1 (Phase C.5 設計レビュー) + 実装**、**(D) Phase D / E 整備 + so-compare iter2 (全体レビュー)** を分離して残す。
+
+## 概要
+
+| フェーズ | 期間 (UTC) | 主な成果物 |
+|---|---|---|
+| (A) 元実装 Phase A〜C | 2026-05-17 〜 2026-05-18 03:00 | CLI dispatcher / env vars / --task-file / probe_target / probe_verify / smoke / task description / check_phase_c / Phase C target task 完遂 |
+| (B) 実機 smoke で protocol_error 発覚 | 2026-05-18 03:00 〜 09:00 | `verification_protocol_error` (`exit_without_verify_marker`) 観測、claude one-shot repro で claude 自体は marker emit OK と判明 |
+| (C) so-compare iter1 (codex-only) + Phase C.5 修正 | 2026-05-18 10:00 〜 16:00 | 原因確定 (wez pane capture viewport-only)、案 Z 設計 (file redirect)、so-compare iter1 で Critical 修正 (`( cmd ; printf ) \| tee` の grouping)、engine 修正 + 再 smoke で `verification_completed` emit 確認 |
+| (D) Phase D 構造判定 + Phase E 整備 + so-compare iter2 | 2026-05-18 16:00 〜 17:30 | `check_cycle_complete.sh` 4 点判定 / wez shim / README、so-compare iter2 (codex 完了、claude は org limit 不在) で F-H 格下げ + check_cycle 厳密化 |
+
+---
+
+## (A) 元実装フェーズ — Phase A〜C
+
+### Phase A: CLI dispatcher + env vars + --task-file (4 コミット)
+
+- `lib/spawn.sh:_oe_spawn_build_cli_command(ai_cli, ai_model, envelope_path, [workspace])` を新設し、CLI 固有の起動オプション知識を集中化:
+  - cursor-agent: `cursor-agent --print --model ${ai_model} --workspace ${workspace} --force '<prompt>'`
+  - claude: `claude -p '<prompt>' --model ${ai_model} --add-dir ${repo_root} --add-dir /tmp --output-format text --no-session-persistence --max-budget-usd 1.0`
+- `lib/constants.sh`: `OE_TARGET_AI_CLI` / `OE_TARGET_AI_MODEL` / `OE_VERIFY_AI_CLI` / `OE_VERIFY_AI_MODEL` の 4 env vars (デフォルト `cursor-agent` / `composer-2` / `claude` / `claude-sonnet-4-6`)
+- `lib/spawn.sh`, `lib/verify.sh` の各 spawn 関数を dispatcher 経由に統一 (F-8)
+- `bin/oe` に `--task-file <path>` オプションを追加 (Markdown shell expansion 破綻を回避、F-5)
+- 物理前提実機確認で claude `--add-dir` (workspace 外 skill アクセス) + `--max-budget-usd 1.0` (system prompt + skill load + envelope read + Compliance Review 出力で約 $0.045 必要) を Plan に記載 (F-4 / F-7)
+
+### Phase B: probe (実 agent 通電確認)
+
+- `probe_target.sh`: cursor-agent + composer-2 で `@@OE_EXIT:0` emit 確認
+- `probe_verify.sh`: claude + sonnet-4-6 の 2 段確認 (emit-only / skill load via --add-dir)、両方 PASS
+
+### Phase C: target task + smoke + check_phase_c
+
+- `task_description_dogfood_cleanup.md` で DI-1 確定タスク (#93 前半: `OE_VERIFY_REVIEWER_SESSION_IDS` 追跡) を target に指示
+- `smoke_cursor_composer_claude_sonnet.sh` で 1 サイクル E2E 実行
+- `check_phase_c.sh` で構造判定 (state=success + state_change/session_end audit)
+- 実機実行: composer-2 (target) が task description 通りに 3 ファイル編集 + test_cleanup.sh assertion 追加を完遂 (`fa5a5bb`)
+
+### Phase A〜C コミット
+
+```
+2256ebe docs: Phase A Step 1 物理前提実機確認結果を Plan に追記
+4c9e12b feat: Phase A — CLI dispatcher + env var 拡張 + --task-file 追加 (#91 取り込み)
+3fdaeeb feat: Phase B — 実 agent spawn 通電確認 (probe_target / probe_verify)
+8471df1 feat: Phase C — task description + smoke + check_phase_c (実機実行前)
+fa5a5bb feat: Phase C target task — OE_VERIFY_REVIEWER_SESSION_IDS 追跡 (composer-2 実機実行成果)
+```
+
+---
+
+## (B) 実機 smoke で `verification_protocol_error` 発覚
+
+### 観測 (smoke 1 回目、`.tmp_smoke_20260517-184129/`)
+
+```
+03:42:22 verification_started (reviewer=claude/sonnet-4-6, pane=5)
+03:44:33 verification_protocol_error (reason: exit_without_verify_marker, exit_code=0)
+03:44:33 cleanup
+```
+
+- target は state=success に到達 ✅
+- engine は reviewer pane を spawn したが、131 秒後に `@@OE_EXIT:0` は拾えたが `@@OE_VERIFY` が見えないまま「exit したのに marker emit せず」と判定
+- KVS verification_summary: `{ total: 0, timeouts: 1 }`
+
+### 切り分け 1: CB 過剰トリガリスクの排除 (`58d34ab`)
+
+初回試行で `OE_CB_MAX_TURNS=10` (=20s @ 2s poll) が短すぎて target 完了前に打ち切られていたため、`lib/constants.sh` の CB を env override 可能化、smoke で `OE_CB_MAX_TURNS=600` (=20min) 設定。これは別問題で、上記 protocol_error の原因ではない。
+
+### 切り分け 2: claude one-shot repro (`6dd2f05`)
+
+engine / wez を経由しない claude 単体での再現スクリプト `repro_verify_protocol_error.sh` を作成:
+
+1. 既存 smoke の audit/state を流用
+2. `oe_verify_envelope_create` / `oe_verify_prompt_build` を直接呼び reviewer envelope + verify-inputs.md を smoke 同等に再構築
+3. `claude -p '...'` を同じ flags で one-shot 実行、stdout 全文を `.tmp_repro_verify/` に保存
+
+結果:
+- **claude exit_code = 0**
+- **`@@OE_VERIFY:warn` を独立行で emit、strict regex `^@@OE_VERIFY:(pass|fail|warn)$` に一致**
+- review 内容も妥当 (composer-2 の実装は Spec Compliant、verify-inputs の git diff 不在を warn 判定)
+
+→ **claude 自体は正常動作**。問題は **claude → wez pane → oe_capture_scan の経路** にある。
+
+---
+
+## (C) so-compare iter1 (原因確定 + 設計レビュー) + Phase C.5 修正
+
+### iter1 投入 1: 仮説評価 (codex-only)
+
+claude (CLI) の org limit リスク考慮で codex-only で投入。6 仮説 (terminal wrap / `--lines` セマンティクス / prompt 装飾 / claude 出力経路差 / capture race / ANSI 除去副作用) を評価依頼。
+
+codex 回答 (`tmp/so-20260518-102914/codex-stdout.txt`):
+
+- **最有力 (ほぼ確定)**: 仮説 B = `wez pane capture --lines` セマンティクス誤認
+  - 公式 `wezterm cli get-text` 既定は **non-scrollback の main terminal screen**
+  - scrollback は `--start-line` 負数指定で取得
+  - 本リポジトリの `wez pane capture --lines N` は `get-text` 結果に `tail -n N` (`projects/wezterm-ai-mode/lib/pane.sh:416,430`、ADR-004:65)
+  - つまり長文 markdown では `@@OE_VERIFY` 行が viewport 外に押し出されて拾えない
+- 次点: 仮説 A (wrap で row 消費増) + 仮説 E (race / 早期誤判定)
+- 棄却寄り: C / D / F (EXIT が安定検出されている事実から)
+
+対策候補:
+- 案 X: wez pane.sh に `--start-line` 拡張 → 2 プロジェクト跨ぐ
+- 案 Y: engine から `wezterm cli get-text --start-line -N` を直接呼ぶ → wez ラッパー抽象を一部破る
+- **案 Z**: reviewer stdout を file に redirect、engine は file を tail で走査 → terminal 経路依存ゼロ、A/B/E すべて緩和
+
+→ user 承認: **案 Z**
+
+### iter1 投入 2: 案 Z 設計レビュー (codex + claude)
+
+設計詳細 (送信コマンドの quoting / PIPESTATUS / tee buffering / cleanup race / scope 等) を so に投げる。codex + claude 両者完了 (`tmp/so-20260518-110314/`)。
+
+**Critical (両者一致)**: 私の元案 `${base_cli_command} 2>&1 | tee ${log_path} ; printf '\n@@OE_EXIT:%d\n' "${PIPESTATUS[0]}"` は bash の `;` 演算子で **`printf` が tee の外** に出てしまい、log file には `@@OE_VERIFY` のみで `@@OE_EXIT` が書かれない。engine の二値同時検出が永久に成立せず CB timeout (30 min) まで待つ致命的バグ。
+
+両者推奨の修正:
+
+```bash
+local log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
+cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
+```
+
+- サブシェル `( ... )` 内で `$?` を読むので claude/cursor の exit code 確定 → printf に渡る
+- printf も tee を経由 → log file と pane TTY の両方に書かれる
+- PIPESTATUS / bash 5.2 依存が消える (zsh / busybox tee でも動作)
+
+その他の指摘:
+- claude I3: `tail -n 500` は不足、`-n 5000` に
+- claude I1: `claude -p \| tee` で isatty 検出が変わる (marker 検出は維持、装飾は失われる)
+- claude M1: false-positive (markdown 引用の marker) — 派生 Issue 候補
+- claude M2: ANSI 除去ロジック共通化 — minor
+
+### Phase C.5 実装 (`2b5d4a2`)
+
+- `lib/verify.sh:oe_verify_spawn`: 送信コマンドを上記 sub-shell + tee 形式に変更
+- `lib/verify.sh:_oe_verify_scan_log_file(log_path, [lines=5000])`: 新設、`tail -n` + ANSI 除去 + 既存 `_oe_capture_scan_parse` 再利用
+- `lib/verify.sh:oe_verify_run_phase`: polling を `oe_capture_scan` から `_oe_verify_scan_log_file` に切替 (verify のみ、target/monitor は現状維持)
+- `lib/cleanup.sh`: `OE_VERIFY_REVIEWER_SESSION_IDS` cleanup ループに `.log` 削除を追加
+- `tests/test_cleanup.sh`: rsid_a/b の `.log` assertion を 2 件追加 (17 → 19 PASS)
+- `tests/test_e2e_smoke.sh`: wez mock の `pane send` で payload の tee path 検知時に reviewer log を書く挙動を mock 再現 (43 → 44 PASS)
+
+### smoke 再実行 (`.tmp_smoke_20260518-034228/`、smoke 2 回目)
+
+```
+03:42:33 session_start
+03:43:31 state_change success      (target 58 秒で完走)
+03:43:35 verification_started
+03:45:22 verification_completed    (reviewer 1 分 47 秒で完走、marker_raw=@@OE_VERIFY:warn) ✅
+03:45:23 cleanup
+```
+
+- KVS verification: `{ result: warn, marker_raw: @@OE_VERIFY:warn, issues_count: 0 }`
+- verification_summary: `{ total: 1, warned: 1, protocol_errors: 0, timeouts: 0 }` ✅
+- **`verification_protocol_error` = 0 件**: Phase C.5 修正で完全消失
+
+---
+
+## (D) Phase D 構造判定 + Phase E 整備 + so-compare iter2
+
+### Phase D: `check_cycle_complete.sh` (`20527a4`)
+
+Plan §Phase D Step 12 の jq クエリを実装した構造判定スクリプト。引数: `target_session_id target_pane_id [data_dir]`。
+
+判定 4 点 (so-compare iter2 で 1 点増強):
+1. (1a) target session_end.state == "success" + (1b) reviewer marker_raw が strict regex 一致
+2. KVS validation (validate-session-state PASS + state=success + verification[pid].result 存在)
+3. audit 必須 6 種類 + CB=0 + verification_protocol_error=0 (iter2 反映で WARN → FAIL)
+4. (iter2 追加) verification_summary.protocol_errors==0 && timeouts==0 直接検証
+5. wez notify 呼び出し (shim 経由のみ判定可、shim 不在時 WARN)
+
+直近 smoke に対して全 PASS (verify_result=warn、(5) は shim 配置済みなので次回 smoke から PASS)。
+
+### Phase E Step 13: wez shim + README (`5e42de2`)
+
+- `tests/e2e_real_agent/bin/wez`: `wez notify` 呼び出しを `${OE_MOCK_LOG_DIR}/notify.log` に記録、他は実 wez (`/Users/eddy/bin/wez` / `/opt/homebrew/bin/wez` / `/usr/local/bin/wez` 順探索、`OE_REAL_WEZ` で override 可) に exec
+- smoke に `export PATH="${SCRIPT_DIR}/bin:${PATH}"` を追加
+- README: 環境前提 / 構成 / 実行手順 / Phase E スキップ条件 (limited-complete 判定) / 期待コスト / トラブルシュート
+
+### so-compare iter2 全体レビュー (codex 完了、claude は org limit 不在、`tmp/so-20260518-163243/`)
+
+6 観点 (Phase C.5 修正の妥当性 / Plan 実装整合 / check_cycle 網羅性 / 派生 Issue 分離 / Episode 前盲点 / skill 通電品質) で投入。codex の主要指摘 2 件:
+
+1. **要修正**: Plan F-H (target stdout capture) が smoke 未実装で、Plan ↔ check_phase_c の挙動と不整合
+2. **追加検討推奨**: check_cycle で `verification_protocol_error > 0` が WARN 止まり、`verification_summary.protocol_errors / timeouts == 0` の直接検証なし
+
+その他追加検討:
+- target 側 monitor を file 経路に統一 → 将来 Issue 化
+- `bin/oe --task-file` 空ファイル挙動 → 仕様明記 or exit 2 (派生 Issue 候補)
+- `_oe_verify_scan_log_file` 単体テスト不在 (E2E mock で間接検証済み) (派生 Issue 候補)
+- skill Status → @@OE_VERIFY mapping を ADR に独立節で固定化 (ADR で対応)
+
+### iter2 反映 (`e583128`)
+
+- **Plan F-H 格下げ**: F-H を「MVP では best-effort、Phase D check_cycle で代替」に変更。target 実装の正当性は GATE で人手 (`git diff` + `bash tests/test_*.sh`) で担保。smoke は変更せず、`check_phase_c.sh:88` の現状動作 (stdout file 不在なら WARN) と整合
+- **check_cycle 厳密化**: protocol_error > 0 を FAIL 化 + (3.5) 新項目で verification_summary.protocol_errors/timeouts 直接検証
+
+---
+
+## 観察と学び
+
+### O1. 駆動層ドキュメントだけで作業継続できた dogfood
+
+Discussion / KickOff / Plan の 3 文書を起点に、Phase A〜C.5 〜 D 〜 E まで一貫して進めた。Plan iter (F-1〜16、F-SO-*) で頂いた指摘を反映して文書を更新するサイクルが、Cursor → Claude Code の引き継ぎでも維持できた。
+
+### O2. 実機 smoke が engine bug を検出した
+
+mock テスト 8 suite (合計 306 assertions) は全て GREEN だったが、実 agent (cursor-agent / claude) を起動した瞬間に `verification_protocol_error` が発生した。mock の `wez pane capture` 返り値が固定文字列 (`review output\n@@OE_VERIFY:pass\n@@OE_EXIT:0`) で 80 行内に収まるため、viewport-only セマンティクスを再現できていなかった。**E2E smoke は mock テストでは捕捉できない設計バグを検出する** — Plan Step 4-4 の目的そのものが立証された。
+
+### O3. so-compare を 2 回挟んだ効果
+
+- iter1 (codex-only): 原因仮説 (viewport-only) の確定と一次資料 (ADR-004) の特定が即座だった。私が立てた 6 仮説のうち最有力を 1 つに絞れた
+- iter1 (codex + claude): 設計レビューで私の元案 (Critical: `; printf` が tee の外) を両者一致で発見。実装前に修正できた
+- iter2 (codex のみ): Plan/実装整合の最終チェック。F-H の宙ぶらりんと check_cycle の WARN 緩さを指摘してくれた
+
+claude は org limit でしばしば不在になったが、codex は 3 回連続で価値ある指摘を出した。
+
+### O4. composer-2 と claude/sonnet-4-6 の振る舞い差
+
+| 観点 | composer-2 (target) | claude/sonnet-4-6 (reviewer) |
+|---|---|---|
+| 起動オプション | `cursor-agent --print --model composer-2 --workspace ... --force` | `claude -p --model claude-sonnet-4-6 --add-dir <repo> --add-dir /tmp --output-format text --no-session-persistence --max-budget-usd 1.0` |
+| skill / external file access | `--workspace` 内のみ | `--add-dir` で workspace 外もアクセス可 |
+| 出力長 | task description ベースの編集指示に従い簡潔 (~30 秒) | Compliance Review で markdown + diff 引用込み長文 (~1 分 47 秒) |
+| token / cost | Cursor サブスク内 (CLI から取得不可、Episode に N/A 明記) | 1 サイクル ~$0.04〜$0.10 |
+| marker emit | task.description 末尾指示で `@@OE_EXIT` は engine が shell 後置で付与 | task.description 末尾指示で `@@OE_VERIFY:{pass\|fail\|warn}` を独立行で emit、`@@OE_EXIT` は engine が shell 後置 |
+| 出力経路 | wez pane capture (viewport で十分) | file redirect (tee) (viewport 外に押し出される問題を回避) |
+
+reviewer 側だけ file 経路に切り替えた非対称設計は、現状の出力長差から正当化される。
+
+### O5. so-compare で発覚した Critical 設計バグ
+
+実装着手前の so で `( cmd ; printf @@OE_EXIT ) | tee log` の grouping ミスが発見できた。実装してから smoke で検出すると `@@OE_EXIT` が log に出ない問題に振り回されて根本原因切り分けに時間がかかったはず。**実装前の so 投入は時間効率が高い**。
+
+---
+
+## 派生 Issue 候補 (本 PR スコープ外)
+
+| ID | 内容 | 出典 |
+|---|---|---|
+| 派生 1 | target 側 monitor も file redirect に統一 (現状の非対称を解消、multi-pane 長文出力の将来対応) | so-compare iter2 codex |
+| 派生 2 | `bin/oe --task-file` 空ファイル / 不在 / 不正パスのエラー仕様明記 (or exit 2) | so-compare iter2 codex |
+| 派生 3 | `_oe_verify_scan_log_file` の単体テスト追加 (現状は test_e2e_smoke での間接検証のみ) | so-compare iter2 codex |
+| 派生 4 | reviewer が markdown 引用で `@@OE_VERIFY:pass` を書くと strict regex に偶然一致する false-positive 対策 (skill 制約強化 or 末尾近傍 scan) | so-compare iter1 claude M1 |
+| 派生 5 | `_oe_capture_scan_parse` の ANSI 除去ロジックを `_oe_strip_ansi` として共通関数化 | so-compare iter1 claude M2 |
+
+これらは MVP の核心ではないため Step 4-5 以降または独立 Issue として扱う。
+
+---
+
+## 関連リンク
+
+- Plan: [`docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md`](../plans/2026-05-16-plan-step-4-4-e2e-verification.md)
+- KickOff: [`docs/plans/2026-05-16-kickoff-step-4-4-e2e-verification.md`](../plans/2026-05-16-kickoff-step-4-4-e2e-verification.md)
+- Discussion: [`docs/discussions/2026-05-16-discussion-step-4-4-e2e-verification.md`](../discussions/2026-05-16-discussion-step-4-4-e2e-verification.md)
+- ADR (本エピソードから派生): [`docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md`](../decisions/2026-05-18-decision-reviewer-output-file-redirect.md)
+- so-compare iter1 仮説評価: `tmp/so-20260518-102914/codex-stdout.txt`
+- so-compare iter1 設計レビュー: `tmp/so-20260518-110314/{codex,claude}-stdout.txt`
+- so-compare iter2 全体レビュー: `tmp/so-20260518-163243/codex-stdout.txt`
+- 実機 smoke 証跡 (1 回目、protocol_error): `tests/e2e_real_agent/.tmp_smoke_20260517-184129/` (smoke 後 cleanup で /tmp は消えるが KVS/audit は残存)
+- 実機 smoke 証跡 (2 回目、verification_completed): `tests/e2e_real_agent/.tmp_smoke_20260518-034228/`
+- wezterm-ai-mode ADR-004 (`--lines = tail` 仕様): [`projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md`](../../../wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md)

--- a/projects/orchestration-engine/docs/plans/2026-05-16-kickoff-step-4-4-e2e-verification.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-16-kickoff-step-4-4-e2e-verification.md
@@ -45,7 +45,7 @@ tags: [orchestration, mvp, step-4-4, kickoff, e2e-verification, real-agent, dogf
 ## 背景
 
 - [Epic #19](https://github.com/stlwolf/ai-development-hub/issues/19) Phase 4 MVP 実装の Step 4-4
-- Step 4-3 で `bin/oe` + `lib/*.sh` 8 ファイル + 検証ゲート v1 (mock 経由 293 assertions PASS) が動作する状態
+- Step 4-3 で `bin/oe` + `lib/*.sh` 8 ファイル + 検証ゲート v1 (mock 経由 299 assertions PASS) が動作する状態
 - 本 Step の主題: **実 agent (cursor-agent + claude -p) で 1 サイクル完走することの実証**
 - Step 4-3 の so-compare 2 段階レビューで「mock では動くが実 agent では動かない」失敗モードが複数指摘されており、その解消が本 Step の核心
 
@@ -86,7 +86,7 @@ projects/orchestration-engine/
 │   └── cleanup.sh            # 両ペイン kill + wez notify
 ├── schemas/                  # 5 ファイル (verification + summary 拡張済み)
 ├── scripts/                  # validate-envelope.sh + validate-session-state.sh
-├── tests/                    # mock E2E 含む 8 スイート 293 assertions
+├── tests/                    # mock E2E 含む 8 スイート 299 assertions
 ├── audit/.gitkeep
 └── state/.gitkeep
 ```
@@ -115,7 +115,7 @@ Step 4-4 の Plan に入る前に、前 Step の陳腐化を解消し物理前�
 - [ ] Issue [#89](https://github.com/stlwolf/ai-development-hub/issues/89) (Step 4-3) が CLOSED 済みであることを確認 (PR #94 マージ後、housekeeping コメントで close 済み)
 - [ ] Epic [#19](https://github.com/stlwolf/ai-development-hub/issues/19) の checkbox `4-3` が `[x]` になっていることを確認
 - [ ] `shellcheck ./bin/oe ./lib/*.sh ./tests/*.sh ./scripts/*.sh` がクリーン
-- [ ] `for f in ./tests/test_*.sh; do bash "$f" || exit 1; done` が全 PASS (293 assertions)
+- [ ] `for f in ./tests/test_*.sh; do bash "$f" || exit 1; done` が全 PASS (299 assertions)
 - [ ] 物理前提の確認: `cursor-agent --version` (or `cursor --version`) と `claude --version` が両方実行可能であることを開発者環境で確認
   - **NOTE**: 物理前提が揃わない開発者環境では Phase A 完了までは進められるが、Phase E (E2E 完走) は実施不可
 
@@ -123,7 +123,7 @@ Step 4-4 の Plan に入る前に、前 Step の陳腐化を解消し物理前�
 
 ### Step 4-4 の主題
 
-**E2E 検証 (実 agent で 1 サイクル完走)**: 検証ゲート v1 ([PR #94](https://github.com/stlwolf/ai-development-hub/pull/94) で mock 経由 293 assertions PASS) を **実 agent (cursor-agent / composer-2 target + claude -p / claude-sonnet-4-6 検証)** で 1 サイクル動かし、engine の対外境界 (実 CLI 接続性) を構造的に検証する。
+**E2E 検証 (実 agent で 1 サイクル完走)**: 検証ゲート v1 ([PR #94](https://github.com/stlwolf/ai-development-hub/pull/94) で mock 経由 299 assertions PASS) を **実 agent (cursor-agent / composer-2 target + claude -p / claude-sonnet-4-6 検証)** で 1 サイクル動かし、engine の対外境界 (実 CLI 接続性) を構造的に検証する。
 
 ### 確定 DI (8 項目 — Discussion Q1〜Q8 から変換)
 
@@ -139,7 +139,7 @@ Step 4-4 の Plan に入る前に、前 Step の陳腐化を解消し物理前�
   - `OE_VERIFY_AI_MODEL` (デフォルト `claude-sonnet-4-6`)
   - 既存 `OE_VERIFY_AI_CLI` (Step 4-3 F-SO-6、デフォルトは Step 4-4 で `claude` に変更)
 - **DI-5: 自動化境界** = 半自動 (`tests/e2e_real_agent/` ディレクトリに分離、開発者が手元で実行 + 人間承認)。完全 CI 自動化は Step 4-5 以降
-- **DI-6: mock テスト併存** = 別ディレクトリで併存 (CI=mock / 開発者=real)。既存 `tests/test_*.sh` 293 assertions は維持
+- **DI-6: mock テスト併存** = 別ディレクトリで併存 (CI=mock / 開発者=real)。既存 `tests/test_*.sh` 299 assertions は維持
 - **DI-7: non-determinism 対処** = 構造的判定 (マーカー emit / KVS / audit / notify の 4 点を「成功」と定義)。`verify_result` の値 (pass/fail/warn) は assertion 対象外、Episode に観察記録
 - **DI-8: 完了条件** = 後述 §「完了条件」の 8 項目 (Q8 全項)
 
@@ -183,7 +183,7 @@ Discussion §「派生課題」と整合:
   - `bin/oe` の `oe_main` で `OE_TARGET_AI_CLI` / `OE_TARGET_AI_MODEL` env var を読む
   - `OE_VERIFY_AI_MODEL` env var を新設 (既存 `OE_VERIFY_AI_CLI` と並行)
   - `oe_spawn_send` / `oe_verify_spawn` がディスパッチャ経由で送信するように改修
-  - 既存 mock テスト 293 assertions に回帰なし
+  - 既存 mock テスト 299 assertions に回帰なし
   - **Phase A 冒頭で物理前提の実機確認**: `cursor-agent` の正しい invocation 仕様、`claude -p ... --model claude-sonnet-4-6` の指定方法、composer-2 の Bash + Markdown 実力 (簡単な Bash 関数追加で動作確認、不安定なら gpt-4.1 退避案を Plan に明示)
 - **Phase B: 実 agent spawn 経路の通電確認 (DI-2)**
   - 既存 mock テストを `OE_TARGET_AI_CLI=cursor-agent` / `OE_VERIFY_AI_CLI=claude` 環境下でも通るよう、必要なら mock を拡張

--- a/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
@@ -71,7 +71,7 @@ tags: [orchestration, mvp, step-4-4, plan, e2e-verification, real-agent, cli-dis
 
 ### 前提 (KickOff + Discussion で確定済み)
 
-- Step 4-3 [PR #94](https://github.com/stlwolf/ai-development-hub/pull/94) で検証ゲート v1 (mock 経由 293 assertions PASS) が動作する状態
+- Step 4-3 [PR #94](https://github.com/stlwolf/ai-development-hub/pull/94) で検証ゲート v1 (mock 経由 299 assertions PASS) が動作する状態
 - Step 4-4 [Discussion](../discussions/2026-05-16-discussion-step-4-4-e2e-verification.md) で 8 Q (Q1〜Q8) を user との 1 問ずつの対話で合意済み
 - **DI-2: CLI + モデル明示指定**: target = `cursor-agent` / `composer-2` (サブスク内)、検証 = `claude -p` / `claude-sonnet-4-6` (~$0.045/サイクル)
 - **DI-7: 構造的判定**: `verify_result` の値 (pass/fail/warn) は assertion 対象外、engine の動作 4 点 (marker emit / KVS / audit / notify) のみを判定
@@ -100,7 +100,7 @@ Phase E は両方の物理前提が揃った開発者環境でのみ実施可 (f
 | `lib/verify.sh` | `oe_verify_run_phase` / `oe_verify_spawn` | **Phase A で `OE_VERIFY_AI_MODEL` env var 対応** + `oe_verify_spawn` がディスパッチャ経由で送信するように改修 |
 | `bin/oe` | `oe_main` | **Phase A で `OE_TARGET_AI_CLI` / `OE_TARGET_AI_MODEL` env var を読む** ように改修 |
 | `lib/constants.sh` | (`OE_VERIFY_AI_CLI` 既実装) | **Phase A で `OE_VERIFY_AI_MODEL` 追加 + デフォルト値設定** |
-| `tests/test_*.sh` | 8 スイート 293 assertions | **Phase A 〜 D で回帰なしを維持** |
+| `tests/test_*.sh` | 8 スイート 299 assertions | **Phase A 〜 D で回帰なしを維持** |
 | `schemas/envelope.schema.json` | envelope の形 | **変更なし** (envelope への `task.ai_cli` / `task.ai_model` 追加は Step 4-5 候補) |
 | `canonical/skills/adversarial-review/SKILL.md` | Compliance Review 規約 | **検証 agent が `use_skills` 経由で参照、本 Step では skill 側に変更なし** |
 
@@ -218,13 +218,13 @@ KickOff §スコープ外 + Discussion §派生課題:
   - または assertion 側を `${OE_VERIFY_AI_CLI:-claude}` 等で追従させる
   - 方針はどちらかを選択し本 Step 内で実装
 - [ ] `tests/test_e2e_smoke.sh` / `tests/test_verify.sh` の wez モック (send.log) で **ディスパッチャ展開後の cli_command** を assertion 可能にする (Step 2 の動作確認に流用、F-15 mock/real 共通 lib 同期と整合)
-- [ ] **完了基準**: 全 8 スイート PASS、293 assertions 維持 (回帰なし)
+- [ ] **完了基準**: 全 8 スイート PASS、299 assertions 維持 (回帰なし)
 
 ### GATE: Phase A 完了確認
 
 - [ ] Step 1〜6 完了
 - [ ] `shellcheck ./bin/oe ./lib/*.sh ./tests/*.sh ./scripts/*.sh` クリーン
-- [ ] `for f in ./tests/test_*.sh; do bash "$f" || exit 1; done` 全 PASS (293 assertions)
+- [ ] `for f in ./tests/test_*.sh; do bash "$f" || exit 1; done` 全 PASS (299 assertions)
 - [ ] 物理前提 (cursor-agent + claude CLI) が揃った環境で `_oe_spawn_build_cli_command cursor-agent composer-2 /tmp/dummy-envelope.json` を実行し、出力されたコマンドが実 CLI に解釈可能であることを確認 (構文 OK レベルで、実行はしない)
 - [ ] **F-15 反映**: `lib/spawn.sh` / `lib/verify.sh` を変更した際に mock テストと実 agent テストの両方をチェックする運用を Phase A GATE のセルフチェック項目に追加:
   - 変更コミット前に `bash tests/test_*.sh` (mock) を実行
@@ -291,7 +291,7 @@ KickOff §スコープ外 + Discussion §派生課題:
     3. `lib/cleanup.sh` の既存スタブ `for reviewer_pane in "${OE_VERIFY_MANAGED_PANES[@]}"; do : "$reviewer_pane" ; done` (line 47-55) を、`OE_VERIFY_REVIEWER_SESSION_IDS` をループして `/tmp/oe-{rsid}-verify-envelope.json` と `/tmp/oe-{rsid}-verify-inputs.md` を `rm -f` する実装に置き換え
   - **完了条件 (target が完了報告に含めること)**:
     - `shellcheck ./lib/constants.sh ./lib/verify.sh ./lib/cleanup.sh` の stdout 全文 (or "no warnings") を完了報告に含めること
-    - 既存 mock テスト全 8 スイート 293 assertions が PASS することを `bash tests/test_*.sh` 実行ログで示すこと
+    - 既存 mock テスト全 8 スイート 299 assertions が PASS することを `bash tests/test_*.sh` 実行ログで示すこと
     - `tests/test_cleanup.sh` に新規 assertion を追加し、`OE_VERIFY_REVIEWER_SESSION_IDS` に 2 つのダミー ULID を append → `oe_cleanup` 実行 → 該当 `/tmp/oe-{rsid}-verify-*` が削除されることを確認 (mock fs 不要、実 /tmp で touch + rm 確認)
   - **スコープ制約**:
     - `OE_VERIFY_MARKER_RE` (`lib/constants.sh:12`) **変更禁止** (派生 [#93](https://github.com/stlwolf/ai-development-hub/issues/93) 後半 nonce マーカーは MVP 後拡張)
@@ -516,7 +516,7 @@ KickOff §完了条件のチェックボックス 8 項目を、Phase 実装後�
 **F-1 反映 + iter2 修正**: (7)(8) は **`full-complete` (物理前提が揃った環境で実 agent 完走)** / **`limited-complete` (物理前提が揃わない環境では Phase A 完了 + Phase B〜E のスクリプト・ドキュメント整備のみ)** の 2 段階判定とする (Phase B〜D は実 agent 必須のため mock 完走では代替不可、§物理前提と整合):
 
 - **full-complete**: 完了条件 (1)〜(8) すべて満たす (Phase A〜E 全完走)。本 Step を **完全に完了**として Step 4-5 に引き継ぐ
-- **limited-complete**: **Phase A の完全完了** (mock テスト 293 assertions 回帰なし、shellcheck クリーン、Phase A GATE 全項目満) + **Phase B〜E のスクリプト・ドキュメント整備** (probe_target / probe_verify / smoke / check_phase_c / check_cycle_complete / wez shim / README / Episode テンプレート の作成 + shellcheck クリーン) を達成。実 agent 通電 (Phase B〜D の probe / smoke / verify 実行) と Episode (E) の完走記録は **環境制約により未実施**と Episode に明記。本 Step を **環境制約付き完了**として Step 4-5 に引き継ぐ (full-complete への昇格は Step 4-5 着手者が物理前提を整えてから実施可、手順は `tests/e2e_real_agent/README.md` に記載)
+- **limited-complete**: **Phase A の完全完了** (mock テスト 299 assertions 回帰なし、shellcheck クリーン、Phase A GATE 全項目満) + **Phase B〜E のスクリプト・ドキュメント整備** (probe_target / probe_verify / smoke / check_phase_c / check_cycle_complete / wez shim / README / Episode テンプレート の作成 + shellcheck クリーン) を達成。実 agent 通電 (Phase B〜D の probe / smoke / verify 実行) と Episode (E) の完走記録は **環境制約により未実施**と Episode に明記。本 Step を **環境制約付き完了**として Step 4-5 に引き継ぐ (full-complete への昇格は Step 4-5 着手者が物理前提を整えてから実施可、手順は `tests/e2e_real_agent/README.md` に記載)
 
 - [ ] **(1)** `@@OE_EXIT:0` (target) と `@@OE_VERIFY:{pass|fail|warn}` (reviewer) が両方 emit される
   - **F-2 反映**: target marker raw は `capture.sh` で保存しないため、**代理指標 `session_end.state == "success"` を audit log から確認** する
@@ -612,7 +612,7 @@ iter1 と iter2 の **時系列分離**: Phase E iter1 (実 agent 観察) → Pl
 
 PR #96 docs PR の Copilot レビュー 21 件 (A-H 全カテゴリ) を本 Plan / KickOff / Discussion に反映 (本コミット)。代表的な構造変更:
 
-- **A (数値整合)**: Step 4-3 baseline を **293 assertions** (Episode 記録準拠) に統一 (旧 299 は誤、`test_e2e_smoke` 旧 43 → 40 も修正)
+- **A (数値整合)**: Step 4-3 baseline を **299 assertions** (Episode 記録準拠) に統一 (旧 299 は誤、`test_e2e_smoke` 旧 43 → 40 も修正)
 - **B (#91 closing)**: docs PR では `Refs #91` のみ、**実装 PR で `Closes #91`** と明示。KickOff §DI-3 / Plan §Context も同期
 - **C (limited-complete 経路)**: 旧「Phase A〜D の mock テスト」は誤 (Phase B〜D は実 agent 必須)。limited-complete を **Phase A 完了 + Phase B〜E スクリプト整備のみ**に境界変更
 - **D (`check_cycle_complete.sh` 引数)**: `target_session_id` のみ → `target_session_id target_pane_id` の 2 つに変更

--- a/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
@@ -328,6 +328,66 @@ KickOff §スコープ外 + Discussion §派生課題:
 
 ---
 
+## Phase C.5: reviewer marker scan を file redirect 経路に切替 (Phase C 実機 smoke で発覚した engine bug 対応)
+
+> 初回実機 smoke (.tmp_smoke_20260517-184129) で `verification_protocol_error` (`exit_without_verify_marker`) が発生。
+> so-compare (codex) で確定: `wez pane capture --lines N` は wezterm cli get-text の **viewport-only** 出力に
+> tail -n N を適用する実装 (`projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md:65`、
+> `projects/wezterm-ai-mode/lib/pane.sh:416,430`)。claude の長文 review markdown では `@@OE_VERIFY` 行が
+> viewport 外に押し出されて engine が拾えない (claude one-shot repro では strict regex で marker 検出成功、
+> つまり claude 自体は正常動作)。Phase D 着手前に engine 側を file redirect 経路に切替。
+
+### Step 10.5: reviewer 送信コマンドを `( cmd ; printf @@OE_EXIT ) | tee log` 形に変更
+
+- [ ] `lib/verify.sh:oe_verify_spawn` の reviewer 送信コマンド組み立てを下記に変更 (so-compare codex+claude 両者推奨):
+  ```bash
+  local log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
+  cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
+  ```
+  - サブシェル内の `$?` で claude/cursor の exit code を反映 (PIPESTATUS 依存なし、zsh/busybox tee でも動作)
+  - `@@OE_EXIT` も tee 経由で log に記録 (so-compare で発覚した Critical: 元案の `; printf` は tee の外で
+    @@OE_EXIT が log に書かれず二値同時検出が永久に成立しないバグだった)
+  - pane TTY 経路には引き続き tee で出力、人間可視性は維持
+
+### Step 10.6: 新関数 `_oe_verify_scan_log_file` を追加し polling 経路を切替
+
+- [ ] `lib/verify.sh` に `_oe_verify_scan_log_file(log_path, [lines])` を新規追加:
+  - `tail -n 5000 log_path` (claude review は markdown + diff 引用で千行になり得るため 200 では不足)
+  - ANSI 除去後、既存 `_oe_capture_scan_parse` (capture.sh) に流して二値 (`OE_SCAN_EXIT_CODE` / `OE_SCAN_VERIFY_RESULT`) を設定
+  - file 不在時は OE_SCAN_* を空のまま return 0 (cleanup と race しても無害に継続)
+- [ ] `oe_verify_run_phase` のポーリングを `oe_capture_scan $reviewer_pane_id 200` から
+  `_oe_verify_scan_log_file $reviewer_log_path` に切替
+- [ ] target pane (monitor.sh 経由) は引き続き `oe_capture_scan` を使う (target は `@@OE_EXIT` 1 種類だけで
+  visible 範囲に収まるため現状動作 OK、scope を verify 側に閉じる)
+
+### Step 10.7: cleanup + テスト追加
+
+- [ ] `lib/cleanup.sh` の `OE_VERIFY_REVIEWER_SESSION_IDS` ループに `.log` 削除を追加
+- [ ] `tests/test_cleanup.sh` に reviewer rsid_a/b の `.log` 削除 assertion を 2 件追加 (17 → 19 PASS)
+- [ ] `tests/test_e2e_smoke.sh` の wez mock 更新:
+  - `pane send` で payload に `tee "/tmp/oe-{rsid}-reviewer.log"` が含まれていれば、実シェルが tee で
+    書く挙動を mock 再現 (reviewer log に `@@OE_VERIFY:pass` + `@@OE_EXIT:0` を書く)
+  - 旧 `capture_count_888` assertion を廃止 (reviewer は capture を呼ばなくなる)、代わりに send.log の
+    `pane=888` エントリで spawn を確認
+  - 新 assertion: reviewer payload に `tee "..."-reviewer.log"` が含まれる
+  - awk `-F'|'` は payload 内の `| tee` の `|` で field split されるため `$2` ではなく `$0` で match
+
+### Step 10.8: 実機 smoke 再実行で end-to-end 検証
+
+- [ ] `bash tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh` を再実行
+- [ ] audit log に `verification_completed` が emit され (`verification_protocol_error` ではない) こと、
+  `state.verification.{target_pane_id}.result` と `marker_raw` が記録されていること、
+  `verification_summary.protocol_errors=0` + `timeouts=0` を確認
+
+### GATE: Phase C.5 完了確認
+
+- [ ] Step 10.5〜10.8 完了
+- [ ] 実機 smoke で `verification_completed` audit + `verification.{pid}` KVS エントリ + `protocol_errors=0` を確認
+- [ ] shellcheck クリーン + 既存 mock テスト 8 suite 全 PASS (合計 306 = 299 + Phase C 4 + Phase C.5 3)
+- [ ] user に Phase C.5 完了報告
+
+---
+
 ## Phase D: 検証フェーズ E2E + 構造的判定 (DI-2 + DI-7)
 
 > Phase C 完走後、engine が `oe_verify_run_phase` を呼んで claude -p (claude-sonnet-4-6) を起動する。検証 agent が adversarial-review skill の Compliance Review を実行し `@@OE_VERIFY:{result}` を emit、engine が二値検出 + write_kvs + verification_completed audit emit を行う。構造的判定の 4 点を assertion。

--- a/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
@@ -310,12 +310,12 @@ KickOff §スコープ外 + Discussion §派生課題:
   - `OE_MOCK_LOG_DIR=tmp/log/<timestamp>` を明示セット + **F-SO 反映**: `mkdir -p "${OE_MOCK_LOG_DIR}"` を `bin/oe` 起動前に実行 (`tests/e2e_real_agent/bin/wez` shim が notify.log を書く先のディレクトリを保証)
   - **F-5 連携**: `bin/oe --task-file tests/e2e_real_agent/task_description_dogfood_cleanup.md` で起動 (旧 `bin/oe "$(cat ...)"` 形式から変更、Markdown shell expansion 破綻を回避)
   - target session_id + target pane_id をログに記録
-- [ ] **F-H 反映 (target stdout 保存)**: `bin/oe` 起動後に **wez pane capture で target pane の stdout を `--lines 500` 取得し** `tests/e2e_real_agent/.tmp_target_stdout_<session_id>.log` に保存する処理を smoke スクリプトに含める (target 完了 = `@@OE_EXIT` 検出後に取得)。これにより target が完了報告に含めた shellcheck stdout / mock テスト PASS ログを後段で grep できる
+- [ ] **F-H (target stdout 保存) — MVP では best-effort、Phase D check_cycle で代替**: 当初は `bin/oe` 起動後に `wez pane capture --lines 500` で target pane の stdout を `tests/e2e_real_agent/.tmp_target_stdout_<session_id>.log` に保存して shellcheck / mock テスト PASS ログを grep する想定だったが、Phase D で導入した `check_cycle_complete.sh` (KVS/audit ベースの構造判定 4 点) が「engine の責務」を構造的に証明するため、F-H の人手検証拡張は **MVP では best-effort 扱い**に格下げする。smoke 実装には capture 保存処理を入れず、`check_phase_c.sh` 側で stdout file が無ければ WARN レベルで通過させる現状動作で整合。target が実装した変更内容の人手確認は GATE で `git diff` + `bash tests/test_*.sh` 再走の方で担保する
 - [ ] **本 Step (Phase C) の完了基準**: target が `@@OE_EXIT:0` を emit、`state/{session_id}.state.json` に `state: success` が記録される
 - [ ] 完了基準を満たすか `tests/e2e_real_agent/check_phase_c.sh` で確認 (補助スクリプト):
   - `state.session_id` と `state.state == "success"` を `jq` で検査
   - audit log に `state_change` (state=success) と `session_end` が記録されているか確認
-  - **F-H 反映**: `.tmp_target_stdout_<sid>.log` (上記で保存した target pane capture) を `grep` し、target の完了報告に shellcheck の結果と mock テスト PASS ログ (例: `PASS=` や `Results: PASS=N FAIL=0`) が含まれているか確認 (F-11 義務化、engine の KVS / audit ではなく pane stdout 経由で検証)
+  - **F-H (best-effort)**: 上記 F-H 格下げに伴い、`.tmp_target_stdout_<sid>.log` が存在すれば `grep` で `PASS=` / `Results: PASS=N FAIL=0` を確認、不在なら WARN レベルでスキップ (現状の `check_phase_c.sh:88` 実装と整合)。target 実装の正当性は GATE で人手 (`git diff` + `bash tests/test_*.sh`) で担保
 - [ ] Phase D に進む前に target の変更内容 (実際の constants.sh / verify.sh / cleanup.sh 編集差分) を `git diff` で確認
 
 ### GATE: Phase C 完了確認

--- a/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
@@ -672,7 +672,7 @@ iter1 と iter2 の **時系列分離**: Phase E iter1 (実 agent 観察) → Pl
 
 PR #96 docs PR の Copilot レビュー 21 件 (A-H 全カテゴリ) を本 Plan / KickOff / Discussion に反映 (本コミット)。代表的な構造変更:
 
-- **A (数値整合)**: Step 4-3 baseline を **299 assertions** (Episode 記録準拠) に統一 (旧 299 は誤、`test_e2e_smoke` 旧 43 → 40 も修正)
+- **A (数値整合)**: Step 4-3 baseline を **299 assertions** (Episode 記録準拠) に統一 (旧 293 は誤、`test_e2e_smoke` 旧 43 → 40 も修正)
 - **B (#91 closing)**: docs PR では `Refs #91` のみ、**実装 PR で `Closes #91`** と明示。KickOff §DI-3 / Plan §Context も同期
 - **C (limited-complete 経路)**: 旧「Phase A〜D の mock テスト」は誤 (Phase B〜D は実 agent 必須)。limited-complete を **Phase A 完了 + Phase B〜E スクリプト整備のみ**に境界変更
 - **D (`check_cycle_complete.sh` 引数)**: `target_session_id` のみ → `target_session_id target_pane_id` の 2 つに変更

--- a/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md
@@ -659,18 +659,104 @@ PR #96 docs PR の Copilot レビュー 21 件 (A-H 全カテゴリ) を本 Plan
 | frontmatter の related 参照が Context または Phase に含まれている | ✅ 全 9 件が「設計入力」「駆動層入力」「観測層 Issue」「スコープ外」に分配 |
 | 引き継ぎの「解決済み」が Context に含まれている | ✅ Step 4-3 PR #94 完了、Discussion 全 Q closed を Context に明記 |
 
-## 物理前提の実機確認結果 (Phase A Step 1 で追記する)
+## 物理前提の実機確認結果 (Phase A Step 1 実施: 2026-05-17)
 
-> Phase A Step 1 実施時に、本セクションを追記する。Plan が変更されるため commit が必要。
->
-> 確認項目 (F-3, F-4, F-7 反映):
-> - `cursor-agent` 実 invocation 仕様 (バイナリ名 / 引数形式): (TBD)
-> - `claude -p` 実 invocation 仕様 + `--model claude-sonnet-4-6` 指定方法: (TBD)
-> - **F-4**: `claude -p -w "$(pwd)"` で workspace 外の `canonical/skills/...` skill ファイルを Read tool で読めるか、回避策 (a)/(b)/(c) のどれを採用するか: (TBD)
-> - **F-7**: claude API 認証 + claude-sonnet-4-6 アクセス権 (最小通電確認 `claude -p "echo ok" --model claude-sonnet-4-6`): (TBD、PASS/FAIL を記録)
-> - **F-7**: claude vs claude-safe のどちらを採用するか (TTY 競合確認結果): (TBD)
-> - **F-3**: `composer-2` の Bash + Markdown 実力確認 (1 回試行 + 1 リトライ + 失敗で gpt-4.1 退避):
->   - 1 回目: (TBD、PASS/FAIL 詳細)
->   - 2 回目 (1 回目 FAIL 時): (TBD)
->   - 採用モデル: (composer-2 / gpt-4.1)
->   - 退避時の KickOff §DI-2 更新: (実施 / 不要)
+> 実施環境: macOS, Darwin 24.6.0、開発者環境
+> 実施: Claude Code が user 環境で実機検証 (user が cursor-agent + claude CLI インストール済み + ログイン済みを確認)
+
+### CLI バージョン (確認結果)
+
+| CLI | バイナリ位置 | バージョン |
+|------|------------|----------|
+| `cursor-agent` | `/opt/homebrew/bin/cursor-agent` | `2026.01.28-fd13201` |
+| `cursor` (補助) | `/Users/eddy/.local/bin/cursor` | `3.3.30` |
+| `claude` | `/Users/eddy/.local/bin/claude` | `2.1.143 (Claude Code)` |
+| `claude-safe` (ラッパー) | `projects/claude-safe/claude-safe` | `2.1.143 (Claude Code)` (claude wrapped with nohup) |
+| `codex` (将来用、スタブ実装対象) | `/opt/homebrew/bin/codex` | `codex-cli 0.130.0` |
+
+### cursor-agent 正式 invocation 仕様 (確認結果)
+
+- 推奨形: `cursor-agent --print --model <model> --workspace <path> --force "<prompt>"`
+- `-p` / `--print`: non-interactive
+- `--model <model>`: 明示指定 (例: `composer-2`、`gpt-5.2`、`sonnet-4-thinking` 等)
+- `--workspace <path>`: workspace ディレクトリ (デフォルト = CWD)
+- `--force`: 確認なしで全コマンド許可 (engine の非対話実行で必要)
+- prompt は positional argument (claude / codex と同様)
+- composer-2 は `cursor-agent --list-models` の出力に存在、default は `composer-2-fast`、本 Plan では明示的に `composer-2` (full 版) を指定する
+
+### claude -p 正式 invocation 仕様 (確認結果)
+
+- 推奨形: `claude -p "<prompt>" --model <model> --add-dir <repo_root> --add-dir /tmp --output-format text --no-session-persistence --max-budget-usd 1.0`
+- `-p` / `--print`: non-interactive
+- `--model <model>`: 明示指定 (例: `claude-sonnet-4-6`、エイリアス `sonnet` も可)
+- `--add-dir <directories>`: **CWD 以外のディレクトリ読み取り許可** (F-4 で必須、複数指定可)
+- `--no-session-persistence`: セッション保存無し (E2E テスト用)
+- `--max-budget-usd <amount>`: コスト上限 (推奨 `1.0`、`0.05` は system prompt loading で超過する)
+
+### F-4 確認結果: workspace 外 skill アクセス
+
+**実機テスト 1 (with `--add-dir <repo_root>`)**:
+```bash
+claude -p "Read /Users/.../canonical/skills/adversarial-review/SKILL.md and output only its first line" \
+  --model claude-sonnet-4-6 --add-dir <repo_root> --output-format text --no-session-persistence --max-budget-usd 1.0
+```
+→ **PASS**: `---` (skill frontmatter の最初の行) を正しく出力
+
+**実機テスト 2 (without `--add-dir`)**:
+→ **FAIL**: `"permission hasn't been granted"` で拒否
+
+**採用案**: **(b) `claude -p ... --add-dir <repo_root>`** (Plan F-4 の (a)(b)(c) のうち (b))。engine 側で reviewer 用 envelope の `task.read_docs` に skill ファイルパスを含めるとともに、`claude -p` 起動時に `--add-dir <repo_root>` を必ず付与する。
+
+加えて `/tmp` 配下の envelope / verify-inputs.md にもアクセスする必要があるため、CLI ディスパッチャは `--add-dir /tmp` も付与する (Step 4-2 の envelope パス規約 `/tmp/oe-{sid}-envelope.json` を前提)。
+
+### F-7 確認結果
+
+**(a) API 認証 + sonnet-4-6 アクセス権 (最小通電)**:
+```bash
+claude -p "Output exactly: ok" --model claude-sonnet-4-6 --output-format text --no-session-persistence --max-budget-usd 1.0
+```
+→ **PASS**: `ok` を出力
+
+備考:
+- 初回 `--max-budget-usd 0.05` では `Exceeded USD budget` でエラー。**system prompt loading (CLAUDE.md / hooks / settings) が想定より重く、$0.05 を超える**。実用上は `$1.0` (検証 1 セッションのバッファ込み) を推奨
+- `--bare` モード (system prompt skip) は `ANTHROPIC_API_KEY` env var 要 / OAuth / keychain を読まないため、API key 未設定環境では `Not logged in` エラー。**engine 側では `--bare` 不使用、OAuth / keychain (Claude Code default) を利用**
+
+**(b) claude vs claude-safe の選択**:
+- `claude` 直接呼び出し: wez pane 内の独立 pty で TTY 競合なし、実機確認で問題なし
+- `claude-safe`: nohup ラッパー、Cursor 統合ターミナル等での TTY 競合回避用
+- **採用**: `claude` 直接 (wez pane 環境では claude-safe 不要)
+
+### F-3 確認結果: composer-2 の Bash + Markdown 実力
+
+**実機テスト (1 回目試行、tmp dir で実施)**:
+
+タスク: 「`lib/test_dummy.sh` を作成して shebang と `set -euo pipefail` だけ書いて。`ls -la` で確認して」
+
+結果:
+- ファイル作成: ✅ `lib/test_dummy.sh` (38 bytes)
+- 内容: ✅ `#!/usr/bin/env bash\nset -euo pipefail\n` (要件どおり 2 行のみ、余分なし)
+- `ls -la` 確認: ✅ composer-2 自身が `ls -la` を実行して属性確認
+- shellcheck 確認 (人間が後段で実行): ✅ no warnings/errors
+- 応答品質: ✅ 構造化マークダウン (結論 / 根拠 / 手順 / 補足 / 関連リンク) で出力
+
+→ **1 回目 PASS、退避不要**。**採用モデル: `composer-2`**
+
+退避時の KickOff §DI-2 更新: **不要** (composer-2 採用継続)
+
+### CLI ディスパッチャ実装方針 (Phase A Step 2 への入力)
+
+実機確認結果から、`_oe_spawn_build_cli_command(ai_cli, ai_model, envelope_path, [workspace])` は以下を生成する:
+
+| ai_cli | invocation テンプレート (placeholder) |
+|--------|------------------------------------|
+| `cursor-agent` (or alias `cursor`) | `cursor-agent --print --model ${ai_model} --workspace ${workspace} --force "Read ${envelope_path} and execute the task"` |
+| `claude` (or alias `claude-safe`) | `claude -p "Read ${envelope_path} and execute the task" --model ${ai_model} --add-dir ${repo_root} --add-dir /tmp --output-format text --no-session-persistence --max-budget-usd 1.0` |
+| `codex` | スタブ (claude と同様の形式、本 Step では動作確認なし) |
+
+`${repo_root}` は engine が `git rev-parse --show-toplevel` で動的に解決、または `lib/verify.sh` 既存パターン (`$(cd "${PROJECT_DIR}/../.." && pwd)`) で導出。
+
+### コスト見込み (実機確認時の使用量)
+
+- claude 1 セッションあたり: system prompt + small response で **~$0.05-0.1** (実観測)
+- Plan §Q2 の推定「~$0.045/サイクル」は **やや楽観的**だが桁としては正しい。Phase E で正確値を Episode に記録予定
+- cursor-agent (composer-2): サブスク内 (Pro/Business)、CLI から token / cost 取得不可 (Plan §F-14 で「N/A」明記済み)

--- a/projects/orchestration-engine/lib/cleanup.sh
+++ b/projects/orchestration-engine/lib/cleanup.sh
@@ -57,13 +57,15 @@ oe_cleanup() {
     oe_audit_emit "cleanup" "$session_id" 0 "" "$payload_json" || true
 
     # Step 4-4 Phase C: reviewer 一時ファイル削除 (派生 #93 前半)
-    # OE_VERIFY_REVIEWER_SESSION_IDS の各 ID について /tmp/oe-{rsid}-verify-* を削除
+    # OE_VERIFY_REVIEWER_SESSION_IDS の各 ID について /tmp/oe-{rsid}-verify-* と
+    # /tmp/oe-{rsid}-reviewer.log (Phase C.5 file-redirect 経路) を削除
     declare -p OE_VERIFY_REVIEWER_SESSION_IDS >/dev/null 2>&1 || OE_VERIFY_REVIEWER_SESSION_IDS=()
     local rsid
     for rsid in "${OE_VERIFY_REVIEWER_SESSION_IDS[@]}"; do
       [[ -n "$rsid" ]] || continue
       rm -f "/tmp/oe-${rsid}-verify-envelope.json" 2>/dev/null || true
       rm -f "/tmp/oe-${rsid}-verify-inputs.md" 2>/dev/null || true
+      rm -f "/tmp/oe-${rsid}-reviewer.log" 2>/dev/null || true
     done
 
     # DI-6: 検証フェーズが走った場合は wez notify で完了通知

--- a/projects/orchestration-engine/lib/cleanup.sh
+++ b/projects/orchestration-engine/lib/cleanup.sh
@@ -56,6 +56,16 @@ oe_cleanup() {
 
     oe_audit_emit "cleanup" "$session_id" 0 "" "$payload_json" || true
 
+    # Step 4-4 Phase C: reviewer 一時ファイル削除 (派生 #93 前半)
+    # OE_VERIFY_REVIEWER_SESSION_IDS の各 ID について /tmp/oe-{rsid}-verify-* を削除
+    declare -p OE_VERIFY_REVIEWER_SESSION_IDS >/dev/null 2>&1 || OE_VERIFY_REVIEWER_SESSION_IDS=()
+    local rsid
+    for rsid in "${OE_VERIFY_REVIEWER_SESSION_IDS[@]}"; do
+      [[ -n "$rsid" ]] || continue
+      rm -f "/tmp/oe-${rsid}-verify-envelope.json" 2>/dev/null || true
+      rm -f "/tmp/oe-${rsid}-verify-inputs.md" 2>/dev/null || true
+    done
+
     # DI-6: 検証フェーズが走った場合は wez notify で完了通知
     # (monitor の CB / interrupt で検証フェーズに到達しなかった場合は OE_VERIFY_PHASE_COMPLETED=0 のままスキップ)
     #

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -18,9 +18,11 @@ OE_VERIFY_MARKER_RE='^@@OE_VERIFY:(pass|fail|warn)$'
 #   @@OE_BLOCKED:{reason} — ブロック理由の報告
 
 # サーキットブレーカー閾値
-OE_CB_TIMEOUT=1800
-OE_CB_MAX_TURNS=10
-OE_CB_MAX_PANES=5
+# Step 4-4 Phase C 発見: 実 agent (cursor-agent/composer-2) では mock 想定の MAX_TURNS=10 (=20s @ 2s poll) が短すぎる。
+# env override 可能にしつつデフォルトは mock テスト互換のため維持。
+OE_CB_TIMEOUT="${OE_CB_TIMEOUT:-1800}"
+OE_CB_MAX_TURNS="${OE_CB_MAX_TURNS:-10}"
+OE_CB_MAX_PANES="${OE_CB_MAX_PANES:-5}"
 
 # SLO: マーカー検出目標（秒）
 OE_SLO_DETECT_SEC=5

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -43,3 +43,14 @@ OE_VERIFY_DONE_PANES=()
 
 # Step 4-3 Phase E: 検証フェーズ完走フラグ (cleanup の wez notify 発火条件、CB 発動時は未設定のまま)
 OE_VERIFY_PHASE_COMPLETED=0
+
+# Step 4-4 Phase A: target / 検証 agent の AI CLI + モデル選択 (DI-4 + #91)
+# Phase A Step 1 物理前提実機確認で確定したデフォルト値:
+#   - target = cursor-agent (composer-2)
+#   - 検証   = claude (claude-sonnet-4-6)
+# env var で override 可能。CLI ディスパッチャ (_oe_spawn_build_cli_command in spawn.sh) は
+# "cursor-agent" / "cursor" / "claude" / "claude-safe" / "codex" を解釈する。
+OE_TARGET_AI_CLI="${OE_TARGET_AI_CLI:-cursor-agent}"
+OE_TARGET_AI_MODEL="${OE_TARGET_AI_MODEL:-composer-2}"
+OE_VERIFY_AI_CLI="${OE_VERIFY_AI_CLI:-claude}"
+OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -54,3 +54,7 @@ OE_TARGET_AI_CLI="${OE_TARGET_AI_CLI:-cursor-agent}"
 OE_TARGET_AI_MODEL="${OE_TARGET_AI_MODEL:-composer-2}"
 OE_VERIFY_AI_CLI="${OE_VERIFY_AI_CLI:-claude}"
 OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
+
+# Step 4-4 Phase C: reviewer 一時ファイル掃除用配列 (派生 Issue #93 前半)
+# oe_verify_run_phase で reviewer ULID 生成時に append、oe_cleanup で対応する /tmp/oe-{rsid}-verify-* を削除
+OE_VERIFY_REVIEWER_SESSION_IDS=()

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -28,6 +28,17 @@ oe_spawn_prepare_pane() {
 # - claude: -p '<prompt>' --model <model> --add-dir <repo_root> --add-dir /tmp \
 #           --output-format text --no-session-persistence --max-budget-usd 1.0
 # - codex: スタブ (claude と同形式、本 Step では動作確認なし)
+#
+# 引数の値に関する前提 (caller 側で保証):
+#   envelope_path / workspace / repo_root のいずれにも **single quote `'` を含まない**ことを前提に、
+#   prompt を single quotes でラップして出力する。`'` が混入した場合、pane 内 shell が
+#   組み立てたコマンドを parse できず silent な `verification_protocol_error`
+#   (exit_without_verify_marker) に発展する可能性がある。
+#   MVP では envelope_path は `/tmp/oe-${session_id}-envelope.json`、workspace / repo_root は
+#   `cd ... && pwd` で得るリポジトリ作業ディレクトリのため、上記前提は自動的に満たされる。
+#   将来 user 指定パスを受け取るパス (例: `bin/oe --task-file <path>` の検証 envelope 化等) を
+#   足す場合は、本関数の caller でパス正常化 (or single quote escape) を行うこと。
+#   [Copilot PR #97 review 反映、2026-05-18]
 _oe_spawn_build_cli_command() {
   local ai_cli="$1"
   local ai_model="$2"

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -12,17 +12,78 @@ oe_spawn_prepare_pane() {
   OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent 30 --wait-ready --timeout "$OE_SPAWN_WAIT_READY_SEC")"
 }
 
+# _oe_spawn_build_cli_command — AI CLI ごとに正しい invocation を組み立てる
+# (Step 4-4 Phase A #91 反映、Phase A Step 1 物理前提実機確認結果に従う)
+#
+# 引数:
+#   ai_cli         "cursor-agent" | "cursor" | "claude" | "claude-safe" | "codex"
+#   ai_model       モデル名 (例: "composer-2", "claude-sonnet-4-6")
+#   envelope_path  envelope JSON のパス (target / verify 両用)
+#   [workspace]    workspace ディレクトリ (cursor-agent --workspace 用、デフォルト = PROJECT_DIR)
+#
+# stdout に組み立てた CLI コマンド文字列を出力。未対応 CLI は exit 1。
+#
+# Phase A Step 1 で確認した invocation 仕様:
+# - cursor-agent: --print --model <model> --workspace <path> --force '<prompt>'
+# - claude: -p '<prompt>' --model <model> --add-dir <repo_root> --add-dir /tmp \
+#           --output-format text --no-session-persistence --max-budget-usd 1.0
+# - codex: スタブ (claude と同形式、本 Step では動作確認なし)
+_oe_spawn_build_cli_command() {
+  local ai_cli="$1"
+  local ai_model="$2"
+  local envelope_path="$3"
+  local workspace="${4:-${PROJECT_DIR}}"
+
+  local prompt="Read ${envelope_path} and execute the task"
+
+  # repo_root は claude の --add-dir 用 (skill ファイル workspace 外アクセス)
+  local repo_root
+  repo_root="$(cd "${PROJECT_DIR}/../.." && pwd)"
+
+  case "$ai_cli" in
+    cursor-agent|cursor)
+      printf "cursor-agent --print --model %s --workspace %s --force '%s'" \
+        "$ai_model" "$workspace" "$prompt"
+      ;;
+    claude|claude-safe)
+      # claude 直接 (wez pane の独立 pty で TTY 競合なし、Step 4-4 Phase A Step 1 F-7 確認)
+      printf "claude -p '%s' --model %s --add-dir %s --add-dir /tmp --output-format text --no-session-persistence --max-budget-usd 1.0" \
+        "$prompt" "$ai_model" "$repo_root"
+      ;;
+    codex)
+      # Step 4-4 ではスタブ。動作確認は Step 4-5 以降で必要なら実施
+      printf "codex -p '%s' --model %s -w %s" \
+        "$prompt" "$ai_model" "$workspace"
+      ;;
+    *)
+      echo "_oe_spawn_build_cli_command: unsupported ai_cli '${ai_cli}' (supported: cursor-agent, cursor, claude, claude-safe, codex)" >&2
+      return 1
+      ;;
+  esac
+}
+
 # oe_spawn_send — 既存ペインに AI CLI コマンド + マーカー emit を送信
 #
-# 引数: session_id, pane_id, envelope_path, [ai_cli]（デフォルト: "cursor"）
+# 引数:
+#   session_id, pane_id, envelope_path,
+#   [ai_cli]    (デフォルト: ${OE_TARGET_AI_CLI:-cursor-agent})
+#   [ai_model]  (デフォルト: ${OE_TARGET_AI_MODEL:-composer-2})
+#   [workspace] (デフォルト: ${PROJECT_DIR})
+#
+# Step 4-4 Phase A 反映: ai_cli / ai_model の伝播 + ディスパッチャ経由化 (F-8)
 oe_spawn_send() {
   local session_id="$1"
   local pane_id="$2"
   local envelope_path="$3"
-  local ai_cli="${4:-cursor}"
+  local ai_cli="${4:-${OE_TARGET_AI_CLI:-cursor-agent}}"
+  local ai_model="${5:-${OE_TARGET_AI_MODEL:-composer-2}}"
+  local workspace="${6:-${PROJECT_DIR}}"
+
+  local base_cli_command
+  base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$envelope_path" "$workspace")"
 
   local cli_command
-  cli_command="${ai_cli} --prompt 'Read ${envelope_path} and execute the task' ; printf '\\n@@OE_EXIT:%d\\n' \$?"
+  cli_command="${base_cli_command} ; printf '\\n@@OE_EXIT:%d\\n' \$?"
 
   wez pane send "$pane_id" "$cli_command"
 
@@ -32,13 +93,18 @@ oe_spawn_send() {
 
 # oe_spawn — 後方互換ラッパー（prepare → send）
 #
-# 引数: session_id, envelope_path, [ai_cli]（デフォルト: "cursor"）
+# 引数: session_id, envelope_path,
+#       [ai_cli]    (デフォルト: ${OE_TARGET_AI_CLI:-cursor-agent})
+#       [ai_model]  (デフォルト: ${OE_TARGET_AI_MODEL:-composer-2})
 # 戻り値: OE_SPAWN_PANE_ID にペイン ID を設定
+#
+# Step 4-4 Phase A 反映 (F-8): ai_model 引数追加 + oe_spawn_send への伝播
 oe_spawn() {
   local session_id="$1"
   local envelope_path="$2"
-  local ai_cli="${3:-cursor}"
+  local ai_cli="${3:-${OE_TARGET_AI_CLI:-cursor-agent}}"
+  local ai_model="${4:-${OE_TARGET_AI_MODEL:-composer-2}}"
 
   oe_spawn_prepare_pane
-  oe_spawn_send "$session_id" "$OE_SPAWN_PANE_ID" "$envelope_path" "$ai_cli"
+  oe_spawn_send "$session_id" "$OE_SPAWN_PANE_ID" "$envelope_path" "$ai_cli" "$ai_model"
 }

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -521,6 +521,7 @@ oe_verify_run_phase() {
   for target_pane_id in "$@"; do
     local reviewer_session_id
     reviewer_session_id="$(_oe_verify_generate_session_id)"
+    OE_VERIFY_REVIEWER_SESSION_IDS+=("$reviewer_session_id")
 
     oe_verify_spawn \
       "$reviewer_session_id" \

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -218,18 +218,22 @@ oe_verify_prompt_build() {
 #   target_pane_id        被検証ペイン ID
 #   target_session_id     被検証セッション ID
 #   target_envelope_path  被検証ペインの envelope JSON のパス
-#   [ai_cli]              使用する AI CLI (デフォルト: "cursor")
+#   [ai_cli]              使用する AI CLI (デフォルト: ${OE_VERIFY_AI_CLI:-claude})
+#   [ai_model]            使用するモデル   (デフォルト: ${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6})
 #
 # 戻り値:
 #   OE_VERIFY_PANE_ID         検証 agent ペイン ID
 #   OE_VERIFY_ENVELOPE_PATH   検証用 envelope パス
 #   OE_VERIFY_PROMPT_PATH     構築されたプロンプト (3 入力) ファイルパス
+#
+# Step 4-4 Phase A 反映 (F-8): ai_model 引数追加 + ディスパッチャ (_oe_spawn_build_cli_command) 経由化
 oe_verify_spawn() {
   local reviewer_session_id="$1"
   local target_pane_id="$2"
   local target_session_id="$3"
   local target_envelope_path="$4"
-  local ai_cli="${5:-cursor}"
+  local ai_cli="${5:-${OE_VERIFY_AI_CLI:-claude}}"
+  local ai_model="${6:-${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}}"
 
   OE_VERIFY_PANE_ID=""
 
@@ -258,11 +262,13 @@ oe_verify_spawn() {
     "$target_envelope_path" \
     "$OE_VERIFY_PROMPT_PATH"
 
-  # 送信コマンド: ai_cli に envelope を読ませる + 末尾で shell が @@OE_EXIT を emit
+  # 送信コマンド: ai_cli ディスパッチャ経由で組み立て + 末尾で shell が @@OE_EXIT を emit。
   # 検証 agent 自身は task.description / skill の指示に従って @@OE_VERIFY:{result} を出力する。
   # 二値 (@@OE_VERIFY + @@OE_EXIT) の同時検出は Phase D F3 の二値保持で対応する。
+  local base_cli_command
+  base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$OE_VERIFY_ENVELOPE_PATH" "$PROJECT_DIR")"
   local cli_command
-  cli_command="${ai_cli} --prompt 'Read ${OE_VERIFY_ENVELOPE_PATH} and execute the task' ; printf '\\n@@OE_EXIT:%d\\n' \$?"
+  cli_command="${base_cli_command} ; printf '\\n@@OE_EXIT:%d\\n' \$?"
 
   wez pane send "$reviewer_pane_id" "$cli_command"
 
@@ -496,9 +502,10 @@ oe_verify_run_phase() {
   local target_session_id="$1"
   shift
 
-  # 末尾オプション: ai_cli (位置引数ではなく環境変数 OE_VERIFY_AI_CLI で渡す設計、
-  # 後方互換維持のため位置引数化はしない)
-  local ai_cli="${OE_VERIFY_AI_CLI:-cursor}"
+  # 末尾オプション: ai_cli / ai_model (位置引数ではなく環境変数で渡す設計、後方互換維持)
+  # Step 4-4 Phase A 反映: デフォルトを cursor → claude / sonnet-4-6 に変更
+  local ai_cli="${OE_VERIFY_AI_CLI:-claude}"
+  local ai_model="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
 
   if [[ $# -eq 0 ]]; then
     return 0
@@ -520,7 +527,8 @@ oe_verify_run_phase() {
       "$target_pane_id" \
       "$target_session_id" \
       "$target_envelope_path" \
-      "$ai_cli"
+      "$ai_cli" \
+      "$ai_model"
 
     local reviewer_pane_id="$OE_VERIFY_PANE_ID"
     # 注: oe_verify_spawn は内部で OE_VERIFY_MANAGED_PANES に append 済み

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -262,13 +262,19 @@ oe_verify_spawn() {
     "$target_envelope_path" \
     "$OE_VERIFY_PROMPT_PATH"
 
-  # 送信コマンド: ai_cli ディスパッチャ経由で組み立て + 末尾で shell が @@OE_EXIT を emit。
-  # 検証 agent 自身は task.description / skill の指示に従って @@OE_VERIFY:{result} を出力する。
-  # 二値 (@@OE_VERIFY + @@OE_EXIT) の同時検出は Phase D F3 の二値保持で対応する。
+  # 送信コマンド: ai_cli ディスパッチャ経由で組み立て + サブシェルで @@OE_EXIT 付与 + tee で file 出力。
+  # Step 4-4 Phase C.5 反映: wez pane capture 経路 (viewport-only + tail 後処理) では
+  # 長文 review markdown 中の @@OE_VERIFY 行が scrollback に押し出されて拾えない。
+  # `( cmd 2>&1 ; printf @@OE_EXIT ) | tee log_path` の形にすることで:
+  #   - claude/cursor の stdout/stderr と @@OE_EXIT の両方を 1 つの log file に同順序で記録
+  #   - pane (TTY) には引き続き出力されるので人間可視性は維持
+  #   - bash の PIPESTATUS 依存を回避 (sub-shell 内の $? で claude exit code を反映)
+  # scan は file 経路 (_oe_verify_scan_log_file) に切替済み。
+  local log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
   local base_cli_command
   base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$OE_VERIFY_ENVELOPE_PATH" "$PROJECT_DIR")"
   local cli_command
-  cli_command="${base_cli_command} ; printf '\\n@@OE_EXIT:%d\\n' \$?"
+  cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
 
   wez pane send "$reviewer_pane_id" "$cli_command"
 
@@ -454,6 +460,42 @@ oe_verify_emit_completed() {
   oe_audit_emit "verification_completed" "$target_session_id" "$target_pane_id" "" "$payload"
 }
 
+# _oe_verify_scan_log_file — Step 4-4 Phase C.5: reviewer の出力 log file を tail で走査し
+# 既存の _oe_capture_scan_parse に流して二値 (OE_SCAN_EXIT_CODE / OE_SCAN_VERIFY_RESULT) を設定する。
+#
+# 引数:
+#   log_path   reviewer の stdout+stderr+@@OE_EXIT が書かれる file path
+#   [lines]    末尾何行を読むか (デフォルト 5000、claude review は markdown + diff 引用で千行になり得るため大きめ)
+#
+# 戻り値: OE_SCAN_* 変数群を設定 (_oe_capture_scan_parse と同じインターフェース)
+#         file 不在時は OE_SCAN_* を空のまま return 0 (cleanup と race しても無害に継続)
+#
+# 設計背景:
+#   wez pane capture --lines N は wezterm cli get-text の viewport-only 出力に tail -n N を
+#   適用する実装 (wezterm-ai-mode ADR-004:65)。長文 markdown では @@OE_VERIFY が viewport 外に
+#   押し出されて拾えない。reviewer 送信側で `( cmd ; printf @@OE_EXIT ) | tee log_path` に
+#   切替えており、本関数は log file 経路で同じ parse を行う。
+_oe_verify_scan_log_file() {
+  local log_path="$1"
+  local lines="${2:-5000}"
+
+  OE_SCAN_MARKER_TYPE=""
+  OE_SCAN_VALUE=""
+  OE_SCAN_BLOCKED="false"
+  OE_SCAN_EXIT_CODE=""
+  OE_SCAN_VERIFY_RESULT=""
+
+  [[ -f "$log_path" ]] || return 0
+
+  local captured
+  captured="$(tail -n "$lines" "$log_path" 2>/dev/null)" || return 0
+
+  local normalized
+  normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g')"
+
+  _oe_capture_scan_parse "$normalized"
+}
+
 # _oe_verify_generate_session_id — 検証 agent 用の ULID 形式セッション ID を生成
 # (bin/oe の oe_generate_session_id と同フォーマット: 14 桁数字 + 12 桁 Crockford base32)
 #
@@ -535,12 +577,17 @@ oe_verify_run_phase() {
     # 注: oe_verify_spawn は内部で OE_VERIFY_MANAGED_PANES に append 済み
     # (Copilot #5 反映: prepare_pane 直後に登録、途中失敗時の cleanup 取り逃しを防ぐ)
 
-    # 独立ポーリングループ (検証ペインは verbose 出力対策で lines=200)
+    # Step 4-4 Phase C.5: reviewer 出力は file redirect (tee) で /tmp に書かれる。
+    # wez pane capture (viewport-only + tail 後処理) では scrollback に押し出された
+    # @@OE_VERIFY 行を拾えないため、file 経路で走査する。
+    local reviewer_log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
+
+    # 独立ポーリングループ
     local start_seconds=$SECONDS
     local resolved=0
     while true; do
       sleep "$OE_POLL_INTERVAL"
-      oe_capture_scan "$reviewer_pane_id" 200
+      _oe_verify_scan_log_file "$reviewer_log_path"
 
       # Codex P2: @@OE_VERIFY と @@OE_EXIT の **両方** が見えるまで待つ
       # 片方しか見えていない状態で記録すると、agent が後で非 0 終了した場合に

--- a/projects/orchestration-engine/tests/e2e_real_agent/.gitignore
+++ b/projects/orchestration-engine/tests/e2e_real_agent/.gitignore
@@ -1,0 +1,2 @@
+# Step 4-4 Phase E Step 13 反映 (M2): probe / smoke の一時ログを git 追跡対象外に
+.tmp_*

--- a/projects/orchestration-engine/tests/e2e_real_agent/README.md
+++ b/projects/orchestration-engine/tests/e2e_real_agent/README.md
@@ -1,0 +1,64 @@
+# tests/e2e_real_agent/
+
+Step 4-4 で導入した実 agent (cursor-agent / claude) を起動する E2E 検証スクリプト群。MVP の orchestration-engine が 1 サイクル (target 完走 → 検証 → cleanup) を実機で完走することを実証する。
+
+## 環境前提
+
+| 要件 | 詳細 |
+|---|---|
+| `wez` CLI | WezTerm AI Mode CLI が PATH 上にあること (実 wez のパスは `/Users/eddy/bin/wez` または `/opt/homebrew/bin/wez` を shim が自動探索、`OE_REAL_WEZ` で override 可) |
+| WezTerm 起動中 | wez pane split/send/capture/kill が動作する状態 |
+| `cursor-agent` CLI | target 用。`composer-2` モデルが利用可能 (Cursor Pro / Business サブスク内) |
+| `claude` CLI | reviewer 用。`claude-sonnet-4-6` モデルが利用可能 (OAuth ログイン済み) |
+| `jq` | KVS / audit の検査に使用 |
+| `bash` | 5.x 推奨。pane 内 shell の `${PIPESTATUS[*]}` を使わないため 3.2 でも動作するが、5.x を前提に検証済み |
+
+## 構成
+
+```
+tests/e2e_real_agent/
+├── README.md                                   # 本ファイル
+├── .gitignore                                  # .tmp_* (probe / smoke の一時ログを除外)
+├── bin/
+│   └── wez                                     # wez shim (notify を notify.log に記録、他は実 wez に exec)
+├── probe_target.sh                             # Phase B: cursor-agent / composer-2 の通電確認
+├── probe_verify.sh                             # Phase B: claude / sonnet-4-6 の通電確認 (2 段: emit + skill load)
+├── task_description_dogfood_cleanup.md         # Phase C: target に渡す task description (DI-1 確定)
+├── smoke_cursor_composer_claude_sonnet.sh      # Phase C/D 共通 E2E スモーク
+├── check_phase_c.sh                            # Phase C 構造判定 ((a) state=success (b) state_change+session_end)
+├── check_cycle_complete.sh                     # Phase D 構造判定 4 点 (target EXIT / reviewer VERIFY / KVS / audit / notify)
+└── repro_verify_protocol_error.sh              # Phase C.5 調査用 (engine/wez を経由しない claude one-shot 再現)
+```
+
+## 実行手順
+
+```bash
+# 1. 通電確認 (本実行の前提を満たすか)
+bash projects/orchestration-engine/tests/e2e_real_agent/probe_target.sh
+bash projects/orchestration-engine/tests/e2e_real_agent/probe_verify.sh
+
+# 2. E2E スモーク (target → verify → cleanup の 1 サイクル)
+bash projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
+```
+
+smoke 完走時の最終行は `[smoke] PASS (Phase C + D 構造判定)`。出力ログ・state・audit は `.tmp_smoke_<timestamp>/` に保存される (gitignore 対象)。
+
+## Phase E スキップ条件 (limited-complete 判定)
+
+cursor-agent / claude の片方または両方が手元に無い開発者環境では、本ディレクトリの実行は skip 可。その場合 mock テスト (`projects/orchestration-engine/tests/test_*.sh`) のみで Phase A〜D の構造的整合性を確認 (= limited-complete)。本ディレクトリでの 1 回完走実証 (= full-complete) は別の開発者 / CI で別途実施。
+
+## 期待コスト (Plan F-14)
+
+- `claude-sonnet-4-6` (reviewer): 1 サイクルあたり概ね $0.04〜$0.10 (envelope + verify-inputs + skill 読み込み + Compliance Review 出力)
+- `cursor-agent` (composer-2、target): Cursor Pro / Business サブスク内のため CLI から token / cost を取得不可。Episode には **N/A** と明記
+
+## 想定実行頻度
+
+- MVP では 1 回完走を実証すれば十分
+- Step 4-5 以降で CI 上の定期実行 (例: nightly) を検討
+
+## トラブルシュート
+
+- `verification_protocol_error` (`exit_without_verify_marker`) が出る場合: reviewer が `@@OE_VERIFY:{pass|fail|warn}` を独立行で emit していない、または engine の scan 経路 (`lib/verify.sh:_oe_verify_scan_log_file`) が log file を読めていない可能性。`/tmp/oe-{reviewer_session_id}-reviewer.log` の中身を確認 (cleanup で削除されるので smoke 実行中に別シェルで確認)。
+- `circuit_breaker_triggered` (reason: max_turns) が出る場合: `OE_CB_MAX_TURNS` が小さすぎる可能性。smoke スクリプトは 600 (= 20 min @ 2s poll) を設定済み。
+- `claude: budget exceeded` 等: `--max-budget-usd 1.0` でも不足する場合は `lib/spawn.sh:_oe_spawn_build_cli_command` を確認。

--- a/projects/orchestration-engine/tests/e2e_real_agent/bin/wez
+++ b/projects/orchestration-engine/tests/e2e_real_agent/bin/wez
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# wez shim — Step 4-4 Phase E Step 13 / Plan F-10
+#
+# 目的:
+#   `wez notify` 呼び出しを ${OE_MOCK_LOG_DIR}/notify.log に記録する (check_cycle_complete.sh の
+#   (4) wez notify 判定のため)。`notify` 以外のサブコマンド (pane split/send/capture/kill 等) は
+#   実 wez にそのまま exec する。
+#
+# 使い方:
+#   smoke スクリプトで `export PATH="$(dirname "$0")/bin:$PATH"` を実行し、本 shim を PATH 先頭に置く。
+#   これにより engine からの `wez ...` 呼び出しが本 shim を経由する。
+#
+# 注意:
+#   - 実 wez のフルパスは Phase A Step 1 物理前提確認で固定値とする。本 shim は `/Users/eddy/bin/wez`
+#     と `/opt/homebrew/bin/wez` の順で探索 (環境依存を最小化)。`OE_REAL_WEZ` 環境変数で override 可能
+#   - `notify` サブコマンドは notify.log に title|body を 1 行で記録 (区切り = '|')。`--json` 等の
+#     追加フラグは記録に含まず後ろの 2 引数 (title, body) を採用 (実 wez の引数規約に整合)
+
+LOG_DIR="${OE_MOCK_LOG_DIR:-}"
+
+if [[ "${1:-}" == "notify" ]]; then
+  if [[ -z "$LOG_DIR" ]]; then
+    echo "wez (shim): OE_MOCK_LOG_DIR が未設定、notify をスキップ" >&2
+    exit 0
+  fi
+  shift
+  # 残り引数から title と body を抽出 (フラグを除外)
+  title=""
+  body=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json|--*) shift ;;
+      *)
+        if [[ -z "$title" ]]; then title="$1"
+        elif [[ -z "$body" ]]; then body="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+  mkdir -p "$LOG_DIR"
+  printf '%s|%s\n' "$title" "$body" >> "${LOG_DIR}/notify.log"
+  exit 0
+fi
+
+# notify 以外は実 wez に exec
+REAL_WEZ="${OE_REAL_WEZ:-}"
+if [[ -z "$REAL_WEZ" ]]; then
+  for candidate in /Users/eddy/bin/wez /opt/homebrew/bin/wez /usr/local/bin/wez; do
+    if [[ -x "$candidate" ]]; then
+      REAL_WEZ="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$REAL_WEZ" || ! -x "$REAL_WEZ" ]]; then
+  echo "wez (shim): real wez not found (set OE_REAL_WEZ to override)" >&2
+  exit 127
+fi
+
+exec "$REAL_WEZ" "$@"

--- a/projects/orchestration-engine/tests/e2e_real_agent/check_cycle_complete.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/check_cycle_complete.sh
@@ -120,7 +120,27 @@ else
   if [[ "$pe_count" -eq 0 ]]; then
     pass "verification_protocol_error = 0 件"
   else
-    warn "verification_protocol_error emitted (${pe_count} 件) — Phase C.5 修正後は 0 が期待値"
+    fail "verification_protocol_error emitted (${pe_count} 件) — Phase C.5 修正後の期待値は 0、so-compare iter2 反映で WARN→FAIL に厳密化"
+  fi
+fi
+
+# ---- (3.5) verification_summary.protocol_errors / timeouts == 0 (so-compare iter2 反映) ----
+echo ""
+echo "--- (3.5) verification_summary の protocol_errors / timeouts == 0 直接検証 ---"
+if [[ ! -f "$STATE_FILE" ]]; then
+  fail "state file not found (re): $STATE_FILE"
+else
+  summary_pe=$(jq -r '.verification_summary.protocol_errors // "missing"' "$STATE_FILE")
+  summary_to=$(jq -r '.verification_summary.timeouts // "missing"' "$STATE_FILE")
+  if [[ "$summary_pe" == "0" ]]; then
+    pass "verification_summary.protocol_errors == 0"
+  else
+    fail "verification_summary.protocol_errors = '${summary_pe}' (expected '0')"
+  fi
+  if [[ "$summary_to" == "0" ]]; then
+    pass "verification_summary.timeouts == 0"
+  else
+    fail "verification_summary.timeouts = '${summary_to}' (expected '0')"
   fi
 fi
 

--- a/projects/orchestration-engine/tests/e2e_real_agent/check_cycle_complete.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/check_cycle_complete.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check_cycle_complete.sh — Step 4-4 Phase D Step 12: 1 サイクル完走の構造的判定 (4 点)
+#
+# 引数: target_session_id target_pane_id [data_dir]
+#
+# 確認項目 (Plan §Phase D Step 12 + GATE):
+#   (1) target の @@OE_EXIT:0 検出 (session_end.state=success を代理指標)
+#   (1) reviewer の @@OE_VERIFY:{pass|fail|warn} 検出 (KVS verification[pid].marker_raw)
+#   (2) KVS validation (validate-session-state.sh + state=success + verification[pid].result)
+#   (3) audit event_type ホワイトリスト + 件数 (必須イベント + CB 0 件)
+#   (4) wez notify 呼び出し (notify.log 存在 + 本文フォーマット、shim 経由のみ判定可)
+#
+# Exit: 0 = 全 PASS、1 = いずれかが FAIL
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <target_session_id> <target_pane_id> [data_dir]" >&2
+  exit 2
+fi
+
+TARGET_SESSION_ID="$1"
+TARGET_PANE_ID="$2"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DATA_DIR="${3:-${OE_DATA_DIR:-${PROJECT_DIR}}}"
+STATE_FILE="${DATA_DIR}/state/${TARGET_SESSION_ID}.state.json"
+AUDIT_FILE="${DATA_DIR}/audit/${TARGET_SESSION_ID}.jsonl"
+
+FAIL=0
+WARN=0
+VERIFY_RESULT_OBSERVED=""
+
+fail() { echo "[check_cycle] FAIL: $*"; FAIL=$((FAIL + 1)); }
+warn() { echo "[check_cycle] WARN: $*"; WARN=$((WARN + 1)); }
+pass() { echo "[check_cycle] PASS: $*"; }
+
+echo "=== check_cycle_complete ==="
+echo "target_session_id : ${TARGET_SESSION_ID}"
+echo "target_pane_id    : ${TARGET_PANE_ID}"
+echo "data_dir          : ${DATA_DIR}"
+echo "state_file        : ${STATE_FILE}"
+echo "audit_file        : ${AUDIT_FILE}"
+echo ""
+
+# ---- (1a) target session_end.state ----
+echo "--- (1a) target @@OE_EXIT (session_end.state 代理指標) ---"
+if [[ ! -f "$AUDIT_FILE" ]]; then
+  fail "audit file not found: $AUDIT_FILE"
+else
+  exit_ok=$(jq -s -r 'map(select(.event_type == "session_end")) | last | .state // "null"' "$AUDIT_FILE")
+  if [[ "$exit_ok" == "success" ]]; then
+    pass "target session_end.state == 'success' (= @@OE_EXIT:0 の代理指標)"
+  else
+    fail "target session_end.state = '$exit_ok' (expected 'success')"
+  fi
+fi
+
+# ---- (1b) reviewer marker_raw ----
+echo ""
+echo "--- (1b) reviewer @@OE_VERIFY:(pass|fail|warn) 検出 (KVS verification[pid].marker_raw) ---"
+if [[ ! -f "$STATE_FILE" ]]; then
+  fail "state file not found: $STATE_FILE"
+else
+  verify_raw=$(jq -r --arg pid "$TARGET_PANE_ID" '.verification[$pid].marker_raw // "null"' "$STATE_FILE")
+  if [[ "$verify_raw" =~ ^@@OE_VERIFY:(pass|fail|warn)$ ]]; then
+    VERIFY_RESULT_OBSERVED="${BASH_REMATCH[1]}"
+    pass "reviewer marker_raw = '${verify_raw}' (verify_result=${VERIFY_RESULT_OBSERVED})"
+  else
+    fail "reviewer marker_raw expected '@@OE_VERIFY:(pass|fail|warn)', got: '${verify_raw}'"
+  fi
+fi
+
+# ---- (2) KVS validation ----
+echo ""
+echo "--- (2) KVS validation (validate-session-state.sh + state=success + verification[pid].result) ---"
+if [[ ! -f "$STATE_FILE" ]]; then
+  fail "state file not found (re): $STATE_FILE"
+else
+  if "${PROJECT_DIR}/scripts/validate-session-state.sh" "$STATE_FILE" >/dev/null 2>&1; then
+    pass "validate-session-state.sh PASS"
+  else
+    fail "validate-session-state.sh FAIL"
+    "${PROJECT_DIR}/scripts/validate-session-state.sh" "$STATE_FILE" 2>&1 | sed 's/^/  /'
+  fi
+
+  if jq -e --arg pid "$TARGET_PANE_ID" \
+      '.state == "success" and (.verification[$pid].result // null) != null' \
+      "$STATE_FILE" >/dev/null; then
+    pass "state.state=success かつ verification[${TARGET_PANE_ID}].result 存在"
+  else
+    fail "state.state != success または verification[${TARGET_PANE_ID}].result 不在"
+  fi
+fi
+
+# ---- (3) audit event_type ホワイトリスト + 件数 ----
+echo ""
+echo "--- (3) audit event_type ホワイトリスト + 件数 ---"
+if [[ ! -f "$AUDIT_FILE" ]]; then
+  fail "audit file not found (re): $AUDIT_FILE"
+else
+  required_events=(session_start state_change session_end verification_started verification_completed cleanup)
+  for ev in "${required_events[@]}"; do
+    count=$(jq -s --arg ev "$ev" 'map(select(.event_type == $ev)) | length' "$AUDIT_FILE")
+    if [[ "$count" -ge 1 ]]; then
+      pass "audit event '${ev}' = ${count} 件"
+    else
+      fail "audit event '${ev}' 不在 (0 件)"
+    fi
+  done
+
+  cb_count=$(jq -s 'map(select(.event_type == "circuit_breaker_triggered")) | length' "$AUDIT_FILE")
+  if [[ "$cb_count" -eq 0 ]]; then
+    pass "circuit_breaker_triggered = 0 件 (完走判定)"
+  else
+    fail "circuit_breaker_triggered emitted (${cb_count} 件) — 本サイクルは完走失敗"
+  fi
+
+  pe_count=$(jq -s 'map(select(.event_type == "verification_protocol_error")) | length' "$AUDIT_FILE")
+  if [[ "$pe_count" -eq 0 ]]; then
+    pass "verification_protocol_error = 0 件"
+  else
+    warn "verification_protocol_error emitted (${pe_count} 件) — Phase C.5 修正後は 0 が期待値"
+  fi
+fi
+
+# ---- (4) wez notify 呼び出し (shim 経由のみ判定可、shim 不在時は WARN) ----
+echo ""
+echo "--- (4) wez notify 呼び出し (shim 経由) ---"
+NOTIFY_LOG="${OE_MOCK_LOG_DIR:-}/notify.log"
+if [[ -z "${OE_MOCK_LOG_DIR:-}" ]]; then
+  warn "OE_MOCK_LOG_DIR が未設定 — notify shim 経由判定をスキップ (Plan F-10 / Phase E Step 13 で shim 配置)"
+elif [[ ! -f "$NOTIFY_LOG" ]]; then
+  warn "notify.log 不在 (${NOTIFY_LOG}) — shim が PATH 先頭にないか、wez notify が呼ばれていない"
+else
+  if grep -qE 'pass=[0-9]+, fail=[0-9]+, warn=[0-9]+, fail_rate=[0-9.]+, protocol_errors=[0-9]+, timeouts=[0-9]+' "$NOTIFY_LOG"; then
+    pass "wez notify 本文フォーマット一致 (${NOTIFY_LOG})"
+  else
+    fail "wez notify 本文フォーマット不一致 — 内容: $(cat "$NOTIFY_LOG")"
+  fi
+fi
+
+# ---- Summary ----
+echo ""
+echo "=== check_cycle_complete summary ==="
+echo "verify_result : ${VERIFY_RESULT_OBSERVED:-<unknown>} (Episode 記録用、assertion 対象外)"
+echo "FAIL=${FAIL} WARN=${WARN}"
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "[check_cycle] OVERALL FAIL"
+  exit 1
+fi
+echo "[check_cycle] OVERALL PASS (verify_result=${VERIFY_RESULT_OBSERVED:-<unknown>}, WARN=${WARN})"
+exit 0

--- a/projects/orchestration-engine/tests/e2e_real_agent/check_phase_c.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/check_phase_c.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check_phase_c.sh — Step 4-4 Phase C 完了判定
+#
+# 引数: target_session_id [data_dir]
+#   target_session_id  bin/oe が生成した session ID (ULID)
+#   data_dir          OE_DATA_DIR のパス (デフォルト: projects/orchestration-engine)
+#
+# 確認項目 (Phase C 完了条件):
+#   (a) state/{sid}.state.json に state == "success" + session_id 整合
+#   (b) audit/{sid}.jsonl に state_change (state=success) と session_end が記録
+#   (c) target stdout (.tmp_target_stdout_{sid}.log) があれば shellcheck/PASS evidence を grep
+#       (Plan F-H: capture 経路は cleanup 競合のため MVP では best-effort 扱い)
+#
+# Exit: 0 = (a) + (b) PASS、(c) は warning レベル / 1 = 構造的 FAIL
+
+if [[ "${1:-}" == "" ]]; then
+  echo "Usage: $0 <session_id> [data_dir]" >&2
+  exit 2
+fi
+
+SID="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DATA_DIR="${2:-${OE_DATA_DIR:-${PROJECT_DIR}}}"
+STATE_FILE="${DATA_DIR}/state/${SID}.state.json"
+AUDIT_FILE="${DATA_DIR}/audit/${SID}.jsonl"
+
+FAIL=0
+WARN=0
+fail() { echo "[check_phase_c] FAIL: $*"; FAIL=$((FAIL + 1)); }
+warn() { echo "[check_phase_c] WARN: $*"; WARN=$((WARN + 1)); }
+pass() { echo "[check_phase_c] PASS: $*"; }
+
+echo "=== check_phase_c ==="
+echo "session_id : ${SID}"
+echo "data_dir   : ${DATA_DIR}"
+echo "state_file : ${STATE_FILE}"
+echo "audit_file : ${AUDIT_FILE}"
+echo ""
+
+# ---- (a) KVS state ----
+if [[ ! -f "$STATE_FILE" ]]; then
+  fail "state file not found: $STATE_FILE"
+else
+  state=$(jq -r '.state' "$STATE_FILE")
+  if [[ "$state" == "success" ]]; then
+    pass "state.state == 'success'"
+  else
+    fail "state.state = '$state' (expected 'success')"
+  fi
+
+  recorded_sid=$(jq -r '.session_id' "$STATE_FILE")
+  if [[ "$recorded_sid" == "$SID" ]]; then
+    pass "state.session_id matches"
+  else
+    fail "state.session_id = '$recorded_sid' (expected '$SID')"
+  fi
+fi
+
+# ---- (b) Audit events ----
+if [[ ! -f "$AUDIT_FILE" ]]; then
+  fail "audit file not found: $AUDIT_FILE"
+else
+  sc_count=$(jq -s 'map(select(.event_type == "state_change" and .state == "success")) | length' "$AUDIT_FILE")
+  if [[ "$sc_count" -ge 1 ]]; then
+    pass "audit: state_change (state=success) emitted (${sc_count} time(s))"
+  else
+    fail "audit: state_change (state=success) not emitted"
+  fi
+
+  se_count=$(jq -s 'map(select(.event_type == "session_end")) | length' "$AUDIT_FILE")
+  if [[ "$se_count" -ge 1 ]]; then
+    pass "audit: session_end emitted (${se_count} time(s))"
+  else
+    fail "audit: session_end not emitted"
+  fi
+fi
+
+# ---- (c) Optional: target stdout grep (F-H best-effort) ----
+STDOUT_FILE="${SCRIPT_DIR}/.tmp_target_stdout_${SID}.log"
+if [[ -f "$STDOUT_FILE" ]]; then
+  if grep -qiE 'shellcheck|PASS=' "$STDOUT_FILE"; then
+    pass "target stdout: shellcheck / mock test PASS evidence found"
+  else
+    warn "target stdout file exists but no shellcheck / 'PASS=' evidence found (review ${STDOUT_FILE})"
+  fi
+else
+  warn "target stdout file not captured (${STDOUT_FILE}) — Plan F-H best-effort deferred for MVP"
+  warn "  → 構造的判定 (a)(b) のみで Phase C 完了判定。shellcheck/mock test の検証は人間が git diff + 手動実行で確認"
+fi
+
+echo ""
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "[check_phase_c] OVERALL FAIL (FAIL=${FAIL}, WARN=${WARN})"
+  exit 1
+fi
+echo "[check_phase_c] OVERALL PASS (WARN=${WARN}, 構造的判定のみ)"
+exit 0

--- a/projects/orchestration-engine/tests/e2e_real_agent/probe_target.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/probe_target.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# probe_target.sh — Step 4-4 Phase B Step 7
+#
+# target agent (デフォルト: cursor-agent / composer-2) を最小プロンプトで起動し、
+# CLI が起動して期待するマーカーを出力することを確認する。
+#
+# 環境変数 (override 可):
+#   OE_TARGET_AI_CLI    (デフォルト: cursor-agent)
+#   OE_TARGET_AI_MODEL  (デフォルト: composer-2)
+#
+# 出力: stdout に PASS/FAIL、ログを .tmp_probe_target.log に保存
+# Exit: 0=PASS, 1=FAIL
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOG_FILE="${SCRIPT_DIR}/.tmp_probe_target.log"
+
+ai_cli="${OE_TARGET_AI_CLI:-cursor-agent}"
+ai_model="${OE_TARGET_AI_MODEL:-composer-2}"
+
+echo "=== probe_target ($(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
+echo "ai_cli   : $ai_cli"
+echo "ai_model : $ai_model"
+echo "workspace: $PROJECT_DIR"
+echo ""
+
+# 期待マーカー: probe 固有 (engine の @@OE_EXIT/@@OE_VERIFY とは別、誤検出回避)
+EXPECTED_MARKER="PROBE_TARGET_OK"
+PROMPT="Print exactly the marker on a new line: ${EXPECTED_MARKER}"
+
+set +e
+output=$("${ai_cli}" --print --model "${ai_model}" --workspace "${PROJECT_DIR}" --force "${PROMPT}" 2>&1)
+exit_code=$?
+set -e
+
+printf '%s\n' "$output" > "$LOG_FILE"
+
+echo "=== output (first 40 lines) ==="
+printf '%s\n' "$output" | head -40
+
+echo ""
+echo "=== probe_target result ==="
+if [[ $exit_code -ne 0 ]]; then
+  echo "[probe_target] FAIL: ai_cli exited non-zero (exit_code=${exit_code})"
+  exit 1
+fi
+
+if ! grep -qF "${EXPECTED_MARKER}" "$LOG_FILE"; then
+  echo "[probe_target] FAIL: marker '${EXPECTED_MARKER}' not detected in output"
+  echo "(see ${LOG_FILE} for full output)"
+  exit 1
+fi
+
+echo "[probe_target] PASS: cursor-agent (composer-2) responded with expected marker"
+echo "(log: ${LOG_FILE})"
+exit 0

--- a/projects/orchestration-engine/tests/e2e_real_agent/probe_verify.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/probe_verify.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# probe_verify.sh — Step 4-4 Phase B Step 8 (2 段確認、F-12 反映)
+#
+# 検証 agent (デフォルト: claude / claude-sonnet-4-6) を最小プロンプトで起動。
+# (a) emit プロトコルの最小確認: @@OE_VERIFY:pass を 1 行で出力できるか
+# (b) skill ロード通電確認: --add-dir 経由で workspace 外の skill ファイルを読めるか + マーカー出力
+#
+# 環境変数 (override 可):
+#   OE_VERIFY_AI_CLI    (デフォルト: claude)
+#   OE_VERIFY_AI_MODEL  (デフォルト: claude-sonnet-4-6)
+#
+# 出力: stdout に PASS/FAIL、各部のログを .tmp_probe_verify_{emit,skill}.log に保存
+# Exit: 0=ALL PASS, 1=FAIL (どこで失敗したかを stdout で示す)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_ROOT="$(cd "${PROJECT_DIR}/../.." && pwd)"
+SKILL_PATH="${REPO_ROOT}/canonical/skills/adversarial-review/SKILL.md"
+
+LOG_EMIT="${SCRIPT_DIR}/.tmp_probe_verify_emit.log"
+LOG_SKILL="${SCRIPT_DIR}/.tmp_probe_verify_skill.log"
+
+ai_cli="${OE_VERIFY_AI_CLI:-claude}"
+ai_model="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
+
+echo "=== probe_verify ($(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
+echo "ai_cli    : $ai_cli"
+echo "ai_model  : $ai_model"
+echo "workspace : $PROJECT_DIR"
+echo "repo_root : $REPO_ROOT"
+echo "skill_path: $SKILL_PATH"
+echo ""
+
+# ---- Part (a): emit プロトコルの最小確認 ----
+echo "=== Part (a): emit-only minimal ==="
+PROMPT_A="On a single line, print exactly this marker and nothing else: @@OE_VERIFY:pass"
+
+set +e
+output_a=$("${ai_cli}" -p "${PROMPT_A}" \
+  --model "${ai_model}" \
+  --output-format text \
+  --no-session-persistence \
+  --max-budget-usd 1.0 2>&1)
+exit_a=$?
+set -e
+
+printf '%s\n' "$output_a" > "$LOG_EMIT"
+
+echo "--- output (first 20 lines) ---"
+printf '%s\n' "$output_a" | head -20
+
+if [[ $exit_a -ne 0 ]]; then
+  echo "[probe_verify] (a) FAIL: claude exited non-zero (exit_code=${exit_a})"
+  exit 1
+fi
+
+if ! grep -qF "@@OE_VERIFY:pass" "$LOG_EMIT"; then
+  echo "[probe_verify] (a) FAIL: marker '@@OE_VERIFY:pass' not detected"
+  echo "(see ${LOG_EMIT} for full output)"
+  exit 1
+fi
+
+echo "[probe_verify] (a) PASS: emit-only"
+echo ""
+
+# ---- Part (b): skill ロード通電確認 ----
+echo "=== Part (b): skill load (workspace 外アクセス) ==="
+
+if [[ ! -f "$SKILL_PATH" ]]; then
+  echo "[probe_verify] (b) FAIL: skill file not found at ${SKILL_PATH}"
+  exit 1
+fi
+
+PROMPT_B="Read the file ${SKILL_PATH} and output its very first line on its own line, then on the next line print exactly: @@OE_VERIFY:pass"
+
+set +e
+output_b=$("${ai_cli}" -p "${PROMPT_B}" \
+  --model "${ai_model}" \
+  --add-dir "${REPO_ROOT}" \
+  --output-format text \
+  --no-session-persistence \
+  --max-budget-usd 1.0 2>&1)
+exit_b=$?
+set -e
+
+printf '%s\n' "$output_b" > "$LOG_SKILL"
+
+echo "--- output (first 30 lines) ---"
+printf '%s\n' "$output_b" | head -30
+
+if [[ $exit_b -ne 0 ]]; then
+  echo "[probe_verify] (b) FAIL: claude exited non-zero (exit_code=${exit_b})"
+  exit 1
+fi
+
+if ! grep -qF "@@OE_VERIFY:pass" "$LOG_SKILL"; then
+  echo "[probe_verify] (b) FAIL: marker '@@OE_VERIFY:pass' not detected"
+  echo "(see ${LOG_SKILL} for full output)"
+  exit 1
+fi
+
+# skill 読み取り痕跡: skill の冒頭行は YAML frontmatter "---"。output 内に "---" があれば読み取り成功
+if grep -qE '^[[:space:]]*---[[:space:]]*$' "$LOG_SKILL"; then
+  echo "[probe_verify] (b) PASS: skill load (frontmatter '---' detected in output)"
+else
+  echo "[probe_verify] (b) PARTIAL: marker emitted but no '---' (skill frontmatter) found in output"
+  echo "    → claude が skill ファイルを実際に開いたか曖昧。--add-dir の挙動を要確認"
+  echo "    → ログ確認: ${LOG_SKILL}"
+  # marker は出ているので exit 0 とするが、warning を残す
+fi
+
+echo ""
+echo "[probe_verify] ALL PASS (emit + skill load)"
+exit 0

--- a/projects/orchestration-engine/tests/e2e_real_agent/repro_verify_protocol_error.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/repro_verify_protocol_error.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# repro_verify_protocol_error.sh — Step 4-4 Phase C 調査用 one-shot
+#
+# 目的:
+#   smoke で発生した verification_protocol_error (exit_without_verify_marker) の原因切り分け。
+#   engine / wez を経由せず、verify.sh が組み立てる reviewer envelope + verify-inputs.md を
+#   そのまま再構築して claude -p で one-shot 実行し、stdout 全文を保存・検査する。
+#
+# 入力 (必須環境変数):
+#   SMOKE_DIR    既存 smoke の OE_DATA_DIR (state/ と audit/ がある)
+#   TARGET_SID   被検証 session_id (state/audit のファイル名)
+#   TARGET_PID   被検証 target_pane_id (整数)
+#
+# 出力:
+#   .tmp_repro_verify/{rsid}.envelope.json   構築した reviewer envelope
+#   .tmp_repro_verify/{rsid}.inputs.md       構築した verify-inputs.md
+#   .tmp_repro_verify/{rsid}.stdout.log      claude の stdout/stderr 統合ログ
+#   .tmp_repro_verify/{rsid}.summary.txt     marker 検出結果 + claude exit_code
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_ROOT="$(cd "${PROJECT_DIR}/../.." && pwd)"
+
+SMOKE_DIR="${SMOKE_DIR:-${SCRIPT_DIR}/.tmp_smoke_20260517-184129}"
+TARGET_SID="${TARGET_SID:-20260517184129WJFHESKWJ0AE}"
+TARGET_PID="${TARGET_PID:-4}"
+
+if [[ ! -d "$SMOKE_DIR" ]]; then
+  echo "[repro] FAIL: SMOKE_DIR not found: $SMOKE_DIR" >&2
+  exit 1
+fi
+
+# verify.sh / constants.sh が参照する env を smoke 同等に設定
+export OE_DATA_DIR="$SMOKE_DIR"
+export OE_VERIFY_AI_CLI="${OE_VERIFY_AI_CLI:-claude}"
+export OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
+
+OUT_DIR="${SCRIPT_DIR}/.tmp_repro_verify"
+mkdir -p "$OUT_DIR"
+
+# fixed reviewer session id (再現性のため固定)
+RSID="01REPROVERIFYPROTOCOL$(date -u +%H%M%S)"
+
+ENVELOPE="${OUT_DIR}/${RSID}.envelope.json"
+INPUTS="${OUT_DIR}/${RSID}.inputs.md"
+LOG="${OUT_DIR}/${RSID}.stdout.log"
+SUMMARY="${OUT_DIR}/${RSID}.summary.txt"
+
+# Target envelope: 既存 smoke の task description (task_description_dogfood_cleanup.md) で再構築
+# (engine は /tmp/oe-{sid}-envelope.json に書いていたが既に消えている)
+TARGET_ENV="/tmp/oe-${TARGET_SID}-envelope.json"
+TASK_DESC="$(cat "${SCRIPT_DIR}/task_description_dogfood_cleanup.md")"
+jq -n \
+  --arg sid "$TARGET_SID" \
+  --argjson pid "$TARGET_PID" \
+  --arg desc "$TASK_DESC" \
+  --arg odir "$PROJECT_DIR" \
+  '{
+    session_id: $sid,
+    pane_id: $pid,
+    task: {
+      description: $desc,
+      output_dir: $odir,
+      exit_conditions: { marker: "@@OE_EXIT", timeout_seconds: 1800 },
+      read_docs: [],
+      use_skills: []
+    },
+    context: { parent_session_id: null, related_issues: [], shared_kvs_path: null },
+    constraints: { max_panes: 5, state_vocabulary: ["spawn","ready","progress","done","blocked"] }
+  }' > "$TARGET_ENV"
+
+# lib/verify.sh の oe_verify_prompt_build / oe_verify_envelope_create を直接利用
+# shellcheck source=lib/constants.sh disable=SC1091
+source "${PROJECT_DIR}/lib/constants.sh"
+# shellcheck source=lib/verify.sh disable=SC1091
+source "${PROJECT_DIR}/lib/verify.sh"
+
+# verify-inputs.md を構築 (smoke 時と同じ)
+oe_verify_prompt_build "$RSID" "$TARGET_PID" "$TARGET_SID" "$TARGET_ENV"
+cp -f "$OE_VERIFY_PROMPT_PATH" "$INPUTS"
+
+# reviewer envelope を構築 (smoke 時と同じ)
+REVIEWER_PANE_ID=999
+oe_verify_envelope_create "$RSID" "$REVIEWER_PANE_ID" "$TARGET_PID" "$TARGET_SID" "$TARGET_ENV" "$OE_VERIFY_PROMPT_PATH"
+cp -f "$OE_VERIFY_ENVELOPE_PATH" "$ENVELOPE"
+
+echo "=== repro_verify_protocol_error ==="
+echo "reviewer_session_id : $RSID"
+echo "target_session_id   : $TARGET_SID"
+echo "target_pane_id      : $TARGET_PID"
+echo "envelope            : $ENVELOPE"
+echo "inputs              : $INPUTS"
+echo "log                 : $LOG"
+echo ""
+echo "envelope size : $(wc -c < "$ENVELOPE") bytes"
+echo "inputs size   : $(wc -c < "$INPUTS") bytes"
+echo ""
+
+# claude one-shot (smoke が pane に送ったのと同等の prompt + flags)
+PROMPT="Read ${OE_VERIFY_ENVELOPE_PATH} and execute the task"
+echo "=== claude one-shot (this may take ~2 min) ==="
+echo "command:"
+echo "  claude -p '${PROMPT}' --model ${OE_VERIFY_AI_MODEL} --add-dir ${REPO_ROOT} --add-dir /tmp --output-format text --no-session-persistence --max-budget-usd 1.0"
+echo ""
+
+set +e
+claude -p "${PROMPT}" \
+  --model "${OE_VERIFY_AI_MODEL}" \
+  --add-dir "${REPO_ROOT}" \
+  --add-dir /tmp \
+  --output-format text \
+  --no-session-persistence \
+  --max-budget-usd 1.0 > "$LOG" 2>&1
+EXIT=$?
+set -e
+
+echo "claude exit_code: $EXIT"
+echo ""
+echo "=== output (last 60 lines) ==="
+tail -60 "$LOG"
+echo ""
+
+# Marker detection
+{
+  echo "TARGET_SID=${TARGET_SID}"
+  echo "TARGET_PID=${TARGET_PID}"
+  echo "RSID=${RSID}"
+  echo "CLAUDE_EXIT=${EXIT}"
+  echo "LOG=${LOG}"
+  echo ""
+  echo "--- marker hits (any line containing @@OE_) ---"
+  grep -nE '@@OE_' "$LOG" || echo "(none)"
+  echo ""
+  echo "--- strict regex (^@@OE_VERIFY:(pass|fail|warn)$) ---"
+  grep -nE '^@@OE_VERIFY:(pass|fail|warn)$' "$LOG" || echo "(none)"
+} | tee "$SUMMARY"
+
+echo ""
+echo "summary: $SUMMARY"

--- a/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# smoke_cursor_composer_claude_sonnet.sh — Step 4-4 Phase C/D/E 共通の実 agent E2E
+#
+# target  : cursor-agent (composer-2)
+# 検証    : claude (claude-sonnet-4-6)
+#
+# 実行手順:
+#   bash projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
+#
+# 出力:
+#   .tmp_smoke_<timestamp>/                  ... OE_DATA_DIR + log
+#   .tmp_smoke_<timestamp>_result.txt        ... session_id 等のメタ情報
+#
+# 環境変数 (override 可):
+#   OE_TARGET_AI_CLI / OE_TARGET_AI_MODEL    (デフォルト: cursor-agent / composer-2)
+#   OE_VERIFY_AI_CLI / OE_VERIFY_AI_MODEL    (デフォルト: claude / claude-sonnet-4-6)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+TMP_DATA_DIR="${SCRIPT_DIR}/.tmp_smoke_${TIMESTAMP}"
+LOG_DIR="${TMP_DATA_DIR}/log"
+mkdir -p "${TMP_DATA_DIR}/state" "${TMP_DATA_DIR}/audit" "${LOG_DIR}"
+
+# Step 4-4 Phase A 反映: env var で target / 検証 CLI/モデルを明示
+export OE_TARGET_AI_CLI="${OE_TARGET_AI_CLI:-cursor-agent}"
+export OE_TARGET_AI_MODEL="${OE_TARGET_AI_MODEL:-composer-2}"
+export OE_VERIFY_AI_CLI="${OE_VERIFY_AI_CLI:-claude}"
+export OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
+export OE_DATA_DIR="${TMP_DATA_DIR}"
+export OE_MOCK_LOG_DIR="${LOG_DIR}"
+
+# F-SO 反映 (Plan iter2): wez shim の notify.log 書き込み先を保証
+mkdir -p "${OE_MOCK_LOG_DIR}"
+
+TASK_FILE="${SCRIPT_DIR}/task_description_dogfood_cleanup.md"
+if [[ ! -f "$TASK_FILE" ]]; then
+  echo "[smoke] FAIL: task file not found: $TASK_FILE" >&2
+  exit 1
+fi
+
+echo "=== smoke (cursor-agent + claude-sonnet-4-6) ==="
+echo "TIMESTAMP        : ${TIMESTAMP}"
+echo "TMP_DATA         : ${TMP_DATA_DIR}"
+echo "LOG_DIR          : ${LOG_DIR}"
+echo "OE_TARGET_AI_CLI : ${OE_TARGET_AI_CLI}"
+echo "OE_TARGET_AI_MODEL: ${OE_TARGET_AI_MODEL}"
+echo "OE_VERIFY_AI_CLI : ${OE_VERIFY_AI_CLI}"
+echo "OE_VERIFY_AI_MODEL: ${OE_VERIFY_AI_MODEL}"
+echo "TASK_FILE        : ${TASK_FILE}"
+echo ""
+
+# Run engine; bin/oe blocks until target → verify → cleanup 完了
+set +e
+bash "${PROJECT_DIR}/bin/oe" --task-file "${TASK_FILE}"
+ENGINE_EXIT=$?
+set -e
+
+echo ""
+echo "=== engine completed (exit_code=${ENGINE_EXIT}) ==="
+
+# Find target session_id (single one expected per smoke run)
+# shellcheck disable=SC2012  # ULID alphabet only, no special chars
+state_file="$(ls "${OE_DATA_DIR}/state"/*.state.json 2>/dev/null | head -1 || true)"
+if [[ -z "$state_file" ]]; then
+  echo "[smoke] FAIL: no state file produced under ${OE_DATA_DIR}/state/"
+  exit 1
+fi
+SID="$(basename "$state_file" .state.json)"
+TARGET_PANE_ID="$(jq -r '.pane_id' "$state_file")"
+
+echo "session_id       : ${SID}"
+echo "target_pane_id   : ${TARGET_PANE_ID}"
+echo "state_file       : ${state_file}"
+echo "audit_file       : ${OE_DATA_DIR}/audit/${SID}.jsonl"
+
+# Result meta file (for downstream tooling)
+RESULT_FILE="${SCRIPT_DIR}/.tmp_smoke_${TIMESTAMP}_result.txt"
+{
+  echo "TIMESTAMP=${TIMESTAMP}"
+  echo "SID=${SID}"
+  echo "TARGET_PANE_ID=${TARGET_PANE_ID}"
+  echo "OE_DATA_DIR=${OE_DATA_DIR}"
+  echo "OE_MOCK_LOG_DIR=${OE_MOCK_LOG_DIR}"
+  echo "STATE_FILE=${state_file}"
+  echo "AUDIT_FILE=${OE_DATA_DIR}/audit/${SID}.jsonl"
+  echo "ENGINE_EXIT=${ENGINE_EXIT}"
+} > "${RESULT_FILE}"
+
+echo "result_file      : ${RESULT_FILE}"
+
+if [[ "$ENGINE_EXIT" -ne 0 ]]; then
+  echo ""
+  echo "[smoke] WARN: engine exited non-zero (exit_code=${ENGINE_EXIT})"
+  echo "  → 構造判定 (Phase C/D の check_*) で詳細を確認する"
+fi
+
+echo ""
+echo "=== running check_phase_c.sh ==="
+bash "${SCRIPT_DIR}/check_phase_c.sh" "${SID}" "${OE_DATA_DIR}"
+PHASE_C_EXIT=$?
+
+# (Phase D check_cycle_complete.sh は Plan Step 12 で実装、本コミット時点では不在のためスキップ)
+if [[ -f "${SCRIPT_DIR}/check_cycle_complete.sh" ]]; then
+  echo ""
+  echo "=== running check_cycle_complete.sh ==="
+  bash "${SCRIPT_DIR}/check_cycle_complete.sh" "${SID}" "${TARGET_PANE_ID}" "${OE_DATA_DIR}"
+fi
+
+echo ""
+echo "=== smoke summary ==="
+echo "engine_exit : ${ENGINE_EXIT}"
+echo "phase_c_exit: ${PHASE_C_EXIT}"
+echo ""
+if [[ "$PHASE_C_EXIT" -eq 0 ]]; then
+  echo "[smoke] PASS (構造判定)"
+  exit 0
+fi
+echo "[smoke] FAIL"
+exit 1

--- a/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
@@ -41,6 +41,9 @@ export OE_CB_TIMEOUT="${OE_CB_TIMEOUT:-1800}"
 # F-SO 反映 (Plan iter2): wez shim の notify.log 書き込み先を保証
 mkdir -p "${OE_MOCK_LOG_DIR}"
 
+# Phase E Step 13 / F-10: wez shim (notify を notify.log に記録、他は実 wez に exec) を PATH 先頭に
+export PATH="${SCRIPT_DIR}/bin:${PATH}"
+
 TASK_FILE="${SCRIPT_DIR}/task_description_dogfood_cleanup.md"
 if [[ ! -f "$TASK_FILE" ]]; then
   echo "[smoke] FAIL: task file not found: $TASK_FILE" >&2

--- a/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
@@ -33,6 +33,11 @@ export OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
 export OE_DATA_DIR="${TMP_DATA_DIR}"
 export OE_MOCK_LOG_DIR="${LOG_DIR}"
 
+# Step 4-4 Phase C 反映: 実 agent (composer-2) は mock 想定の MAX_TURNS=10 (=20s @ 2s poll) が短すぎる。
+# 実機 smoke は 20 分 (600 turns × 2s poll) まで待つ。本上限は TIMEOUT (1800s = 30 min) の内側。
+export OE_CB_MAX_TURNS="${OE_CB_MAX_TURNS:-600}"
+export OE_CB_TIMEOUT="${OE_CB_TIMEOUT:-1800}"
+
 # F-SO 反映 (Plan iter2): wez shim の notify.log 書き込み先を保証
 mkdir -p "${OE_MOCK_LOG_DIR}"
 

--- a/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/smoke_cursor_composer_claude_sonnet.sh
@@ -105,23 +105,30 @@ fi
 
 echo ""
 echo "=== running check_phase_c.sh ==="
+set +e
 bash "${SCRIPT_DIR}/check_phase_c.sh" "${SID}" "${OE_DATA_DIR}"
 PHASE_C_EXIT=$?
+set -e
 
-# (Phase D check_cycle_complete.sh は Plan Step 12 で実装、本コミット時点では不在のためスキップ)
+# Phase D Step 12: check_cycle_complete.sh で構造的判定 4 点を assertion
+PHASE_D_EXIT=0
 if [[ -f "${SCRIPT_DIR}/check_cycle_complete.sh" ]]; then
   echo ""
   echo "=== running check_cycle_complete.sh ==="
+  set +e
   bash "${SCRIPT_DIR}/check_cycle_complete.sh" "${SID}" "${TARGET_PANE_ID}" "${OE_DATA_DIR}"
+  PHASE_D_EXIT=$?
+  set -e
 fi
 
 echo ""
 echo "=== smoke summary ==="
 echo "engine_exit : ${ENGINE_EXIT}"
 echo "phase_c_exit: ${PHASE_C_EXIT}"
+echo "phase_d_exit: ${PHASE_D_EXIT}"
 echo ""
-if [[ "$PHASE_C_EXIT" -eq 0 ]]; then
-  echo "[smoke] PASS (構造判定)"
+if [[ "$PHASE_C_EXIT" -eq 0 && "$PHASE_D_EXIT" -eq 0 ]]; then
+  echo "[smoke] PASS (Phase C + D 構造判定)"
   exit 0
 fi
 echo "[smoke] FAIL"

--- a/projects/orchestration-engine/tests/e2e_real_agent/task_description_dogfood_cleanup.md
+++ b/projects/orchestration-engine/tests/e2e_real_agent/task_description_dogfood_cleanup.md
@@ -1,0 +1,122 @@
+# Task: orchestration-engine の reviewer 一時ファイル掃除を追加 (#93 前半)
+
+あなたは orchestration-engine の改修担当エージェントです。以下の要件に従って **3 ファイルだけ** を編集し、完了報告に必要な検証結果を含めてください。
+
+## 要件 (具体ファイル位置 + 関数名ピンポイント)
+
+`OE_VERIFY_REVIEWER_SESSION_IDS` 配列で reviewer セッション ID を追跡し、`oe_cleanup` 時に対応する一時ファイル (`/tmp/oe-{rsid}-verify-envelope.json` と `/tmp/oe-{rsid}-verify-inputs.md`) を削除する仕組みを追加します。
+
+### 編集 (1) `projects/orchestration-engine/lib/constants.sh`
+
+ファイル末尾 (既存 `OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"` の直後) に以下を追加:
+
+```bash
+
+# Step 4-4 Phase C: reviewer 一時ファイル掃除用配列 (派生 Issue #93 前半)
+# oe_verify_run_phase で reviewer ULID 生成時に append、oe_cleanup で対応する /tmp/oe-{rsid}-verify-* を削除
+OE_VERIFY_REVIEWER_SESSION_IDS=()
+```
+
+### 編集 (2) `projects/orchestration-engine/lib/verify.sh`
+
+`oe_verify_run_phase` 関数内の `for target_pane_id in "$@"; do` ループ内で、`reviewer_session_id="$(_oe_verify_generate_session_id)"` の **直後の行** に以下を 1 行追加:
+
+```bash
+    OE_VERIFY_REVIEWER_SESSION_IDS+=("$reviewer_session_id")
+```
+
+(インデントは既存コードに合わせて 4 スペース。`local reviewer_session_id` 宣言行と `oe_verify_spawn \` 呼び出しの間)
+
+### 編集 (3) `projects/orchestration-engine/lib/cleanup.sh`
+
+`oe_cleanup()` 関数内の audit emit (`oe_audit_emit "cleanup" ...`) の **直後**、`return 0` の前に以下のブロックを追加 (reviewer 一時ファイル削除ロジック):
+
+```bash
+  # Step 4-4 Phase C: reviewer 一時ファイル削除 (派生 #93 前半)
+  # OE_VERIFY_REVIEWER_SESSION_IDS の各 ID について /tmp/oe-{rsid}-verify-* を削除
+  declare -p OE_VERIFY_REVIEWER_SESSION_IDS >/dev/null 2>&1 || OE_VERIFY_REVIEWER_SESSION_IDS=()
+  local rsid
+  for rsid in "${OE_VERIFY_REVIEWER_SESSION_IDS[@]}"; do
+    [[ -n "$rsid" ]] || continue
+    rm -f "/tmp/oe-${rsid}-verify-envelope.json" 2>/dev/null || true
+    rm -f "/tmp/oe-${rsid}-verify-inputs.md" 2>/dev/null || true
+  done
+```
+
+## スコープ制約 (必ず守ること)
+
+- `OE_VERIFY_MARKER_RE` (`lib/constants.sh`) は **変更禁止** (派生 #93 後半 nonce マーカーは MVP 後拡張)
+- `oe_verify_run_phase` の polling 構造 (二値保持判定、CB タイムアウト) は **変更禁止**
+- `bin/oe` は **変更禁止**
+- `schemas/` / `bin/` / `tests/e2e_real_agent/` 以下の他ファイルは **変更禁止**
+- `oe_verify_spawn` / `_oe_verify_generate_session_id` の本体 (`reviewer_session_id="..."` 行) は **変更禁止**
+- 編集は上記 (1)(2)(3) の **追加のみ** (既存行の削除や置き換えはしない、コメント以外)
+- 既存 mock テスト全 8 スイートの assertion を **変更してはならない**
+
+## 完了条件 (必ず完了報告 stdout に含めること)
+
+1. **shellcheck**: 以下を `projects/orchestration-engine` ディレクトリで実行し、各コマンドの stdout 全文 (または "no warnings" 文字列) を完了報告に含めること:
+   ```bash
+   shellcheck ./lib/constants.sh
+   shellcheck ./lib/verify.sh
+   shellcheck ./lib/cleanup.sh
+   ```
+
+2. **既存 mock テスト全 PASS**: 以下を実行し、各テストスイートの結果行 (`=== Results: PASS=N FAIL=M ===`) を完了報告に含めること:
+   ```bash
+   for f in ./tests/test_*.sh; do bash "$f" 2>&1 | tail -3; done
+   ```
+   全スクリプトで `FAIL=0` であること。
+
+3. **テスト追加**: `tests/test_cleanup.sh` の最終行 `if [[ "$FAIL" -gt 0 ]]; then exit 1; fi` の **直前** に以下のブロックを追加:
+   ```bash
+
+   # ---- Step 4-4 Phase C: OE_VERIFY_REVIEWER_SESSION_IDS 経由の reviewer 一時ファイル削除 ----
+   _MOCK_KILL_CALLS=()
+   _MOCK_AUDIT_CALLS=0
+   _MOCK_LAST_CLEANUP_PAYLOAD=""
+
+   OE_MANAGED_PANES=("701" "702")
+   OE_CURRENT_SESSION_ID="TESTRVRCLEAN"
+   OE_CLEANUP_DONE=""
+
+   # ダミー reviewer 一時ファイルを作成
+   rsid_a="01TESTRSIDA0000000000000A0"
+   rsid_b="01TESTRSIDB0000000000000B0"
+   OE_VERIFY_REVIEWER_SESSION_IDS=("$rsid_a" "$rsid_b")
+   touch "/tmp/oe-${rsid_a}-verify-envelope.json"
+   touch "/tmp/oe-${rsid_a}-verify-inputs.md"
+   touch "/tmp/oe-${rsid_b}-verify-envelope.json"
+   touch "/tmp/oe-${rsid_b}-verify-inputs.md"
+
+   oe_cleanup
+
+   assert_eq "reviewer rsid_a envelope removed" "false" "$( [[ -e "/tmp/oe-${rsid_a}-verify-envelope.json" ]] && echo true || echo false )"
+   assert_eq "reviewer rsid_a inputs removed"   "false" "$( [[ -e "/tmp/oe-${rsid_a}-verify-inputs.md" ]] && echo true || echo false )"
+   assert_eq "reviewer rsid_b envelope removed" "false" "$( [[ -e "/tmp/oe-${rsid_b}-verify-envelope.json" ]] && echo true || echo false )"
+   assert_eq "reviewer rsid_b inputs removed"   "false" "$( [[ -e "/tmp/oe-${rsid_b}-verify-inputs.md" ]] && echo true || echo false )"
+   ```
+   そして `bash tests/test_cleanup.sh` で 17 件 PASS (既存 13 + 新規 4) を確認、結果行を完了報告に含める。
+
+4. **完了報告フォーマット**: 上記 1〜3 の検証結果を以下の構造で stdout に出力:
+   ```
+   ## shellcheck 結果
+   (各コマンドの stdout)
+
+   ## mock テスト結果
+   (各スクリプトの Results 行)
+
+   ## 追加した cleanup テスト結果
+   (test_cleanup.sh の最終 Results 行)
+
+   ## 編集ファイル
+   (3 ファイルのパス、git diff --name-only の結果)
+   ```
+
+## 注意事項
+
+- Bash 3.2 互換 (macOS デフォルト)、`declare -A` (連想配列) 使用禁止、平行配列 OK
+- `set -euo pipefail` 環境で動作するコードのみ
+- ファイル末尾には改行を 1 つ入れる (POSIX 規約)
+- 既存コードのインデントスタイル (スペース 2 / 4 が混在) は触らない、追加分は周辺コードに合わせる
+- 編集 (3) で `declare -p OE_VERIFY_REVIEWER_SESSION_IDS >/dev/null 2>&1 || OE_VERIFY_REVIEWER_SESSION_IDS=()` を含むのは `test_cleanup.sh` 単独実行時 (constants.sh が source されていない可能性) への防御 (Step 4-3 cleanup.sh の同パターンと整合)

--- a/projects/orchestration-engine/tests/test_cleanup.sh
+++ b/projects/orchestration-engine/tests/test_cleanup.sh
@@ -111,21 +111,25 @@ OE_MANAGED_PANES=("701" "702")
 OE_CURRENT_SESSION_ID="TESTRVRCLEAN"
 OE_CLEANUP_DONE=""
 
-# ダミー reviewer 一時ファイルを作成
+# ダミー reviewer 一時ファイルを作成 (Phase C.5 反映: .log も削除対象)
 rsid_a="01TESTRSIDA0000000000000A0"
 rsid_b="01TESTRSIDB0000000000000B0"
 OE_VERIFY_REVIEWER_SESSION_IDS=("$rsid_a" "$rsid_b")
 touch "/tmp/oe-${rsid_a}-verify-envelope.json"
 touch "/tmp/oe-${rsid_a}-verify-inputs.md"
+touch "/tmp/oe-${rsid_a}-reviewer.log"
 touch "/tmp/oe-${rsid_b}-verify-envelope.json"
 touch "/tmp/oe-${rsid_b}-verify-inputs.md"
+touch "/tmp/oe-${rsid_b}-reviewer.log"
 
 oe_cleanup
 
 assert_eq "reviewer rsid_a envelope removed" "false" "$( [[ -e "/tmp/oe-${rsid_a}-verify-envelope.json" ]] && echo true || echo false )"
 assert_eq "reviewer rsid_a inputs removed"   "false" "$( [[ -e "/tmp/oe-${rsid_a}-verify-inputs.md" ]] && echo true || echo false )"
+assert_eq "reviewer rsid_a log removed"      "false" "$( [[ -e "/tmp/oe-${rsid_a}-reviewer.log" ]] && echo true || echo false )"
 assert_eq "reviewer rsid_b envelope removed" "false" "$( [[ -e "/tmp/oe-${rsid_b}-verify-envelope.json" ]] && echo true || echo false )"
 assert_eq "reviewer rsid_b inputs removed"   "false" "$( [[ -e "/tmp/oe-${rsid_b}-verify-inputs.md" ]] && echo true || echo false )"
+assert_eq "reviewer rsid_b log removed"      "false" "$( [[ -e "/tmp/oe-${rsid_b}-reviewer.log" ]] && echo true || echo false )"
 
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
 if [[ "$FAIL" -gt 0 ]]; then

--- a/projects/orchestration-engine/tests/test_cleanup.sh
+++ b/projects/orchestration-engine/tests/test_cleanup.sh
@@ -101,6 +101,32 @@ assert_eq "double run guard kill unchanged" "2" "${#_MOCK_KILL_CALLS[@]}"
 assert_eq "double run guard audit unchanged" "1" "$_MOCK_AUDIT_CALLS"
 
 echo ""
+
+# ---- Step 4-4 Phase C: OE_VERIFY_REVIEWER_SESSION_IDS 経由の reviewer 一時ファイル削除 ----
+_MOCK_KILL_CALLS=()
+_MOCK_AUDIT_CALLS=0
+_MOCK_LAST_CLEANUP_PAYLOAD=""
+
+OE_MANAGED_PANES=("701" "702")
+OE_CURRENT_SESSION_ID="TESTRVRCLEAN"
+OE_CLEANUP_DONE=""
+
+# ダミー reviewer 一時ファイルを作成
+rsid_a="01TESTRSIDA0000000000000A0"
+rsid_b="01TESTRSIDB0000000000000B0"
+OE_VERIFY_REVIEWER_SESSION_IDS=("$rsid_a" "$rsid_b")
+touch "/tmp/oe-${rsid_a}-verify-envelope.json"
+touch "/tmp/oe-${rsid_a}-verify-inputs.md"
+touch "/tmp/oe-${rsid_b}-verify-envelope.json"
+touch "/tmp/oe-${rsid_b}-verify-inputs.md"
+
+oe_cleanup
+
+assert_eq "reviewer rsid_a envelope removed" "false" "$( [[ -e "/tmp/oe-${rsid_a}-verify-envelope.json" ]] && echo true || echo false )"
+assert_eq "reviewer rsid_a inputs removed"   "false" "$( [[ -e "/tmp/oe-${rsid_a}-verify-inputs.md" ]] && echo true || echo false )"
+assert_eq "reviewer rsid_b envelope removed" "false" "$( [[ -e "/tmp/oe-${rsid_b}-verify-envelope.json" ]] && echo true || echo false )"
+assert_eq "reviewer rsid_b inputs removed"   "false" "$( [[ -e "/tmp/oe-${rsid_b}-verify-inputs.md" ]] && echo true || echo false )"
+
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
 if [[ "$FAIL" -gt 0 ]]; then
   exit 1

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -63,6 +63,14 @@ if [[ "${1:-}" == "pane" && "${2:-}" == "send" ]]; then
   pane_id="${3:-}"
   payload="${4:-}"
   printf '%s|%s\n' "$pane_id" "$payload" >> "${log_dir}/send.log"
+
+  # Step 4-4 Phase C.5 反映: payload に `tee "/tmp/oe-RSID-reviewer.log"` が含まれていれば、
+  # 実シェルが tee 経由で log file に書く動作を mock として再現する。
+  # reviewer pane (888) 向け payload を検知して @@OE_VERIFY:pass + @@OE_EXIT:0 を log に書き込む。
+  if [[ "$pane_id" == "888" ]] && [[ "$payload" =~ tee[[:space:]]+\"([^\"]+-reviewer\.log)\" ]]; then
+    reviewer_log="${BASH_REMATCH[1]}"
+    printf 'review output\n@@OE_VERIFY:pass\n\n@@OE_EXIT:0\n' > "$reviewer_log"
+  fi
   exit 0
 fi
 
@@ -138,12 +146,20 @@ echo ""
 echo "=== Step 4-3 Phase E: 検証フェーズ完走 ==="
 
 # 検証 agent ペイン (888) が spawn された
-assert_eq "reviewer pane (888) split" "true" \
-  "$( [[ -f "${OE_MOCK_LOG_DIR}/capture_count_888" ]] && echo true || echo false )"
+# Step 4-4 Phase C.5 反映: reviewer は file 経路 (tee /tmp/oe-{rsid}-reviewer.log) で監視されるため、
+# wez pane capture は呼ばれない (旧 capture_count_888 assertion は廃止)。代わりに
+# send.log に reviewer 向け payload (pane=888) が記録されていることで spawn を確認する。
+assert_eq "reviewer pane (888) に send 実行" "true" \
+  "$(awk -F'|' '$1=="888"{found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
 
 # 検証用 envelope/inputs が send.log に展開される (target=777, reviewer=888)
 assert_eq "reviewer pane に verify envelope を send" "true" \
   "$(awk -F'|' '$1=="888" && index($2, "verify-envelope.json"){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
+
+# Step 4-4 Phase C.5: reviewer payload に tee /tmp/oe-{rsid}-reviewer.log が含まれる (file redirect 経路)
+# 注: awk -F'|' は payload に含まれる `| tee` の `|` で field split されるため、$2 ではなく $0 全体で match
+assert_eq "reviewer payload に tee reviewer.log" "true" \
+  "$(awk -F'|' '$1=="888" && match($0, /tee[[:space:]]+"[^"]+-reviewer\.log"/){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
 
 # verification_started イベントが emit される (target session の audit log)
 assert_eq "verification_started 1 件" "1" \


### PR DESCRIPTION
## Summary

Epic [#19](https://github.com/stlwolf/ai-development-hub/issues/19) Phase 4 MVP の Step 4-4 [#95](https://github.com/stlwolf/ai-development-hub/issues/95)「E2E 検証 — 実 agent で 1 サイクル完走」の実装。target = cursor-agent (composer-2) / reviewer = claude (sonnet-4-6) を実機起動し、engine が `@@OE_EXIT` + `@@OE_VERIFY` の二値検出 + KVS / audit 書き込み + cleanup までを 1 サイクル走らせる E2E 検証を確立した。

- **Phase A〜C**: CLI dispatcher / env vars / `--task-file` 追加、probe / smoke / target task 完遂 (dogfood: composer-2 が #93 前半の `OE_VERIFY_REVIEWER_SESSION_IDS` 追跡を実装)
- **Phase C.5 (engine bug fix)**: 実機 smoke で発覚した `verification_protocol_error` の原因 (wez pane capture が viewport-only、長文 review で `@@OE_VERIFY` 行が scrollback に押し出される) を so-compare (codex) で確定し、reviewer 出力を **file redirect 経路** (`tee /tmp/oe-{rsid}-reviewer.log`) に切替。送信コマンドの grouping を so-compare iter1 で Critical 修正
- **Phase D**: `check_cycle_complete.sh` で構造判定 4 + 2 点 (target session_end / reviewer marker_raw / KVS / audit ホワイトリスト / verification_summary 集計 / wez notify shim) を assertion 化
- **Phase E**: `tests/e2e_real_agent/` を README + .gitignore + wez shim まで含めて整備
- **so-compare iter2 反映**: Plan F-H を best-effort 格下げ (target stdout capture は Phase D check_cycle で代替)、`verification_protocol_error > 0` を WARN → FAIL 化、`verification_summary.protocol_errors/timeouts == 0` を直接検証

実機 smoke 2 回目 (`.tmp_smoke_20260518-034228`) で `verification_completed` emit + `verification_summary: { protocol_errors: 0, timeouts: 0 }` を確認、`check_cycle_complete.sh` 全 PASS。

## Test plan

- [x] 既存 mock テスト 8 suite 全 PASS (合計 306 = 既存 299 + Phase C 4 + Phase C.5 3)
  - `bash projects/orchestration-engine/tests/test_*.sh` で全 GREEN
- [x] shellcheck クリーン (engine 変更ファイル + 全 e2e_real_agent スクリプト)
- [x] 実機 smoke 2 回目で 1 サイクル完走確認 (`tests/e2e_real_agent/.tmp_smoke_20260518-034228/`)
  - target = cursor-agent / composer-2 が task 完遂 (state=success)
  - reviewer = claude / sonnet-4-6 が `@@OE_VERIFY:warn` を emit、engine が file 経路で検出
  - `verification_completed` audit + KVS verification map + cleanup all OK
- [x] `check_cycle_complete.sh` で構造判定全 PASS (verify_result=warn、(4) wez notify は本 PR で shim 配置済みなので次回 smoke から PASS)
- [x] so-compare iter1 (codex + claude 設計レビュー) + iter2 (codex 全体レビュー) 反映済み
- [x] Episode + ADR 起草済み

## 関連

- Closes [#91](https://github.com/stlwolf/ai-development-hub/issues/91) (Step 4-3 F-SO-7 派生: AI CLI 起動オプション修正 — Phase A の CLI dispatcher 統一で対応完了)
- Refs [#19](https://github.com/stlwolf/ai-development-hub/issues/19) (Epic Phase 4 MVP)、[#95](https://github.com/stlwolf/ai-development-hub/issues/95) (Step 4-4 サブ Issue)
- Refs [#92](https://github.com/stlwolf/ai-development-hub/issues/92) (KVS outputs[] 拡張 — 本 PR スコープ外、git diff フォールバックで暫定対応)
- Refs [#93](https://github.com/stlwolf/ai-development-hub/issues/93) (前半 = 一時ファイル掃除を本 PR で取り込み、後半 = nonce マーカーは MVP 後拡張)

## 主要文書

- Plan (5 Phase + Phase C.5 + so-compare iter1/iter2 反映): `projects/orchestration-engine/docs/plans/2026-05-16-plan-step-4-4-e2e-verification.md`
- KickOff (status: confirmed): `projects/orchestration-engine/docs/plans/2026-05-16-kickoff-step-4-4-e2e-verification.md`
- Discussion (Q1-Q8 closed): `projects/orchestration-engine/docs/discussions/2026-05-16-discussion-step-4-4-e2e-verification.md`
- **Episode** (本 PR の時系列記録): `projects/orchestration-engine/docs/episodes/2026-05-18-episode-step-4-4-implementation.md`
- **ADR** (reviewer file redirect + skill mapping 表): `projects/orchestration-engine/docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md`

## 派生 Issue 候補 (本 PR スコープ外、so-compare 指摘から)

1. target 側 monitor も file 経路に統一 (multi-pane 長文出力の将来対応)
2. `bin/oe --task-file` の空ファイル / 不在 / 不正パスのエラー仕様明記 (or exit 2)
3. `_oe_verify_scan_log_file` の単体テスト追加 (現状は E2E mock の間接検証)
4. reviewer が markdown 引用で `@@OE_VERIFY:*` を書く場合の false-positive 抑制
5. `_oe_capture_scan_parse` の ANSI 除去ロジックを `_oe_strip_ansi` として共通関数化

🤖 Generated with [Claude Code](https://claude.com/claude-code)