### PR TITLE
feat(hooks): add macOS notification hook for agent completion/input-wait

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -87,6 +87,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | force push ブロック | `hooks/scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
 | CC 形式チェック | `hooks/scripts/cc-lint.sh` | `git commit -m` の Conventional Commits 形式を検証（3ツール共通） |
 | コミットゲート | `hooks/scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（Claude Code のみ） |
+| 通知 | `hooks/scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory、並走時のポーリング解消） |
 
 ## ツール固有拡張
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -154,6 +154,7 @@ CLI/フック文脈からは macOS 通知 API（osascript/terminal-notifier）�
 
 - title: `{tool} {✅ / ⌨️} {repo}`（✅=完了 / ⌨️=入力待ち）
 - body: `{branch} · {session}:{window}.{pane}`（tmux の居場所。入力待ちは ` — {message を80字 truncate}` を追加）
+  - 居場所は `$TMUX_PANE` が取れる発火元のみ表示。取れない場合（一部フック環境）はアクティブペインを誤って指さないよう省略する
 - 完了通知に assistant メッセージ本文は載せない（画面共有・録画時の漏えい防止）
 - 制限: OSC 777 はサウンド指定不可のため完了/入力待ちで通知音の出し分けはできない（区別は絵文字）
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -153,7 +153,7 @@ CLI/フック文脈からは macOS 通知 API（osascript/terminal-notifier）�
 ### 通知フォーマット
 
 - title: `{tool} {✅ / ⌨️} {repo}`（✅=完了 / ⌨️=入力待ち）
-- body: `{branch} · {session}:{window}.{pane}`（tmux の居場所。入力待ちは ` — {message を80字 truncate}` を追加）
+- body: `{branch} · {window}:{window名} [{pane}]`（tmux ステータスバーの `#I:#W` + status-left `[#P]` と一致させ、番号で移動しやすく。入力待ちは ` — {message を80字 truncate}` を追加）
   - 居場所は `$TMUX_PANE` が取れる発火元のみ表示。取れない場合（一部フック環境）はアクティブペインを誤って指さないよう省略する
 - 完了通知に assistant メッセージ本文は載せない（画面共有・録画時の漏えい防止）
 - 制限: OSC 777 はサウンド指定不可のため完了/入力待ちで通知音の出し分けはできない（区別は絵文字）

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -6,7 +6,7 @@
 
 - `jq` が必要（Homebrew で管理: `etc/init/assets/brew/Brewfile`）
 - Codex は hooks 機能が必要（実験的機能）。`config.toml` の `[features].hooks = true`。旧名 `codex_hooks` は現行版（v0.135 で確認）では `hooks` の legacy alias として扱われ、`codex_hooks = true` のままでも有効（ただし非推奨警告が出るため `hooks` への移行が推奨）
-- 通知フック（`notify.sh`）は macOS ネイティブ通知を使う。`terminal-notifier`（あれば優先）または `osascript`（標準。フォールバック）
+- 通知フック（`notify.sh`）は macOS ネイティブ通知を使う。**`terminal-notifier` 推奨**（dotfiles の Brewfile で管理。クリックで該当アプリ前面化・セッション別 group 集約・確実な表示が得られる）。未導入時は `osascript` にフォールバックするが、「スクリプトエディタ」名義のため見落としやすい
 
 ## フック一覧
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -5,7 +5,8 @@
 ## 前提条件
 
 - `jq` が必要（Homebrew で管理: `etc/init/assets/brew/Brewfile`）
-- Codex は `config.toml` に `codex_hooks = true` が必要（実験的機能）
+- Codex は hooks 機能が必要（実験的機能）。`config.toml` の `[features].hooks = true`。旧名 `codex_hooks` は現行版（v0.135 で確認）では `hooks` の legacy alias として扱われ、`codex_hooks = true` のままでも有効（ただし非推奨警告が出るため `hooks` への移行が推奨）
+- 通知フック（`notify.sh`）は macOS ネイティブ通知を使う。`terminal-notifier`（あれば優先）または `osascript`（標準。フォールバック）
 
 ## フック一覧
 
@@ -15,6 +16,7 @@
 | force push ブロック | `scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
 | コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
 | CC 形式チェック | `scripts/cc-lint.sh` | `git commit -m` のメッセージが Conventional Commits 形式に準拠しているかチェック |
+| 通知 | `scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory）。並走時のポーリング解消が目的 |
 
 ## ツール別カバレッジ
 
@@ -24,6 +26,10 @@
 | force push ブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | コミットゲート | — | `TaskCompleted` | — |
 | CC 形式チェック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
+| 通知: 完了 | — | `Stop` | `Stop` ※ |
+| 通知: 入力待ち | — | `Notification`（matcher `permission_prompt\|idle_prompt`） | `PermissionRequest` ※ |
+
+※ Codex のライフサイクル hook（`Stop` / `PermissionRequest`）は対話 TUI 想定。非対話 `codex exec` では発火しないことを確認済み（v0.135）。実 emit は対話セッションで要検証であり、現状は best-effort（発火しない場合は Codex 側は無通知に縮退するのみで、エージェント動作には影響しない）。Cursor は既存の通知機構があるため対象外。
 
 ## block-destructive.sh
 
@@ -116,6 +122,36 @@ Claude Code のみ。Cursor / Codex は `TaskCompleted` 相当のイベントを
 ### deny 時の出力
 
 フォーマット例と型リストを含むメッセージを出力する。
+
+## notify.sh
+
+エージェントの「完了」「入力待ち」を macOS 通知し、複数セッション並走時のポーリング（まだ動いてる？の見に行き）をやめるための advisory フック。
+
+### 配線（意図は引数で明示渡し）
+
+どのイベントに配線したかは hooks.json 側で既知なので、stdin からイベント種別を推論せず**第1引数 `done`/`wait`** で意図を渡す。
+
+| ツール | 完了 → `notify.sh done` | 入力待ち → `notify.sh wait` |
+|--------|------------------------|---------------------------|
+| Claude Code | `Stop` | `Notification`（matcher `permission_prompt\|idle_prompt`） |
+| Codex | `Stop`（matcher なし） | `PermissionRequest`（matcher `*`） |
+
+- `done`（完了）: タイトル `✅ {repo} 完了` / 本文 `{branch}` のみ・**無音** + `terminal-notifier` 時 `-group {session_id}` で集約（`Stop` は毎ターン発火するためノイズを抑制）
+- `wait`（入力待ち）: タイトル `⌨️ {repo} 入力待ち` / 本文 `{branch} — {message を80字 truncate}`・**音あり（Glass）**
+- 完了通知に assistant メッセージ本文は載せない（画面共有・録画時の漏えい防止）
+
+### 完了イベントの選択
+
+完了通知は `Stop`（ターン完了）を使う。`TaskCompleted`（タスク項目完了、commit-gate が使用）とは粒度が異なる。
+
+### advisory 安全性
+
+- `set -e` を使わず、非ゼロ exit を出さない（エージェントを止めない）
+- 非 macOS / `jq` 不在は no-op、外部呼び出しは全て `|| true`、**通知発火は background**（Codex `PermissionRequest` は承認パスに同期的に入るため遅延させない）、**stdout 無出力**（制御 JSON 誤返却の副作用回避）、末尾は無条件 `exit 0`
+
+### デバッグ
+
+`NOTIFY_DEBUG=1` または `~/.notify-hook-debug` が存在すると `/tmp/notify-hook.log` に記録する。Codex の対話セッションで `Stop` / `PermissionRequest` の emit を検証する際に使う。
 
 ## 設定ファイル
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -6,7 +6,8 @@
 
 - `jq` が必要（Homebrew で管理: `etc/init/assets/brew/Brewfile`）
 - Codex は hooks 機能が必要（実験的機能）。`config.toml` の `[features].hooks = true`。旧名 `codex_hooks` は現行版（v0.135 で確認）では `hooks` の legacy alias として扱われ、`codex_hooks = true` のままでも有効（ただし非推奨警告が出るため `hooks` への移行が推奨）
