### PR TITLE
docs(rules): add subagent delegation routing gate

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -73,7 +73,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | input-style-rule | Handle voice-input typos and fragments; prioritize intent over polish | `rules/input-style-rule.md` |
 | output-format-rule | Conclusion → evidence → steps → risks → links output structure | `rules/output-format-rule.md` |
 | skill-first-operations-rule | Load and follow skills for routine dev operations; do NOT skip skill loading | `rules/skill-first-operations-rule.md` |
-| subagent-strategy-rule | Subagent delegation: custom agents first, one task per subagent, implementer-contract; routing gate (new-thread escalation signal, PR-unit) | `rules/subagent-strategy-rule.md` |
+| subagent-strategy-rule | Subagent delegation: custom agents first, one task per subagent, implementer-contract; routing gate (new thread escalation signal, PR-unit) | `rules/subagent-strategy-rule.md` |
 | workflow-awareness-rule | GitHub Flow; autonomously start branching for issue-driven work | `rules/workflow-awareness-rule.md` |
 
 ## Hooks

--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -16,7 +16,7 @@
 | branch-finish | ブランチ完了判定フロー（検証→4択→実行→クリーンアップ） | `skills/branch-finish/SKILL.md` | skill: worktrunk-worktrees, skill: pr-conventions, skill: conventional-commits |
 | branch-naming | ブランチ命名規則を適用する | `skills/branch-naming/SKILL.md` | — |
 | conventional-commits | コミットメッセージをConventional Commits規約に従って生成する | `skills/conventional-commits/SKILL.md` | — |
-| implementer-contract | サブエージェントへの実装委譲時の返却契約 | `skills/implementer-contract/SKILL.md` | — |
+| implementer-contract | サブエージェントへの実装委譲時の返却契約（ステータスenum・報告フォーマット・スコープ外報告） | `skills/implementer-contract/SKILL.md` | — |
 | issue-conventions | Issue作成の規約を適用する | `skills/issue-conventions/SKILL.md` | — |
 | kickoff-to-plan | Kickoff Documentを実行可能なプランに忠実変換する | `skills/kickoff-to-plan/SKILL.md` | skill: adversarial-review |
 | markdown-conventions | Markdown記法の規約を適用する | `skills/markdown-conventions/SKILL.md` | — |
@@ -73,7 +73,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | input-style-rule | Handle voice-input typos and fragments; prioritize intent over polish | `rules/input-style-rule.md` |
 | output-format-rule | Conclusion → evidence → steps → risks → links output structure | `rules/output-format-rule.md` |
 | skill-first-operations-rule | Load and follow skills for routine dev operations; do NOT skip skill loading | `rules/skill-first-operations-rule.md` |
-| subagent-strategy-rule | Subagent delegation: custom agents first, one task per subagent, implementer-contract | `rules/subagent-strategy-rule.md` |
+| subagent-strategy-rule | Subagent delegation: custom agents first, one task per subagent, implementer-contract; routing gate (new-thread escalation signal, PR-unit) | `rules/subagent-strategy-rule.md` |
 | workflow-awareness-rule | GitHub Flow; autonomously start branching for issue-driven work | `rules/workflow-awareness-rule.md` |
 
 ## Hooks

--- a/canonical/rules/subagent-strategy-rule.md
+++ b/canonical/rules/subagent-strategy-rule.md
@@ -13,3 +13,24 @@
   - Use the tool's native agent launch mechanism when available.
   - Otherwise, read the definition file and inject its full content into the subagent prompt.
 - Fall back to standard subagents only when no custom agent matches.
+
+## Routing Gate
+The harness already routes inline ⇄ subagent and selects custom agents — do not re-decide that; keep delegating investigation, exploration, and parallel analysis proactively. This gate adds only what the harness does not: a human-facing escalation signal and a PR-unit check.
+
+Default: subagent or inline. Surface a one-line recommendation to the user ONLY when escalation is warranted — when ≥2 escalate-lean axes hold, or judgment is dense with no objective gate. The model cannot open a thread, so this never blocks delegation:
+
+```text
+[routing] recommend new thread — reason: scope emerges mid-run; no objective gate
+```
+
+Escalate-lean axes (else the default holds):
+- Pre-specifiability: scope / acceptance criteria cannot be fully written yet
+- Objective verifiability: no mechanical gate (build / test / schema) decides pass/fail — needs human eyes
+- Blast radius: outward-facing or irreversible
+
+An environment or platform quirk is not a capability difference — never route by presumed subagent capability.
+
+Principles:
+- A task with an objective gate can run as subagent + parent review — review substitutes for a thread's "eyes". Autonomous subagents cannot stop at a user gate (`implementation-gate-rule`), so keep judgment-dense or direction-shifting work where that gate applies, not fire-and-forget. Advisory, not hook-enforced.
+- For implementation delegation, 1 PR = one logical change with definable acceptance criteria (mechanical or review-based); delegation unit = PR unit. Investigation and exploration are exempt — decompose them first.
+- Delegation prompts surface out-of-scope findings and follow-ups without implementing them — see `implementer-contract`.

