### PR TITLE
feat(hooks): 無名セッションを初回プロンプトで命名し通知にセッション名を表示

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -87,7 +87,8 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | force push ブロック | `hooks/scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
 | CC 形式チェック | `hooks/scripts/cc-lint.sh` | `git commit -m` の Conventional Commits 形式を検証（3ツール共通） |
 | コミットゲート | `hooks/scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（Claude Code のみ） |
-| 通知 | `hooks/scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory、並走時のポーリング解消） |
+| 通知 | `hooks/scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory、並走時のポーリング解消）。loc にセッション名を表示 |
+| セッション命名 | `hooks/scripts/session-name.sh` | セッション名を自動設定（Claude Code のみ・UserPromptSubmit）。worktree は `#<issue> <slug>`（`scripts/wt/wt-pane-issue.sh`＝worktrunk post-switch と連携）、それ以外の無名セッションはリポ名。並列セッション識別用 |
 
 ## ツール固有拡張
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -38,7 +38,7 @@
 
 ## session-name.sh + wt-pane-issue.sh（セッション命名）
 
-並列セッションを識別するため、セッション名を自動設定する（Claude Code のみ）。(1) `wt switch` で入った worktree のセッションは Issue 番号＝`#<issue> <slug>`。(2) それ以外の無名セッションは初回プロンプト（空ならリポ名）から簡易命名し、常に名前が付いている状態にする。plan-accept / 手動 `/rename` は尊重。
+並列セッションを識別するため、セッション名を自動設定する（Claude Code のみ）。(1) `wt switch` で入った worktree のセッションは Issue 番号＝`#<issue> <slug>`。(2) それ以外の無名セッションは**リポ名**（payload `cwd` 由来）で命名し、常に名前が付いている状態にする。plan-accept / 手動 `/rename` は尊重。
 
 ### 背景
 
@@ -50,12 +50,12 @@
 - `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレートは `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外領域**（手動セットアップ。全リポ横断のため user config）。
 - `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）:
   - **Path1（issue）**: 同じ `$TMUX_PANE` の state があれば `sessionTitle`＝`#<issue> <slug>` を出力（tmux pane title にも伝播）。`pending` 消費で 1 switch 1 回（手動 `/rename` を尊重）。**issue pane は早期 return**し Path2 に落ちない（#issue 名を保護）。
-  - **Path2（フォールバック）**: state 無し＆無名（payload `session_title` 空）＆非 plan のセッションは、初回プロンプト先頭〜80byte（マルチバイト保持・UTF-8 境界 truncate、空なら payload `cwd` のリポ名）から簡易命名。**session_id キーのマーカー**で set-once（往復非依存・非 tmux でも可）。命名済 / plan-accept / スラッシュコマンド始まりは命名しない。
+  - **Path2（フォールバック）**: state 無し＆無名（payload `session_title` 空）＆非 plan のセッションは、**payload `cwd` のリポ名**で命名。prompt 文字列は**使わない**（pane title / 通知に伝播するため、秘密混入の漏洩チャネルを避ける）。**session_id キーのマーカー**（専用 dir `state/session-named/`、pane-issue の GC 対象外）で set-once（往復非依存・非 tmux でも可）。命名済 / plan-accept / スラッシュコマンド始まりは命名しない。
 
 ### 注意
 
 - `UserPromptSubmit` の stdout は**モデル文脈に注入される**ため、`jq` で構築した sessionTitle JSON 以外を stdout に出さない（診断は出さない）。
-- グローバル設定ゆえ全セッション・全リポで発火する。issue worktree は `#issue`、それ以外の無名セッションは初回プロンプト由来名で命名する（命名済・plan-accept・手動 `/rename` は不変。スラッシュコマンド始まりは命名源にしない）。
+- グローバル設定ゆえ全セッション・全リポで発火する。issue worktree は `#issue`、それ以外の無名セッションは**リポ名**で命名する（prompt 文字列は出さない＝秘密漏洩を避ける。命名済・plan-accept・手動 `/rename` は不変）。
 - `jq` / `tmux` が前提。無い場合は no-op（advisory・非ゼロ終了しない）。
 
 ## block-destructive.sh

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -38,7 +38,7 @@
 
 ## session-name.sh + wt-pane-issue.sh（セッション命名）
 
-並列セッション（複数 worktree）を識別するため、`wt switch` で入った worktree の Issue 番号をセッション名（`#<issue> <slug>`）に自動設定する。Claude Code のみ。
+並列セッションを識別するため、セッション名を自動設定する（Claude Code のみ）。(1) `wt switch` で入った worktree のセッションは Issue 番号＝`#<issue> <slug>`。(2) それ以外の無名セッションは初回プロンプト（空ならリポ名）から簡易命名し、常に名前が付いている状態にする。plan-accept / 手動 `/rename` は尊重。
 
 ### 背景
 
