### PR TITLE
feat(hooks): worktree/issue からセッション名を自動命名

### DIFF
--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -5,7 +5,7 @@
 ## 前提条件
 
 - `jq` が必要（Homebrew で管理: `etc/init/assets/brew/Brewfile`）
-- Codex は hooks 機能が必要（実験的機能）。`config.toml` の `[features].hooks = true`。旧名 `codex_hooks` は現行版（v0.135 で確認）では `hooks` の legacy alias として扱われ、`codex_hooks = true` のままでも有効（ただし非推奨警告が出るため `hooks` への移行が推奨）
+- Codex は hooks 機能が必要（実験的機能）。`config.toml` の `[features].hooks = true`。旧名 `codex_hooks` は現行版（v0.135 で確認）では `hooks` の legacy alias で、`codex_hooks = true` のままでも有効だが非推奨警告が出る。`sync-codex.sh` → `apply-codex-notify-config.sh` が `[features].hooks = true` を冪等適用し、旧 `codex_hooks` を自動で `hooks` へ移行する（手動編集は不要）
 - 通知フック（`notify.sh`）の配信は **WezTerm の OSC 777 通知**を主とする（tmux 内は DCS passthrough で `#{pane_tty}` へ直書き、非 tmux は `/dev/tty`）。**前提: tmux は `set -g allow-passthrough on`（3.3+, dotfiles の `tmux.conf`）、WezTerm.app に macOS 通知許可**。非 WezTerm / headless 環境では `terminal-notifier`（dotfiles の Brewfile で管理）→ `osascript` にフォールバックする
   - 背景: macOS では CLI/フック文脈から `osascript`/`terminal-notifier` を叩いても通知が表示されないことがある（GUI 権限を持つアプリが出す必要がある）。WezTerm は GUI アプリなので OSC を受けて通知を出せる。詳細は `docs/research/2026-03-30-ai-tool-hooks-specification-survey.md` の追記参照
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -46,7 +46,7 @@
 
 ### 仕組み（3 パート）
 
-- `scripts/wt/wt-pane-issue.sh`（worktrunk post-switch hook、`scripts/sync/sync-bin.sh` で `~/bin/wt-pane-issue` へ配備）: `{{ branch }}` から `#<issue> <slug>` を導出し `~/.claude/state/pane-issue/<TMUX_PANE>` に記録（非 issue ブランチは clear）。`wt switch` のたびに発火（エージェント/人間どちらも）。worktrunk が `{{ branch }}` をシェルクォートするため自前のクォートは付けない。
+- `scripts/wt/wt-pane-issue.sh`（worktrunk post-switch hook、`scripts/sync/sync-bin.sh` で `~/bin/wt-pane-issue` へ配備）: `{{ branch }}` から `#<issue> <slug>` を導出し `~/.claude/state/pane-issue/<tmux server PID>_<pane>` に記録（非 issue ブランチは clear）。`wt switch` のたびに発火（エージェント/人間どちらも）。worktrunk が `{{ branch }}` をシェルクォートするため自前のクォートは付けない。キーに tmux server PID を含めるのは、`tmux kill-server`/再起動で pane id（`%N`）が再採番されても旧 server の stale state と衝突させないため（誤命名防止）。24h 触れられない marker は GC。
 - `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレートは `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外領域**（手動セットアップ。全リポ横断のため user config）。
 - `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）: 同じ `$TMUX_PANE` の state を読み `sessionTitle` を出力 → セッション名＝`#<issue> <slug>`（tmux pane title にも伝播）。`pending` を消費するので 1 switch につき 1 回だけ（以後の手動 `/rename` を尊重）。state が無いセッション（他リポ・master・research 等）は無反応で Claude の自動命名のまま。
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -18,6 +18,7 @@
 | コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
 | CC 形式チェック | `scripts/cc-lint.sh` | `git commit -m` のメッセージが Conventional Commits 形式に準拠しているかチェック |
 | 通知 | `scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory）。並走時のポーリング解消が目的 |
+| セッション命名 | `scripts/session-name.sh` ＋ `scripts/wt/wt-pane-issue.sh` | `wt switch` で worktree(#issue)に移動時、セッション名を `#<issue> <slug>` に自動設定し並列セッションを識別（Claude のみ・advisory） |
 
 ## ツール別カバレッジ
 