--- a/canonical/skills/implementer-contract/SKILL.md
+++ b/canonical/skills/implementer-contract/SKILL.md
@@ -45,6 +45,9 @@ superpowers ([obra/superpowers](https://github.com/obra/superpowers), MIT) の I
 **Self-review findings:**
 - [self-review で発見した事項。なければ「Issues: None」]
 
+**Out-of-scope findings (optional):**
+- [スコープ外で気づいた問題・follow-up 候補。実装はせず報告のみ。タスク完了判断・レビューに影響するもの（materiality）に限る。なければ省略]
+
 **Concerns (DONE_WITH_CONCERNS の場合):**
 - [具体的な懸念事項]
 
@@ -55,7 +58,7 @@ superpowers ([obra/superpowers](https://github.com/obra/superpowers), MIT) の I
 - [上位に求める決定: 何をどう決めてほしいか]
 ````
 
-該当しないセクション（Concerns, Blocked on）は省略する。
+該当しないセクション（Out-of-scope findings, Concerns, Blocked on）は省略する。
 
 「What I implemented」に要件との対応（要件X → 実装箇所Y）を含めることで、Compliance Review での照合コストを下げる。対応が自明な場合は省略可。
 
@@ -155,6 +158,7 @@ Task tool でサブエージェントに注入する完成形テンプレート�
 - 計画にないファイル分割・再構成をしない。必要だと感じたら報告する
 - 既存コードのパターン・命名規則に従う
 - ファイルが計画以上に肥大化したら、分割せず DONE_WITH_CONCERNS で報告する
+- スコープ外で気づいた問題・follow-up は実装せず報告する（完了判断・レビューに影響するもののみ）
 
 ## テスト
 
@@ -203,6 +207,9 @@ Task tool でサブエージェントに注入する完成形テンプレート�
 
 **Self-review findings:**
 - [self-review で発見した事項。なければ「Issues: None」]
+
+**Out-of-scope findings (optional):**
+- [スコープ外で気づいた問題・follow-up。実装はしない。完了判断・レビューに影響するもののみ。なければ省略]
 
 **Concerns (DONE_WITH_CONCERNS の場合):**
 - [具体的な懸念事項]


### PR DESCRIPTION
## 目的

`subagent-strategy-rule` に委譲ルーティング判定ゲートを導入する（Issue #118）。harness が自律処理する inline⇄subagent 判定は再規定せず、harness が決めない領域——new-thread エスカレーション信号と PR 単位判定——に絞る。

## 背景

- harness/モデルは subagent 起動を `description` マッチで自律判定し、「積極委譲」がトレンド（[Claude Code subagents](https://code.claude.com/docs/en/sub-agents.md)）。
- 一方 new-thread / 新規セッションをモデル側から起動する仕組みは公式に無く、エスカレーションは構造的に人間向き。
- 委譲時の「スコープ外も報告」契約は公式に無く、`implementer-contract` で補える。

## 変更内容

- `canonical/rules/subagent-strategy-rule.md`: `## Routing Gate` を追記
  - Default は subagent/inline。エスカレーション推奨は「≥2 軸が escalate 側」または「客観ゲート無しで判断密度高」のときだけ1行 surface（積極委譲を阻害しない）
  - 判定軸を3つに圧縮（Pre-specifiability / Objective verifiability / Blast radius）
  - PR 単位原則は実装委譲に限定し、調査・探索は除外（定義可能な受け入れ基準＝機械的 or レビュー）
  - 「環境差は能力差ではない」を明記
- `canonical/skills/implementer-contract/SKILL.md`: 報告契約に `Out-of-scope findings` を追加（materiality で絞る／実装はしない）。文言の正本を skill 側に置き、rule は参照のみ（二重統治回避）
- `canonical/CATALOG.md`: 2行の説明を更新

## 検証

- 3レーン セカンドオピニオン（Codex / Claude / Cursor）で設計を反証検証。初版は「net で改善にならない」と3者一致 → 必須修正6点（報告契約の正本一元化・PR粒度の矛盾解消・軸圧縮+default・散文削除・new-thread 語感・過剰報告抑制）を反映。
- markdown-conventions 準拠、rule⇄skill 参照整合を手動確認（本リポジトリに markdown linter / ビルドは無し）。

## 影響範囲

- ルール / スキル / カタログのドキュメントのみ。コード・スクリプト変更なし。
- `canonical/` の各ツールへの配布は別途 `./scripts/sync.sh claude` 実行時（本 PR には含めない）。

Refs #118