@@ -48,12 +48,14 @@
 
 - `scripts/wt/wt-pane-issue.sh`（worktrunk post-switch hook、`scripts/sync/sync-bin.sh` で `~/bin/wt-pane-issue` へ配備）: `{{ branch }}` から `#<issue> <slug>` を導出し `~/.claude/state/pane-issue/<tmux server PID>_<pane>` に記録（非 issue ブランチは clear）。`wt switch` のたびに発火（エージェント/人間どちらも）。worktrunk が `{{ branch }}` をシェルクォートするため自前のクォートは付けない。キーに tmux server PID を含めるのは、`tmux kill-server`/再起動で pane id（`%N`）が再採番されても旧 server の stale state と衝突させないため（誤命名防止）。24h 触れられない marker は GC。
 - `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレートは `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外領域**（手動セットアップ。全リポ横断のため user config）。
-- `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）: 同じ `$TMUX_PANE` の state を読み `sessionTitle` を出力 → セッション名＝`#<issue> <slug>`（tmux pane title にも伝播）。`pending` を消費するので 1 switch につき 1 回だけ（以後の手動 `/rename` を尊重）。state が無いセッション（他リポ・master・research 等）は無反応で Claude の自動命名のまま。
+- `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）:
+  - **Path1（issue）**: 同じ `$TMUX_PANE` の state があれば `sessionTitle`＝`#<issue> <slug>` を出力（tmux pane title にも伝播）。`pending` 消費で 1 switch 1 回（手動 `/rename` を尊重）。**issue pane は早期 return**し Path2 に落ちない（#issue 名を保護）。
+  - **Path2（フォールバック）**: state 無し＆無名（payload `session_title` 空）＆非 plan のセッションは、初回プロンプト先頭〜80byte（マルチバイト保持・UTF-8 境界 truncate、空なら payload `cwd` のリポ名）から簡易命名。**session_id キーのマーカー**で set-once（往復非依存・非 tmux でも可）。命名済 / plan-accept / スラッシュコマンド始まりは命名しない。
 
 ### 注意
 
 - `UserPromptSubmit` の stdout は**モデル文脈に注入される**ため、`jq` で構築した sessionTitle JSON 以外を stdout に出さない（診断は出さない）。
-- グローバル設定ゆえ全セッションで発火するが、**pane state がある時だけ命名する条件付き**設計（他セッションを汚さない）。
+- グローバル設定ゆえ全セッション・全リポで発火する。issue worktree は `#issue`、それ以外の無名セッションは初回プロンプト由来名で命名する（命名済・plan-accept・手動 `/rename` は不変。スラッシュコマンド始まりは命名源にしない）。
 - `jq` / `tmux` が前提。無い場合は no-op（advisory・非ゼロ終了しない）。
 
 ## block-destructive.sh

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -66,10 +66,11 @@ if [[ -n "${TMUX:-}" ]]; then
     pt="$(tmux display-message -t "$pane" -p '#{pane_tty}' 2>/dev/null || true)"
     # 居場所: window番号:window名 [セッション名]（#126: 旧 [#{pane_index}] を pane_title=
     # セッション名に差し替え。window 番号ナビは #{window_index} を維持。
-    # - 非空判定は #{!=:#{pane_title},} で明示（#{?str,} は条件を数値解釈し得るため）
-    # - 空（未命名/非Claudeペイン）なら #{pane_index} にフォールバックして [] を避ける
     # - 先頭の Claude 状態グリフ（"⠐ " 等＝1文字+空白）は #{s/^. //} で除去
