### PR TITLE
feat(orchestration-engine): 既存ペインに attach する入口 oe-capture を追加

### DIFF
--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -10,6 +10,8 @@ export PROJECT_DIR
 # source lib/*.sh
 # shellcheck source=../lib/constants.sh
 source "${LIB_DIR}/constants.sh"
+# shellcheck source=../lib/session.sh
+source "${LIB_DIR}/session.sh"
 # shellcheck source=../lib/envelope.sh
 source "${LIB_DIR}/envelope.sh"
 # shellcheck source=../lib/spawn.sh
@@ -28,20 +30,7 @@ source "${LIB_DIR}/cleanup.sh"
 export OE_CURRENT_SESSION_ID=""
 trap oe_cleanup EXIT INT TERM
 
-oe_generate_session_id() {
-  local ts
-  local raw
-  local rand
-  # 26 文字: 先頭 14 は数字（ULID 時刻部相当）、残り 12 は Crockford base32（I/L/O/U 除外）
-  #
-  # Copilot #4 反映: tr の出力を head -c で早期 close すると tr に SIGPIPE が飛び、
-  # set -o pipefail 環境下で assignment が失敗する。固定バイト数を先に読んでから tr で
-  # filter する形に変更 (パイプの早期 close を回避)。
-  ts="$(date -u +%Y%m%d%H%M%S)"
-  raw="$(LC_ALL=C head -c 4096 /dev/urandom | LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z')"
-  rand="${raw:0:12}"
-  printf '%s%s\n' "$ts" "$rand"
-}
+# oe_generate_session_id は lib/session.sh に移設（bin/oe-capture と共有）
 
 oe_main() {
   # 3) state/audit ディレクトリ準備

--- a/projects/orchestration-engine/bin/oe-capture
+++ b/projects/orchestration-engine/bin/oe-capture
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# oe-capture — 既存（対話中）ペインに attach して終端マーカーを読み取り、KVS/audit に記録
+#
+# usage: oe-capture <pane_id> [--session-id <id>] [--lines <N>]
+#
+# bin/oe の spawn フローとは独立した読み取り専用入口（Issue #109 / Slice A）。
+# ペインの kill / cleanup は行わない（対話中ペインを壊さない）ため spawn/monitor/cleanup は source しない。
+#
+# viewport-only 制約: 読めるのは対象 pane の viewport 末尾 N 行（既定 50）のみ。
+# @@OE_EXIT マーカーは末尾近傍の単独行である必要がある。スクロールアウトしたマーカーは
+# --lines を増やしても回収不能（incomplete = exit 1）。
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_DIR="${PROJECT_DIR}/lib"
+export PROJECT_DIR
+
+# 必要な lib のみ source（spawn/monitor/verify/cleanup は不要）
+# shellcheck source=../lib/constants.sh
+source "${LIB_DIR}/constants.sh"
+# shellcheck source=../lib/session.sh
+source "${LIB_DIR}/session.sh"
+# shellcheck source=../lib/capture.sh
+source "${LIB_DIR}/capture.sh"
+# shellcheck source=../lib/audit.sh
+source "${LIB_DIR}/audit.sh"
+# shellcheck source=../lib/attach.sh
+source "${LIB_DIR}/attach.sh"
+
+oe_capture_usage() {
+  cat >&2 <<'USAGE'
+usage: oe-capture <pane_id> [--session-id <id>] [--lines <N>]
+  <pane_id>      WezTerm ペイン ID（非負整数、必須）
+  --session-id   KVS/audit のセッション ID（26 文字 ULID。省略時は自動生成）
+  --lines        capture する末尾行数（既定 50。viewport-only 制約: マーカーは末尾単独行）
+USAGE
+}
+
+oe_capture_cli() {
+  local pane_id="" session_id="" lines=50 session_id_supplied=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session-id) session_id="${2:-}"; session_id_supplied=1; shift 2 ;;
+      --lines)      lines="${2:-}"; shift 2 ;;
+      -h|--help)    oe_capture_usage; return 0 ;;
+      -*)           echo "oe-capture: unknown option: $1" >&2; oe_capture_usage; return 2 ;;
+      *)
+        if [[ -z "$pane_id" ]]; then
+          pane_id="$1"; shift
+        else
+          echo "oe-capture: unexpected argument: $1" >&2; return 2
+        fi
+        ;;
+    esac
+  done
+
+  # wez 不在は環境エラー（exit 2）として「未完了 (exit 1)」と区別する
+  if ! command -v wez >/dev/null 2>&1; then
+    echo "oe-capture: 'wez' not found in PATH (required to capture pane output)" >&2
+    return 2
+  fi
+
+  if [[ -z "$pane_id" ]]; then
+    echo "oe-capture: pane_id is required" >&2
+    oe_capture_usage
+    return 2
+  fi
+  # pane_id は jq --argjson の数値リテラル制約（先頭ゼロ不可・RFC 8259）+ schema minimum:0 を満たす整数のみ
+  if [[ ! "$pane_id" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    echo "oe-capture: pane_id must be a non-negative integer without leading zeros (got: '${pane_id}')" >&2
+    return 2
+  fi
+  if [[ ! "$lines" =~ ^[1-9][0-9]*$ ]]; then
+    echo "oe-capture: --lines must be a positive integer (got: '${lines}')" >&2
+    return 2
+  fi
+
+  # user 指定 session_id は ULID 形式必須（downstream の validate-session-state.sh と整合）
+  if [[ "$session_id_supplied" -eq 1 && ! "$session_id" =~ ^[0-9A-HJKMNP-TV-Z]{26}$ ]]; then
+    echo "oe-capture: --session-id must be a 26-char ULID (Crockford base32, excl. I/L/O/U)" >&2
+    return 2
+  fi
+
+  mkdir -p "${OE_STATE_DIR}" "${OE_AUDIT_DIR}"
+
+  session_id="${session_id:-$(oe_generate_session_id)}"
+
+  # 衝突拒否: 既存 state があると oe_capture_write_kvs の mv -f が verification map を黙って破壊するため拒否
+  if [[ "$session_id_supplied" -eq 1 && -e "${OE_STATE_DIR}/${session_id}.state.json" ]]; then
+    echo "oe-capture: state file already exists for session-id '${session_id}' (refusing to overwrite); use a fresh id" >&2
+    return 2
+  fi
+
+  if oe_capture_attach "$session_id" "$pane_id" "$lines"; then
+    printf 'session_id=%s pane_id=%s state=%s\n' "$session_id" "$pane_id" "$OE_ATTACH_STATE"
+    printf 'kvs=%s\n'   "${OE_STATE_DIR}/${session_id}.state.json"
+    printf 'audit=%s\n' "${OE_AUDIT_DIR}/${session_id}.jsonl"
+    return 0
+  else
+    echo "oe-capture: no @@OE_EXIT marker in last ${lines} lines of pane ${pane_id} (not finished, or marker scrolled out of viewport)" >&2
+    return 1
+  fi
+}
+
+# 直接実行時のみ CLI を起動（test から source した場合は自動実行しない）
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  oe_capture_cli "$@"
+fi

--- a/projects/orchestration-engine/bin/oe-capture
+++ b/projects/orchestration-engine/bin/oe-capture
@@ -42,8 +42,12 @@ oe_capture_cli() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --session-id) session_id="${2:-}"; session_id_supplied=1; shift 2 ;;
-      --lines)      lines="${2:-}"; shift 2 ;;
+      --session-id)
+        [[ $# -ge 2 ]] || { echo "oe-capture: --session-id requires a value" >&2; return 2; }
+        session_id="$2"; session_id_supplied=1; shift 2 ;;
+      --lines)
+        [[ $# -ge 2 ]] || { echo "oe-capture: --lines requires a value" >&2; return 2; }
+        lines="$2"; shift 2 ;;
       -h|--help)    oe_capture_usage; return 0 ;;
       -*)           echo "oe-capture: unknown option: $1" >&2; oe_capture_usage; return 2 ;;
       *)