-- 通知フック（`notify.sh`）は macOS ネイティブ通知を使う。**`terminal-notifier` 推奨**（dotfiles の Brewfile で管理。クリックで該当アプリ前面化・セッション別 group 集約・確実な表示が得られる）。未導入時は `osascript` にフォールバックするが、「スクリプトエディタ」名義のため見落としやすい
+- 通知フック（`notify.sh`）の配信は **WezTerm の OSC 777 通知**を主とする（tmux 内は DCS passthrough で `#{pane_tty}` へ直書き、非 tmux は `/dev/tty`）。**前提: tmux は `set -g allow-passthrough on`（3.3+, dotfiles の `tmux.conf`）、WezTerm.app に macOS 通知許可**。非 WezTerm / headless 環境では `terminal-notifier`（dotfiles の Brewfile で管理）→ `osascript` にフォールバックする
+  - 背景: macOS では CLI/フック文脈から `osascript`/`terminal-notifier` を叩いても通知が表示されないことがある（GUI 権限を持つアプリが出す必要がある）。WezTerm は GUI アプリなので OSC を受けて通知を出せる。詳細は `docs/research/2026-03-30-ai-tool-hooks-specification-survey.md` の追記参照
 
 ## フック一覧
 
@@ -26,10 +27,10 @@
 | force push ブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | コミットゲート | — | `TaskCompleted` | — |
 | CC 形式チェック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
-| 通知: 完了 | — | `Stop` | `Stop` ※ |
-| 通知: 入力待ち | — | `Notification`（matcher `permission_prompt\|idle_prompt`） | `PermissionRequest` ※ |
+| 通知: 完了 | — | `Stop` hook → notify.sh | `notify`(config.toml) → notify.sh |
+| 通知: 入力待ち | — | `Notification`（matcher `permission_prompt\|idle_prompt`） → notify.sh | `[tui] notifications=["approval-requested"]` + `notification_method="osc9"`（ネイティブ）※ |
 
-※ Codex のライフサイクル hook（`Stop` / `PermissionRequest`）は対話 TUI 想定。非対話 `codex exec` では発火しないことを確認済み（v0.135）。実 emit は対話セッションで要検証であり、現状は best-effort（発火しない場合は Codex 側は無通知に縮退するのみで、エージェント動作には影響しない）。Cursor は既存の通知機構があるため対象外。
+※ Codex は通知に lifecycle hook を**使わない**（`Stop` は対話で発火しない報告 [openai/codex#17532]、`PermissionRequest` は observability only で実 emit 不確実）。完了は `config.toml` の `notify`→notify.sh（Claude と統一フォーマット）、入力待ちは Codex ネイティブ `[tui] notifications`(osc9) で出す。`notify` / `[tui]` は `scripts/sync/apply-codex-notify-config.sh` が `~/.codex/config.toml` へ冪等適用する（symlink 不可な状態ファイルのためキー単位で適用）。Codex 入力待ち osc9 の tmux 越えは対話セッションで要検証（best-effort）。Cursor は既存の通知機構があるため対象外。
 
 ## block-destructive.sh
 
@@ -127,31 +128,41 @@ Claude Code のみ。Cursor / Codex は `TaskCompleted` 相当のイベントを
 
 エージェントの「完了」「入力待ち」を macOS 通知し、複数セッション並走時のポーリング（まだ動いてる？の見に行き）をやめるための advisory フック。
 
-### 配線（意図は引数で明示渡し）
+### 配信経路（WezTerm OSC 777）
 
-どのイベントに配線したかは hooks.json 側で既知なので、stdin からイベント種別を推論せず**第1引数 `done`/`wait`** で意図を渡す。
+CLI/フック文脈からは macOS 通知 API（osascript/terminal-notifier）が表示されないことがあるため、**WezTerm（GUI アプリ）に OSC 777 通知を出させる**:
 
-| ツール | 完了 → `notify.sh done` | 入力待ち → `notify.sh wait` |
-|--------|------------------------|---------------------------|
-| Claude Code | `Stop` | `Notification`（matcher `permission_prompt\|idle_prompt`） |
-| Codex | `Stop`（matcher なし） | `PermissionRequest`（matcher `*`） |
+- tmux 内: DCS passthrough（`\ePtmux;\e\e]777;notify;…\a\e\\`）で包み、`tmux display-message -t "$TMUX_PANE" -p '#{pane_tty}'` で得たペイン TTY へ直接書く（フックは controlling TTY を持たないため `/dev/tty` 不可）
+- 非 tmux: `/dev/tty` へ OSC 777
+- どちらも不可: `terminal-notifier` → `osascript` にフォールバック（非 WezTerm / headless 用）
 
-- `done`（完了）: タイトル `✅ {repo} 完了` / 本文 `{branch}` のみ・**無音** + `terminal-notifier` 時 `-group {session_id}` で集約（`Stop` は毎ターン発火するためノイズを抑制）
-- `wait`（入力待ち）: タイトル `⌨️ {repo} 入力待ち` / 本文 `{branch} — {message を80字 truncate}`・**音あり（Glass）**
+前提: tmux `set -g allow-passthrough on`、WezTerm.app の macOS 通知許可。
+
+### 呼ばれ方（意図は引数で明示渡し）
+
+- Claude Code hooks: 第1引数 `done`/`wait`（任意 第2引数 tool 名）+ stdin JSON（underscore キー）
+- Codex notify: 第1引数が JSON 文字列（hyphen キー, agent-turn-complete=完了）→ tool=Codex
+
+| ツール | 完了 | 入力待ち |
+|--------|------|----------|
+| Claude Code | `Stop` hook → `notify.sh done` | `Notification`(matcher `permission_prompt\|idle_prompt`) → `notify.sh wait` |
+| Codex | `notify`(config.toml) → `notify.sh`（JSON 判定で done） | `[tui] notifications`(osc9 ネイティブ・notify.sh 経由せず) |
+
+### 通知フォーマット
+
+- title: `{tool} {✅ / ⌨️} {repo}`（✅=完了 / ⌨️=入力待ち）
+- body: `{branch} · win{window.pane}`（入力待ちは ` — {message を80字 truncate}` を追加）
 - 完了通知に assistant メッセージ本文は載せない（画面共有・録画時の漏えい防止）
-
-### 完了イベントの選択
-
-完了通知は `Stop`（ターン完了）を使う。`TaskCompleted`（タスク項目完了、commit-gate が使用）とは粒度が異なる。
+- 制限: OSC 777 はサウンド指定不可のため完了/入力待ちで通知音の出し分けはできない（区別は絵文字）
 
 ### advisory 安全性
 
-- `set -e` を使わず、非ゼロ exit を出さない（エージェントを止めない）
-- 非 macOS / `jq` 不在は no-op、外部呼び出しは全て `|| true`、**通知発火は background**（Codex `PermissionRequest` は承認パスに同期的に入るため遅延させない）、**stdout 無出力**（制御 JSON 誤返却の副作用回避）、末尾は無条件 `exit 0`
+- `set -e` を使わず非ゼロ exit を出さない（エージェントを止めない）
+- `jq` 不在は no-op、外部呼び出しは全て `|| true`、**stdout 無出力**（制御 JSON 誤返却の副作用回避）、末尾は無条件 `exit 0`
 
 ### デバッグ
 
-`NOTIFY_DEBUG=1` または `~/.notify-hook-debug` が存在すると `/tmp/notify-hook.log` に記録する。Codex の対話セッションで `Stop` / `PermissionRequest` の emit を検証する際に使う。
+`NOTIFY_DEBUG=1` または `~/.notify-hook-debug` で `/tmp/notify-hook.log` に記録（tool / mode / repo / branch / loc / tmux）。
 
 ## 設定ファイル
 
@@ -159,7 +170,8 @@ Claude Code のみ。Cursor / Codex は `TaskCompleted` 相当のイベントを
 |---------|------|--------|
 | `cursor.hooks.json` | Cursor native (version: 1) | `~/.cursor/hooks.json` |
 | `claude.hooks.json` | Claude Code (hooks セクション) | `~/.claude/settings.json` の `hooks` キーにマージ |
-| `codex.hooks.json` | Codex | `~/.codex/hooks.json` |
+| `codex.hooks.json` | Codex | `~/.codex/hooks.json`（block 系のみ。通知は config.toml 経由） |
+| Codex 通知設定 | `config.toml` キー（`notify` / `[tui]`） | `scripts/sync/apply-codex-notify-config.sh` が `~/.codex/config.toml` へ冪等適用 |
 
 ## 設計判断
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -30,7 +30,9 @@
 | 通知: 完了 | — | `Stop` hook → notify.sh | `notify`(config.toml) → notify.sh |
 | 通知: 入力待ち | — | `Notification`（matcher `permission_prompt\|idle_prompt`） → notify.sh | `[tui] notifications=["approval-requested"]` + `notification_method="osc9"`（ネイティブ）※ |
 
-※ Codex は通知に lifecycle hook を**使わない**（`Stop` は対話で発火しない報告 [openai/codex#17532]、`PermissionRequest` は observability only で実 emit 不確実）。完了は `config.toml` の `notify`→notify.sh（Claude と統一フォーマット）、入力待ちは Codex ネイティブ `[tui] notifications`(osc9) で出す。`notify` / `[tui]` は `scripts/sync/apply-codex-notify-config.sh` が `~/.codex/config.toml` へ冪等適用する（symlink 不可な状態ファイルのためキー単位で適用）。Codex 入力待ち osc9 の tmux 越えは対話セッションで要検証（best-effort）。Cursor は既存の通知機構があるため対象外。
+※ Codex は通知に lifecycle hook を**使わない**（`Stop` は対話で発火しない報告 [openai/codex#17532]、`PermissionRequest` は対話で承認プロンプトが出ても**発火しないことを実機確認**）。完了は `config.toml` の `notify`→notify.sh（Claude と統一フォーマット）で出る。入力待ちは Codex ネイティブ `[tui] notifications=["approval-requested"]`(osc9) を設定するが、**Codex は OSC を tmux passthrough で包まないため tmux 環境では通知が出ない（実機確認＝既知ギャップ）**。`notify` / `[tui]` は `scripts/sync/apply-codex-notify-config.sh` が `~/.codex/config.toml` へ冪等適用する（symlink 不可な状態ファイルのためキー単位で適用）。
+
+**Codex まとめ**: 完了通知は動作。入力待ち通知は tmux 環境では出ない（best-effort・既知ギャップ。tmux 外なら `[tui] osc9` が機能）。Cursor は既存の通知機構があるため対象外。
 
 ## block-destructive.sh
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -151,7 +151,7 @@ CLI/フック文脈からは macOS 通知 API（osascript/terminal-notifier）�
 ### 通知フォーマット
 
 - title: `{tool} {✅ / ⌨️} {repo}`（✅=完了 / ⌨️=入力待ち）
-- body: `{branch} · win{window.pane}`（入力待ちは ` — {message を80字 truncate}` を追加）
+- body: `{branch} · {session}:{window}.{pane}`（tmux の居場所。入力待ちは ` — {message を80字 truncate}` を追加）
 - 完了通知に assistant メッセージ本文は載せない（画面共有・録画時の漏えい防止）
 - 制限: OSC 777 はサウンド指定不可のため完了/入力待ちで通知音の出し分けはできない（区別は絵文字）
 

--- a/canonical/hooks/claude.hooks.json
+++ b/canonical/hooks/claude.hooks.json
@@ -28,6 +28,28 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/notify.sh done"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/notify.sh wait"
+          }
+        ]
+      }
     ]
   }
 }