-    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{?#{!=:#{pane_title},},#{s/^. //:pane_title},#{pane_index}}]' 2>/dev/null || true)"
+    # - 非空判定は「除去後」の値に対して #{!=:...,} で行う（グリフのみのタイトルが
+    #   除去後に空になるケースで [] になるのを防ぐ）
+    # - 空（未命名/非Claudeペイン/グリフのみ）なら #{pane_index} にフォールバック
+    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{?#{!=:#{s/^. //:pane_title},},#{s/^. //:pane_title},#{pane_index}}]' 2>/dev/null || true)"
   else
     # $TMUX_PANE 不在: 配信はアクティブペイン TTY 経由（通知は window レベルで表示される）。
     # ただし loc はアクティブペインを指すと別ペインの通知に誤った番号が付くため省略する。

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -13,7 +13,7 @@
 #   Codex notify      : 第1引数 = JSON 文字列（hyphen キー, type=agent-turn-complete）→ tool=Codex
 #
 # 通知フォーマット:
-#   title: "{tool} {✅|⌨️} {repo}"   body: "{branch} · {window_index}:{window_name} [{pane_index}] — {message}"
+#   title: "{tool} {✅|⌨️} {repo}"   body: "{branch} · {window_index}:{window_name} [{session_name}] — {message}"
 #
 # advisory 契約: 非ゼロ exit を出さない / stdout 無出力 / 末尾は無条件 exit 0。
 # デバッグ: NOTIFY_DEBUG=1 または ~/.notify-hook-debug で /tmp/notify-hook.log に記録。
@@ -64,8 +64,10 @@ if [[ -n "${TMUX:-}" ]]; then
   if [[ -n "$pane" ]]; then
     # 発火元ペインが特定できる場合のみ TTY と loc を取る
     pt="$(tmux display-message -t "$pane" -p '#{pane_tty}' 2>/dev/null || true)"
-    # 居場所: window番号:window名 [pane]（tmux ステータスバーの #I:#W と status-left [#P] に一致。番号移動は window 番号）
-    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{pane_index}]' 2>/dev/null || true)"
+    # 居場所: window番号:window名 [セッション名]（#126: 旧 [#{pane_index}] を pane_title=
+    # セッション名に差し替え、どのセッションかを名前で識別できるようにした。window 番号
+    # ナビは #{window_index} を維持。pane_title は Claude が状態グリフ付きで設定する）
+    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{pane_title}]' 2>/dev/null || true)"
   else
     # $TMUX_PANE 不在: 配信はアクティブペイン TTY 経由（通知は window レベルで表示される）。
     # ただし loc はアクティブペインを指すと別ペインの通知に誤った番号が付くため省略する。

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -66,8 +66,9 @@ if [[ -n "${TMUX:-}" ]]; then
     pt="$(tmux display-message -t "$pane" -p '#{pane_tty}' 2>/dev/null || true)"
     # 居場所: window番号:window名 [セッション名]（#126: 旧 [#{pane_index}] を pane_title=
     # セッション名に差し替え、どのセッションかを名前で識別できるようにした。window 番号