--- a/projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md
@@ -23,7 +23,7 @@ tags: [orchestration, phase-5, issue-109, episode, oe-capture, attach, capture-g
 
 `bin/oe` の spawn 専用フローとは独立した、**既存（対話中）ペインに attach して終端マーカーを読み取る**
 最小入口 `bin/oe-capture` を実装した（#105 Phase 5 dogfood の Slice A）。既存 capture/classify/KVS は無改変、
-mock suite は 306 → 335 assertions に増加し全 GREEN。実 wez 自己検証も PASS。
+mock suite は 306 → 337 assertions に増加し全 GREEN。実 wez 自己検証も PASS。
 
 ## 何を作ったか
 
@@ -33,7 +33,7 @@ mock suite は 306 → 335 assertions に増加し全 GREEN。実 wez 自己検�
 | `bin/oe` | 改修 | ローカル定義を削除し `source lib/session.sh` に置換（挙動不変） |
 | `lib/attach.sh` | 新規 | `oe_capture_attach()` グルー: scan→（EXIT検出時）classify→`session_end` audit→write_kvs |
 | `bin/oe-capture` | 新規 | 読み取り専用入口。引数解析 + バリデーション + `oe_capture_attach` 呼び出し。末尾ガードで source 可能 |
-| `tests/test_attach.sh` | 新規 | mock hermetic テスト（29 assertions）。グルー + 入口バリデーション |
+| `tests/test_attach.sh` | 新規 | mock hermetic テスト（31 assertions）。グルー + 入口バリデーション |
 | `tests/e2e_real_agent/self_verify_attach.sh` | 新規 | 実 wez 自己検証（local-only） |
 
 ## 設計判断（確定）
@@ -80,8 +80,8 @@ mock suite GREEN でも見つからなかった実引数エッジを SO ゲー�
 | ゲート | 内容 | 結果 |
 |---|---|---|
 | G1 | `bash tests/test_e2e_smoke.sh`（bin/oe 抽出の回帰） | PASS=44 / FAIL=0 |
-| G2 | `bash tests/test_attach.sh`（新規） | PASS=29 / FAIL=0 |
-| G3 | 全 mock suite（`for f in ./tests/test_*.sh`） | TOTAL PASS=335 / FAIL=0（既存 306 維持 + 新規 29） |
+| G2 | `bash tests/test_attach.sh`（新規） | PASS=31 / FAIL=0 |
+| G3 | 全 mock suite（`for f in ./tests/test_*.sh`） | TOTAL PASS=337 / FAIL=0（既存 306 維持 + 新規 31） |
 | G4 | `shellcheck bin/oe-capture bin/oe lib/session.sh lib/attach.sh tests/test_attach.sh` | ALL CLEAN |
 | G5 | `self_verify_attach.sh`（実 wez） | PASS（state=success / KVS / audit(session_end, source=attach)） |
 | G6 | `so-compare`（実装 diff）→ shift バグ修正 → 再検証 | `shift 2` バグ検出・修正、G2 31 / G3 337 / FAIL=0 |

--- a/projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md
@@ -62,6 +62,19 @@ mock suite は 306 → 335 assertions に増加し全 GREEN。実 wez 自己検�
 - **wez 不在チェック / PROJECT_DIR・mkdir 前提**: `set -u` 下で `${PROJECT_DIR}` ネスト展開が unbound だと abort する点を明記反映
 - 実装完了後にも diff へ so-compare を当てる SO ゲート（G6）を Plan に追加
 
+### G6 SO ゲート（実装 diff）で検出・修正したバグ
+
+実装完了後に diff を `so-compare`（`tmp/so-20260526-111125`）にかけたところ、両者一致で **`shift 2` バグ**（Medium）を検出:
+
+- `bin/oe-capture` の `--session-id` / `--lines` が値なしで末尾に来ると（例 `oe-capture 42 --lines`）`$#==1` で `shift 2` が失敗。
+  - 実 CLI（`set -e`）: while body 末尾コマンドの失敗で**無言の exit 1**（=「未完了」と誤認）。
+  - `set -e` 無効文脈（テストの `|| rc=$?`）: shift が何も消費せず**無限ループ（ハング）**。
+- 修正: `[[ $# -ge 2 ]]` ガードを追加し、値欠落時は exit 2 + メッセージ。
+- 回帰テスト: `test_attach.sh` に末尾値欠落 2 ケースを追加（29→31 assertions、全 suite 337）。
+
+mock suite GREEN でも見つからなかった実引数エッジを SO ゲートが捕捉した（Plan の SO ゲート追加が機能した実例）。
+その他の指摘（自動生成 session_id の衝突チェック無し・SKIP の exit code・wez 不在分岐の mock 不能）は軽微 or 設計通りでスコープ外とした。
+
 ## ゲート結果
 
 | ゲート | 内容 | 結果 |
@@ -71,6 +84,7 @@ mock suite は 306 → 335 assertions に増加し全 GREEN。実 wez 自己検�
 | G3 | 全 mock suite（`for f in ./tests/test_*.sh`） | TOTAL PASS=335 / FAIL=0（既存 306 維持 + 新規 29） |
 | G4 | `shellcheck bin/oe-capture bin/oe lib/session.sh lib/attach.sh tests/test_attach.sh` | ALL CLEAN |
 | G5 | `self_verify_attach.sh`（実 wez） | PASS（state=success / KVS / audit(session_end, source=attach)） |
+| G6 | `so-compare`（実装 diff）→ shift バグ修正 → 再検証 | `shift 2` バグ検出・修正、G2 31 / G3 337 / FAIL=0 |
 
 ### G5 実機実行の所見（stale socket gotcha）
 

--- a/projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md
@@ -1,0 +1,92 @@
+---
+id: "01KSH0G8ZEZ8WX3RPH2D1K80J0"
+title: "Issue #109 実装エピソード — 既存ペイン attach 入口 oe-capture（capture グルー + 実wez自己検証）"
+date: 2026-05-26
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/109"
+    reason: "本 Episode の対象 Issue"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-05-26-plan-issue-109-oe-capture-attach.md"
+    reason: "本 Episode が実行した Plan（so-compare 反映済み）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-05-18-episode-step-4-4-implementation.md"
+    reason: "wez pane capture viewport-only セマンティクスの一次資料（Step 4-4）"
+tags: [orchestration, phase-5, issue-109, episode, oe-capture, attach, capture-glue, self-verify]
+---
+
+# Issue #109 実装エピソード — 既存ペイン attach 入口 oe-capture
+
+## 概要
+
+`bin/oe` の spawn 専用フローとは独立した、**既存（対話中）ペインに attach して終端マーカーを読み取る**
+最小入口 `bin/oe-capture` を実装した（#105 Phase 5 dogfood の Slice A）。既存 capture/classify/KVS は無改変、
+mock suite は 306 → 335 assertions に増加し全 GREEN。実 wez 自己検証も PASS。
+
+## 何を作ったか
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `lib/session.sh` | 新規 | `oe_generate_session_id` を `bin/oe` から抽出（spawn/monitor を source せずに id 生成するため lib 化） |
+| `bin/oe` | 改修 | ローカル定義を削除し `source lib/session.sh` に置換（挙動不変） |
+| `lib/attach.sh` | 新規 | `oe_capture_attach()` グルー: scan→（EXIT検出時）classify→`session_end` audit→write_kvs |
+| `bin/oe-capture` | 新規 | 読み取り専用入口。引数解析 + バリデーション + `oe_capture_attach` 呼び出し。末尾ガードで source 可能 |
+| `tests/test_attach.sh` | 新規 | mock hermetic テスト（29 assertions）。グルー + 入口バリデーション |
+| `tests/e2e_real_agent/self_verify_attach.sh` | 新規 | 実 wez 自己検証（local-only） |
+
+## 設計判断（確定）
+
+- **グルーを `lib/attach.sh` に隔離**: `capture.sh` を純粋（audit 非依存）なまま維持し、`test_capture.sh` の source 前提を崩さない。
+- **audit は `session_end`（`payload.source="attach"`）のみ emit**: spawn 無しのため `session_start`/`state_change` は出さない。audit schema は1行単位検証で違反なし（so-compare 両者確認）。`source=attach` で monitor 由来と区別可能。
+- **EXIT マーカー未検出は exit 1（未完了）**: `@@OE_VERIFY:` 単独 / マーカー無しを含む。`monitor.sh` が EXIT 以外を「未完了（ポーリング継続）」とする設計と整合。KVS は書かない（誤記録防止）。
+- **読み取り専用**: spawn/monitor/cleanup/trap を source しない。ペインを kill しないため対話中ペインを壊さない。
+
+## viewport スコープ契約（option 2）
+
+`wez pane capture --lines N` は viewport の `tail -n N` セマンティクス（Step 4-4 / ADR-004）。
+**スクロールアウトしたマーカーは `--lines` 拡大でも回収不能**（verify.sh が tee log 経路に逃げた制約と同一）。
+そのため「attach が読める pane の条件」を契約として明文化し、[Issue #109 にコメント](https://github.com/stlwolf/ai-development-hub/issues/109#issuecomment-4535751802)で残した:
+
+- 読めるのは「マーカー規約でコマンドを流し、直前に完了し、まだ追加出力で流れていない pane」の viewport 末尾 N 行
+- self-verify（マーカー送出→即読み取り）は必ず viewport 内 → 成立
+- スクロールアウト時は incomplete=exit 1、回復策は「マーカーを末尾に再出力して再 capture」
+
+## セカンドオピニオン（so-compare）
+
+実装前に Plan を `so-compare`（Codex + Claude、`tmp/so-20260526-003703`）にかけ、以下を反映:
+
+- **pane_id regex 強化** `^(0|[1-9][0-9]*)$`: 先頭ゼロ（`07`）で `jq --argjson` が `Invalid numeric literal`（RFC 8259）
+- **`--session-id` 衝突拒否 + ULID 形式検証**: 既存 state があると `oe_capture_write_kvs` の `mv -f` が verification map を黙って破壊する欠落を両者が指摘。指定 id の state ファイル存在時は exit 2 で拒否。非 ULID は downstream `validate-session-state.sh` 整合のため弾く
+- **wez 不在チェック / PROJECT_DIR・mkdir 前提**: `set -u` 下で `${PROJECT_DIR}` ネスト展開が unbound だと abort する点を明記反映
+- 実装完了後にも diff へ so-compare を当てる SO ゲート（G6）を Plan に追加
+
+## ゲート結果
+
+| ゲート | 内容 | 結果 |
+|---|---|---|
+| G1 | `bash tests/test_e2e_smoke.sh`（bin/oe 抽出の回帰） | PASS=44 / FAIL=0 |
+| G2 | `bash tests/test_attach.sh`（新規） | PASS=29 / FAIL=0 |
+| G3 | 全 mock suite（`for f in ./tests/test_*.sh`） | TOTAL PASS=335 / FAIL=0（既存 306 維持 + 新規 29） |
+| G4 | `shellcheck bin/oe-capture bin/oe lib/session.sh lib/attach.sh tests/test_attach.sh` | ALL CLEAN |
+| G5 | `self_verify_attach.sh`（実 wez） | PASS（state=success / KVS / audit(session_end, source=attach)） |
+
+### G5 実機実行の所見（stale socket gotcha）
+
+実行環境（Claude Code の Bash）が**消滅済み WezTerm セッションの `WEZTERM_UNIX_SOCKET`（gui-sock-92240）を継承**しており、
+初回は `no WezTerm socket found` で失敗。生きているソケット（`default-org.wezfurlong.wezterm` → gui-sock-38784）を
+`WEZTERM_UNIX_SOCKET` で明示指定して PASS。`self_verify_attach.sh` は live な WezTerm セッションを前提とする
+（README の e2e_real_agent 同様、socket 不在環境では skip 可）。
+
+## スコープ外（本 Issue では未対応）
+
+- 実 target case への適用（Slice B dogfood）
+- `--workspace` 外部出力（#108 側）
+- `lib/verify.sh` の `_oe_verify_generate_session_id` は session_id 生成の3個目の重複として残存（寄せるなら別 Issue）
+- `capture.sh` の OSC 7/133 エスケープ未除去（capture.sh 無改変方針のため認識のみ）
+
+## 関連
+- [Issue #109](https://github.com/stlwolf/ai-development-hub/issues/109) / [viewport スコープ契約コメント](https://github.com/stlwolf/ai-development-hub/issues/109#issuecomment-4535751802)
+- Plan: `docs/plans/2026-05-26-plan-issue-109-oe-capture-attach.md`
+- `lib/spawn.sh:97`（marker emit 自動注入の手動版）/ Step 4-4 episode（viewport-only）

--- a/projects/orchestration-engine/docs/plans/2026-05-26-plan-issue-109-oe-capture-attach.md
+++ b/projects/orchestration-engine/docs/plans/2026-05-26-plan-issue-109-oe-capture-attach.md
@@ -1,0 +1,322 @@
+---
+id: "01KSFZFHXNZZXMV1AM06TXQAAR"
+title: "Issue #109 Plan: 既存ペイン attach 入口 oe-capture（capture グルー）"
+date: 2026-05-26
+type: plan
+status: ready
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/109"
+    reason: "本 Plan の対象 Issue（attach グルー実装 + 自己検証）"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/105"
+    reason: "Phase 5 dogfood（本作業はその Slice A）"
+  - type: integration_target
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/108"
+    reason: "--workspace 外部出力は #108 側（相補関係、本 Plan スコープ外）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-05-18-episode-step-4-4-implementation.md"
+    reason: "wez pane capture viewport-only セマンティクスの一次資料（Step 4-4）"
+tags: [orchestration, phase-5, issue-109, plan, oe-capture, attach, capture-glue]
+---
+
+# Issue #109 Plan: 既存ペイン attach 入口 oe-capture（capture グルー）
+
+> 統括スレッドからのハンドオフ + so-compare（Codex + Claude）セカンドオピニオンを反映した実行計画。
+> harness plan（承認済み）と同等。実装着手前に Issue #109 へ viewport スコープ契約をコメントする（option 2）。
+
+## Context
+
+orchestration-engine の `bin/oe` は spawn 専用フロー（新ペイン生成 → CLI 送信 → monitor → verify）で、
+**既にある対話中のペインに attach して結果を読み取る**経路を持たない。#105 Phase 5 の dogfood として、
+「対話セッションの末尾に人間/エージェントが終端マーカー（`@@OE_EXIT:0`）を出す → engine が読み取る」
+最小経路を検証したい（[Issue #109](https://github.com/stlwolf/ai-development-hub/issues/109)）。
+
+これは `lib/spawn.sh:97` が自動注入している `; printf '\n@@OE_EXIT:%d\n' $?` の**手動版**であり、既存設計と整合する。
+既存 capture は pane_id + マーカーベースで「ペインがどう生まれたか」を問わないため、薄いグルーを足すだけで成立する。
+
+**ゴール（#109 = Slice A のみ）**: 読み取り専用の薄い入口 `bin/oe-capture <pane_id>` を新設し、
+`oe_capture_scan → oe_capture_classify → audit emit → oe_capture_write_kvs` を1ショットで実行する。
+既存 capture/classify/KVS は**無改変**、mock suite（306 assertions）GREEN 維持。
+
+**スコープ外**: 実 target case への適用（Slice B dogfood）は別途。`--workspace` 外部出力は #108 側。
+
+## 開発フロー（spec-card パイプライン準拠）
+
+- Discussion: Issue #109 本文で充足（新規 Discussion doc 不要）
+- KickOff: ハンドオフ + 本 Plan で代替
+- **Plan → 実装 → Episode** を `projects/orchestration-engine/docs/` に残す
+- ブランチ: `branch-naming`（`feature/#109_oe_capture_attach`）/ コミット: `conventional-commits` / PR: `pr-conventions`
+- **セカンドオピニオン（so-compare）を2箇所のゲートに**:
+  - Plan 確定前（実施済み: `tmp/so-20260526-003703`）
+  - 実装完了後・PR 前（**G6**、後述）
+
+## 設計判断（確定済み）
+
+| 項目 | 決定 | 根拠 |
+|---|---|---|
+| 入口名 | `bin/oe-capture <pane_id>` | Issue 提案。`bin/oe` と並列の薄い entry |
+| session_id 生成 | `lib/session.sh` に抽出し `bin/oe` と共有 | DRY。`bin/oe` ローカル定義を移設（挙動不変、`test_e2e_smoke` で回帰カバー）。`lib/verify.sh` の重複解消は #109 スコープ外 |
+| グルー配置 | 新規 `lib/attach.sh` の `oe_capture_attach()` | `capture.sh` を純粋（audit 非依存）なまま維持し新ロジックを隔離。`test_capture.sh` の source 前提を崩さない |
+| audit 粒度 | `session_end`（`payload={source:"attach"}`）のみ emit | spawn 無しのため `session_start`/`state_change` は出さない。schema は1行単位検証で違反なし（SO 両者一致）。timeline 再構成上も正直な記録 |
+| no-marker 時 | stderr 警告 + exit 1、KVS 書かない | 「まだ完了マーカー無し」を success/error と誤記録しない |
+| VERIFY 単独 | EXIT 無しは「未完了」扱いで exit 1 | `monitor.sh` が EXIT のみで動く設計と整合（VERIFY は検証ゲート専用経路） |
+| viewport-only（SO最重要） | **読める pane の条件を契約として明文化**（option 2）。`--lines`（既定 50）で末尾行数制御 | `wez pane capture --lines N` = viewport の `tail -n N`。**スクロールアウトしたマーカーは `--lines` 拡大でも回収不能**（verify.sh が tee log に逃げた制約と同一）。詳細は下記「viewport スコープ契約」 |
+| pane_id 検証 | `^(0\|[1-9][0-9]*)$`（非負整数・先頭ゼロ不可） | `jq --argjson pane_id` は先頭ゼロ(`07`)で `Invalid numeric literal`（RFC 8259）。schema は `minimum:0`（SO 両者一致で強化） |
+| --session-id 検証 | ① ULID 形式必須 `^[0-9A-HJKMNP-TV-Z]{26}$` ② 既存 state ファイルとの衝突は exit 2 で拒否 | 非 ULID は downstream `validate-session-state.sh` が落ちる。衝突時 `oe_capture_write_kvs` の `mv -f` が既存 verification map を黙って破壊（SO 両者指摘の新規欠落） |
+| wez 不在 | 入口で `command -v wez` → exit 2 | 環境エラーを「未完了(exit1)」と区別（Claude Q7） |
+| 入口の安全性 | spawn/monitor/cleanup/trap を source しない | 読み取り専用。ペインを kill しない（対話中ペインを壊さない） |
+| PROJECT_DIR / mkdir | entry 冒頭で `PROJECT_DIR` export（constants.sh source 前）+ 書き込み前に `mkdir -p` | `set -u` 下で `constants.sh` の `${PROJECT_DIR}` ネスト展開が unbound だと abort（SO 両者指摘）。`bin/oe` と同初期化 |
+
+### viewport スコープ契約（option 2 — Issue #109 にコメントで残す）
+
+`oe-capture` が読めるのは対象 pane の **現在の viewport 末尾 N 行（既定 50）** のみ。成立条件:
+
+- `@@OE_EXIT:{code}` が **末尾近傍に単独行**で存在する pane
+- 想定: 「マーカー規約でコマンドを流し、**直前に完了**し、まだ追加出力でマーカーが流れていない pane」
+  - **#109 self-verify**: マーカー送出 → 即読み取り = 必ず viewport 内 → 成立（制約に当たらない）
+  - **dogfood (Slice B)**: 作業の終端で `@@OE_EXIT` を末尾単独行として出す運用。読み取りまでに大量出力を挟まない
+- 非対応（incomplete = exit 1）: マーカーがスクロールアウト / 未出力 / 単独行でない
+  - スクロールアウトは原理的に回収不能（`--lines` 拡大でも viewport 外は返らない）→ 回復策は「マーカーを末尾に再出力して再 capture」
+- この契約を `usage` / `README` / Episode に明記し、Issue #109 にスコープコメントとして残す（S0.5）
+
+## 実装ステップ（最小粒度・ゲート interleave）
+
+### S0. ブランチ/worktree + Plan doc
+- `wt switch --create feature/#109_oe_capture_attach`（worktrunk、master 最新から）
+- 本 Plan doc を `docs/plans/2026-05-26-plan-issue-109-oe-capture-attach.md` に保存
+
+### S0.5. Issue #109 に viewport スコープ契約コメント（option 2、着手前）
+- 上記「viewport スコープ契約」を Issue #109 にコメント投稿し、attach が現実に読める pane の条件を明文化・合意化（Claude SO 最重要提言）
+
+### S1. `lib/session.sh` 新設（session_id 生成の抽出）
+
+```bash
+# shellcheck shell=bash
+# session.sh — セッション ID 生成（source 専用）
+
+# oe_generate_session_id — 26 文字 ULID 風 ID を stdout に出力
+# 先頭 14 = 数字（時刻部 YYYYMMDDHHMMSS）、残り 12 = Crockford base32（I/L/O/U 除外）
+#
+# Copilot #4 反映: tr の出力を head -c で早期 close すると tr に SIGPIPE が飛び、
+# set -o pipefail 環境下で assignment が失敗する。固定バイト数を先に読んでから tr で
+# filter する形に変更（パイプの早期 close を回避）。
+oe_generate_session_id() {
+  local ts raw rand
+  ts="$(date -u +%Y%m%d%H%M%S)"
+  raw="$(LC_ALL=C head -c 4096 /dev/urandom | LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z')"
+  rand="${raw:0:12}"
+  printf '%s%s\n' "$ts" "$rand"
+}
+```
+
+### S2. `bin/oe` 改修（抽出に伴う最小変更・挙動不変）
+- `oe_generate_session_id()` のローカル定義を削除（lib/session.sh に移設）
+- source ブロックに `source "${LIB_DIR}/session.sh"` を追加（`constants.sh` の直後）
+- **[gate] G1**: `bash tests/test_e2e_smoke.sh` GREEN（`bin/oe` 抽出の回帰確認）
+
+### S3. `lib/attach.sh` 新設（グルー本体）
+
+```bash
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# attach.sh — 既存（対話中）ペインに attach して capture→classify→audit/KVS（source 専用）
+# 前提: constants.sh / capture.sh / audit.sh が source 済み（呼び出し側 entry が保証）
+
+OE_ATTACH_STATE=""
+
+# oe_capture_attach — pane を1回 scan し、EXIT マーカー検出時に classify→audit→KVS
+# 引数: session_id pane_id [lines=50]
+# 戻り値: 0=検出（OE_ATTACH_STATE 設定 + audit/KVS 書込済）, 1=未検出（書かない）
+oe_capture_attach() {
+  local session_id="$1"
+  local pane_id="$2"
+  local lines="${3:-50}"
+
+  OE_ATTACH_STATE=""
+
+  oe_capture_scan "$pane_id" "$lines"
+
+  # EXIT マーカー未検出（VERIFY 単独 / マーカー無し含む）は未完了扱い
+  if [[ "$OE_SCAN_MARKER_TYPE" != "EXIT" ]]; then
+    return 1
+  fi
+
+  oe_capture_classify "$OE_SCAN_VALUE" "$OE_SCAN_BLOCKED"
+  OE_ATTACH_STATE="$OE_CLASSIFY_STATE"
+
+  local payload
+  payload="$(jq -cn '{source:"attach"}')"
+  oe_audit_emit "session_end" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE" "$payload"
+  oe_capture_write_kvs "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
+  return 0
+}
+```
+
+### S4. `bin/oe-capture` 新設（入口）
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# oe-capture — 既存（対話中）ペインに attach して終端マーカーを読み取り、KVS/audit に記録
+#
+# usage: oe-capture <pane_id> [--session-id <id>] [--lines <N>]
+#
+# 読み取り専用: ペインの kill / cleanup は行わない（対話中ペインを壊さない）。
+# spawn フローとは独立した最小入口（Issue #109 / Slice A）。
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_DIR="${PROJECT_DIR}/lib"
+export PROJECT_DIR
+
+# 必要な lib のみ source（spawn/monitor/verify/cleanup は不要）
+# shellcheck source=../lib/constants.sh
+source "${LIB_DIR}/constants.sh"
+# shellcheck source=../lib/session.sh
+source "${LIB_DIR}/session.sh"
+# shellcheck source=../lib/capture.sh
+source "${LIB_DIR}/capture.sh"
+# shellcheck source=../lib/audit.sh
+source "${LIB_DIR}/audit.sh"
+# shellcheck source=../lib/attach.sh
+source "${LIB_DIR}/attach.sh"
+
+oe_capture_usage() {
+  cat >&2 <<'USAGE'
+usage: oe-capture <pane_id> [--session-id <id>] [--lines <N>]
+  <pane_id>      WezTerm ペイン ID（整数、必須）
+  --session-id   KVS/audit のセッション ID（省略時は自動生成）
+  --lines        capture する末尾行数（既定 50。viewport-only 制約: マーカーは末尾単独行）
+USAGE
+}
+
+oe_capture_cli() {
+  local pane_id="" session_id="" lines=50 session_id_supplied=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session-id) session_id="${2:-}"; session_id_supplied=1; shift 2 ;;
+      --lines)      lines="${2:-}"; shift 2 ;;
+      -h|--help)    oe_capture_usage; return 0 ;;
+      -*)           echo "oe-capture: unknown option: $1" >&2; oe_capture_usage; return 2 ;;
+      *)
+        if [[ -z "$pane_id" ]]; then
+          pane_id="$1"; shift
+        else
+          echo "oe-capture: unexpected argument: $1" >&2; return 2
+        fi
+        ;;
+    esac
+  done
+
+  # wez 不在は環境エラー（exit 2）として「未完了(exit1)」と区別
+  if ! command -v wez >/dev/null 2>&1; then
+    echo "oe-capture: 'wez' not found in PATH (required to capture pane output)" >&2; return 2
+  fi
+
+  if [[ -z "$pane_id" ]]; then
+    echo "oe-capture: pane_id is required" >&2; oe_capture_usage; return 2
+  fi
+  # jq --argjson の数値リテラル制約（先頭ゼロ不可・RFC 8259）+ schema minimum:0
+  if [[ ! "$pane_id" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    echo "oe-capture: pane_id must be a non-negative integer without leading zeros (got: '$pane_id')" >&2; return 2
+  fi
+  if [[ ! "$lines" =~ ^[1-9][0-9]*$ ]]; then
+    echo "oe-capture: --lines must be a positive integer (got: '$lines')" >&2; return 2
+  fi
+
+  # user 指定 session_id は ULID 形式必須（downstream validate-session-state.sh 整合）
+  if [[ "$session_id_supplied" -eq 1 && ! "$session_id" =~ ^[0-9A-HJKMNP-TV-Z]{26}$ ]]; then
+    echo "oe-capture: --session-id must be a 26-char ULID (Crockford base32, excl. I/L/O/U)" >&2; return 2
+  fi
+
+  mkdir -p "${OE_STATE_DIR}" "${OE_AUDIT_DIR}"
+
+  session_id="${session_id:-$(oe_generate_session_id)}"
+
+  # 衝突拒否: 既存 state があると oe_capture_write_kvs の mv -f が verification map を破壊するため拒否
+  if [[ "$session_id_supplied" -eq 1 && -e "${OE_STATE_DIR}/${session_id}.state.json" ]]; then
+    echo "oe-capture: state file already exists for session-id '${session_id}' (refusing to overwrite); use a fresh id" >&2
+    return 2
+  fi
+
+  if oe_capture_attach "$session_id" "$pane_id" "$lines"; then
+    printf 'session_id=%s pane_id=%s state=%s\n' "$session_id" "$pane_id" "$OE_ATTACH_STATE"
+    printf 'kvs=%s\n'   "${OE_STATE_DIR}/${session_id}.state.json"
+    printf 'audit=%s\n' "${OE_AUDIT_DIR}/${session_id}.jsonl"
+    return 0
+  else
+    echo "oe-capture: no @@OE_EXIT marker in last ${lines} lines of pane ${pane_id} (not finished, or marker scrolled out of viewport)" >&2
+    return 1
+  fi
+}
+
+oe_capture_cli "$@"
+```
+
+### S5. `tests/test_attach.sh` 新設（mock hermetic、suite に加算）
+
+`test_capture.sh` / `test_kvs.sh` のパターン踏襲（`OE_DATA_DIR` を temp に、`wez` を関数 mock）。検証ケース:
+
+- `@@OE_EXIT:0` 末尾 → return 0 / `OE_ATTACH_STATE=success` / KVS `.state=success` / audit に `session_end` + `.payload.source=="attach"`
+- `@@OE_BLOCKED` + `@@OE_EXIT:2` → `OE_ATTACH_STATE=blocked` / KVS `.blockers=["@@OE_BLOCKED"]`
+- マーカー無し → return 1 / KVS ファイル未生成
+- `@@OE_VERIFY:pass` 単独（EXIT 無し）→ return 1（未完了扱い）
+- 入口バリデーション（`oe_capture_cli` を source して直接呼ぶ）: pane_id 先頭ゼロ `07`/非整数/未指定 → exit 2、`--session-id` 非 ULID/衝突 → exit 2、`--lines` 非正整数 → exit 2
+
+- **[gate] G2**: `bash tests/test_attach.sh` GREEN
+- **[gate] G3**: 全 mock suite 再実行 → 既存 **306 維持** + 新規分加算（`for f in ./tests/test_*.sh; do bash "$f"; done`）
+- **[gate] G4**: `shellcheck bin/oe-capture bin/oe lib/session.sh lib/attach.sh tests/test_attach.sh` クリーン
+
+### S6. `tests/e2e_real_agent/self_verify_attach.sh` 新設（実wez, local-only）+ 実機実行
+
+使い捨てペインを split → 末尾に `@@OE_EXIT:0` を独立行で送出 → `bin/oe-capture` 実行 → `state=success` 確認 → pane kill。
+`OE_DATA_DIR` を temp に向けてリポジトリ `state/`・`audit/` を汚さない。
+
+- **[gate] G5**: `self_verify_attach.sh` を**この作業内で実機実行**し `state=success` + audit emit 確認（`wez` 在: `/Users/eddy/bin/wez`）
+
+### S7. Episode + コミット分割
+- `docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md` を spec-card で作成（設計判断・self-verify 結果・viewport-only 対処を記録）
+- コミット分割（conventional-commits、1コミット1論理変更）:
+  1. `refactor(orchestration-engine): oe_generate_session_id を lib/session.sh に抽出`（S1+S2）
+  2. `feat(orchestration-engine): 既存ペイン attach 入口 oe-capture を追加`（S3+S4+S5）
+  3. `test(orchestration-engine): oe-capture の実wez self-verify スクリプト追加`（S6）
+  4. `docs(orchestration-engine): #109 Plan/Episode を追加`（S0 doc + S7）
+
+### S8. SO ゲート（実装 diff にセカンドオピニオン）→ PR
+- **[gate] G6 (SO)**: 実装完了後・PR 前に、ブランチ diff に対し `so-compare` でセカンドオピニオンを取得し、実装の正当性・既存への回帰・規約逸脱・SO 反映漏れを検証。指摘は反映してから次へ（必要なら追コミット）
+- PR は `pr-conventions`（Issue #109 連携、test plan = G1〜G6 の結果を本文に記載）
+
+## 検証（end-to-end）
+
+| ゲート | コマンド | 期待 |
+|---|---|---|
+| G1 | `bash tests/test_e2e_smoke.sh` | PASS（bin/oe 抽出の回帰なし） |
+| G2 | `bash tests/test_attach.sh` | PASS（新規） |
+| G3 | `for f in ./tests/test_*.sh; do bash "$f"; done` | 既存 306 維持 + 新規加算、FAIL=0 |
+| G4 | `shellcheck bin/oe-capture bin/oe lib/session.sh lib/attach.sh tests/test_attach.sh` | 警告なし |
+| G5 | `bash tests/e2e_real_agent/self_verify_attach.sh`（実wez） | `state=success`、KVS `.state==success`、audit に `session_end`/`source=="attach"` |
+| G6 (SO) | `so-compare -w "$(pwd)" "<実装 diff の検証プロンプト>"` | 重大な未解決指摘なし（あれば反映後に再判定） |
+
+## セカンドオピニオン（so-compare）
+
+- **Plan 確定前**（実施済み）: `tmp/so-20260526-003703`（Codex + Claude、両者成功）。反映:
+  - pane_id regex 強化 `^(0|[1-9][0-9]*)$`（先頭ゼロで jq 落ち）
+  - `--session-id` 衝突拒否 + ULID 形式検証（既存 verification map 破壊防止 + downstream validator 整合）
+  - wez 不在チェック / PROJECT_DIR・mkdir 必須前提の明記 / Copilot SIGPIPE コメント移植
+  - viewport スコープ契約を明文化し Issue #109 にコメント（option 2）
+- **実装完了後**（G6）: 実装 diff に対し再度 so-compare（上記参照）
+
+## Open questions / リスク
+
+- audit 粒度 `session_end` のみ: SO 両者「schema 違反なし」確認済み。`payload.source="attach"` で monitor 由来と区別（妥当と評価）。`state_change` 併発は任意 → 今回は出さない
+- `bin/oe` 抽出はリスク低（挙動保存・G1 でカバー）。capture.sh/classify/KVS は一切触らない
+- `lib/verify.sh` の session_id 生成は3個目の重複として残る → #109 スコープ外（明示）。寄せるなら別 Issue
+- viewport-only: スクロールアウトしたマーカーは原理的に回収不能（capture.sh の `wez pane capture` viewport 経路を再利用、tee log 代替は持たない）→ スコープ契約で明文化。OSC 7/133 エスケープ未除去リスクは capture.sh 側（無改変方針のためスコープ外、認識のみ）
+
+## 関連
+- [Issue #109](https://github.com/stlwolf/ai-development-hub/issues/109)
+- `lib/capture.sh`（scan/classify/KVS）/ `lib/spawn.sh:97`（marker emit 自動注入の手動版）/ `lib/audit.sh` / `lib/monitor.sh`
+- Step 4-4 episode（viewport-only / `wez pane capture --lines` = tail）: `docs/episodes/2026-05-18-episode-step-4-4-implementation.md`
+- wezterm-ai-mode ADR-004（`--lines = tail` 仕様）

--- a/projects/orchestration-engine/lib/attach.sh
+++ b/projects/orchestration-engine/lib/attach.sh
@@ -1,0 +1,48 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# attach.sh — 既存（対話中）ペインに attach して capture→classify→audit/KVS（source 専用）
+#
+# 前提: constants.sh / capture.sh / audit.sh が source 済み（呼び出し側 entry が保証）。
+# bin/oe の spawn フローとは独立した最小経路（Issue #109 / Slice A）。
+# 「対話セッションの末尾に終端マーカーを出す → engine が読む」を成立させる
+# （spawn.sh が自動注入する marker emit の手動版）。
+
+# グローバル: oe_capture_attach() の結果（分類後 state）
+OE_ATTACH_STATE=""
+
+# oe_capture_attach — pane を1回 scan し、EXIT マーカー検出時に classify→audit→KVS
+#
+# 引数: session_id pane_id [lines=50]
+# 戻り値:
+#   0 = EXIT マーカー検出。OE_ATTACH_STATE に分類結果を設定し audit/KVS 書き込み済み
+#   1 = EXIT マーカー未検出（まだ完了していない）。KVS/audit は書かない
+#
+# viewport-only 制約: oe_capture_scan は `wez pane capture --lines N`（viewport の tail）を
+# 使うため、マーカーは末尾近傍の単独行である必要がある。スクロールアウトしたマーカーは
+# lines を増やしても回収できない（Plan の「viewport スコープ契約」を参照）。
+oe_capture_attach() {
+  local session_id="$1"
+  local pane_id="$2"
+  local lines="${3:-50}"
+
+  OE_ATTACH_STATE=""
+
+  oe_capture_scan "$pane_id" "$lines"
+
+  # EXIT マーカー未検出（VERIFY 単独 / マーカー無し含む）は未完了扱い。
+  # monitor.sh が EXIT 以外を「未完了（ポーリング継続）」とする設計と整合。
+  if [[ "$OE_SCAN_MARKER_TYPE" != "EXIT" ]]; then
+    return 1
+  fi
+
+  oe_capture_classify "$OE_SCAN_VALUE" "$OE_SCAN_BLOCKED"
+  OE_ATTACH_STATE="$OE_CLASSIFY_STATE"
+
+  # spawn 無しのため session_start は出さず session_end のみ。
+  # payload.source="attach" で monitor 由来の session_end と区別できるようにする。
+  local payload
+  payload="$(jq -cn '{source:"attach"}')"
+  oe_audit_emit "session_end" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE" "$payload"
+  oe_capture_write_kvs "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
+  return 0
+}

--- a/projects/orchestration-engine/lib/session.sh
+++ b/projects/orchestration-engine/lib/session.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+# session.sh — セッション ID 生成（source 専用）
+
+# oe_generate_session_id — 26 文字の ULID 風 ID を stdout に出力
+#
+# bin/oe / bin/oe-capture で共有（DI: spawn/monitor を source せずに id 生成するため lib 化）。
+oe_generate_session_id() {
+  local ts
+  local raw
+  local rand
+  # 26 文字: 先頭 14 は数字（ULID 時刻部相当）、残り 12 は Crockford base32（I/L/O/U 除外）
+  #
+  # Copilot #4 反映: tr の出力を head -c で早期 close すると tr に SIGPIPE が飛び、
+  # set -o pipefail 環境下で assignment が失敗する。固定バイト数を先に読んでから tr で
+  # filter する形に変更 (パイプの早期 close を回避)。
+  ts="$(date -u +%Y%m%d%H%M%S)"
+  raw="$(LC_ALL=C head -c 4096 /dev/urandom | LC_ALL=C tr -dc '0-9A-HJKMNP-TV-Z')"
+  rand="${raw:0:12}"
+  printf '%s%s\n' "$ts" "$rand"
+}

--- a/projects/orchestration-engine/tests/e2e_real_agent/self_verify_attach.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/self_verify_attach.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# self_verify_attach.sh — bin/oe-capture の実 wez 自己検証（Issue #109 / Slice A）
+#
+# 使い捨てペインを split → 末尾に @@OE_EXIT:0 を独立行で送出 → bin/oe-capture で attach
+# → state=success / KVS / audit(session_end, source=attach) を確認 → pane kill。
+#
+# 実 wez 必須（ローカル mac でのみ動作）。OE_DATA_DIR を temp に向けるため
+# リポジトリの state/・audit/ は汚さない。
+#
+# 実行: bash projects/orchestration-engine/tests/e2e_real_agent/self_verify_attach.sh
+# Exit: 0=PASS, 1=FAIL
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if ! command -v wez >/dev/null 2>&1; then
+  echo "[self_verify_attach] SKIP: 'wez' not found in PATH (real-wez only)" >&2
+  exit 1
+fi
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+TMP_DATA_DIR="${SCRIPT_DIR}/.tmp_self_verify_${TIMESTAMP}"
+mkdir -p "${TMP_DATA_DIR}/state" "${TMP_DATA_DIR}/audit"
+
+PANE_ID=""
+# shellcheck disable=SC2317  # trap 経由で呼ばれる（shellcheck は到達不能と誤判定）
+cleanup() {
+  if [[ -n "$PANE_ID" ]]; then
+    wez pane kill "$PANE_ID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DATA_DIR"
+}
+trap cleanup EXIT
+
+echo "=== self_verify_attach ($(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
+echo "PROJECT_DIR : ${PROJECT_DIR}"
+echo "TMP_DATA    : ${TMP_DATA_DIR}"
+echo ""
+
+# 1) 使い捨てペインを作成
+PANE_ID="$(wez pane split --bottom --percent 25 --wait-ready --timeout 10)"
+echo "pane_id     : ${PANE_ID}"
+
+# 2) 末尾に終端マーカーを独立行で送出（spawn.sh の marker emit 注入の手動版）
+wez pane send "$PANE_ID" "printf '\\n@@OE_EXIT:0\\n'"
+sleep 2
+
+# 3) bin/oe-capture で attach（OE_DATA_DIR を temp に）
+echo ""
+echo "--- oe-capture output ---"
+set +e
+OUTPUT="$(OE_DATA_DIR="$TMP_DATA_DIR" bash "${PROJECT_DIR}/bin/oe-capture" "$PANE_ID" 2>&1)"
+CAPTURE_RC=$?
+set -e
+printf '%s\n' "$OUTPUT"
+echo ""
+
+# 4) 結果検証
+FAIL=0
+
+if [[ $CAPTURE_RC -ne 0 ]]; then
+  echo "[self_verify_attach] FAIL: oe-capture exit=${CAPTURE_RC} (expected 0)"
+  FAIL=1
+fi
+
+STATE_LINE="$(printf '%s\n' "$OUTPUT" | grep -oE 'state=[a-z_]+' | head -1)"
+if [[ "$STATE_LINE" != "state=success" ]]; then
+  echo "[self_verify_attach] FAIL: stdout state は '${STATE_LINE}' (expected state=success)"
+  FAIL=1
+fi
+
+KVS_PATH="$(printf '%s\n' "$OUTPUT" | sed -nE 's/^kvs=(.*)$/\1/p' | head -1)"
+AUDIT_PATH="$(printf '%s\n' "$OUTPUT" | sed -nE 's/^audit=(.*)$/\1/p' | head -1)"
+
+if [[ -z "$KVS_PATH" || ! -f "$KVS_PATH" ]]; then
+  echo "[self_verify_attach] FAIL: KVS ファイルが見つからない (kvs='${KVS_PATH}')"
+  FAIL=1
+else
+  kvs_state="$(jq -r '.state' "$KVS_PATH")"
+  [[ "$kvs_state" == "success" ]] || { echo "[self_verify_attach] FAIL: KVS .state='${kvs_state}' (expected success)"; FAIL=1; }
+fi
+
+if [[ -z "$AUDIT_PATH" || ! -f "$AUDIT_PATH" ]]; then
+  echo "[self_verify_attach] FAIL: audit ファイルが見つからない (audit='${AUDIT_PATH}')"
+  FAIL=1
+else
+  audit_event="$(jq -r '.event_type' "$AUDIT_PATH")"
+  audit_source="$(jq -r '.payload.source' "$AUDIT_PATH")"
+  audit_state="$(jq -r '.state' "$AUDIT_PATH")"
+  [[ "$audit_event" == "session_end" ]] || { echo "[self_verify_attach] FAIL: audit .event_type='${audit_event}' (expected session_end)"; FAIL=1; }
+  [[ "$audit_source" == "attach" ]] || { echo "[self_verify_attach] FAIL: audit .payload.source='${audit_source}' (expected attach)"; FAIL=1; }
+  [[ "$audit_state" == "success" ]] || { echo "[self_verify_attach] FAIL: audit .state='${audit_state}' (expected success)"; FAIL=1; }
+fi
+
+echo ""
+echo "=== self_verify_attach result ==="
+if [[ "$FAIL" -ne 0 ]]; then
+  echo "[self_verify_attach] FAIL"
+  exit 1
+fi
+echo "[self_verify_attach] PASS: state=success / KVS / audit(session_end, source=attach) すべて確認"
+exit 0

--- a/projects/orchestration-engine/tests/e2e_real_agent/self_verify_attach.sh
+++ b/projects/orchestration-engine/tests/e2e_real_agent/self_verify_attach.sh
@@ -10,14 +10,14 @@ set -euo pipefail
 # リポジトリの state/・audit/ は汚さない。
 #
 # 実行: bash projects/orchestration-engine/tests/e2e_real_agent/self_verify_attach.sh
-# Exit: 0=PASS, 1=FAIL
+# Exit: 0=PASS, 1=FAIL, 77=SKIP（wez 不在）
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 if ! command -v wez >/dev/null 2>&1; then
   echo "[self_verify_attach] SKIP: 'wez' not found in PATH (real-wez only)" >&2
-  exit 1
+  exit 77
 fi
 
 TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"

--- a/projects/orchestration-engine/tests/test_attach.sh
+++ b/projects/orchestration-engine/tests/test_attach.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_attach.sh — lib/attach.sh (oe_capture_attach) と bin/oe-capture (oe_capture_cli) のテスト
+#
+# wez は関数 mock で置換し hermetic に実行（実 wez 不要）。
+# bin/oe-capture は末尾ガードにより source しても自動実行されない。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+_TMP_DIR="${SCRIPT_DIR}/.tmp_test_attach_$$"
+mkdir -p "$_TMP_DIR/state" "$_TMP_DIR/audit"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+OE_DATA_DIR="$_TMP_DIR"
+export OE_DATA_DIR
+
+# wez モック（test_capture.sh と同形式）: "pane capture ..." のときだけ _MOCK_WEZ_OUTPUT を返す
+wez() {
+  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+    echo "$_MOCK_WEZ_OUTPUT"
+    return 0
+  fi
+  return 1
+}
+_MOCK_WEZ_OUTPUT=""
+
+# bin/oe-capture を source（constants/session/capture/audit/attach も連鎖 source される）
+# shellcheck source=../bin/oe-capture
+source "${PROJECT_DIR}/bin/oe-capture"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+# ---- Layer 1: oe_capture_attach (glue) ----
+echo "=== oe_capture_attach (mock wez) ==="
+
+echo "-- EXIT:0 → success + audit/KVS --"
+_MOCK_WEZ_OUTPUT=$'task output\n@@OE_EXIT:0\ndone'
+sid="S_SUCCESS_$$"
+rc=0; oe_capture_attach "$sid" 42 50 || rc=$?
+sf="${OE_STATE_DIR}/${sid}.state.json"
+af="${OE_AUDIT_DIR}/${sid}.jsonl"
+assert_eq "rc" "0" "$rc"
+assert_eq "OE_ATTACH_STATE" "success" "$OE_ATTACH_STATE"
+assert_eq "kvs .state" "success" "$(jq -r '.state' "$sf")"
+assert_eq "kvs .pane_id" "42" "$(jq -r '.pane_id' "$sf")"
+assert_eq "audit .event_type" "session_end" "$(jq -r '.event_type' "$af")"
+assert_eq "audit .state" "success" "$(jq -r '.state' "$af")"
+assert_eq "audit .payload.source" "attach" "$(jq -r '.payload.source' "$af")"
+assert_eq "audit single line" "1" "$(wc -l < "$af" | tr -d ' ')"
+
+echo "-- @@OE_BLOCKED + EXIT:2 → blocked --"
+_MOCK_WEZ_OUTPUT=$'log\n@@OE_BLOCKED\n@@OE_EXIT:2'
+sid="S_BLOCKED_$$"
+rc=0; oe_capture_attach "$sid" 7 50 || rc=$?
+sf="${OE_STATE_DIR}/${sid}.state.json"
+assert_eq "rc" "0" "$rc"
+assert_eq "OE_ATTACH_STATE" "blocked" "$OE_ATTACH_STATE"
+assert_eq "kvs .state" "blocked" "$(jq -r '.state' "$sf")"
+assert_eq "kvs .blockers" '["@@OE_BLOCKED"]' "$(jq -c '.blockers' "$sf")"
+
+echo "-- マーカー無し → rc 1 / KVS 未生成 --"
+_MOCK_WEZ_OUTPUT="just logs, no marker here"
+sid="S_NOMARK_$$"
+rc=0; oe_capture_attach "$sid" 1 50 || rc=$?
+assert_eq "rc" "1" "$rc"
+assert_eq "OE_ATTACH_STATE empty" "" "$OE_ATTACH_STATE"
+assert_eq "kvs not created" "false" "$( [[ -f "${OE_STATE_DIR}/${sid}.state.json" ]] && echo true || echo false )"
+
+echo "-- @@OE_VERIFY:pass 単独 (EXIT 無し) → rc 1 (未完了) --"
+_MOCK_WEZ_OUTPUT=$'review output\n@@OE_VERIFY:pass'
+sid="S_VERIFYONLY_$$"
+rc=0; oe_capture_attach "$sid" 2 50 || rc=$?
+assert_eq "rc" "1" "$rc"
+assert_eq "kvs not created" "false" "$( [[ -f "${OE_STATE_DIR}/${sid}.state.json" ]] && echo true || echo false )"
+
+# ---- Layer 2: oe_capture_cli (entry validation) ----
+echo ""
+echo "=== oe_capture_cli (入口バリデーション) ==="
+
+echo "-- pane_id 先頭ゼロ '07' → exit 2 --"
+rc=0; oe_capture_cli 07 >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- pane_id 非整数 'abc' → exit 2 --"
+rc=0; oe_capture_cli abc >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- pane_id 未指定 → exit 2 --"
+rc=0; oe_capture_cli >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- --lines 非正整数 '0' → exit 2 --"
+rc=0; oe_capture_cli 42 --lines 0 >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- --session-id 非 ULID → exit 2 --"
+rc=0; oe_capture_cli 42 --session-id not-a-ulid >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- 未知オプション → exit 2 --"
+rc=0; oe_capture_cli 42 --bogus >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- 正常系 (自動生成 session_id, EXIT:0) → exit 0 + state=success 出力 --"
+_MOCK_WEZ_OUTPUT=$'@@OE_EXIT:0'
+rc=0; out="$(oe_capture_cli 99 2>/dev/null)" || rc=$?
+assert_eq "rc" "0" "$rc"
+assert_eq "stdout に state=success" "1" "$(printf '%s\n' "$out" | grep -c 'state=success')"
+
+echo "-- 正常系 (--session-id 指定 ULID, fresh) → exit 0 + KVS --"
+freshid="00000000000000000000000001"
+_MOCK_WEZ_OUTPUT=$'@@OE_EXIT:0'
+rc=0; oe_capture_cli 99 --session-id "$freshid" >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "0" "$rc"
+assert_eq "kvs .state" "success" "$(jq -r '.state' "${OE_STATE_DIR}/${freshid}.state.json")"
+
+echo "-- --session-id 衝突 (既存 state) → exit 2 で拒否 --"
+collisionid="00000000000000000000000002"
+printf '{"session_id":"%s","verification":{"x":1}}\n' "$collisionid" > "${OE_STATE_DIR}/${collisionid}.state.json"
+rc=0; oe_capture_cli 99 --session-id "$collisionid" >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+# 既存ファイルが破壊されていない（verification 保持）
+assert_eq "既存 state 非破壊" "1" "$(jq -r '.verification.x' "${OE_STATE_DIR}/${collisionid}.state.json")"
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_attach.sh
+++ b/projects/orchestration-engine/tests/test_attach.sh
@@ -114,6 +114,14 @@ echo "-- --session-id 非 ULID → exit 2 --"
 rc=0; oe_capture_cli 42 --session-id not-a-ulid >/dev/null 2>&1 || rc=$?
 assert_eq "rc" "2" "$rc"
 
+echo "-- --session-id 値欠落 (末尾) → exit 2 (shift 2 ガード, SO検出バグ回帰) --"
+rc=0; oe_capture_cli 42 --session-id >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
+echo "-- --lines 値欠落 (末尾) → exit 2 (shift 2 ガード, SO検出バグ回帰) --"
+rc=0; oe_capture_cli 42 --lines >/dev/null 2>&1 || rc=$?
+assert_eq "rc" "2" "$rc"
+
 echo "-- 未知オプション → exit 2 --"
 rc=0; oe_capture_cli 42 --bogus >/dev/null 2>&1 || rc=$?
 assert_eq "rc" "2" "$rc"


### PR DESCRIPTION
## 目的

`bin/oe` の spawn 専用フローとは独立した、**既存（対話中）ペインに attach して終端マーカーを読み取る**最小入口 `bin/oe-capture` を追加する（#105 Phase 5 dogfood の Slice A）。

「対話セッション末尾に `@@OE_EXIT:0` を出す → engine が読み取る」経路を成立させる。これは `lib/spawn.sh` が自動注入している marker emit の手動版で、既存設計と整合する。既存 capture/classify/KVS は**無改変**。

## 変更内容

- `lib/session.sh`（新規）: `oe_generate_session_id` を `bin/oe` から抽出し共有（spawn/monitor を source せずに id 生成するための DI）。`bin/oe` は source 化（挙動不変）
- `lib/attach.sh`（新規）: `oe_capture_attach()` グルー。scan→（EXIT検出時）classify→`session_end` audit(`source=attach`)→write_kvs を1ショット実行。EXIT 未検出（VERIFY 単独/マーカー無し）は exit 1 で「未完了」扱い（KVS 書かない）
- `bin/oe-capture`（新規）: 読み取り専用入口。spawn/monitor/cleanup/trap を source せずペインを kill しない。pane_id 整数検証 / `--session-id` ULID+衝突拒否 / `--lines` / wez 不在チェック
- `tests/test_attach.sh`（新規）: mock hermetic テスト（31 assertions）
- `tests/e2e_real_agent/self_verify_attach.sh`（新規）: 実 wez 自己検証（local-only）
- `docs/plans` / `docs/episodes`（新規）: spec-card パイプライン文書

## viewport スコープ契約

`wez pane capture --lines N` は viewport の `tail -n N`。スクロールアウトしたマーカーは `--lines` 拡大でも回収不能。読めるのは「マーカー規約でコマンドを流し、直前に完了し、まだ追加出力で流れていない pane」の末尾 N 行に限る（[Issue コメント](https://github.com/stlwolf/ai-development-hub/issues/109#issuecomment-4535751802)で合意化）。

## テスト（test plan: G1〜G6）

- **G1** `bash tests/test_e2e_smoke.sh`（bin/oe 抽出の回帰）: PASS=44 / FAIL=0
- **G2** `bash tests/test_attach.sh`（新規）: PASS=31 / FAIL=0
- **G3** 全 mock suite（`for f in ./tests/test_*.sh`）: TOTAL PASS=337 / FAIL=0（既存 306 維持 + 新規 31）
- **G4** `shellcheck`（bin/oe-capture bin/oe lib/session.sh lib/attach.sh tests/test_attach.sh）: ALL CLEAN
- **G5** `self_verify_attach.sh`（実 wez 実機実行）: PASS（state=success / KVS / audit(session_end, source=attach)）
- **G6** SO ゲート（実装 diff に so-compare）: `shift 2` バグ（値欠落フラグで誤動作）を検出 → ガード追加修正 → G2/G3 再検証で回帰なし

## スコープ外

- 実 target case への適用（Slice B dogfood）
- `--workspace` 外部出力（#108 側）
- `lib/verify.sh` の session_id 生成重複の解消（別 Issue 候補）

## セカンドオピニオン

- Plan 確定前（`so-20260526-003703`）: pane_id regex / `--session-id` 衝突拒否+ULID 検証 / wez 不在チェック等を反映
- 実装後 G6（`so-20260526-111125`）: `shift 2` バグを検出・修正

Refs #109