--- a/canonical/hooks/codex.hooks.json
+++ b/canonical/hooks/codex.hooks.json
@@ -18,6 +18,27 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.codex/hooks/notify.sh done"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.codex/hooks/notify.sh wait"
+          }
+        ]
+      }
     ]
   }
 }

--- a/canonical/hooks/codex.hooks.json
+++ b/canonical/hooks/codex.hooks.json
@@ -18,27 +18,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.codex/hooks/notify.sh done"
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.codex/hooks/notify.sh wait"
-          }
-        ]
-      }
     ]
   }
 }

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -63,8 +63,8 @@ if [[ -n "${TMUX:-}" ]]; then
   if [[ -n "$pane" ]]; then
     # 発火元ペインが特定できる場合のみ TTY と loc を取る
     pt="$(tmux display-message -t "$pane" -p '#{pane_tty}' 2>/dev/null || true)"
-    # 居場所: session名:window.pane（並走時の識別。番号移動は window 番号）
-    loc="$(tmux display-message -t "$pane" -p '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
+    # 居場所: window番号:window名 [pane]（tmux ステータスバーの #I:#W と status-left [#P] に一致。番号移動は window 番号）
+    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{pane_index}]' 2>/dev/null || true)"
   else
     # $TMUX_PANE 不在: 配信はアクティブペイン TTY 経由（通知は window レベルで表示される）。
     # ただし loc はアクティブペインを指すと別ペインの通知に誤った番号が付くため省略する。

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# notify.sh — エージェントの完了 / 入力待ちを macOS 通知する advisory フック
+#
+# Claude Code / Codex の hooks から呼ばれる共有ハンドラ。
+#   完了    : Claude `Stop` / Codex `Stop`            → 第1引数 done（無音 + group 集約）
+#   入力待ち: Claude `Notification` / Codex `PermissionRequest` → 第1引数 wait（音あり）
+#
+# 意図(done/wait)は hook 設定側の引数で明示渡しする（stdin からのイベント推論より堅い）。
+# stdin の JSON からは cwd / message / session_id のみ読む。
+#
+# advisory 契約: エージェントを絶対に止めない。
+#   - `set -e` は使わない（非ゼロ exit を出さない）
+#   - 非 macOS / jq 不在は no-op
+#   - 外部呼び出しは全て `|| true`、発火は background、末尾は無条件 exit 0
+#   - stdout には何も出さない（Codex Stop で制御 JSON を返すと副作用）
+#
+# デバッグ: NOTIFY_DEBUG=1 または ~/.notify-hook-debug があれば /tmp/notify-hook.log に記録。
+
+set -uo pipefail
+
+# 非 macOS / jq 不在は no-op
+[[ "$(uname 2>/dev/null || echo)" == "Darwin" ]] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+mode="${1:-done}"
+
+input="$(cat 2>/dev/null || true)"
+cwd="$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || true)"
+message="$(printf '%s' "$input" | jq -r '.message // ""' 2>/dev/null || true)"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // ""' 2>/dev/null || true)"
+event="$(printf '%s' "$input" | jq -r '.hook_event_name // ""' 2>/dev/null || true)"
+
+# cwd → repo / branch（並走時の識別用）
+repo=""
+branch=""
+if [[ -n "$cwd" && "$cwd" != "null" ]] && git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  repo="$(basename "$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "")")"
+  branch="$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || echo "")"
+fi
+label="${repo:-agent}"
+
+# デバッグログ
+if [[ -n "${NOTIFY_DEBUG:-}" || -f "$HOME/.notify-hook-debug" ]]; then
+  printf '%s mode=%s event=%s repo=%s branch=%s msg=%.40s\n' \
+    "$(date '+%H:%M:%S' 2>/dev/null || echo '?')" "$mode" "$event" "$repo" "$branch" "$message" \
+    >> /tmp/notify-hook.log 2>/dev/null || true
+fi
+
+# モード → 表示内容
+case "$mode" in
+  wait)
+    title="⌨️ ${label} 入力待ち"
+    msg_clean="$(printf '%s' "$message" | tr '\n' ' ' | cut -c1-80)"
+    body="${branch}"
+    [[ -n "$msg_clean" ]] && body="${body:+${body} — }${msg_clean}"
+    [[ -z "$body" ]] && body="入力を待っています"
+    sound="Glass"
+    ;;
+  done|*)
+    # 完了: 機微情報を載せない（repo/branch のみ）。無音 + group 集約でノイズ抑制
+    title="✅ ${label} 完了"
+    body="${branch:-${label}}"
+    sound=""
+    ;;
+esac
+
+# terminal-notifier の -message が "-" 始まりだとフラグ誤認するため回避
+[[ "$body" == -* ]] && body="• ${body#-}"
+
+dispatch() {
+  if command -v terminal-notifier >/dev/null 2>&1; then
+    local args=(-title "$title" -message "$body")
+    [[ -n "$session_id" ]] && args+=(-group "$session_id")
+    if [[ -n "$sound" ]]; then
+      args+=(-sound "$sound")
+    else
+      args+=(-sound none)
+    fi
+    terminal-notifier "${args[@]}" >/dev/null 2>&1 || true
+  elif [[ -n "$sound" ]]; then
+    osascript - "$title" "$body" "$sound" >/dev/null 2>&1 <<'OSA' || true
+on run argv
+  display notification (item 2 of argv) with title (item 1 of argv) sound name (item 3 of argv)
+end run
+OSA
+  else
+    osascript - "$title" "$body" >/dev/null 2>&1 <<'OSA' || true
+on run argv
+  display notification (item 2 of argv) with title (item 1 of argv)
+end run
+OSA
+  fi
+}
+
+# 承認パスを遅延させないため background で発火し、即 return
+( dispatch ) >/dev/null 2>&1 &
+
+exit 0

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -1,36 +1,52 @@
 #!/usr/bin/env bash