-    # ナビは #{window_index} を維持。pane_title は Claude が状態グリフ付きで設定する）
-    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{pane_title}]' 2>/dev/null || true)"
+    # ナビは #{window_index} を維持。pane_title が空（未命名/非Claudeペイン）の時は
+    # pane_index にフォールバックして [] にしない。pane_title は Claude が状態グリフ付きで設定）
+    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{?#{pane_title},#{pane_title},#{pane_index}}]' 2>/dev/null || true)"
   else
     # $TMUX_PANE 不在: 配信はアクティブペイン TTY 経由（通知は window レベルで表示される）。
     # ただし loc はアクティブペインを指すと別ペインの通知に誤った番号が付くため省略する。

--- a/canonical/hooks/scripts/notify.sh
+++ b/canonical/hooks/scripts/notify.sh
@@ -65,10 +65,11 @@ if [[ -n "${TMUX:-}" ]]; then
     # 発火元ペインが特定できる場合のみ TTY と loc を取る
     pt="$(tmux display-message -t "$pane" -p '#{pane_tty}' 2>/dev/null || true)"
     # 居場所: window番号:window名 [セッション名]（#126: 旧 [#{pane_index}] を pane_title=
-    # セッション名に差し替え、どのセッションかを名前で識別できるようにした。window 番号
-    # ナビは #{window_index} を維持。pane_title が空（未命名/非Claudeペイン）の時は
-    # pane_index にフォールバックして [] にしない。pane_title は Claude が状態グリフ付きで設定）
-    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{?#{pane_title},#{pane_title},#{pane_index}}]' 2>/dev/null || true)"
+    # セッション名に差し替え。window 番号ナビは #{window_index} を維持。
+    # - 非空判定は #{!=:#{pane_title},} で明示（#{?str,} は条件を数値解釈し得るため）
+    # - 空（未命名/非Claudeペイン）なら #{pane_index} にフォールバックして [] を避ける
+    # - 先頭の Claude 状態グリフ（"⠐ " 等＝1文字+空白）は #{s/^. //} で除去
+    loc="$(tmux display-message -t "$pane" -p '#{window_index}:#{window_name} [#{?#{!=:#{pane_title},},#{s/^. //:pane_title},#{pane_index}}]' 2>/dev/null || true)"
   else
     # $TMUX_PANE 不在: 配信はアクティブペイン TTY 経由（通知は window レベルで表示される）。
     # ただし loc はアクティブペインを指すと別ペインの通知に誤った番号が付くため省略する。

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -7,73 +7,96 @@
 # the pane title (notify.sh) — can be told apart. Two behaviors, in priority:
 #
 #   1. Active issue worktree: when wt-pane-issue.sh recorded "#<issue> <slug>"
-#      for this tmux pane (on `wt switch`), title the session with it. Emitted
-#      once per switch (the "pending" flag is consumed) so a later manual
-#      /rename is preserved.
+#      for this tmux pane (on `wt switch`), title the session with it, once per
+#      switch (the "pending" flag is consumed). An issue pane is handled here
+#      and NEVER falls through to the fallback below (which would clobber it).
 #   2. Fallback (unnamed, non-issue): Claude's built-in auto-naming only fires
 #      on plan-accept or `/rename`, so a plain session can stay nameless. If the
-#      session has no name yet (payload `session_title` empty) and is not in
-#      plan mode, derive a simple name from the first prompt. Once named, the
-#      payload's session_title is non-empty on later prompts, so this is a
-#      natural set-once that respects plan-accept / manual renames.
+#      session has no name yet and is not in plan mode, name it from the first
+#      prompt (or, if that's empty, the repository directory name). A per-session
+#      marker makes this set-once regardless of whether the hook-set title shows
+#      up in a later payload, and works with or without tmux.
 #
 # `sessionTitle` is a documented hookSpecificOutput field for UserPromptSubmit
-# (Claude Code hooks reference) and was verified live. UserPromptSubmit stdout
-# is injected into the model context, so this emits ONLY a single
-# hookSpecificOutput JSON object (built with jq), or nothing. No diagnostics to
-# stdout.
+# (Claude Code hooks reference), verified live. UserPromptSubmit stdout is
+# injected into the model context, so this emits ONLY a single hookSpecificOutput
+# JSON object (built with jq), or nothing. No diagnostics to stdout.
 #
 set -uo pipefail
 
 payload="$(cat 2>/dev/null || true)"
-
-pane="${TMUX_PANE:-}"
 home="${HOME:-}"
-[ -n "$pane" ] || exit 0
 [ -n "$home" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-# Emit a sessionTitle and exit. Nothing but this JSON ever reaches stdout; if jq
-# fails (e.g. invalid UTF-8 after truncation) emit nothing.
+state_dir="${home}/.claude/state/pane-issue"
+
+# Emit a sessionTitle and exit. Nothing but this JSON reaches stdout; on jq
+# failure emit nothing. The prompt is already control-char-stripped and kept
+# valid UTF-8 (iconv), and jq --arg JSON-escapes it. With a marker path ($2),
+# touch it only on a successful emit so the fallback stays set-once.
 emit_title() {
   local out
   out="$(jq -cn --arg t "$1" \
     '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",sessionTitle:$t}}' 2>/dev/null)" || exit 0
-  [ -n "$out" ] && printf '%s' "$out"
+  [ -n "$out" ] || exit 0
+  if [ -n "${2:-}" ]; then : > "$2" 2>/dev/null || true; fi
+  printf '%s' "$out"
   exit 0
 }
 
-# --- 1) Active issue worktree (recorded by wt-pane-issue.sh) ---
-# Key by tmux server PID + pane id (restart-safe), identical to wt-pane-issue.sh.
-server="${TMUX:-}"; server="${server#*,}"; server="${server%%,*}"
-key="${server}_${pane}"; key="${key//[^A-Za-z0-9]/_}"
-state_file="${home}/.claude/state/pane-issue/${key}"
-
-if [ -f "$state_file" ] && [ "$(jq -r '.pending // false' "$state_file" 2>/dev/null)" = "true" ]; then
-  name="$(jq -r '.name // empty' "$state_file" 2>/dev/null)"
-  if [ -n "$name" ]; then
-    # Consume pending (one-shot per switch). A concurrent `wt switch` between
-    # read and write is a rare lost-update; re-emit of the same title is benign.
-    tmp="${state_file}.tmp.$$"
-    if jq -c '.pending=false' "$state_file" >"$tmp" 2>/dev/null; then
-      mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+# --- 1) Active issue worktree (tmux pane keyed; recorded by wt-pane-issue.sh) ---
+pane="${TMUX_PANE:-}"
+if [ -n "$pane" ]; then
+  server="${TMUX:-}"; server="${server#*,}"; server="${server%%,*}"
+  key="${server}_${pane}"; key="${key//[^A-Za-z0-9]/_}"
+  state_file="${state_dir}/${key}"
+  if [ -f "$state_file" ]; then
+    # Issue pane: Path 1 owns naming and must not fall through to the fallback.
+    if [ "$(jq -r '.pending // false' "$state_file" 2>/dev/null)" = "true" ]; then
+      name="$(jq -r '.name // empty' "$state_file" 2>/dev/null)"
+      if [ -n "$name" ]; then
+        tmp="${state_file}.tmp.$$"
+        if jq -c '.pending=false' "$state_file" >"$tmp" 2>/dev/null; then
+          mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+        fi
+        emit_title "$name"
+      fi
     fi
-    emit_title "$name"
+    exit 0
   fi
 fi
 
-# --- 2) Fallback: name an unnamed, non-issue session from its first prompt ---
-# Skip when already named (session_title present) or in plan mode (let
-# plan-accept name it from the plan).
+# --- 2) Fallback: name an unnamed, non-issue session on its first prompt ---
+# Respect an existing name (manual /rename, plan-accept) and plan mode.
 [ -z "$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)" ] || exit 0
 [ "$(printf '%s' "$payload" | jq -r '.permission_mode // ""' 2>/dev/null || true)" != "plan" ] || exit 0
 
+# Set-once via a per-session marker (session_id keyed) — independent of payload
+# round-trip, and works without tmux.
+sid="$(printf '%s' "$payload" | jq -r '.session_id // ""' 2>/dev/null || true)"
+[ -n "$sid" ] || exit 0
+mkdir -p "$state_dir" 2>/dev/null || exit 0
+marker="${state_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').named"
+[ -f "$marker" ] && exit 0
+
 prompt="$(printf '%s' "$payload" | jq -r '.prompt // ""' 2>/dev/null || true)"
-# Drop control chars, collapse whitespace; keep multibyte as-is (no ASCII
-# slugging — it would erase Japanese prompts). Truncate to ~80 bytes at a valid
-# UTF-8 boundary (iconv -c drops a clipped trailing multibyte char).
-fallback="$(printf '%s' "$prompt" | tr '\n\r\t' '   ' | tr -d '\000-\037' | sed 's/  */ /g; s/^ *//; s/ *$//')"
+# Don't name a session after a slash command (e.g. /rename, /clear).
+case "$prompt" in /*) exit 0 ;; esac
+
+# Prefer the first prompt: drop control chars, collapse whitespace, keep
+# multibyte as-is (no ASCII slugging — it would erase Japanese), truncate to
+# ~80 bytes on a UTF-8 boundary (iconv -c trims a clipped trailing char).
+fallback="$(printf '%s' "$prompt" | tr '\n\r\t' '   ' | tr -d '\000-\037' | sed 's/  */ /g; s/^ *//; s/ *$//' 2>/dev/null || true)"
 fallback="$(printf '%s' "$fallback" | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
-fallback="$(printf '%s' "$fallback" | sed 's/ *$//')"
+fallback="$(printf '%s' "$fallback" | sed 's/ *$//' 2>/dev/null || true)"
+
+# If the prompt yielded nothing usable, fall back to the repo directory name
+# (payload cwd is the launch repo root; stable identifier — dotfiles#17 finding).
+if [ -z "$fallback" ]; then
+  cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null || true)"
+  [ -n "$cwd" ] && fallback="$(basename "$cwd" 2>/dev/null || true)"
+fi
 [ -n "$fallback" ] || exit 0
