### PR TITLE
fix(orchestration-engine): マーカー検知を TUI 字下げ対応に緩和

### DIFF
--- a/projects/orchestration-engine/docs/discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md
+++ b/projects/orchestration-engine/docs/discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md
@@ -1,0 +1,56 @@
+---
+id: "01KSWPBTEY6Y5S2CQ5F6KNDDK0"
+title: "orchestrate 対象のクリーン出力チャネル統一方針（scrape 脱却）— 探索メモ"
+date: 2026-05-30
+type: discussion
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
+    reason: "本 Discussion を観測層で追跡する独立 Issue（Part 2）"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/112"
+    reason: "発見元 Issue（Part 1=regex 緩和は実装・クローズ済み、本メモは Part 2）"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/98"
+    reason: "target 出力 file-redirect 統一。本方針の target 経路における具体実装に当たる"
+tags: [orchestration, phase-5, issue-114, discussion, capture, clean-channel, scrape, file-redirect]
+---
+
+# orchestrate 対象のクリーン出力チャネル統一方針（探索メモ）
+
+> status: draft。本メモは #112 クローズ時に Part 2 を駆動層に残す**種**。実際の KickOff → Plan → 実装は別スレッドで立ち上げる前提。ADR には未昇格（大きな設計判断として確定したら昇格を検討）。
+
+## 課題
+
+`wez pane capture` による非所有ペインの覗き見は本質的に脆い。Part 1（regex 緩和, #112）は観測された TUI 字下げ `  @@OE_EXIT:0` には効くが、以下はいずれも救えない:
+
+- ボックス装飾 `│ @@OE_EXIT:0 │`
+- 行折返し / TUI 再描画 / viewport-only
+
+「マーカーはどんな形であれ取れる」を満たすには、スクレイプでなくクリーンな出力チャネルが要る。
+
+## なぜ scrape は本質的に脆いか
+
+- **Cursor/Claude Code が確実な理由**: 親プロセスとして子の PTY/パイプを所有し生バイトストリームを源で読む。one-shot なら stdout はクリーンテキスト。
+- **oe-capture が脆い理由**: 非所有ペインを `wez pane capture` で覗く＝WezTerm が解釈・描画済みの 2D グリッドを返す（生ストリームでない）。
+- **OS API の壁**: 非所有プロセスの stdout 直読は原則不可。クリーンに取る道は (a) 所有（子として PTY 付き起動） か (b) 協調（出力を file redirect させて読む） の 2 つ。
+- **対話 TUI の本質**: 生ストリームを取れても対話 TUI 出力は制御コード列でクリーンテキストでない。クリーンテキストは構造化/print モード（`claude -p --output-format`）でのみ得られる。対話 TUI は人間用で機械可読チャネルではない。
+
+## 方針案
+
+- orchestrate 対象タスクは **「非対話 `claude -p` + 構造化出力」を基本**とし、その stdout を **所有 or file-redirect してクリーンに取る**。
+- TUI scrape は人間補助の補完に留める。
+- engine の `claude -p` dispatch + file-redirect 経路の方向と一致。
+
+## #98 / #114 との関係
+
+- **#98**（target 出力を file redirect 経路に統一）= 本方針の **target 経路における具体実装**。reviewer は PR #97 で既に file-redirect 化済み、target 側が未統一で経路の非対称性が残る。
+- **#114**（本メモの観測層 Issue）= 方針レベルのトラッキング。
+- 別スレッドで駆動層を立ち上げる際の論点:
+  - 非対話 + file-redirect を「基本経路」として明文化（ADR 化の検討タイミング）
+  - 対話 Claude Code TUI を orchestrate する場合の残課題（別チャネル: セッションログ / フック等）の切り分け
+
+## 関連
+- [Issue #114](https://github.com/stlwolf/ai-development-hub/issues/114) / [Issue #112](https://github.com/stlwolf/ai-development-hub/issues/112) / [Issue #98](https://github.com/stlwolf/ai-development-hub/issues/98)
+- Part 1 Episode: `docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md`

--- a/projects/orchestration-engine/docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md
@@ -27,22 +27,33 @@ tags: [orchestration, phase-5, issue-112, episode, oe-capture, marker, regex, tu
 
 | ファイル | 種別 | 内容 |
 |---|---|---|
-| `lib/constants.sh` | 改修 | `OE_EXIT_MARKER_RE` / `OE_VERIFY_MARKER_RE` を `^[[:space:]]*…[[:space:]]*$` に緩和（先頭/末尾空白許容、行末アンカー維持） |
-| `lib/capture.sh` | 改修 | `@@OE_BLOCKED` インライン regex を `^[[:space:]]*@@OE_BLOCKED($\|:.*$)` に緩和（理由テキストの後置は従来どおり許容） |
-| `tests/test_capture.sh` | 改修 | #112 セクション追加（字下げ EXIT / タブ字下げ / 末尾空白 / 字下げ BLOCKED+EXIT / 字下げ VERIFY のマッチ、字下げエコー・marker 後テキストの非マッチ） |
+| `lib/constants.sh` | 改修 | `OE_EXIT_MARKER_RE` / `OE_VERIFY_MARKER_RE` を `^[[:space:]]*…[[:space:]]*$` に緩和（先頭/末尾空白許容、行末アンカー維持）。`@@OE_BLOCKED` の stale コメント訂正 |
+| `lib/capture.sh` | 改修 | `@@OE_BLOCKED` regex を `^[[:space:]]*@@OE_BLOCKED([[:space:]]*$\|:.*$)` に緩和（末尾空白許容で EXIT/VERIFY と対称化、SO 指摘）。正規化(sed)に U+3000/NBSP→ASCII 空白の畳み込みを追加（ロケール依存解消、SO 指摘） |
+| `tests/test_capture.sh` | 改修 | #112 セクション追加。マッチ: 字下げ/タブ/末尾空白 EXIT・字下げ BLOCKED+EXIT・字下げ VERIFY・末尾空白 BLOCKED・CR+字下げフルパイプ・U+3000/NBSP 正規化。非マッチ: 字下げエコー・marker 後テキスト・引用/リスト glyph・ボックス装飾・コロン直後スペース・VERIFY エコー・後続英字 BLOCKED |
 
 ## 設計判断（確定）
 
 - **行末アンカーを維持して誤検知を防ぐ**: 同じペインにはプロンプト文中のマーカー文字列もエコーされる（例「正確に `@@OE_EXIT:0` とだけ出力…」）。`[[:space:]]*$` で末尾は空白のみ許容＝「マーカー後に非空白テキストが続く行」は非マッチとなり、エコー行を除外できる。既存テスト「行途中のマーカーは無視」の延長で担保。
 - **先頭は空白のみ許容（任意文字の prefix は許容しない）**: `^[[:space:]]*` に限定。`prefix @@OE_EXIT:0` のような行途中マーカーは引き続き非マッチ。観測された TUI 字下げ（空白・タブ）のみを救済する最小緩和。
 - **regex 緩和は scrape 経路の小パッチという位置づけ**: ボックス装飾（`│ @@OE_EXIT:0 │`）・行折返し・viewport-only など screen-scrape の本質的脆さはこの緩和では救えない。根治は #114（クリーン出力チャネル）に委ねる。
+- **全角空白 U+3000 / NBSP はロケール依存のため正規化で根治（SO 指摘）**: `[[:space:]]` のマルチバイト空白判定は環境依存（実機で `ja_JP.UTF-8`=MATCH / `LC_ALL=C`=NOMATCH を再現）。regex 側でなく `oe_capture_scan` の正規化(sed)で U+3000/NBSP を ASCII 空白へ畳み、parse 前に環境差を消す。CR・ANSI 除去と同じ層に置く設計。
+- **単独行マーカーのエコーは regex で区別不能（既知限界、トレードオフ明記）**: プロンプトが `@@OE_EXIT:0` を単独行で復唱すると本物と同形になりマッチする。先頭緩和でこの露出が「列0」→「字下げ込み」にわずかに拡大した。行末アンカーで「marker 後に非空白が続くインラインエコー」は除外できるが、単独行エコーは原理的に scrape では識別不能で #114（プロトコル側: 署名 / sentinel block / 直近N行限定等）の領域。
 
 ## ゲート結果
 
 | ゲート | 内容 | 結果 |
 |---|---|---|
 | G1 | `shellcheck lib/constants.sh lib/capture.sh` | CLEAN |
-| G2 | `bash tests/test_capture.sh`（#112 新規ケース + 既存回帰） | PASS=80 / FAIL=0 |
+| G2 | `bash tests/test_capture.sh`（#112 新規ケース + 既存回帰） | PASS=98 / FAIL=0 |
+| G3 | ロケール非依存確認 `LC_ALL=C bash tests/test_capture.sh` | PASS=98 / FAIL=0 |
+| G4 | SO ゲート `so-compare`（Codex + Claude）→ 指摘反映・再検証 | BLOCKED 末尾空白取りこぼし修正 / U+3000 ロケール依存を正規化で根治 / コメント訂正 / 負例追加 |
+
+### G4 SO ゲートで検出・修正した穴（2者）
+
+- **Codex**: `@@OE_BLOCKED   `（末尾空白のみ）が `($\|:.*$)` で取りこぼし＝EXIT/VERIFY と非対称。bash で再現確認し `([[:space:]]*$\|:.*$)` に修正。
+- **Claude**: 全角空白 U+3000 字下げが `[[:space:]]` のロケール依存で割れる未定義動作。「スコープ外でなく #112 で定義を確定すべき」との指摘を受け、正規化で根治（上記設計判断）。あわせて「確実に除外」表現の過大さ（単独行エコー）・`capture.sh`/`constants.sh` の stale コメント・テスト負例不足を指摘。
+- 反映済み: 上記2件の修正 + コメント正確化 + 負例テスト（glyph/引用・コロン直後スペース・VERIFY エコー・CR+字下げ・U+3000/NBSP）。
+- #114 へ委譲（regex で解けない）: 単独行エコーの識別、glyph/引用/box プレフィックス、行折返し分断。
 
 ## スコープ外（本 Issue では未対応 → #114）
 

--- a/projects/orchestration-engine/docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md
@@ -28,7 +28,8 @@ tags: [orchestration, phase-5, issue-112, episode, oe-capture, marker, regex, tu
 | ファイル | 種別 | 内容 |
 |---|---|---|
 | `lib/constants.sh` | 改修 | `OE_EXIT_MARKER_RE` / `OE_VERIFY_MARKER_RE` を `^[[:space:]]*…[[:space:]]*$` に緩和（先頭/末尾空白許容、行末アンカー維持）。`@@OE_BLOCKED` の stale コメント訂正 |
-| `lib/capture.sh` | 改修 | `@@OE_BLOCKED` regex を `^[[:space:]]*@@OE_BLOCKED([[:space:]]*$\|:.*$)` に緩和（末尾空白許容で EXIT/VERIFY と対称化、SO 指摘）。正規化(sed)に U+3000/NBSP→ASCII 空白の畳み込みを追加（ロケール依存解消、SO 指摘） |
+| `lib/capture.sh` | 改修 | `@@OE_BLOCKED` regex を `^[[:space:]]*@@OE_BLOCKED([[:space:]]*$\|:.*$)` に緩和（末尾空白許容で EXIT/VERIFY と対称化、SO 指摘）。正規化を `_oe_normalize_capture_output()` に抽出し U+3000/NBSP→ASCII 空白の畳み込みを追加（ロケール依存解消、SO 指摘） |
+| `lib/verify.sh` | 改修 | `_oe_verify_scan_log_file` の正規化を共通ヘルパー呼び出しに変更。log-file 経路だけ字下げ marker がロケール依存で残る取りこぼしを解消（Copilot 指摘） |
 | `tests/test_capture.sh` | 改修 | #112 セクション追加。マッチ: 字下げ/タブ/末尾空白 EXIT・字下げ BLOCKED+EXIT・字下げ VERIFY・末尾空白 BLOCKED・CR+字下げフルパイプ・U+3000/NBSP 正規化。非マッチ: 字下げエコー・marker 後テキスト・引用/リスト glyph・ボックス装飾・コロン直後スペース・VERIFY エコー・後続英字 BLOCKED |
 
 ## 設計判断（確定）
@@ -36,17 +37,19 @@ tags: [orchestration, phase-5, issue-112, episode, oe-capture, marker, regex, tu
 - **行末アンカーを維持して誤検知を防ぐ**: 同じペインにはプロンプト文中のマーカー文字列もエコーされる（例「正確に `@@OE_EXIT:0` とだけ出力…」）。`[[:space:]]*$` で末尾は空白のみ許容＝「マーカー後に非空白テキストが続く行」は非マッチとなり、エコー行を除外できる。既存テスト「行途中のマーカーは無視」の延長で担保。
 - **先頭は空白のみ許容（任意文字の prefix は許容しない）**: `^[[:space:]]*` に限定。`prefix @@OE_EXIT:0` のような行途中マーカーは引き続き非マッチ。観測された TUI 字下げ（空白・タブ）のみを救済する最小緩和。
 - **regex 緩和は scrape 経路の小パッチという位置づけ**: ボックス装飾（`│ @@OE_EXIT:0 │`）・行折返し・viewport-only など screen-scrape の本質的脆さはこの緩和では救えない。根治は #114（クリーン出力チャネル）に委ねる。
-- **全角空白 U+3000 / NBSP はロケール依存のため正規化で根治（SO 指摘）**: `[[:space:]]` のマルチバイト空白判定は環境依存（実機で `ja_JP.UTF-8`=MATCH / `LC_ALL=C`=NOMATCH を再現）。regex 側でなく `oe_capture_scan` の正規化(sed)で U+3000/NBSP を ASCII 空白へ畳み、parse 前に環境差を消す。CR・ANSI 除去と同じ層に置く設計。
+- **全角空白 U+3000 / NBSP はロケール依存のため正規化で根治（SO 指摘）**: `[[:space:]]` のマルチバイト空白判定は環境依存（実機で `ja_JP.UTF-8`=MATCH / `LC_ALL=C`=NOMATCH を再現）。regex 側でなく正規化(sed)で U+3000/NBSP を ASCII 空白へ畳み、parse 前に環境差を消す。CR・ANSI 除去と同じ層に置く設計。
+- **正規化を共通ヘルパー `_oe_normalize_capture_output()` に集約（Copilot 指摘）**: 正規化 sed が `oe_capture_scan`（capture 経路）と `_oe_verify_scan_log_file`（verify の log-file 経路）に複製されており、capture 側だけ U+3000/NBSP 畳みを足すと verify 経路に取り残しが残る。複製が今回のバグの根本原因のため、ヘルパーに集約して両経路から呼び、経路間ドリフトを防ぐ。
 - **単独行マーカーのエコーは regex で区別不能（既知限界、トレードオフ明記）**: プロンプトが `@@OE_EXIT:0` を単独行で復唱すると本物と同形になりマッチする。先頭緩和でこの露出が「列0」→「字下げ込み」にわずかに拡大した。行末アンカーで「marker 後に非空白が続くインラインエコー」は除外できるが、単独行エコーは原理的に scrape では識別不能で #114（プロトコル側: 署名 / sentinel block / 直近N行限定等）の領域。
 
 ## ゲート結果
 
 | ゲート | 内容 | 結果 |
 |---|---|---|
-| G1 | `shellcheck lib/constants.sh lib/capture.sh` | CLEAN |
-| G2 | `bash tests/test_capture.sh`（#112 新規ケース + 既存回帰） | PASS=98 / FAIL=0 |
-| G3 | ロケール非依存確認 `LC_ALL=C bash tests/test_capture.sh` | PASS=98 / FAIL=0 |
+| G1 | `shellcheck lib/constants.sh lib/capture.sh lib/verify.sh` | CLEAN |
+| G2 | 全 mock suite（`tests/test_*.sh`） | ALL GREEN（capture=102 / verify=104 ほか FAIL=0） |
+| G3 | ロケール非依存確認 `LC_ALL=C` で capture / verify | PASS 一致 / FAIL=0 |
 | G4 | SO ゲート `so-compare`（Codex + Claude）→ 指摘反映・再検証 | BLOCKED 末尾空白取りこぼし修正 / U+3000 ロケール依存を正規化で根治 / コメント訂正 / 負例追加 |
+| G5 | Copilot レビュー反映 | verify log-file 経路の正規化漏れを共通ヘルパー集約で根治（コミット 1ffb673） |
 
 ### G4 SO ゲートで検出・修正した穴（2者）
 

--- a/projects/orchestration-engine/docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md
+++ b/projects/orchestration-engine/docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md
@@ -1,0 +1,56 @@
+---
+id: "01KSWPBTE6F5JBHGNM0RJQ65KD"
+title: "Issue #112 実装エピソード — マーカー検知の TUI 字下げ対応（regex 緩和 / Part 1）"
+date: 2026-05-30
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/112"
+    reason: "本 Episode の対象 Issue（Part 1 を実装し本 Issue をクローズ）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md"
+    reason: "発見元の #109 ライブ dogfood（対話 Claude Code TUI 字下げで marker 取り逃し）"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
+    reason: "本 Issue Part 2（クリーン出力チャネル方針）を切り出した独立 Issue"
+tags: [orchestration, phase-5, issue-112, episode, oe-capture, marker, regex, tui]
+---
+
+# Issue #112 実装エピソード — マーカー検知の TUI 字下げ対応（Part 1）
+
+## 概要
+
+#109 oe-capture のライブ dogfood（2026-05-26, #105 Phase 5）で、対話 Claude Code TUI への marker 検知が失敗していた。claude は `pong` + `@@OE_EXIT:0` を正しく出力したが、TUI が応答本文を字下げするため行が `  @@OE_EXIT:0`（先頭空白2）になり、行頭・行末完全一致の `OE_EXIT_MARKER_RE` が拾えなかった。本 Episode は Issue 本文の **Part 1（regex 緩和）** を実装し、観測された字下げケースを通せるようにした。**Part 2（クリーン出力チャネルによる scrape 脱却）は #114 として独立切り出し**、本 Issue はクローズ。
+
+## 何を変えたか
+
+| ファイル | 種別 | 内容 |
+|---|---|---|
+| `lib/constants.sh` | 改修 | `OE_EXIT_MARKER_RE` / `OE_VERIFY_MARKER_RE` を `^[[:space:]]*…[[:space:]]*$` に緩和（先頭/末尾空白許容、行末アンカー維持） |
+| `lib/capture.sh` | 改修 | `@@OE_BLOCKED` インライン regex を `^[[:space:]]*@@OE_BLOCKED($\|:.*$)` に緩和（理由テキストの後置は従来どおり許容） |
+| `tests/test_capture.sh` | 改修 | #112 セクション追加（字下げ EXIT / タブ字下げ / 末尾空白 / 字下げ BLOCKED+EXIT / 字下げ VERIFY のマッチ、字下げエコー・marker 後テキストの非マッチ） |
+
+## 設計判断（確定）
+
+- **行末アンカーを維持して誤検知を防ぐ**: 同じペインにはプロンプト文中のマーカー文字列もエコーされる（例「正確に `@@OE_EXIT:0` とだけ出力…」）。`[[:space:]]*$` で末尾は空白のみ許容＝「マーカー後に非空白テキストが続く行」は非マッチとなり、エコー行を除外できる。既存テスト「行途中のマーカーは無視」の延長で担保。
+- **先頭は空白のみ許容（任意文字の prefix は許容しない）**: `^[[:space:]]*` に限定。`prefix @@OE_EXIT:0` のような行途中マーカーは引き続き非マッチ。観測された TUI 字下げ（空白・タブ）のみを救済する最小緩和。
+- **regex 緩和は scrape 経路の小パッチという位置づけ**: ボックス装飾（`│ @@OE_EXIT:0 │`）・行折返し・viewport-only など screen-scrape の本質的脆さはこの緩和では救えない。根治は #114（クリーン出力チャネル）に委ねる。
+
+## ゲート結果
+
+| ゲート | 内容 | 結果 |
+|---|---|---|
+| G1 | `shellcheck lib/constants.sh lib/capture.sh` | CLEAN |
+| G2 | `bash tests/test_capture.sh`（#112 新規ケース + 既存回帰） | PASS=80 / FAIL=0 |
+
+## スコープ外（本 Issue では未対応 → #114）
+
+- ボックス装飾 `│ @@OE_EXIT:0 │`・行折返し・TUI 再描画・viewport-only に起因する取り逃し（regex 緩和では救えない）
+- 非対話 `claude -p` + 構造化出力 + file-redirect を基本経路とする方針（Part 2）。#98（target 出力 file-redirect 統一）と方向一致
+
+## 関連
+- [Issue #112](https://github.com/stlwolf/ai-development-hub/issues/112)（本 Episode の対象、Part 1 でクローズ）
+- [Issue #114](https://github.com/stlwolf/ai-development-hub/issues/114)（Part 2 独立切り出し）/ [Issue #98](https://github.com/stlwolf/ai-development-hub/issues/98)（file-redirect 統一）
+- 発見元: #109 ライブ dogfood Episode `docs/episodes/2026-05-26-episode-issue-109-oe-capture-attach.md`
+- Part 2 設計メモ: `docs/discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md`

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -15,6 +15,20 @@ OE_SCAN_VERIFY_RESULT=""
 # グローバル変数: oe_capture_classify() の戻り値
 OE_CLASSIFY_STATE=""
 
+# _oe_normalize_capture_output — marker 走査前に capture/log 出力を正規化する共通ヘルパー
+#
+# CR 除去・ANSI エスケープ除去に加え、全角空白(U+3000)/NBSP(U+00A0) を ASCII 空白へ畳む。
+# `[[:space:]]` のマルチバイト空白判定はロケール依存（ja_JP.UTF-8 では U+3000 が真、
+# LC_ALL=C では偽）で marker 検知が割れるため、parse 前にここで環境差を消す。
+# capture 経路 (oe_capture_scan) と verify 経路 (verify.sh:_oe_verify_scan_log_file) の
+# 両方から呼ぶ。正規化を1箇所に集約し、経路間の差異（=ロケール依存の取り残し）を防ぐ。
+#
+# 引数: 生の capture 文字列
+# 出力: 正規化済み文字列を stdout へ
+_oe_normalize_capture_output() {
+  printf '%s' "$1" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g; s/\xE3\x80\x80/ /g; s/\xC2\xA0/ /g'
+}
+
 # oe_capture_scan — pane 出力からマーカーをスキャンし種別と値を返す
 #
 # 引数: pane_id（WezTerm ペイン ID）
@@ -33,11 +47,8 @@ oe_capture_scan() {
   local captured
   captured="$(wez pane capture "$pane_id" --lines "$lines" 2>/dev/null)" || return 0
 
-  # #112: CR・ANSI 除去に加え、全角空白(U+3000)/NBSP(U+00A0) を ASCII 空白へ畳む。
-  # `[[:space:]]` のマルチバイト空白判定はロケール依存（ja_JP.UTF-8 では U+3000 が真、
-  # LC_ALL=C では偽）で marker 検知が割れるため、parse 前にここで正規化して環境差を消す。
   local normalized
-  normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g; s/\xE3\x80\x80/ /g; s/\xC2\xA0/ /g')"
+  normalized="$(_oe_normalize_capture_output "$captured")"
 
   _oe_capture_scan_parse "$normalized"
 }

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -60,8 +60,9 @@ _oe_capture_scan_parse() {
 
   local line
   while IFS= read -r line; do
-    # #112: TUI 字下げ対応で先頭空白を許容（理由テキストの後置は従来どおり許容）
-    if [[ "$line" =~ ^[[:space:]]*@@OE_BLOCKED($|:.*$) ]]; then
+    # #112: TUI 字下げ対応で先頭/末尾空白を許容（EXIT/VERIFY と対称化）。
+    # 理由なし `@@OE_BLOCKED` は末尾空白のみ許容、理由付き `@@OE_BLOCKED:reason` は従来どおり後置自由。
+    if [[ "$line" =~ ^[[:space:]]*@@OE_BLOCKED([[:space:]]*$|:.*$) ]]; then
       OE_SCAN_BLOCKED="true"
     fi
 

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -60,7 +60,8 @@ _oe_capture_scan_parse() {
 
   local line
   while IFS= read -r line; do
-    if [[ "$line" =~ ^@@OE_BLOCKED($|:.*$) ]]; then
+    # #112: TUI 字下げ対応で先頭空白を許容（理由テキストの後置は従来どおり許容）
+    if [[ "$line" =~ ^[[:space:]]*@@OE_BLOCKED($|:.*$) ]]; then
       OE_SCAN_BLOCKED="true"
     fi
 

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -33,8 +33,11 @@ oe_capture_scan() {
   local captured
   captured="$(wez pane capture "$pane_id" --lines "$lines" 2>/dev/null)" || return 0
 
+  # #112: CR・ANSI 除去に加え、全角空白(U+3000)/NBSP(U+00A0) を ASCII 空白へ畳む。
+  # `[[:space:]]` のマルチバイト空白判定はロケール依存（ja_JP.UTF-8 では U+3000 が真、
+  # LC_ALL=C では偽）で marker 検知が割れるため、parse 前にここで正規化して環境差を消す。
   local normalized
-  normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g')"
+  normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g; s/\xE3\x80\x80/ /g; s/\xC2\xA0/ /g')"
 
   _oe_capture_scan_parse "$normalized"
 }
@@ -60,8 +63,10 @@ _oe_capture_scan_parse() {
 
   local line
   while IFS= read -r line; do
-    # #112: TUI 字下げ対応で先頭/末尾空白を許容（EXIT/VERIFY と対称化）。
-    # 理由なし `@@OE_BLOCKED` は末尾空白のみ許容、理由付き `@@OE_BLOCKED:reason` は従来どおり後置自由。
+    # #112: TUI 字下げ対応で先頭空白を許容。
+    # 理由なし `@@OE_BLOCKED` は末尾空白のみ許容し EXIT/VERIFY と対称。
+    # 理由付き `@@OE_BLOCKED:reason` は後置自由（行末アンカーなし）＝エコー保護がない点に注意。
+    # ただし blocked は exit_code==2 のときのみ昇格する fail-safe 設計（oe_capture_classify 参照）。
     if [[ "$line" =~ ^[[:space:]]*@@OE_BLOCKED([[:space:]]*$|:.*$) ]]; then
       OE_SCAN_BLOCKED="true"
     fi

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -5,11 +5,13 @@
 # マーカープレフィックス
 OE_MARKER_PREFIX="@@OE_"
 
-# EXIT マーカー正規表現（行頭・行末アンカー付き）
-OE_EXIT_MARKER_RE='^@@OE_EXIT:([0-9]{1,3})$'
+# EXIT マーカー正規表現（先頭/末尾空白を許容、行末アンカーは維持）
+# #112: 対話 Claude Code TUI が応答本文を字下げするため `  @@OE_EXIT:0` を拾えるよう先頭空白を許容。
+# 行末アンカー維持で「マーカー後にテキストが続く行＝プロンプトのエコー」を除外する。
+OE_EXIT_MARKER_RE='^[[:space:]]*@@OE_EXIT:([0-9]{1,3})[[:space:]]*$'
 
-# VERIFY マーカー正規表現 (Step 4-3 検証ゲート v1、行頭・行末アンカー付き)
-OE_VERIFY_MARKER_RE='^@@OE_VERIFY:(pass|fail|warn)$'
+# VERIFY マーカー正規表現 (Step 4-3 検証ゲート v1、先頭/末尾空白を許容、行末アンカーは維持)
+OE_VERIFY_MARKER_RE='^[[:space:]]*@@OE_VERIFY:(pass|fail|warn)[[:space:]]*$'
 
 # 将来マーカー種別の予約（MVP では未使用）:
 #   @@OE_STATUS:{state}  — 進捗状態の報告

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -13,11 +13,11 @@ OE_EXIT_MARKER_RE='^[[:space:]]*@@OE_EXIT:([0-9]{1,3})[[:space:]]*$'
 # VERIFY マーカー正規表現 (Step 4-3 検証ゲート v1、先頭/末尾空白を許容、行末アンカーは維持)
 OE_VERIFY_MARKER_RE='^[[:space:]]*@@OE_VERIFY:(pass|fail|warn)[[:space:]]*$'
 
+# @@OE_BLOCKED / @@OE_BLOCKED:{reason} は実装済み（capture.sh の _oe_capture_scan_parse で検出）。
 # 将来マーカー種別の予約（MVP では未使用）:
 #   @@OE_STATUS:{state}  — 進捗状態の報告
 #   @@OE_READY           — サブエージェント準備完了
 #   @@OE_OUTPUT:{path}   — 成果物パスの通知
-#   @@OE_BLOCKED:{reason} — ブロック理由の報告
 
 # サーキットブレーカー閾値
 # Step 4-4 Phase C 発見: 実 agent (cursor-agent/composer-2) では mock 想定の MAX_TURNS=10 (=20s @ 2s poll) が短すぎる。

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -490,8 +490,10 @@ _oe_verify_scan_log_file() {
   local captured
   captured="$(tail -n "$lines" "$log_path" 2>/dev/null)" || return 0
 
+  # #112: capture 経路と同じ正規化（U+3000/NBSP 畳み込み含む）を共通ヘルパーで適用し、
+  # log-file 経路だけ字下げ marker がロケール依存で残る取りこぼしを防ぐ（Copilot 指摘）。
   local normalized
-  normalized="$(printf '%s' "$captured" | sed -E $'s/\r//g; s/\x1B\\[[0-9;?]*[ -/]*[@-~]//g')"
+  normalized="$(_oe_normalize_capture_output "$captured")"
 
   _oe_capture_scan_parse "$normalized"
 }

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -172,6 +172,27 @@ _oe_capture_scan_parse "│ @@OE_EXIT:0 │"
 assert_eq "marker_type (ボックス装飾)" "" "$OE_SCAN_MARKER_TYPE"
 assert_eq "value (ボックス装飾)" "" "$OE_SCAN_VALUE"
 
+echo "-- 引用/リスト glyph プレフィックスは非マッチ（#114 領域） --"
+_oe_capture_scan_parse "> @@OE_EXIT:0"
+assert_eq "marker_type (引用glyph)" "" "$OE_SCAN_MARKER_TYPE"
+_oe_capture_scan_parse "- @@OE_EXIT:0"
+assert_eq "marker_type (リストglyph)" "" "$OE_SCAN_MARKER_TYPE"
+
+echo "-- コロン直後スペースは非マッチ（内部空白は救わない境界） --"
+_oe_capture_scan_parse "@@OE_EXIT: 0"
+assert_eq "marker_type (コロン直後スペース)" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (コロン直後スペース)" "" "$OE_SCAN_VALUE"
+
+echo "-- 字下げ + 後置テキスト VERIFY はエコーとして非マッチ（EXIT と同じ行末アンカー） --"
+_oe_capture_scan_parse "  @@OE_VERIFY:pass など出力してください"
+assert_eq "verify_result (VERIFYエコー)" "" "$OE_SCAN_VERIFY_RESULT"
+
+echo "-- 単独行エコーは本物の marker と区別不能（scrape 本質限界、#114 領域）--"
+# プロンプトが `@@OE_EXIT:0` 単独行を復唱すると本物と同形になりマッチする。
+# regex では救えないトレードオフを負例ではなく「既知の限界」として固定する。
+_oe_capture_scan_parse "@@OE_EXIT:0"
+assert_eq "marker_type (単独行エコー=本物と同形)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+
 # --- Step 4-3 F3: @@OE_VERIFY: 検出と二値保持 ---
 echo ""
 echo "=== _oe_capture_scan_parse — @@OE_VERIFY: (Step 4-3 F3) ==="
@@ -262,6 +283,24 @@ _MOCK_WEZ_OUTPUT=$'\033[32m@@OE_EXIT:1\033[0m'
 oe_capture_scan "42"
 assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
 assert_eq "value" "1" "$OE_SCAN_VALUE"
+
+echo "-- #112: CR + 字下げ併用をフルパイプ（oe_capture_scan 経由）で検出 --"
+_MOCK_WEZ_OUTPUT=$'pong\r\n  @@OE_EXIT:0\r\n'
+oe_capture_scan "42"
+assert_eq "marker_type (CR+字下げ)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (CR+字下げ)" "0" "$OE_SCAN_VALUE"
+
+echo "-- #112: 全角空白(U+3000)字下げを正規化して検出（ロケール非依存）--"
+_MOCK_WEZ_OUTPUT=$'\xE3\x80\x80@@OE_EXIT:0'
+oe_capture_scan "42"
+assert_eq "marker_type (U+3000字下げ)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (U+3000字下げ)" "0" "$OE_SCAN_VALUE"
+
+echo "-- #112: NBSP(U+00A0)字下げを正規化して検出 --"
+_MOCK_WEZ_OUTPUT=$'\xC2\xA0@@OE_EXIT:1'
+oe_capture_scan "42"
+assert_eq "marker_type (NBSP字下げ)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (NBSP字下げ)" "1" "$OE_SCAN_VALUE"
 
 # --- oe_capture_classify テスト ---
 echo ""

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -111,6 +111,46 @@ assert_eq "marker_type" "EXIT" "$OE_SCAN_MARKER_TYPE"
 assert_eq "value" "2" "$OE_SCAN_VALUE"
 assert_eq "blocked_flag" "true" "$OE_SCAN_BLOCKED"
 
+# --- #112: TUI 字下げ marker 対応（先頭/末尾空白許容、行末アンカー維持） ---
+echo ""
+echo "=== _oe_capture_scan_parse — #112 TUI 字下げ対応 ==="
+
+echo "-- 字下げ EXIT marker（空白2: Claude Code TUI 実測ケース） --"
+_oe_capture_scan_parse "pong
+  @@OE_EXIT:0"
+assert_eq "marker_type (字下げ)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (字下げ)" "0" "$OE_SCAN_VALUE"
+
+echo "-- タブ字下げ EXIT marker --"
+_oe_capture_scan_parse $'\t@@OE_EXIT:1'
+assert_eq "marker_type (タブ)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (タブ)" "1" "$OE_SCAN_VALUE"
+
+echo "-- 末尾空白付き EXIT marker --"
+_oe_capture_scan_parse "@@OE_EXIT:124   "
+assert_eq "marker_type (末尾空白)" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (末尾空白)" "124" "$OE_SCAN_VALUE"
+
+echo "-- 字下げ + 後置テキスト（プロンプトエコー）は無視（行末アンカー維持） --"
+_oe_capture_scan_parse "  正確に @@OE_EXIT:0 とだけ出力してください"
+assert_eq "marker_type (字下げエコー)" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (字下げエコー)" "" "$OE_SCAN_VALUE"
+
+echo "-- 字下げ marker の直後に非空白が続く行は無視 --"
+_oe_capture_scan_parse "  @@OE_EXIT:0 done"
+assert_eq "marker_type (marker後テキスト)" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (marker後テキスト)" "" "$OE_SCAN_VALUE"
+
+echo "-- 字下げ @@OE_BLOCKED 検出 --"
+_oe_capture_scan_parse "  @@OE_BLOCKED
+  @@OE_EXIT:2"
+assert_eq "blocked_flag (字下げ)" "true" "$OE_SCAN_BLOCKED"
+assert_eq "value (字下げ BLOCKED+EXIT)" "2" "$OE_SCAN_VALUE"
+
+echo "-- 字下げ @@OE_VERIFY 検出 --"
+_oe_capture_scan_parse "  @@OE_VERIFY:pass"
+assert_eq "verify_result (字下げ)" "pass" "$OE_SCAN_VERIFY_RESULT"
+
 # --- Step 4-3 F3: @@OE_VERIFY: 検出と二値保持 ---
 echo ""
 echo "=== _oe_capture_scan_parse — @@OE_VERIFY: (Step 4-3 F3) ==="

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -147,9 +147,30 @@ _oe_capture_scan_parse "  @@OE_BLOCKED
 assert_eq "blocked_flag (字下げ)" "true" "$OE_SCAN_BLOCKED"
 assert_eq "value (字下げ BLOCKED+EXIT)" "2" "$OE_SCAN_VALUE"
 
+echo "-- 末尾空白のみ @@OE_BLOCKED 検出（EXIT/VERIFY と対称化, SO 指摘） --"
+_oe_capture_scan_parse "@@OE_BLOCKED   "
+assert_eq "blocked_flag (末尾空白)" "true" "$OE_SCAN_BLOCKED"
+
+echo "-- 字下げ + 末尾空白 @@OE_BLOCKED 検出 --"
+_oe_capture_scan_parse "  @@OE_BLOCKED   "
+assert_eq "blocked_flag (字下げ+末尾空白)" "true" "$OE_SCAN_BLOCKED"
+
+echo "-- 字下げ + 理由 + 末尾空白 @@OE_BLOCKED 検出 --"
+_oe_capture_scan_parse "  @@OE_BLOCKED:needs-human   "
+assert_eq "blocked_flag (字下げ+理由+末尾空白)" "true" "$OE_SCAN_BLOCKED"
+
+echo "-- @@OE_BLOCKED に英字が続く行は無視（誤検知回避） --"
+_oe_capture_scan_parse "@@OE_BLOCKEDX"
+assert_eq "blocked_flag (後続英字)" "false" "$OE_SCAN_BLOCKED"
+
 echo "-- 字下げ @@OE_VERIFY 検出 --"
 _oe_capture_scan_parse "  @@OE_VERIFY:pass"
 assert_eq "verify_result (字下げ)" "pass" "$OE_SCAN_VERIFY_RESULT"
+
+echo "-- ボックス装飾は非マッチ（scrape 本質限界の境界、#114 領域） --"
+_oe_capture_scan_parse "│ @@OE_EXIT:0 │"
+assert_eq "marker_type (ボックス装飾)" "" "$OE_SCAN_MARKER_TYPE"
+assert_eq "value (ボックス装飾)" "" "$OE_SCAN_VALUE"
 
 # --- Step 4-3 F3: @@OE_VERIFY: 検出と二値保持 ---
 echo ""

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -302,6 +302,14 @@ oe_capture_scan "42"
 assert_eq "marker_type (NBSP字下げ)" "EXIT" "$OE_SCAN_MARKER_TYPE"
 assert_eq "value (NBSP字下げ)" "1" "$OE_SCAN_VALUE"
 
+# --- #112: 共通正規化ヘルパー（capture/verify 両経路から呼ぶ）---
+echo ""
+echo "=== _oe_normalize_capture_output (#112 共通ヘルパー) ==="
+assert_eq "U+3000→ASCII空白" " @@OE_EXIT:0" "$(_oe_normalize_capture_output $'\xE3\x80\x80@@OE_EXIT:0')"
+assert_eq "NBSP→ASCII空白" " @@OE_EXIT:0" "$(_oe_normalize_capture_output $'\xC2\xA0@@OE_EXIT:0')"
+assert_eq "CR 除去" "@@OE_EXIT:0" "$(_oe_normalize_capture_output $'@@OE_EXIT:0\r')"
+assert_eq "ANSI 除去" "@@OE_EXIT:1" "$(_oe_normalize_capture_output $'\033[32m@@OE_EXIT:1\033[0m')"
+
 # --- oe_capture_classify テスト ---
 echo ""
 echo "=== oe_capture_classify ==="

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -594,6 +594,23 @@ assert_eq "F-SO-4: lines=200 を渡せる" "200" "$(tail -1 "$_F_SO_4_log")"
 
 unset -f wez
 
+# ---- #112: log-file 経路でも字下げ marker を正規化して検出する (Copilot 指摘) ----
+echo ""
+echo "=== #112: _oe_verify_scan_log_file の字下げ marker 正規化 ==="
+
+# capture 経路と verify(log-file)経路で正規化が共通ヘルパー化されたことの回帰。
+# 全角空白(U+3000)字下げの @@OE_VERIFY / @@OE_EXIT がログ経路でもロケール非依存で拾えること。
+_VERIFY_NORM_LOG="${_TMP_DIR}/verify_norm_indent.log"
+printf '%s\n' "reviewer output" $'\xE3\x80\x80@@OE_VERIFY:pass' $'\xE3\x80\x80@@OE_EXIT:0' > "$_VERIFY_NORM_LOG"
+_oe_verify_scan_log_file "$_VERIFY_NORM_LOG"
+assert_eq "log経路 U+3000字下げ VERIFY" "pass" "$OE_SCAN_VERIFY_RESULT"
+assert_eq "log経路 U+3000字下げ EXIT" "0" "$OE_SCAN_EXIT_CODE"
+
+# 字下げなし marker は従来どおり検出 (回帰)
+printf '%s\n' "@@OE_VERIFY:fail" > "$_VERIFY_NORM_LOG"
+_oe_verify_scan_log_file "$_VERIFY_NORM_LOG"
+assert_eq "log経路 字下げなし VERIFY (回帰)" "fail" "$OE_SCAN_VERIFY_RESULT"
+
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## 目的

#109 oe-capture ライブ dogfood（2026-05-26, #105 Phase 5）で、対話 Claude Code TUI への marker 検知が失敗していた。claude は `pong` + `@@OE_EXIT:0` を正しく出力したが、TUI が応答本文を字下げするため行が `  @@OE_EXIT:0`（先頭空白2）になり、行頭・行末完全一致の `OE_EXIT_MARKER_RE` が拾えなかった。本 PR は #112 の **Part 1（regex 緩和）** を実装する。

## 変更内容

- `lib/constants.sh`: `OE_EXIT_MARKER_RE` / `OE_VERIFY_MARKER_RE` を `^[[:space:]]*…[[:space:]]*$` に緩和（先頭/末尾空白許容、**行末アンカーは維持**）。`@@OE_BLOCKED` の stale コメント訂正
- `lib/capture.sh`:
  - `@@OE_BLOCKED` regex を `^[[:space:]]*@@OE_BLOCKED([[:space:]]*$|:.*$)` に緩和（末尾空白許容で EXIT/VERIFY と対称化）
  - 正規化(sed)に **U+3000/NBSP→ASCII 空白の畳み込み** を追加（ロケール依存解消）
- `tests/test_capture.sh`: #112 セクション追加
  - マッチ: 字下げ/タブ/末尾空白 EXIT・字下げ BLOCKED+EXIT・字下げ VERIFY・末尾空白 BLOCKED・CR+字下げフルパイプ・U+3000/NBSP 正規化
  - 非マッチ（誤検知回避・境界）: 字下げ+後置エコー・引用/リスト glyph・ボックス装飾・コロン直後スペース・VERIFY エコー・後続英字 BLOCKED
- 駆動層蒸留（engine フロー準拠）:
  - Episode `docs/episodes/2026-05-30-episode-issue-112-marker-detection-indent.md`
  - Discussion draft `docs/discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md`（Part 2 の種、別スレッドで駆動層を立ち上げる前提）

## 設計判断

- **行末アンカー維持で誤検知を防ぐ**: プロンプト文中のマーカー文字列もエコーされるため、`[[:space:]]*$` で末尾を空白のみに限定し「マーカー後に非空白が続くインラインエコー」を除外する。
- **先頭は空白のみ許容**（任意 prefix は不許可）。観測された TUI 字下げ（空白・タブ）のみを救済する最小緩和。
- **全角空白 U+3000 / NBSP はロケール依存のため正規化で根治**: `[[:space:]]` のマルチバイト判定は環境依存（実機で `ja_JP.UTF-8`=MATCH / `LC_ALL=C`=NOMATCH を再現）。CR・ANSI 除去と同じ正規化層で ASCII 空白へ畳み、環境差を消す。
- **単独行マーカーのエコーは regex で区別不能（既知限界）**: `@@OE_EXIT:0` を単独行で復唱されると本物と同形でマッチする。先頭緩和でこの露出がわずかに拡大した。原理的に scrape では識別不能で **#114**（プロトコル側）の領域。
- regex 緩和は scrape 経路の小パッチ。ボックス装飾・行折返し・viewport-only は救えず、根治は **#114（クリーン出力チャネル, Part 2）** に委譲。

## 検証

- `shellcheck lib/constants.sh lib/capture.sh` → CLEAN
- `bash tests/test_capture.sh` → **PASS=98 / FAIL=0**
- `LC_ALL=C bash tests/test_capture.sh` → **PASS=98 / FAIL=0**（ロケール非依存を実証）
- **SO ゲート（so-compare: Codex + Claude）**:
  - Codex → `@@OE_BLOCKED   `（末尾空白のみ）取りこぼしを検出 → 修正
  - Claude → U+3000 字下げのロケール依存を検出 → 正規化で根治。stale コメント・負例不足も指摘 → 反映

## 影響範囲

- 既存の正常系（字下げなし marker）の挙動は不変（既存テスト全合格）。
- 行途中マーカー・4桁 exit code・値なし marker・glyph プレフィックスの非マッチも維持。

## Part 2 の扱い

本 PR は Part 1 のみ。Part 2（scrape 脱却の方針）は独立 Issue #114 に切り出し済み。#98（target 出力 file-redirect 統一）と方向一致。本 PR マージ後に #112 は手動クローズ予定。

Refs #112
Refs #114
Refs #98