-# notify.sh — エージェントの完了 / 入力待ちを macOS 通知する advisory フック
+# notify.sh — エージェントの完了 / 入力待ちを通知する advisory フック
 #
-# Claude Code / Codex の hooks から呼ばれる共有ハンドラ。
-#   完了    : Claude `Stop` / Codex `Stop`            → 第1引数 done（無音 + group 集約）
-#   入力待ち: Claude `Notification` / Codex `PermissionRequest` → 第1引数 wait（音あり）
+# 配信は WezTerm の OSC 777 通知を主とする。tmux 内では DCS passthrough で包んで
+# ペイン TTY (#{pane_tty}) に直接書く（フックは controlling TTY を持たないため
+# /dev/tty は使えない）。非 tmux は /dev/tty。どちらも不可なら terminal-notifier →
+# osascript にフォールバック（非 WezTerm / headless 環境用）。
 #
-# 意図(done/wait)は hook 設定側の引数で明示渡しする（stdin からのイベント推論より堅い）。
-# stdin の JSON からは cwd / message / session_id のみ読む。
+# 前提: tmux は `set -g allow-passthrough on`（3.3+）、WezTerm に macOS 通知許可。
 #
-# advisory 契約: エージェントを絶対に止めない。
-#   - `set -e` は使わない（非ゼロ exit を出さない）
-#   - 非 macOS / jq 不在は no-op
-#   - 外部呼び出しは全て `|| true`、発火は background、末尾は無条件 exit 0
-#   - stdout には何も出さない（Codex Stop で制御 JSON を返すと副作用）
+# 呼ばれ方:
+#   Claude Code hooks : 第1引数 = done|wait（任意 第2引数 = tool 名）、stdin に JSON（underscore キー）
+#   Codex notify      : 第1引数 = JSON 文字列（hyphen キー, type=agent-turn-complete）→ tool=Codex
 #
-# デバッグ: NOTIFY_DEBUG=1 または ~/.notify-hook-debug があれば /tmp/notify-hook.log に記録。
+# 通知フォーマット:
+#   title: "{tool} {✅|⌨️} {repo}"   body: "{branch} · win{window.pane} — {message}"
+#
+# advisory 契約: 非ゼロ exit を出さない / stdout 無出力 / 末尾は無条件 exit 0。
+# デバッグ: NOTIFY_DEBUG=1 または ~/.notify-hook-debug で /tmp/notify-hook.log に記録。
+#
+# 制限: OSC 777 にはサウンド指定が無いため、完了/入力待ちで通知音は出し分けられない
+# （WezTerm の通知設定に従う）。区別はタイトルの絵文字（✅ / ⌨️）で行う。
 
 set -uo pipefail
 
-# 非 macOS / jq 不在は no-op
-[[ "$(uname 2>/dev/null || echo)" == "Darwin" ]] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-mode="${1:-done}"
+arg1="${1:-}"
+mode="done"
+cwd=""
+message=""
+tool="Claude"
 
-input="$(cat 2>/dev/null || true)"
-cwd="$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || true)"
-message="$(printf '%s' "$input" | jq -r '.message // ""' 2>/dev/null || true)"
-session_id="$(printf '%s' "$input" | jq -r '.session_id // ""' 2>/dev/null || true)"
-event="$(printf '%s' "$input" | jq -r '.hook_event_name // ""' 2>/dev/null || true)"
+if [[ "$arg1" == "{"* ]]; then
+  # Codex notify: argv[1] が JSON（hyphen キー、完了のみ）
+  tool="Codex"
+  cwd="$(printf '%s' "$arg1" | jq -r '.cwd // ""' 2>/dev/null || true)"
+  message="$(printf '%s' "$arg1" | jq -r '."last-assistant-message" // ""' 2>/dev/null || true)"
+  mode="done"
+else
+  # hooks: argv[1]=mode, argv[2]=tool(任意), stdin に JSON（underscore キー）
+  mode="${arg1:-done}"
+  [[ -n "${2:-}" ]] && tool="$2"
+  input="$(cat 2>/dev/null || true)"
+  cwd="$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || true)"
+  message="$(printf '%s' "$input" | jq -r '.message // .last_assistant_message // ""' 2>/dev/null || true)"
+fi
 
-# cwd → repo / branch（並走時の識別用）
+# cwd → repo / branch
 repo=""
 branch=""
 if [[ -n "$cwd" && "$cwd" != "null" ]] && git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -39,60 +55,66 @@ if [[ -n "$cwd" && "$cwd" != "null" ]] && git -C "$cwd" rev-parse --is-inside-wo
 fi
 label="${repo:-agent}"
 