-emit_title "$fallback"
+
+emit_title "$fallback" "$marker"

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -11,11 +11,12 @@
 #      switch (the "pending" flag is consumed). An issue pane is handled here
 #      and NEVER falls through to the fallback below (which would clobber it).
 #   2. Fallback (unnamed, non-issue): Claude's built-in auto-naming only fires
-#      on plan-accept or `/rename`, so a plain session can stay nameless. If the
-#      session has no name yet and is not in plan mode, name it from the first
-#      prompt (or, if that's empty, the repository directory name). A per-session
-#      marker makes this set-once regardless of whether the hook-set title shows
-#      up in a later payload, and works with or without tmux.
+#      on plan-accept or `/rename`, so a plain session can stay nameless. Name
+#      it after the repository directory (payload cwd) — NOT the prompt text:
+#      the title propagates to the tmux pane title and OS notifications, so
+#      prompt content (which may contain secrets) must not leak there. A
+#      per-session marker in a dedicated dir (not touched by wt-pane-issue.sh's
+#      pane-issue GC) makes this set-once.
 #
 # `sessionTitle` is a documented hookSpecificOutput field for UserPromptSubmit
 # (Claude Code hooks reference), verified live. UserPromptSubmit stdout is
@@ -32,9 +33,8 @@ command -v jq >/dev/null 2>&1 || exit 0
 state_dir="${home}/.claude/state/pane-issue"
 
 # Emit a sessionTitle and exit. Nothing but this JSON reaches stdout; on jq