@@ -28,11 +29,32 @@
 | コミットゲート | — | `TaskCompleted` | — |
 | CC 形式チェック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | 通知: 完了 | — | `Stop` hook → notify.sh | `notify`(config.toml) → notify.sh |
+| セッション命名 | — | `UserPromptSubmit` → session-name.sh | — |
 | 通知: 入力待ち | — | `Notification`（matcher `permission_prompt\|idle_prompt`） → notify.sh | `[tui] notifications=["approval-requested"]` + `notification_method="osc9"`（ネイティブ）※ |
 
 ※ Codex は通知に lifecycle hook を**使わない**（`Stop` は対話で発火しない報告 [openai/codex#17532]、`PermissionRequest` は対話で承認プロンプトが出ても**発火しないことを実機確認**）。完了は `config.toml` の `notify`→notify.sh（Claude と統一フォーマット）で出る。入力待ちは Codex ネイティブ `[tui] notifications=["approval-requested"]`(osc9) を設定するが、**Codex は OSC を tmux passthrough で包まないため tmux 環境では通知が出ない（実機確認＝既知ギャップ）**。`notify` / `[tui]` は `scripts/sync/apply-codex-notify-config.sh` が `~/.codex/config.toml` へ冪等適用する（symlink 不可な状態ファイルのためキー単位で適用）。
 
 **Codex まとめ**: 完了通知は動作。入力待ち通知は tmux 環境では出ない（best-effort・既知ギャップ。tmux 外なら `[tui] osc9` が機能）。Cursor は既存の通知機構があるため対象外。
+
+## session-name.sh + wt-pane-issue.sh（セッション命名）
+
+並列セッション（複数 worktree）を識別するため、`wt switch` で入った worktree の Issue 番号をセッション名（`#<issue> <slug>`）に自動設定する。Claude Code のみ。
+
+### 背景
+
+`wt switch` は Claude セッションの cwd を worktree に移さない（シェルの `cd` は親プロセス＝Claude に伝わらず、`!pwd` はリポジトリルートのまま）。よって cwd からは active worktree を知れない。代わりに `$TMUX_PANE` を共有キーに、worktrunk の post-switch hook と Claude の `UserPromptSubmit` hook を繋ぐ。
+
+### 仕組み（3 パート）
+
+- `scripts/wt/wt-pane-issue.sh`（worktrunk post-switch hook、`scripts/sync/sync-bin.sh` で `~/bin/wt-pane-issue` へ配備）: `{{ branch }}` から `#<issue> <slug>` を導出し `~/.claude/state/pane-issue/<TMUX_PANE>` に記録（非 issue ブランチは clear）。`wt switch` のたびに発火（エージェント/人間どちらも）。worktrunk が `{{ branch }}` をシェルクォートするため自前のクォートは付けない。
+- `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレートは `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外領域**（手動セットアップ。全リポ横断のため user config）。
+- `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）: 同じ `$TMUX_PANE` の state を読み `sessionTitle` を出力 → セッション名＝`#<issue> <slug>`（tmux pane title にも伝播）。`pending` を消費するので 1 switch につき 1 回だけ（以後の手動 `/rename` を尊重）。state が無いセッション（他リポ・master・research 等）は無反応で Claude の自動命名のまま。
+
+### 注意
+
+- `UserPromptSubmit` の stdout は**モデル文脈に注入される**ため、`jq` で構築した sessionTitle JSON 以外を stdout に出さない（診断は出さない）。
+- グローバル設定ゆえ全セッションで発火するが、**pane state がある時だけ命名する条件付き**設計（他セッションを汚さない）。
+- `jq` / `tmux` が前提。無い場合は no-op（advisory・非ゼロ終了しない）。
 
 ## block-destructive.sh
 

--- a/canonical/hooks/claude.hooks.json
+++ b/canonical/hooks/claude.hooks.json
@@ -50,6 +50,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/session-name.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# session-name.sh — Claude Code UserPromptSubmit hook.
+#
+# Titles the session "#<issue> <slug>" using the active worktree recorded by
+# wt-pane-issue.sh for this tmux pane ($TMUX_PANE). The session name is what
+# Claude Code shows in its UI and writes to the terminal (tmux pane) title, so
+# this is how parallel sessions become identifiable.
+#
+# Emits the title once per worktree switch (the "pending" flag is consumed), so
+# a manual /rename afterwards is preserved. Emits nothing when there is no pane
+# marker — so sessions not on an issue worktree (other repos, master, plain
+# research) keep Claude's automatic Haiku naming untouched. This conditional
+# emit is essential: the hook is registered globally and fires for every
+# session across every repo.
+#
+# Output contract: UserPromptSubmit stdout is injected into the model context,
+# so this emits ONLY a single hookSpecificOutput JSON object (built with jq),
+# or nothing at all. Diagnostics never go to stdout.
+#
+set -uo pipefail
+
+# Drain the hook payload on stdin (unused here).
+cat >/dev/null 2>&1 || true
+
+pane="${TMUX_PANE:-}"
+[ -n "$pane" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+key="${pane//[^A-Za-z0-9]/_}"
+state_file="${HOME}/.claude/state/pane-issue/${key}"
+[ -f "$state_file" ] || exit 0
+
+# Only act on a freshly recorded switch (pending). Otherwise leave the title
+# alone, so a manual /rename is respected.
+[ "$(jq -r '.pending // false' "$state_file" 2>/dev/null)" = "true" ] || exit 0
+
+name="$(jq -r '.name // empty' "$state_file" 2>/dev/null)"
+[ -n "$name" ] || exit 0
+
+# Consume the pending flag (one-shot). Re-emitting the same title later is
+# harmless, so a failed update is not fatal.
+tmp="${state_file}.tmp.$$"
+if jq -c '.pending=false' "$state_file" >"$tmp" 2>/dev/null; then
+  mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+fi
+
+# Emit the session title (and nothing else on stdout).
+jq -cn --arg t "$name" \
+  '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",sessionTitle:$t}}'
+exit 0

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -3,20 +3,21 @@
 # session-name.sh — Claude Code UserPromptSubmit hook.
 #
 # Titles the session "#<issue> <slug>" using the active worktree recorded by
-# wt-pane-issue.sh for this tmux pane ($TMUX_PANE). The session name is what
-# Claude Code shows in its UI and writes to the terminal (tmux pane) title, so
-# this is how parallel sessions become identifiable.
+# wt-pane-issue.sh for this tmux pane. The session name is what Claude Code
+# shows in its UI and writes to the terminal (tmux pane) title, so this is how
+# parallel sessions become identifiable.
 #
 # Emits the title once per worktree switch (the "pending" flag is consumed), so
 # a manual /rename afterwards is preserved. Emits nothing when there is no pane
 # marker — so sessions not on an issue worktree (other repos, master, plain
-# research) keep Claude's automatic Haiku naming untouched. This conditional
-# emit is essential: the hook is registered globally and fires for every
-# session across every repo.
+# research) keep Claude's automatic naming untouched. This conditional emit is
+# essential: the hook is registered globally and fires for every session.
 #
-# Output contract: UserPromptSubmit stdout is injected into the model context,
-# so this emits ONLY a single hookSpecificOutput JSON object (built with jq),
-# or nothing at all. Diagnostics never go to stdout.
+# `sessionTitle` is a documented hookSpecificOutput field for UserPromptSubmit
+# (Claude Code hooks reference) and was verified live (session + tmux pane title
+# rename on submit). UserPromptSubmit stdout is injected into the model context,
+# so this emits ONLY a single hookSpecificOutput JSON object (built with jq), or
+# nothing at all. Diagnostics never go to stdout.
 #
 set -uo pipefail
 
@@ -24,11 +25,16 @@ set -uo pipefail
 cat >/dev/null 2>&1 || true
 
 pane="${TMUX_PANE:-}"
+home="${HOME:-}"
 [ -n "$pane" ] || exit 0
+[ -n "$home" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-key="${pane//[^A-Za-z0-9]/_}"
-state_file="${HOME}/.claude/state/pane-issue/${key}"
+# Same key as wt-pane-issue.sh: tmux server PID + pane id (restart-safe).
+server="${TMUX:-}"; server="${server#*,}"; server="${server%%,*}"
+key="${server}_${pane}"
+key="${key//[^A-Za-z0-9]/_}"
+state_file="${home}/.claude/state/pane-issue/${key}"
 [ -f "$state_file" ] || exit 0
 
 # Only act on a freshly recorded switch (pending). Otherwise leave the title
@@ -38,8 +44,13 @@ state_file="${HOME}/.claude/state/pane-issue/${key}"
 name="$(jq -r '.name // empty' "$state_file" 2>/dev/null)"
 [ -n "$name" ] || exit 0
 
-# Consume the pending flag (one-shot). Re-emitting the same title later is
-# harmless, so a failed update is not fatal.
+# Consume the pending flag (one-shot), then emit. Ordering note: a concurrent
+# `wt switch` between read and write could roll a fresh marker back to
+# pending:false (a rare lost-update), and a crash between consume and emit drops
+# this turn's rename. Both windows are tiny and self-correct on the next
+# switch/prompt. Re-emitting the same title is benign EXCEPT if `mv` permanently
+# fails (e.g. disk full) it could re-assert over a manual /rename — accepted
+# given the rarity.
 tmp="${state_file}.tmp.$$"
 if jq -c '.pending=false' "$state_file" >"$tmp" 2>/dev/null; then
   mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null

--- a/canonical/skills/worktrunk-worktrees/SKILL.md
+++ b/canonical/skills/worktrunk-worktrees/SKILL.md
@@ -50,6 +50,12 @@ wt list
 - `wt list` に新しい worktree が見えているのに `pwd` が想定外なら、「作成は成功したが現在位置だけがずれている」状態として扱う
 - この状態で `wt switch --create` を再実行しない。まず既存 worktree を再利用する
 
+#### Claude Code での挙動（cwd は追従しない）
+
+Claude Code セッションでは、`wt switch` してもセッションの cwd は worktree に**移らない**（シェルの `cd` が親プロセス＝Claude に消費されないため。`!pwd` はリポジトリルートのまま）。これは異常ではなく、ファイル操作は**絶対パス**で行われるため編集は正しく worktree に落ちる（cwd は表示上の話）。worktrunk 本来の「セッション re-root」は `EnterWorktree`（`/wt-switch-create`）経由のときだけ起きる。
+
+cwd が追従しない結果、cwd ベースでは「今どの worktree か」を識別できない。並列セッションの識別は **セッション命名フック**（`canonical/hooks/`、Issue #124）が担う: `wt switch` のたびに `post-switch` hook が `#<issue> <slug>` を記録し、セッション名（→ tmux pane title）へ反映する。設定は `canonical/hooks/README.md` の「session-name.sh」節を参照。
+
 ### 既存 worktree の再利用
 
 作成後に現在位置がずれていた場合や、fallback で別の worktree 進入手段を使いたい場合は、先に既存 worktree の有無を確認する。

--- a/scripts/sync/apply-codex-notify-config.sh
+++ b/scripts/sync/apply-codex-notify-config.sh
@@ -12,6 +12,7 @@
 #   notify                  完了(agent-turn-complete)で notify.sh を起動（Claude と統一フォーマットの OSC 通知）
 #   tui.notifications        入力待ち(approval-requested)を Codex ネイティブ OSC9 で通知
 #   tui.notification_method  osc9（WezTerm が描画。notify は完了のみで入力待ちを拾えないため tui 併用）
+#   features.hooks           Codex hooks 有効化フラグ。旧 codex_hooks を hooks へ移行（v0.135+ で codex_hooks は非推奨 alias）
 #
 # notify は top-level key のため最初のテーブルより前に置く。tui.* は super-table として末尾に追加。
 #
@@ -80,7 +81,35 @@ else
   info "Appended [tui] notifications at bottom"
 fi
 
-# 3) TOML 検証（python3 tomllib があれば）。壊れていたら復元
+# 3) [features].hooks = true（Codex hooks 有効化フラグ）。旧 codex_hooks は v0.135+ で
+#    hooks の legacy alias = 非推奨警告が出るため hooks へ移行する。
+if grep -qE '^[[:space:]]*codex_hooks[[:space:]]*=' "$CONFIG"; then
+  tmp="$(mktemp "${CONFIG}.tmp.XXXXXX" 2>/dev/null)" || { rm -f "$backup"; warn "tmp 作成失敗のため変更しません"; exit 0; }
+  if sed 's/^\([[:space:]]*\)codex_hooks\([[:space:]]*=\)/\1hooks\2/' "$CONFIG" > "$tmp"; then
+    mv "$tmp" "$CONFIG" || { rm -f "$tmp" "$backup"; warn "config 置換に失敗したため変更しません"; exit 0; }
+    changed=1
+    info "Migrated [features].codex_hooks -> hooks"
+  else
+    rm -f "$tmp"; warn "codex_hooks の移行に失敗（skip）"
+  fi
+elif grep -qE '^[[:space:]]*hooks[[:space:]]*=' "$CONFIG"; then
+  info "[features].hooks already present (skip)"
+elif grep -qE '^[[:space:]]*\[features\][[:space:]]*$' "$CONFIG"; then
+  tmp="$(mktemp "${CONFIG}.tmp.XXXXXX" 2>/dev/null)" || { rm -f "$backup"; warn "tmp 作成失敗のため変更しません"; exit 0; }
+  if awk '{print} /^[[:space:]]*\[features\][[:space:]]*$/ && !ins {print "hooks = true"; ins=1}' "$CONFIG" > "$tmp"; then
+    mv "$tmp" "$CONFIG" || { rm -f "$tmp" "$backup"; warn "config 置換に失敗したため変更しません"; exit 0; }
+    changed=1
+    info "Inserted hooks = true into [features]"
+  else
+    rm -f "$tmp"; warn "[features].hooks の追記に失敗（skip）"
+  fi
+else
+  printf '\n[features]\nhooks = true\n' >> "$CONFIG"
+  changed=1
+  info "Appended [features] with hooks = true"
+fi
+
+# 4) TOML 検証（python3 tomllib があれば）。壊れていたら復元
 if command -v python3 >/dev/null 2>&1 && python3 -c 'import tomllib' >/dev/null 2>&1; then
   if python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' "$CONFIG" 2>/dev/null; then
     info "TOML parse OK"

--- a/scripts/sync/sync-bin.sh
+++ b/scripts/sync/sync-bin.sh
@@ -42,11 +42,12 @@ usage() {
 
 [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
 
-CMD_NAMES=("so-compare" "arena-compare" "wez")
+CMD_NAMES=("so-compare" "arena-compare" "wez" "wt-pane-issue")
 CMD_SOURCES=(
     "${REPO_ROOT}/scripts/so-compare.sh"
     "${REPO_ROOT}/projects/arena-compare/arena-compare.sh"
     "${REPO_ROOT}/projects/wezterm-ai-mode/bin/wez"
+    "${REPO_ROOT}/scripts/wt/wt-pane-issue.sh"
 )
 
 main() {

--- a/scripts/wt/worktrunk-config.toml
+++ b/scripts/wt/worktrunk-config.toml
@@ -1,0 +1,20 @@
+# worktrunk user config — Claude Code session-naming integration (#124).
+#
+# Install into worktrunk's USER config so it applies across ALL repositories
+# (a project .config/wt.toml would only cover one repo):
+#
+#   mkdir -p ~/.config/worktrunk
+#   # merge the [post-switch] block below into ~/.config/worktrunk/config.toml
+#
+# Requires `wt-pane-issue` on PATH (scripts/sync/sync-bin.sh → ~/bin/wt-pane-issue).
+#
+# On every `wt switch`, worktrunk runs this post-switch hook with the resolved
+# branch. wt-pane-issue records "#<issue> <slug>" for the current tmux pane;
+# the Claude Code UserPromptSubmit hook (canonical/hooks/scripts/session-name.sh)
+# then titles the session accordingly. cwd-independent and fires for both agent
+# and human `wt switch`.
+#
+# NOTE: worktrunk shell-quotes {{ branch }} on substitution (it expands to
+# '<branch>'), so do NOT add your own quotes around it.
+[post-switch]
+claude-session-name = 'wt-pane-issue {{ branch }}'

--- a/scripts/wt/wt-pane-issue.sh
+++ b/scripts/wt/wt-pane-issue.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# wt-pane-issue.sh — worktrunk post-switch hook helper.
+#
+# Records the active issue for the current tmux pane so the Claude Code
+# UserPromptSubmit hook (session-name.sh) can title the session
+# "#<issue> <slug>". Keyed by $TMUX_PANE so parallel sessions stay isolated.
+#
+# Why this exists: `wt switch` does NOT move the Claude session's cwd (the
+# shell cd is not consumed by the parent process), so neither Claude hooks nor
+# notify.sh can learn the active worktree from cwd. worktrunk's own post-switch
+# hook fires on every `wt switch` (agent or human) with the resolved branch, so
+# we capture it here, keyed by the tmux pane the session lives in.
+#
+# Invoked from ~/.config/worktrunk/config.toml:
+#   [post-switch]
+#   claude-session-name = 'wt-pane-issue "{{ branch }}"'
+#
+# Advisory: never fails the wt operation (always exits 0), writes nothing to
+# stdout. No-op outside tmux or without jq.
+#
+set -uo pipefail
+
+branch="${1:-}"
+pane="${TMUX_PANE:-}"
+
+# Need a tmux pane to key on, and jq to write JSON safely.
+[ -n "$pane" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+key="${pane//[^A-Za-z0-9]/_}"
+state_dir="${HOME}/.claude/state/pane-issue"
+state_file="${state_dir}/${key}"
+
+# Derive "#<issue> <slug>" from "{prefix}/#<issue>_<desc>"; empty otherwise.
+name=""
+if [[ "$branch" =~ ^[a-z]+/#([0-9]+)_(.+)$ ]]; then
+  name="#${BASH_REMATCH[1]} ${BASH_REMATCH[2]//_/-}"
+fi
+
+mkdir -p "$state_dir" 2>/dev/null || exit 0
+
+# Non-issue branch (master, `wt switch ^`, pr:, etc.) → clear the marker.
+if [ -z "$name" ]; then
+  rm -f "$state_file" 2>/dev/null || true
+  exit 0
+fi
+
+# Record {name, pending:true} atomically. `pending` drives a one-shot rename
+# on the next UserPromptSubmit, after which a manual /rename is respected.
+tmp="${state_file}.tmp.$$"
+if jq -cn --arg n "$name" '{name:$n, pending:true}' >"$tmp" 2>/dev/null; then
+  mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+fi
+exit 0

--- a/scripts/wt/wt-pane-issue.sh
+++ b/scripts/wt/wt-pane-issue.sh
@@ -4,7 +4,7 @@
 #
 # Records the active issue for the current tmux pane so the Claude Code
 # UserPromptSubmit hook (session-name.sh) can title the session
-# "#<issue> <slug>". Keyed by $TMUX_PANE so parallel sessions stay isolated.
+# "#<issue> <slug>".
 #
 # Why this exists: `wt switch` does NOT move the Claude session's cwd (the
 # shell cd is not consumed by the parent process), so neither Claude hooks nor
@@ -12,9 +12,10 @@
 # hook fires on every `wt switch` (agent or human) with the resolved branch, so
 # we capture it here, keyed by the tmux pane the session lives in.
 #
-# Invoked from ~/.config/worktrunk/config.toml:
+# Invoked from ~/.config/worktrunk/config.toml (worktrunk shell-quotes
+# {{ branch }}, so do NOT add your own quotes):
 #   [post-switch]
-#   claude-session-name = 'wt-pane-issue "{{ branch }}"'
+#   claude-session-name = 'wt-pane-issue {{ branch }}'
 #
 # Advisory: never fails the wt operation (always exits 0), writes nothing to
 # stdout. No-op outside tmux or without jq.
@@ -23,22 +24,39 @@ set -uo pipefail
 
 branch="${1:-}"
 pane="${TMUX_PANE:-}"
+home="${HOME:-}"
 
-# Need a tmux pane to key on, and jq to write JSON safely.
+# Need a tmux pane to key on, $HOME for state, and jq to write JSON safely.
 [ -n "$pane" ] || exit 0
+[ -n "$home" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-key="${pane//[^A-Za-z0-9]/_}"
-state_dir="${HOME}/.claude/state/pane-issue"
+# Key by tmux server PID + pane id. $TMUX_PANE (%N) is only unique within one
+# tmux server; after `tmux kill-server`/restart panes renumber from %0. Folding
+# in the server PID (field 2 of $TMUX = "socket,pid,session") means a reused
+# pane id under a new server gets a fresh key, so stale state from a previous
+# server can never misname an unrelated session.
+server="${TMUX:-}"; server="${server#*,}"; server="${server%%,*}"
+key="${server}_${pane}"
+key="${key//[^A-Za-z0-9]/_}"
+
+state_dir="${home}/.claude/state/pane-issue"
 state_file="${state_dir}/${key}"
 
 # Derive "#<issue> <slug>" from "{prefix}/#<issue>_<desc>"; empty otherwise.
+# Cap slug length defensively (jq --arg already makes it JSON-safe, and git ref
+# names forbid control chars, so there is no escape-injection surface).
 name=""
 if [[ "$branch" =~ ^[a-z]+/#([0-9]+)_(.+)$ ]]; then
-  name="#${BASH_REMATCH[1]} ${BASH_REMATCH[2]//_/-}"
+  slug="${BASH_REMATCH[2]//_/-}"
+  name="#${BASH_REMATCH[1]} ${slug:0:48}"
 fi
 
 mkdir -p "$state_dir" 2>/dev/null || exit 0
+
+# Opportunistic GC: markers untouched for >24h are orphans (consumed long ago,
+# or left by a now-dead server). Bounds unbounded growth. Runs before we write.
+find "$state_dir" -maxdepth 1 -type f -mmin +1440 -delete 2>/dev/null || true
 
 # Non-issue branch (master, `wt switch ^`, pr:, etc.) → clear the marker.
 if [ -z "$name" ]; then


### PR DESCRIPTION
Refs #124

## 目的

複数 worktree の並列 Claude Code セッションを識別するため、`wt switch` で入った worktree の Issue 番号をセッション名 `#<issue> <slug>` に自動設定する（Claude UI ＋ tmux pane title に反映）。

## 背景（なぜ cwd ベースにしないか）

`wt switch` は Claude セッションの cwd を worktree に移さない（シェルの `cd` が親プロセス＝Claude に消費されない。実機 `!pwd` で確認＝リポジトリルートのまま）。よって cwd からは active worktree を知れない。代わりに **`$TMUX_PANE`（+ tmux server PID）を共有キー**に、worktrunk の post-switch hook と Claude の UserPromptSubmit hook を繋ぐ。worktrunk 本来のセッション re-root は `EnterWorktree`（`/wt-switch-create`）経由のときだけで、`wt switch` 運用では起きない。

## 仕組み（3 パート）

- `scripts/wt/wt-pane-issue.sh`（worktrunk **post-switch** hook、`sync-bin.sh` で `~/bin/wt-pane-issue` へ配備）: `{{ branch }}` から `#<issue> <slug>` を導出し `~/.claude/state/pane-issue/<server PID>_<pane>` に記録（非 issue は clear、24h 未触は GC）。エージェント/人間どちらの `wt switch` でも発火。
- `canonical/hooks/scripts/session-name.sh`（Claude **UserPromptSubmit** hook）: 同 pane の state を読み `sessionTitle` を `jq` で安全出力 → セッション名＝`#<issue> <slug>`。`pending` 消費で 1 switch 1 回・以後の手動 `/rename` を尊重。state が無いセッション（他リポ・master・research）は無反応で自動命名のまま。
- `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレート `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外＝手動セットアップ**（全リポ横断のため user config）。

## デプロイ手順

```bash
./scripts/sync.sh                 # sync-bin: ~/bin/wt-pane-issue / sync-claude: session-name.sh + claude.hooks.json マージ
mkdir -p ~/.config/worktrunk      # scripts/wt/worktrunk-config.toml の [post-switch] を config.toml にマージ
```

hooks は hot-reload するため再起動不要。

## テスト

- `shellcheck`: PASS（`wt-pane-issue.sh` / `session-name.sh` / `sync-bin.sh` / `apply-codex-notify-config.sh`）
- 単体: branch→name 導出 / `pending` 消費（set-once）/ 非 issue clear / slug truncate / `HOME` 未設定 exit0
- 実機 e2e: worktrunk post-switch → state 記録 → UserPromptSubmit → セッション改名（tmux pane title へ伝播）を確認

## レビュー（peer-ai-review / so-compare）

Claude レビュー実施。Codex レーンは `gpt-5.3-codex` が ChatGPT アカウント非対応のため失敗（2者＋ユーザー承認で代替）。指摘対応:

- **H1**: pane key に tmux server PID を追加し、`tmux kill-server`/再起動での pane id 再採番による別セッション誤命名を防止（＋24h GC）
- **L1** slug truncate / **L2** `HOME` 未設定ガード / **M1・M2・L3** は仕様・トレードオフをコメントで明文化

## 追加: Codex `[features].hooks` の codify（同ブランチに同梱）

レビュー中に判明した別件: `~/.codex/config.toml` の hooks 有効化フラグが手動編集依存で、Codex v0.135 の `codex_hooks`→`hooks` 非推奨化により起動時警告が出ていた。`apply-codex-notify-config.sh` に **`[features].hooks = true` の冪等適用＋旧 `codex_hooks` の自動移行**を追加（migrate / skip / awk挿入 / 末尾追記の4ケースを単体テスト + TOML 検証）。次回 `./scripts/sync.sh` で自動移行され、再セットアップ時の再発も防止。

## 影響範囲

- 命名 hook はグローバル発火だが **pane state がある時だけ命名**（他セッション・他リポを汚さない）
- 既存 hook（Stop / Notification / PreToolUse / TaskCompleted）は不変
- `notify.sh` 変更なし
- 命名は Claude のみ（`sessionTitle` 対応は Claude 固有）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