-# デバッグログ
+# tmux: ペイン TTY と 居場所(window.pane) を取得
+pt=""
+loc=""
+if [[ -n "${TMUX:-}" ]]; then
+  pane="${TMUX_PANE:-}"
+  tmux_target=()
+  [[ -n "$pane" ]] && tmux_target=(-t "$pane")
+  pt="$(tmux display-message "${tmux_target[@]}" -p '#{pane_tty}' 2>/dev/null || true)"
+  loc="$(tmux display-message "${tmux_target[@]}" -p '#{window_index}.#{pane_index}' 2>/dev/null || true)"
+fi
+
+# title / body
+case "$mode" in
+  wait)
+    emoji="⌨️"
+    msg="$(printf '%s' "$message" | tr -d '\033\007' | tr '\n\r' '  ' | cut -c1-80)"
+    ;;
+  *)
+    emoji="✅"
+    msg=""
+    ;;
+esac
+title="${tool} ${emoji} ${label}"
+body="${branch}"
+[[ -n "$loc" ]] && body="${body:+$body · }win${loc}"
+[[ -n "$msg" ]] && body="${body:+$body — }$msg"
+[[ -z "$body" ]] && body="$mode"
+
+# サニタイズ（OSC を壊す制御文字・改行を除去。title は区切りの ; も除去）
+title="$(printf '%s' "$title" | tr -d '\033\007;' | tr '\n\r' '  ')"
+body="$(printf '%s' "$body" | tr -d '\033\007' | tr '\n\r' '  ')"
+
 if [[ -n "${NOTIFY_DEBUG:-}" || -f "$HOME/.notify-hook-debug" ]]; then
-  printf '%s mode=%s event=%s repo=%s branch=%s msg=%.40s\n' \
-    "$(date '+%H:%M:%S' 2>/dev/null || echo '?')" "$mode" "$event" "$repo" "$branch" "$message" \
+  printf '%s tool=%s mode=%s repo=%s branch=%s loc=%s tmux=%s\n' \
+    "$(date '+%H:%M:%S' 2>/dev/null || echo '?')" "$tool" "$mode" "$repo" "$branch" "$loc" "${TMUX:+yes}" \
     >> /tmp/notify-hook.log 2>/dev/null || true
 fi
 
-# モード → 表示内容
-case "$mode" in
-  wait)
-    title="⌨️ ${label} 入力待ち"
-    msg_clean="$(printf '%s' "$message" | tr '\n' ' ' | cut -c1-80)"
-    body="${branch}"
-    [[ -n "$msg_clean" ]] && body="${body:+${body} — }${msg_clean}"
-    [[ -z "$body" ]] && body="入力を待っています"
-    sound="Glass"
-    ;;
-  done|*)
-    # 完了: 機微情報を載せない（repo/branch のみ）。無音 + group 集約でノイズ抑制
-    title="✅ ${label} 完了"
-    body="${branch:-${label}}"
-    sound=""
-    ;;
-esac
+# --- 配信 ---
+delivered=0
 
-# terminal-notifier の -message が "-" 始まりだとフラグ誤認するため回避
-[[ "$body" == -* ]] && body="• ${body#-}"
+if [[ -n "${TMUX:-}" && -n "$pt" && -w "$pt" ]]; then
+  # tmux: ペイン TTY へ DCS passthrough（内側 ESC を二重化、終端は ESC + \134=backslash）
+  printf '\033Ptmux;\033\033]777;notify;%s;%s\007\033\134' "$title" "$body" > "$pt" 2>/dev/null && delivered=1
+elif [[ -z "${TMUX:-}" && -w /dev/tty ]]; then
+  printf '\033]777;notify;%s;%s\007' "$title" "$body" > /dev/tty 2>/dev/null && delivered=1
+fi
 
-dispatch() {
+# フォールバック（非 WezTerm / 非 tmux / headless 用）
+if [[ "$delivered" -eq 0 ]]; then
   if command -v terminal-notifier >/dev/null 2>&1; then
-    local args=(-title "$title" -message "$body")
-    [[ -n "$session_id" ]] && args+=(-group "$session_id")
-    if [[ -n "$sound" ]]; then
-      args+=(-sound "$sound")
-    else
-      args+=(-sound none)
-    fi
-    terminal-notifier "${args[@]}" >/dev/null 2>&1 || true
-  elif [[ -n "$sound" ]]; then
-    osascript - "$title" "$body" "$sound" >/dev/null 2>&1 <<'OSA' || true
-on run argv
-  display notification (item 2 of argv) with title (item 1 of argv) sound name (item 3 of argv)
-end run
-OSA
-  else
-    osascript - "$title" "$body" >/dev/null 2>&1 <<'OSA' || true
+    ( terminal-notifier -title "$title" -message "${body:-notify}" >/dev/null 2>&1 ) &
+  elif command -v osascript >/dev/null 2>&1; then
+    ( osascript - "$title" "${body:-notify}" >/dev/null 2>&1 <<'OSA'
 on run argv
   display notification (item 2 of argv) with title (item 1 of argv)
 end run
 OSA
+    ) &
   fi
-}
-
-# 承認パスを遅延させないため background で発火し、即 return
-( dispatch ) >/dev/null 2>&1 &
+fi
 
 exit 0

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -92,7 +92,7 @@ body="${branch}"
 
 # サニタイズ（OSC を壊す制御文字・改行を除去。title は区切りの ; も除去）
 title="$(printf '%s' "$title" | tr -d '\033\007;' | tr '\n\r' '  ')"
-body="$(printf '%s' "$body" | tr -d '\033\007' | tr '\n\r' '  ')"
+body="$(printf '%s' "$body" | tr -d '\033\007;' | tr '\n\r' '  ')"
 
 if [[ -n "${NOTIFY_DEBUG:-}" || -f "$HOME/.notify-hook-debug" ]]; then
   printf '%s tool=%s mode=%s repo=%s branch=%s loc=%s tmux=%s\n' \

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -60,11 +60,17 @@ pt=""
 loc=""
 if [[ -n "${TMUX:-}" ]]; then
   pane="${TMUX_PANE:-}"
-  tmux_target=()
-  [[ -n "$pane" ]] && tmux_target=(-t "$pane")
-  pt="$(tmux display-message "${tmux_target[@]}" -p '#{pane_tty}' 2>/dev/null || true)"
-  # 居場所: session名:window.pane（並走時の識別。番号移動は window 番号）
-  loc="$(tmux display-message "${tmux_target[@]}" -p '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
+  if [[ -n "$pane" ]]; then
+    # 発火元ペインが特定できる場合のみ TTY と loc を取る
+    pt="$(tmux display-message -t "$pane" -p '#{pane_tty}' 2>/dev/null || true)"
+    # 居場所: session名:window.pane（並走時の識別。番号移動は window 番号）
+    loc="$(tmux display-message -t "$pane" -p '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
+  else
+    # $TMUX_PANE 不在: 配信はアクティブペイン TTY 経由（通知は window レベルで表示される）。
+    # ただし loc はアクティブペインを指すと別ペインの通知に誤った番号が付くため省略する。
+    pt="$(tmux display-message -p '#{pane_tty}' 2>/dev/null || true)"
+    loc=""
+  fi
 fi
 
 # title / body

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -63,7 +63,8 @@ if [[ -n "${TMUX:-}" ]]; then
   tmux_target=()
   [[ -n "$pane" ]] && tmux_target=(-t "$pane")
   pt="$(tmux display-message "${tmux_target[@]}" -p '#{pane_tty}' 2>/dev/null || true)"