-# failure emit nothing. The prompt is already control-char-stripped and kept
-# valid UTF-8 (iconv), and jq --arg JSON-escapes it. With a marker path ($2),
-# touch it only on a successful emit so the fallback stays set-once.
+# failure emit nothing. jq --arg JSON-escapes the title. With a marker path
+# ($2), touch it only on a successful emit so the fallback stays set-once.
 emit_title() {
   local out
   out="$(jq -cn --arg t "$1" \
@@ -67,36 +67,33 @@ if [ -n "$pane" ]; then
   fi
 fi
 
-# --- 2) Fallback: name an unnamed, non-issue session on its first prompt ---
+# --- 2) Fallback: name an unnamed, non-issue session after its repository ---
 # Respect an existing name (manual /rename, plan-accept) and plan mode.
 [ -z "$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)" ] || exit 0
 [ "$(printf '%s' "$payload" | jq -r '.permission_mode // ""' 2>/dev/null || true)" != "plan" ] || exit 0
 
-# Set-once via a per-session marker (session_id keyed) — independent of payload
-# round-trip, and works without tmux.
+# Don't preempt a manual /rename: skip when the prompt is a slash command. (We
+# only inspect the first character; the prompt text is never used as the name.)
+case "$(printf '%s' "$payload" | jq -r '.prompt // ""' 2>/dev/null || true)" in /*) exit 0 ;; esac
+
+# Set-once via a per-session marker (session_id keyed) in a DEDICATED dir so the
+# pane-issue GC in wt-pane-issue.sh can't delete it. A long-window GC here bounds
+# growth without clobbering live sessions.
 sid="$(printf '%s' "$payload" | jq -r '.session_id // ""' 2>/dev/null || true)"
 [ -n "$sid" ] || exit 0
-mkdir -p "$state_dir" 2>/dev/null || exit 0
-marker="${state_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').named"
+named_dir="${home}/.claude/state/session-named"
+mkdir -p "$named_dir" 2>/dev/null || exit 0
+find "$named_dir" -maxdepth 1 -type f -mmin +43200 -delete 2>/dev/null || true
+marker="${named_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').named"
 [ -f "$marker" ] && exit 0
 
-prompt="$(printf '%s' "$payload" | jq -r '.prompt // ""' 2>/dev/null || true)"
-# Don't name a session after a slash command (e.g. /rename, /clear).
-case "$prompt" in /*) exit 0 ;; esac
-
-# Prefer the first prompt: drop control chars, collapse whitespace, keep
-# multibyte as-is (no ASCII slugging — it would erase Japanese), truncate to
-# ~80 bytes on a UTF-8 boundary (iconv -c trims a clipped trailing char).
-fallback="$(printf '%s' "$prompt" | tr '\n\r\t' '   ' | tr -d '\000-\037' | sed 's/  */ /g; s/^ *//; s/ *$//' 2>/dev/null || true)"
-fallback="$(printf '%s' "$fallback" | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
-fallback="$(printf '%s' "$fallback" | sed 's/ *$//' 2>/dev/null || true)"
-
-# If the prompt yielded nothing usable, fall back to the repo directory name
-# (payload cwd is the launch repo root; stable identifier — dotfiles#17 finding).
-if [ -z "$fallback" ]; then
-  cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null || true)"
-  [ -n "$cwd" ] && fallback="$(basename "$cwd" 2>/dev/null || true)"
-fi
+# Name = repository directory (payload cwd is the launch repo root). Using the
+# repo name — not prompt text — keeps secrets out of the pane title / OS
+# notifications. Strip control chars and keep it short / valid UTF-8.
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null || true)"
+[ -n "$cwd" ] || exit 0
+fallback="$(basename "$cwd" 2>/dev/null || true)"
+fallback="$(printf '%s' "$fallback" | tr -d '\000-\037' | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
 [ -n "$fallback" ] || exit 0
 
 emit_title "$fallback" "$marker"

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -2,27 +2,30 @@
 #
 # session-name.sh — Claude Code UserPromptSubmit hook.
 #
-# Titles the session "#<issue> <slug>" using the active worktree recorded by
-# wt-pane-issue.sh for this tmux pane. The session name is what Claude Code
-# shows in its UI and writes to the terminal (tmux pane) title, so this is how
-# parallel sessions become identifiable.
+# Gives every session an identifiable name (shown in Claude's UI and written to
+# the tmux pane title), so parallel sessions — and the notifications built from
+# the pane title (notify.sh) — can be told apart. Two behaviors, in priority:
 #
-# Emits the title once per worktree switch (the "pending" flag is consumed), so
-# a manual /rename afterwards is preserved. Emits nothing when there is no pane
-# marker — so sessions not on an issue worktree (other repos, master, plain
-# research) keep Claude's automatic naming untouched. This conditional emit is
-# essential: the hook is registered globally and fires for every session.
+#   1. Active issue worktree: when wt-pane-issue.sh recorded "#<issue> <slug>"
+#      for this tmux pane (on `wt switch`), title the session with it. Emitted
+#      once per switch (the "pending" flag is consumed) so a later manual
+#      /rename is preserved.
+#   2. Fallback (unnamed, non-issue): Claude's built-in auto-naming only fires
+#      on plan-accept or `/rename`, so a plain session can stay nameless. If the
+#      session has no name yet (payload `session_title` empty) and is not in
+#      plan mode, derive a simple name from the first prompt. Once named, the
+#      payload's session_title is non-empty on later prompts, so this is a
+#      natural set-once that respects plan-accept / manual renames.
 #
 # `sessionTitle` is a documented hookSpecificOutput field for UserPromptSubmit
-# (Claude Code hooks reference) and was verified live (session + tmux pane title
-# rename on submit). UserPromptSubmit stdout is injected into the model context,
-# so this emits ONLY a single hookSpecificOutput JSON object (built with jq), or
-# nothing at all. Diagnostics never go to stdout.
+# (Claude Code hooks reference) and was verified live. UserPromptSubmit stdout
+# is injected into the model context, so this emits ONLY a single
+# hookSpecificOutput JSON object (built with jq), or nothing. No diagnostics to
+# stdout.
 #
 set -uo pipefail
 
-# Drain the hook payload on stdin (unused here).
-cat >/dev/null 2>&1 || true
+payload="$(cat 2>/dev/null || true)"
 
 pane="${TMUX_PANE:-}"
 home="${HOME:-}"
@@ -30,33 +33,47 @@ home="${HOME:-}"
 [ -n "$home" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-# Same key as wt-pane-issue.sh: tmux server PID + pane id (restart-safe).
+# Emit a sessionTitle and exit. Nothing but this JSON ever reaches stdout; if jq
+# fails (e.g. invalid UTF-8 after truncation) emit nothing.
+emit_title() {
+  local out
+  out="$(jq -cn --arg t "$1" \
+    '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",sessionTitle:$t}}' 2>/dev/null)" || exit 0
+  [ -n "$out" ] && printf '%s' "$out"
+  exit 0
+}
+
+# --- 1) Active issue worktree (recorded by wt-pane-issue.sh) ---
+# Key by tmux server PID + pane id (restart-safe), identical to wt-pane-issue.sh.
 server="${TMUX:-}"; server="${server#*,}"; server="${server%%,*}"
-key="${server}_${pane}"
-key="${key//[^A-Za-z0-9]/_}"
+key="${server}_${pane}"; key="${key//[^A-Za-z0-9]/_}"
 state_file="${home}/.claude/state/pane-issue/${key}"
-[ -f "$state_file" ] || exit 0
 
-# Only act on a freshly recorded switch (pending). Otherwise leave the title
-# alone, so a manual /rename is respected.
-[ "$(jq -r '.pending // false' "$state_file" 2>/dev/null)" = "true" ] || exit 0
-
-name="$(jq -r '.name // empty' "$state_file" 2>/dev/null)"
-[ -n "$name" ] || exit 0
-
-# Consume the pending flag (one-shot), then emit. Ordering note: a concurrent
-# `wt switch` between read and write could roll a fresh marker back to
-# pending:false (a rare lost-update), and a crash between consume and emit drops
-# this turn's rename. Both windows are tiny and self-correct on the next
-# switch/prompt. Re-emitting the same title is benign EXCEPT if `mv` permanently
-# fails (e.g. disk full) it could re-assert over a manual /rename — accepted
-# given the rarity.
-tmp="${state_file}.tmp.$$"
-if jq -c '.pending=false' "$state_file" >"$tmp" 2>/dev/null; then
-  mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+if [ -f "$state_file" ] && [ "$(jq -r '.pending // false' "$state_file" 2>/dev/null)" = "true" ]; then
+  name="$(jq -r '.name // empty' "$state_file" 2>/dev/null)"
+  if [ -n "$name" ]; then
+    # Consume pending (one-shot per switch). A concurrent `wt switch` between
+    # read and write is a rare lost-update; re-emit of the same title is benign.
+    tmp="${state_file}.tmp.$$"
+    if jq -c '.pending=false' "$state_file" >"$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    fi
+    emit_title "$name"
+  fi
 fi
 
-# Emit the session title (and nothing else on stdout).
-jq -cn --arg t "$name" \
-  '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",sessionTitle:$t}}'
-exit 0
+# --- 2) Fallback: name an unnamed, non-issue session from its first prompt ---
+# Skip when already named (session_title present) or in plan mode (let
+# plan-accept name it from the plan).
+[ -z "$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)" ] || exit 0
+[ "$(printf '%s' "$payload" | jq -r '.permission_mode // ""' 2>/dev/null || true)" != "plan" ] || exit 0
+
+prompt="$(printf '%s' "$payload" | jq -r '.prompt // ""' 2>/dev/null || true)"
+# Drop control chars, collapse whitespace; keep multibyte as-is (no ASCII
+# slugging — it would erase Japanese prompts). Truncate to ~80 bytes at a valid
+# UTF-8 boundary (iconv -c drops a clipped trailing multibyte char).
+fallback="$(printf '%s' "$prompt" | tr '\n\r\t' '   ' | tr -d '\000-\037' | sed 's/  */ /g; s/^ *//; s/ *$//')"
+fallback="$(printf '%s' "$fallback" | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
+fallback="$(printf '%s' "$fallback" | sed 's/ *$//')"
+[ -n "$fallback" ] || exit 0
+emit_title "$fallback"

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -82,9 +82,9 @@ case "$(printf '%s' "$payload" | jq -r '.prompt // ""' 2>/dev/null || true)" in 
 sid="$(printf '%s' "$payload" | jq -r '.session_id // ""' 2>/dev/null || true)"
 [ -n "$sid" ] || exit 0
 named_dir="${home}/.claude/state/session-named"