-  loc="$(tmux display-message "${tmux_target[@]}" -p '#{window_index}.#{pane_index}' 2>/dev/null || true)"
+  # 居場所: session名:window.pane（並走時の識別。番号移動は window 番号）
+  loc="$(tmux display-message "${tmux_target[@]}" -p '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
 fi
 
 # title / body
@@ -79,7 +80,7 @@ case "$mode" in
 esac
 title="${tool} ${emoji} ${label}"
 body="${branch}"
-[[ -n "$loc" ]] && body="${body:+$body · }win${loc}"
+[[ -n "$loc" ]] && body="${body:+$body · }${loc}"
 [[ -n "$msg" ]] && body="${body:+$body — }$msg"
 [[ -z "$body" ]] && body="$mode"
 

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -41,7 +41,8 @@ else
   # hooks: argv[1]=mode, argv[2]=tool(任意), stdin に JSON（underscore キー）
   mode="${arg1:-done}"
   [[ -n "${2:-}" ]] && tool="$2"
-  input="$(cat 2>/dev/null || true)"
+  # stdin が TTY（手動実行等）なら EOF 待ちでブロックしないよう空入力扱い
+  if [[ -t 0 ]]; then input=""; else input="$(cat 2>/dev/null || true)"; fi
   cwd="$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || true)"
   message="$(printf '%s' "$input" | jq -r '.message // .last_assistant_message // ""' 2>/dev/null || true)"
 fi

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -13,7 +13,7 @@
 #   Codex notify      : 第1引数 = JSON 文字列（hyphen キー, type=agent-turn-complete）→ tool=Codex
 #
 # 通知フォーマット:
-#   title: "{tool} {✅|⌨️} {repo}"   body: "{branch} · win{window.pane} — {message}"
+#   title: "{tool} {✅|⌨️} {repo}"   body: "{branch} · {window_index}:{window_name} [{pane_index}] — {message}"
 #
 # advisory 契約: 非ゼロ exit を出さない / stdout 無出力 / 末尾は無条件 exit 0。
 # デバッグ: NOTIFY_DEBUG=1 または ~/.notify-hook-debug で /tmp/notify-hook.log に記録。

--- a/docs/research/2026-03-30-ai-tool-hooks-specification-survey.md
+++ b/docs/research/2026-03-30-ai-tool-hooks-specification-survey.md
@@ -12,7 +12,10 @@
 - **Codex のイベント拡張**: 現行公式 docs では `Stop` / `PermissionRequest` 等が記載され、当時の「5 イベントのみ」より増えている。ただし **`codex exec`（非対話）では `Stop` フックが発火しないことを実機確認**。ライフサイクル hook は対話 TUI 想定の可能性が高く、`PermissionRequest` の実 emit は対話セッションで要検証。
 - **shell_snapshot**: `codex exec` 実行時に `Shell snapshot validation failed`（ユーザーシェル環境スナップショットの構文エラー）が出る環境がある。command 系 hook 実行への影響可能性があり別途要調査（本 Issue の通知フックとは独立）。
 - **macOS 通知の配信経路（最重要）**: CLI/フック文脈から `osascript`（スクリプトエディタ名義・通知一覧に出ず許可不可）や `terminal-notifier`（2.0.0 は Sequoia で表示不発）を叩いても**通知が表示されない**ことを実機確認（Cursor 等 GUI アプリは出る＝macOS 通知自体は正常）。**GUI 権限を持つアプリが出す必要がある**。WezTerm ユーザーでは **OSC 777 を WezTerm に出させる**のが解。tmux 内はフックが controlling TTY を持たないため、`tmux display-message -t "$TMUX_PANE" -p '#{pane_tty}'` で得たペイン TTY に **DCS passthrough** で包んで書く（`set -g allow-passthrough on` 前提、tmux 3.3+）。実機で OSC 9 / OSC 777 の表示・pane_tty 直書きを確認済み。
-- **Codex 通知の最終方針**: hooks は通知に使わない（`Stop` 対話非発火 [openai/codex#17532]、`PermissionRequest` observability only）。完了は `config.toml` の `notify`→共有 notify.sh（OSC、Claude と統一フォーマット）、入力待ちは Codex ネイティブ `[tui] notifications=["approval-requested"] notification_method="osc9"`。`notify` は `agent-turn-complete` のみで入力待ちを拾えないため `[tui]` 併用。
+- **Codex 通知の最終方針（実機確認込み）**: hooks は通知に使わない。完了は `config.toml` の `notify`→共有 notify.sh（OSC、Claude と統一フォーマット）で**動作確認済み**。入力待ちは:
+  - `PermissionRequest` hook → **対話で承認プロンプトが出ても発火しないことを実機確認**（`Stop` 非発火 [openai/codex#17532] と同様、observability only で通知に使えない）。
+  - Codex ネイティブ `[tui] notifications=["approval-requested"] notification_method="osc9"` → **Codex は OSC を tmux passthrough で包まないため tmux 内で通知が出ないことを実機確認**（bare OSC を tmux が遮断）。
+  - → **Codex 入力待ち通知は tmux 環境では出せない既知ギャップ**。`notify` は `agent-turn-complete` のみで入力待ちを拾えない。完了通知は動くため best-effort として許容。tmux 外なら `[tui] osc9` が機能する見込み。
 
 ## 要約
 

--- a/docs/research/2026-03-30-ai-tool-hooks-specification-survey.md
+++ b/docs/research/2026-03-30-ai-tool-hooks-specification-survey.md
@@ -4,6 +4,14 @@
 - 関連 Issue: [#10](https://github.com/stlwolf/ai-development-hub/issues/10), [#17](https://github.com/stlwolf/ai-development-hub/issues/17)
 - 出典: [Cursor Hooks Docs](https://cursor.com/docs/hooks), [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks), [Codex Hooks Docs](https://developers.openai.com/codex/hooks)
 
+## 2026-06-01 追記（[#119](https://github.com/stlwolf/ai-development-hub/issues/119) 通知フック実装時の実機検証）
+
+本調査は 2026-03-30 時点のスナップショット。Codex hooks は experimental で変化が速く、v0.135 実機検証で以下の差分を確認した（下記の歴史的な表は当時のまま保持）。
+
+- **Codex の有効化フラグ**: 旧 `codex_hooks` は `hooks` の **legacy alias**（`codex doctor` で `legacy alias codex_hooks -> hooks` と表示）。`codex_hooks = true` のままでも機能するが非推奨警告が出る → `[features].hooks = true` 推奨。
+- **Codex のイベント拡張**: 現行公式 docs では `Stop` / `PermissionRequest` 等が記載され、当時の「5 イベントのみ」より増えている。ただし **`codex exec`（非対話）では `Stop` フックが発火しないことを実機確認**。ライフサイクル hook は対話 TUI 想定の可能性が高く、`PermissionRequest` の実 emit は対話セッションで要検証。
+- **shell_snapshot**: `codex exec` 実行時に `Shell snapshot validation failed`（ユーザーシェル環境スナップショットの構文エラー）が出る環境がある。command 系 hook 実行への影響可能性があり別途要調査（本 Issue の通知フックとは独立）。
+
 ## 要約
 
 3ツールとも hooks は **JSON stdin/stdout + exit code** プロトコルを共有し、Claude Code の hooks フォーマットが事実上の共通語になりつつある（Cursor は Claude Code hooks の読み込みに対応、Codex も同構造を採用）。ただしイベント名の casing（Cursor: camelCase / Claude Code・Codex: PascalCase）、設定ファイルパス、対応イベント数に差がある。

--- a/docs/research/2026-03-30-ai-tool-hooks-specification-survey.md
+++ b/docs/research/2026-03-30-ai-tool-hooks-specification-survey.md
@@ -11,6 +11,8 @@
 - **Codex の有効化フラグ**: 旧 `codex_hooks` は `hooks` の **legacy alias**（`codex doctor` で `legacy alias codex_hooks -> hooks` と表示）。`codex_hooks = true` のままでも機能するが非推奨警告が出る → `[features].hooks = true` 推奨。
 - **Codex のイベント拡張**: 現行公式 docs では `Stop` / `PermissionRequest` 等が記載され、当時の「5 イベントのみ」より増えている。ただし **`codex exec`（非対話）では `Stop` フックが発火しないことを実機確認**。ライフサイクル hook は対話 TUI 想定の可能性が高く、`PermissionRequest` の実 emit は対話セッションで要検証。
 - **shell_snapshot**: `codex exec` 実行時に `Shell snapshot validation failed`（ユーザーシェル環境スナップショットの構文エラー）が出る環境がある。command 系 hook 実行への影響可能性があり別途要調査（本 Issue の通知フックとは独立）。
+- **macOS 通知の配信経路（最重要）**: CLI/フック文脈から `osascript`（スクリプトエディタ名義・通知一覧に出ず許可不可）や `terminal-notifier`（2.0.0 は Sequoia で表示不発）を叩いても**通知が表示されない**ことを実機確認（Cursor 等 GUI アプリは出る＝macOS 通知自体は正常）。**GUI 権限を持つアプリが出す必要がある**。WezTerm ユーザーでは **OSC 777 を WezTerm に出させる**のが解。tmux 内はフックが controlling TTY を持たないため、`tmux display-message -t "$TMUX_PANE" -p '#{pane_tty}'` で得たペイン TTY に **DCS passthrough** で包んで書く（`set -g allow-passthrough on` 前提、tmux 3.3+）。実機で OSC 9 / OSC 777 の表示・pane_tty 直書きを確認済み。
+- **Codex 通知の最終方針**: hooks は通知に使わない（`Stop` 対話非発火 [openai/codex#17532]、`PermissionRequest` observability only）。完了は `config.toml` の `notify`→共有 notify.sh（OSC、Claude と統一フォーマット）、入力待ちは Codex ネイティブ `[tui] notifications=["approval-requested"] notification_method="osc9"`。`notify` は `agent-turn-complete` のみで入力待ちを拾えないため `[tui]` 併用。
 
 ## 要約
 

--- a/scripts/sync/apply-codex-notify-config.sh
+++ b/scripts/sync/apply-codex-notify-config.sh
@@ -42,7 +42,11 @@ if [[ ! -f "$CONFIG" ]]; then
 fi
 
 backup="${CONFIG}.bak.$(date +%Y%m%d-%H%M%S 2>/dev/null || echo manual)"
-cp "$CONFIG" "$backup"
+# backup を作れない場合（権限/容量/read-only FS 等）は config を一切変更せず安全に抜ける
+if ! cp "$CONFIG" "$backup" 2>/dev/null; then
+  warn "backup を作成できないため変更しません: ${CONFIG}"
+  exit 0
+fi
 changed=0
 
 # 1) notify (top-level key) → 無ければ先頭に挿入（最初のテーブルより前である必要があるため）

--- a/scripts/sync/apply-codex-notify-config.sh
+++ b/scripts/sync/apply-codex-notify-config.sh
@@ -53,12 +53,13 @@ changed=0
 if grep -qE '^[[:space:]]*notify[[:space:]]*=' "$CONFIG"; then
   info "notify already present (skip)"
 else
-  tmp="$(mktemp)"
+  # tmp は CONFIG と同じディレクトリに作る（同一 FS で mv が atomic rename になり cross-device 失敗を避ける）
+  tmp="$(mktemp "${CONFIG}.tmp.XXXXXX" 2>/dev/null)" || { rm -f "$backup"; warn "tmp 作成失敗のため変更しません"; exit 0; }
   {
     printf '%s\n%s\n%s\n\n' "$NOTIFY_BEGIN" "$NOTIFY_LINE" "$NOTIFY_END"
     cat "$CONFIG"
   } > "$tmp"
-  mv "$tmp" "$CONFIG"
+  mv "$tmp" "$CONFIG" || { rm -f "$tmp" "$backup"; warn "config 置換に失敗したため変更しません"; exit 0; }
   changed=1
   info "Inserted notify at top"
 fi

--- a/scripts/sync/apply-codex-notify-config.sh
+++ b/scripts/sync/apply-codex-notify-config.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# apply-codex-notify-config.sh
+#
+# Codex の通知設定を ~/.codex/config.toml に冪等適用する。
+#
+# config.toml は Codex が実行時に書き換える状態ファイルのため symlink 不可。
+# dotfiles の symlink 運用にも乗らない。そこで「正本キーをハーネス側で管理し、
+# 有無を検知して挿入する冪等 apply」とする（sync-codex.sh から呼ばれる）。
+#
+# 管理キー:
+#   notify                  完了(agent-turn-complete)で notify.sh を起動（Claude と統一フォーマットの OSC 通知）
+#   tui.notifications        入力待ち(approval-requested)を Codex ネイティブ OSC9 で通知
+#   tui.notification_method  osc9（WezTerm が描画。notify は完了のみで入力待ちを拾えないため tui 併用）
+#
+# notify は top-level key のため最初のテーブルより前に置く。tui.* は super-table として末尾に追加。
+#
+# Usage:
+#   ./scripts/sync/apply-codex-notify-config.sh [CONFIG_PATH]
+#   CODEX_HOOKS_DIR=/path ./scripts/sync/apply-codex-notify-config.sh   # notify.sh の場所を上書き
+
+set -uo pipefail
+
+CONFIG="${1:-$HOME/.codex/config.toml}"
+HOOKS_DIR="${CODEX_HOOKS_DIR:-$HOME/.codex/hooks}"
+NOTIFY_LINE="notify = [\"bash\", \"${HOOKS_DIR}/notify.sh\"]"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+NOTIFY_BEGIN="# >>> ai-hub codex notify (managed) >>>"
+NOTIFY_END="# <<< ai-hub codex notify (managed) <<<"
+TUI_BEGIN="# >>> ai-hub codex tui-notify (managed) >>>"
+TUI_END="# <<< ai-hub codex tui-notify (managed) <<<"
+
+if [[ ! -f "$CONFIG" ]]; then
+  warn "config.toml not found: ${CONFIG} (skip)"
+  exit 0
+fi
+
+backup="${CONFIG}.bak.$(date +%Y%m%d-%H%M%S 2>/dev/null || echo manual)"
+cp "$CONFIG" "$backup"
+changed=0
+
+# 1) notify (top-level key) → 無ければ先頭に挿入（最初のテーブルより前である必要があるため）
+if grep -qE '^[[:space:]]*notify[[:space:]]*=' "$CONFIG"; then
+  info "notify already present (skip)"
+else
+  tmp="$(mktemp)"
+  {
+    printf '%s\n%s\n%s\n\n' "$NOTIFY_BEGIN" "$NOTIFY_LINE" "$NOTIFY_END"
+    cat "$CONFIG"
+  } > "$tmp"
+  mv "$tmp" "$CONFIG"
+  changed=1
+  info "Inserted notify at top"
+fi
+
+# 2) tui.notification_method → 無ければ [tui] super-table を末尾に追加
+#    （既存の [tui.model_availability_nux] 等の subtable があっても super-table 後置は TOML 上有効）
+if grep -qE '^[[:space:]]*notification_method[[:space:]]*=' "$CONFIG"; then
+  info "tui.notification_method already present (skip)"
+else
+  {
+    printf '\n%s\n' "$TUI_BEGIN"
+    printf '[tui]\n'
+    printf 'notifications = ["approval-requested"]\n'
+    printf 'notification_method = "osc9"\n'
+    printf '%s\n' "$TUI_END"
+  } >> "$CONFIG"
+  changed=1
+  info "Appended [tui] notifications at bottom"
+fi
+
+# 3) TOML 検証（python3 tomllib があれば）。壊れていたら復元
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import tomllib' >/dev/null 2>&1; then
+  if python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' "$CONFIG" 2>/dev/null; then
+    info "TOML parse OK"
+  else
+    warn "TOML parse failed after apply -> restoring backup"
+    cp "$backup" "$CONFIG"
+    exit 1
+  fi
+else
+  warn "python3 tomllib 不在: TOML 検証はスキップ（codex doctor で確認推奨）"
+fi
+
+if [[ "$changed" -eq 0 ]]; then
+  rm -f "$backup"
+  info "No changes (already applied): ${CONFIG}"
+else
+  info "Applied to ${CONFIG} (backup: ${backup})"
+fi
+exit 0

--- a/scripts/sync/sync-codex.sh
+++ b/scripts/sync/sync-codex.sh
@@ -295,9 +295,10 @@ main() {
     echo ""
 
     # Codex 通知設定（config.toml への冪等 apply。symlink 不可な状態ファイルのためキー単位で適用）
-    if [[ -x "${SCRIPT_DIR}/apply-codex-notify-config.sh" ]]; then
+    if [[ -f "${SCRIPT_DIR}/apply-codex-notify-config.sh" ]]; then
         info "Applying Codex notify config: ${TARGET_BASE}/config.toml"
-        CODEX_HOOKS_DIR="${TARGET_BASE}/hooks" "${SCRIPT_DIR}/apply-codex-notify-config.sh" "${TARGET_BASE}/config.toml" || warn "apply-codex-notify-config 失敗（非致命）"
+        # 実行ビットに依存せず bash で起動（+x が落ちた環境でも skip しない）
+        CODEX_HOOKS_DIR="${TARGET_BASE}/hooks" bash "${SCRIPT_DIR}/apply-codex-notify-config.sh" "${TARGET_BASE}/config.toml" || warn "apply-codex-notify-config 失敗（非致命）"
         echo ""
     fi
 

--- a/scripts/sync/sync-codex.sh
+++ b/scripts/sync/sync-codex.sh
@@ -294,6 +294,13 @@ main() {
     sync_hook_scripts "${CANONICAL_DIR}/hooks/scripts" "${TARGET_BASE}/hooks" "hook scripts"
     echo ""
 
+    # Codex 通知設定（config.toml への冪等 apply。symlink 不可な状態ファイルのためキー単位で適用）
+    if [[ -x "${SCRIPT_DIR}/apply-codex-notify-config.sh" ]]; then
+        info "Applying Codex notify config: ${TARGET_BASE}/config.toml"
+        CODEX_HOOKS_DIR="${TARGET_BASE}/hooks" "${SCRIPT_DIR}/apply-codex-notify-config.sh" "${TARGET_BASE}/config.toml" || warn "apply-codex-notify-config 失敗（非致命）"
+        echo ""
+    fi
+
     info "=== sync-codex complete ==="
 }
 


### PR DESCRIPTION
## 目的

AI エージェント並走時の「まだ動いてる？／入力待ちで止まってない？」のポーリングをやめ、**完了・入力待ちを macOS 通知で push** する。Cursor は既に通知済みで、穴だった Claude Code を埋めるのが主目的。Codex も対象（best-effort）。

Refs #119

## 配信方式（重要・実機検証で確定）

CLI/フック文脈からは `osascript` / `terminal-notifier` が macOS 通知を表示できない（GUI 権限を持つアプリが出す必要がある。Cursor が出るのは GUI アプリだから）。WezTerm ユーザー向けに **WezTerm（GUI アプリ）に OSC 777 通知を出させる**方式を採用:

- tmux 内: フックは controlling TTY を持たないため、`tmux display-message -t "$TMUX_PANE" -p '#{pane_tty}'` のペイン TTY に **DCS passthrough** で包んだ OSC を直接書く（`set -g allow-passthrough on` 前提）
- 非 tmux: `/dev/tty`
- どちらも不可: `terminal-notifier` → `osascript` にフォールバック（非 WezTerm / headless 用）

## 変更内容

- `canonical/hooks/scripts/notify.sh`（新規）: 共有 advisory 通知ハンドラ。3系統（Claude hooks=stdin/underscore、Codex notify=argv JSON/hyphen）を1本で処理。OSC 777 配信、`set -e` なし・stdout 無出力・常に exit 0・stdin TTY 時はブロック回避
  - フォーマット: `{tool} {✅/⌨️} {repo}` / `{branch} · {window}:{window_name} [{pane}]`（tmux ステータスバー `#I:#W` + `[#P]` と一致）
- `canonical/hooks/claude.hooks.json`: `Stop`→`notify.sh done` / `Notification`(matcher `permission_prompt|idle_prompt`)→`notify.sh wait`（既存 block 系は保持）
- `canonical/hooks/codex.hooks.json`: **変更なし**（block 系のみ）。Codex は通知に lifecycle hook を**使わない**（`Stop` 対話非発火 [openai/codex#17532]、`PermissionRequest` は承認時も発火しないことを実機確認）
- `scripts/sync/apply-codex-notify-config.sh`（新規）+ `sync-codex.sh` 統合: `~/.codex/config.toml` に `notify`（完了→notify.sh）と `[tui] notifications=["approval-requested"] notification_method="osc9"`（入力待ち→ネイティブ）を**冪等適用**（config.toml は Codex が書き換える状態ファイルで symlink 不可のためキー単位、tomllib 検証・backup・同一dir atomic replace）
- `canonical/hooks/README.md` / `CATALOG.md` / `docs/research/2026-03-30-...survey.md`: OSC 方式・Codex 方針・既知ギャップを反映

## 検証結果

| | 完了 | 入力待ち |
|---|---|---|
| Claude | ✅ live | ✅ live（複数セッションで実発火） |
| Codex | ✅ 対話で実発火 | ❌ **tmux 既知ギャップ**（PermissionRequest 非発火・native osc9 は tmux passthrough されず。完了は動くため best-effort 合意内） |

全 shellcheck PASS。`codex doctor` で config parse ok 確認。

## 前提（別 PR / 設定）

- tmux `set -g allow-passthrough on` → dotfiles PR stlwolf/dotfiles#16
- WezTerm.app の macOS 通知許可（手動）
- `terminal-notifier`（フォールバック用）→ dotfiles#15（マージ済）

## マージ後

master から `./scripts/sync.sh` 再実行（現状 hooks symlink が worktree を指すため）。

## レビュー

Copilot レビュー指摘（3巡）反映済み（OSC body サニタイズ、apply の堅牢化、stdin ブロック回避、loc 誤帰属修正 等）。