-mkdir -p "$named_dir" 2>/dev/null || exit 0
-find "$named_dir" -maxdepth 1 -type f -mmin +43200 -delete 2>/dev/null || true
 marker="${named_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').named"
+# Already fallback-named this session → short-circuit before any dir scan
+# (repeat turns when session_title keeps coming through empty hit this).
 [ -f "$marker" ] && exit 0
 
 # Name = repository directory (payload cwd is the launch repo root). Using the
@@ -96,4 +96,8 @@ fallback="$(basename "$cwd" 2>/dev/null || true)"
 fallback="$(printf '%s' "$fallback" | tr -d '\000-\037' | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
 [ -n "$fallback" ] || exit 0
 
+# About to create a marker — run the opportunistic stale-marker GC now (not on
+# every prompt; the marker check above already short-circuited repeat turns).
+mkdir -p "$named_dir" 2>/dev/null || exit 0
+find "$named_dir" -maxdepth 1 -type f -mmin +43200 -delete 2>/dev/null || true
 emit_title "$fallback" "$marker"


### PR DESCRIPTION
Refs #126

#124/#125（worktree→`#issue` 命名）の拡張。**どのセッションにも名前が付く**ことを保証し、通知にセッション名を表示する。

## 背景

Claude 組み込みの自動命名は plan-accept / `/rename` でしか発火せず、通常セッションは無名のまま（`wt switch` は cwd を動かさないため cwd ベース識別も不可）。通知（notify.sh）に「どのセッションか」を出すには名前が常に付いている必要がある。

## 仕組み

`canonical/hooks/scripts/session-name.sh`（UserPromptSubmit hook）を2経路化:

- **Path1（issue）**: `$TMUX_PANE`+server PID キーの state（`wt-pane-issue.sh` が記録）があれば `#<issue> <slug>` を出力（`pending` 消費で 1 switch 1 回）。**issue pane は早期 return** し Path2 に落ちない（#issue 名を保護）。
- **Path2（フォールバック）**: state 無し＆無名（payload `session_title` 空）＆非 plan のセッションを、**リポジトリ名（payload `cwd` の basename）**で命名。**プロンプト文字列は使わない**（pane title / OS 通知に伝播するため、秘密混入の漏洩を避ける — Copilot 指摘）。**session_id キーのマーカー**（専用 dir `state/session-named/`、pane-issue の GC 対象外）で set-once。命名済 / plan-accept / スラッシュコマンド始まりは命名しない。

`canonical/hooks/scripts/notify.sh`: loc のペイン番号を **セッション名（`#{pane_title}`）**に差し替え。空時は `#{pane_index}` フォールバック（`#{!=:...,}` で明示判定）、先頭の状態グリフは `#{s/^. //}` で除去。

## テスト

- `shellcheck` PASS（session-name.sh / notify.sh）
- 単体: Path1 issue 命名 / **F1 回帰（issue pane で早期 return し #issue を破壊しない）** / Path2 リポ名（秘密プロンプトでも非露出）/ marker set-once / slash・命名済・plan skip
- 実機: issue worktree 入場でセッション改名、notify loc にセッション名（グリフ除去後）表示を確認

## レビュー（peer-ai-review / so-compare + Copilot）

- **SO（Claude lane）**: F1（Path2 フォールスルーで #issue 破壊の回帰）→ Path1 早期 return + session_id マーカーで解消。F2-F6 対応。
- **Copilot（2 ラウンド）**:
  - prompt 由来名の秘密漏洩 → **リポ名フォールバック**に変更
  - marker が pane-issue GC で消える → 専用 dir に分離
  - notify 条件式の堅牢化（明示的非空判定）
  - 通知の状態グリフ除去

## デプロイ

```bash
./scripts/sync.sh                 # session-name.sh / notify.sh を ~/.claude/hooks/ へ
```

worktrunk config（#125 で設定済）と既存 hook はそのまま。

## 影響範囲

- 命名 hook はグローバル発火だが、命名済・plan・スラッシュは尊重。issue は #issue 優先。非 issue はリポ名。
- 既存 hook（Stop/Notification/PreToolUse/TaskCompleted/#124 Path1）非破壊。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
