### PR TITLE
feat(hooks): 非wtセッションを現在gitブランチ名で命名しブランチ変化で再命名する

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -89,7 +89,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | CC 形式チェック | `hooks/scripts/cc-lint.sh` | `git commit -m` の Conventional Commits 形式を検証（3ツール共通） |
 | コミットゲート | `hooks/scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（Claude Code のみ） |
 | 通知 | `hooks/scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory、並走時のポーリング解消）。loc にセッション名を表示 |
-| セッション命名 | `hooks/scripts/session-name.sh` | セッション名を自動設定（Claude Code のみ・UserPromptSubmit）。worktree は `#<issue> <slug>`（`scripts/wt/wt-pane-issue.sh`＝worktrunk post-switch と連携）、それ以外の無名セッションはリポ名。並列セッション識別用 |
+| セッション命名 | `hooks/scripts/session-name.sh` | セッション名を自動設定（Claude Code のみ・UserPromptSubmit）。worktree は `#<issue> <slug>`（`scripts/wt/wt-pane-issue.sh`＝worktrunk post-switch と連携）、非 wt は現在 git ブランチ名（issue規約→`#<issue> <slug>` / デフォルト・非git→リポ名）でブランチ変化に追従。並列セッション識別用 |
 
 ## ツール固有拡張
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -18,7 +18,7 @@
 | コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
 | CC 形式チェック | `scripts/cc-lint.sh` | `git commit -m` のメッセージが Conventional Commits 形式に準拠しているかチェック |
 | 通知 | `scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory）。並走時のポーリング解消が目的 |
-| セッション命名 | `scripts/session-name.sh` ＋ `scripts/wt/wt-pane-issue.sh` | セッション名を自動設定し並列セッションを識別（Claude のみ・advisory）。`wt switch` の worktree は `#<issue> <slug>`、非 wt は現在 git ブランチ名（issue規約→`#<issue> <slug>` / デフォルト→リポ名）でブランチ変化に追従 |
+| セッション命名 | `scripts/session-name.sh` ＋ リポジトリルートの `scripts/wt/wt-pane-issue.sh` | セッション名を自動設定し並列セッションを識別（Claude のみ・advisory）。`wt switch` の worktree は `#<issue> <slug>`、非 wt は現在 git ブランチ名（issue規約→`#<issue> <slug>` / デフォルト→リポ名）でブランチ変化に追従 |
 
 ## ツール別カバレッジ
 
@@ -50,7 +50,7 @@
 - `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレートは `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外領域**（手動セットアップ。全リポ横断のため user config）。
 - `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）:
   - **Path1（issue）**: 同じ `$TMUX_PANE` の state があれば `sessionTitle`＝`#<issue> <slug>` を出力（tmux pane title にも伝播）。`pending` 消費で 1 switch 1 回（手動 `/rename` を尊重）。**issue pane は早期 return**し Path2 に落ちない（#issue 名を保護）。
-  - **Path2（ブランチ認識）**: state 無しの非 plan セッションは、`git -C "$cwd" symbolic-ref --short HEAD` の現在ブランチで命名する — issue規約 `^[a-z]+/#([0-9]+)_(.+)$`→`#<issue> <slug>`、`master`/`main`/空(非git・detached)→**リポ名**、その他→**ブランチ名**。prompt 文字列は**使わない**（pane title / 通知に伝播するため秘密混入を避ける）。**session_id キーの state**（専用 dir `state/session-branch/<sid>.json`、`last_branch`/`last_emitted` を保持、pane-issue の GC 対象外）を使い、**ブランチ変化時に再命名**する（wt の per-switch rename と同等。命名済みセッションへの sessionTitle 再emitが効くことは実機検証済み）。冪等（既に出す名前なら no-op）＆同一ブランチ内の手動 `/rename` は尊重。plan-accept / スラッシュコマンド始まりは命名しない。30日触れられない state は GC。
+  - **Path2（ブランチ認識）**: state 無しの非 plan セッションは、`git -C "$cwd" symbolic-ref --short HEAD` の現在ブランチで命名する — issue規約 `^[a-z]+/#([0-9]+)_(.+)$`→`#<issue> <slug>`、`master`/`main`/空(非git・detached)→**リポ名**、その他→**ブランチ名**。prompt 文字列は**使わない**（pane title / 通知に伝播するため秘密混入を避ける）。**session_id キーの state**（専用 dir `~/.claude/state/session-branch/<sid>.json`、`last_branch` を保持、pane-issue の GC 対象外）を使い、**ブランチ変化時に再命名**する（wt の per-switch rename と同等。命名済みセッションへの sessionTitle 再emitが効くことは実機検証済み）。冪等（既に出す名前なら no-op）＆同一ブランチ内の手動 `/rename` は尊重。plan-accept / スラッシュコマンド始まりは命名しない。30日触れられない state は GC。
 
 ### 注意
 

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -18,7 +18,7 @@
 | コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
 | CC 形式チェック | `scripts/cc-lint.sh` | `git commit -m` のメッセージが Conventional Commits 形式に準拠しているかチェック |
 | 通知 | `scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory）。並走時のポーリング解消が目的 |
-| セッション命名 | `scripts/session-name.sh` ＋ `scripts/wt/wt-pane-issue.sh` | `wt switch` で worktree(#issue)に移動時、セッション名を `#<issue> <slug>` に自動設定し並列セッションを識別（Claude のみ・advisory） |
+| セッション命名 | `scripts/session-name.sh` ＋ `scripts/wt/wt-pane-issue.sh` | セッション名を自動設定し並列セッションを識別（Claude のみ・advisory）。`wt switch` の worktree は `#<issue> <slug>`、非 wt は現在 git ブランチ名（issue規約→`#<issue> <slug>` / デフォルト→リポ名）でブランチ変化に追従 |
 
 ## ツール別カバレッジ
 
@@ -38,7 +38,7 @@
 
 ## session-name.sh + wt-pane-issue.sh（セッション命名）
 
-並列セッションを識別するため、セッション名を自動設定する（Claude Code のみ）。(1) `wt switch` で入った worktree のセッションは Issue 番号＝`#<issue> <slug>`。(2) それ以外の無名セッションは**リポ名**（payload `cwd` 由来）で命名し、常に名前が付いている状態にする。plan-accept / 手動 `/rename` は尊重。
+並列セッションを識別するため、セッション名を自動設定する（Claude Code のみ）。(1) `wt switch` で入った worktree のセッションは Issue 番号＝`#<issue> <slug>`。(2) それ以外のセッションは **`cwd` の現在 git ブランチ**で命名（issue規約→`#<issue> <slug>` / デフォルト・非git→リポ名 / その他→ブランチ名）し、**ブランチ変化で再命名**する（wt 同等）。同一ブランチ内の手動 `/rename` は次のブランチ変化まで尊重、plan-accept も尊重。
 
 ### 背景
 
@@ -50,12 +50,12 @@
 - `~/.config/worktrunk/config.toml`（worktrunk user config、テンプレートは `scripts/wt/worktrunk-config.toml`）: 上記を post-switch hook として登録。**hub の sync 対象外領域**（手動セットアップ。全リポ横断のため user config）。
 - `scripts/session-name.sh`（Claude `UserPromptSubmit` hook）:
   - **Path1（issue）**: 同じ `$TMUX_PANE` の state があれば `sessionTitle`＝`#<issue> <slug>` を出力（tmux pane title にも伝播）。`pending` 消費で 1 switch 1 回（手動 `/rename` を尊重）。**issue pane は早期 return**し Path2 に落ちない（#issue 名を保護）。
-  - **Path2（フォールバック）**: state 無し＆無名（payload `session_title` 空）＆非 plan のセッションは、**payload `cwd` のリポ名**で命名。prompt 文字列は**使わない**（pane title / 通知に伝播するため、秘密混入の漏洩チャネルを避ける）。**session_id キーのマーカー**（専用 dir `state/session-named/`、pane-issue の GC 対象外）で set-once（往復非依存・非 tmux でも可）。命名済 / plan-accept / スラッシュコマンド始まりは命名しない。
+  - **Path2（ブランチ認識）**: state 無しの非 plan セッションは、`git -C "$cwd" symbolic-ref --short HEAD` の現在ブランチで命名する — issue規約 `^[a-z]+/#([0-9]+)_(.+)$`→`#<issue> <slug>`、`master`/`main`/空(非git・detached)→**リポ名**、その他→**ブランチ名**。prompt 文字列は**使わない**（pane title / 通知に伝播するため秘密混入を避ける）。**session_id キーの state**（専用 dir `state/session-branch/<sid>.json`、`last_branch`/`last_emitted` を保持、pane-issue の GC 対象外）を使い、**ブランチ変化時に再命名**する（wt の per-switch rename と同等。命名済みセッションへの sessionTitle 再emitが効くことは実機検証済み）。冪等（既に出す名前なら no-op）＆同一ブランチ内の手動 `/rename` は尊重。plan-accept / スラッシュコマンド始まりは命名しない。30日触れられない state は GC。
 
 ### 注意
 
 - `UserPromptSubmit` の stdout は**モデル文脈に注入される**ため、`jq` で構築した sessionTitle JSON 以外を stdout に出さない（診断は出さない）。
-- グローバル設定ゆえ全セッション・全リポで発火する。issue worktree は `#issue`、それ以外の無名セッションは**リポ名**で命名する（prompt 文字列は出さない＝秘密漏洩を避ける。命名済・plan-accept・手動 `/rename` は不変）。
+- グローバル設定ゆえ全セッション・全リポで発火する。issue worktree は `#issue`、それ以外は**現在ブランチ名**（デフォルト/非gitはリポ名）で命名し**ブランチ変化で再命名**する（prompt 文字列は出さない＝秘密漏洩を避ける）。**ブランチ名そのものが Claude UI / tmux pane title / OS 通知に表示される**点に留意（顧客名・内部識別子をブランチ名に含める運用では露出面が増える）。
 - `jq` / `tmux` が前提。無い場合は no-op（advisory・非ゼロ終了しない）。
 
 ## block-destructive.sh

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -96,8 +96,8 @@ elif [ -z "$branch" ] || [ "$branch" = "master" ] || [ "$branch" = "main" ]; the
 else
   desired="$branch"
 fi
-# Strip control chars, cap length, keep valid UTF-8 (title -> pane title / notifications).
-desired="$(printf '%s' "$desired" | tr -d '\000-\037' | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
+# Strip control chars (incl. DEL 0x7F), cap length, keep valid UTF-8 (title -> pane title / notifications).
+desired="$(printf '%s' "$desired" | tr -d '\000-\037\177' | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
 [ -n "$desired" ] || exit 0
 
 # Per-session state (session_id keyed) in a DEDICATED dir, separate from the
@@ -112,19 +112,20 @@ if [ -f "$sfile" ]; then
 fi
 session_title="$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)"
 
-# Idempotent: if the session already shows the name we'd emit, there is nothing
-# to do. This also prevents a re-emit-every-prompt loop when the state file can't
-# be persisted (quota/read-only/NFS): emit_title still set the name, so the next
-# prompt short-circuits here even though last_branch was never written.
-[ "$session_title" = "$desired" ] && exit 0
-
-# (Re)name when the branch changed (wt-equivalent: overwrites even a manual
-# /rename, like wt re-naming on every switch) or when the session is unnamed.
-# Otherwise leave it (a same-branch manual /rename — non-empty and, per the guard
-# above, different from our name).
-if [ "$branch" = "$last_branch" ] && [ -n "$session_title" ]; then
+# No-op when the session already shows the name we'd emit (idempotent — also
+# prevents a re-emit loop if the state file can't be persisted: emit_title set the
+# name, so we short-circuit here next time), OR when it's the same branch with a
+# different, manual /rename title (respected until the branch changes). Touch the
+# state file on no-op so a long-lived same-branch session isn't GC'd out from under
+# us — losing it would reset last_branch and let the next prompt look like a branch
+# change and clobber the manual title.
+if [ "$session_title" = "$desired" ] || { [ "$branch" = "$last_branch" ] && [ -n "$session_title" ]; }; then
+  [ -f "$sfile" ] && touch -- "$sfile" 2>/dev/null
   exit 0
 fi
+
+# Branch changed (wt-equivalent re-name — overwrites even a manual /rename, like wt
+# on every switch) or the session is unnamed: (re)name it.
 
 # About to (re)name — run the opportunistic stale-state GC now (only on a naming
 # event, not every prompt). Long window bounds growth without clobbering sessions.

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -106,11 +106,26 @@ desired="$(printf '%s' "$desired" | tr -d '\000-\037\177' | head -c 80 | { iconv
 # check below — session_title == desired — so no "last emitted" field is needed.)
 branch_dir="${home}/.claude/state/session-branch"
 sfile="${branch_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').json"
-last_branch=""
+last_branch=""; state_exists=0
 if [ -f "$sfile" ]; then
+  state_exists=1
   last_branch="$(jq -r '.last_branch // ""' "$sfile" 2>/dev/null || true)"
 fi
 session_title="$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)"
+
+# First time we see an ALREADY-NAMED session (no state file yet): the title
+# predates our state (a manual /rename, plan-accept, or a session from before this
+# mechanism). Record the current branch as the baseline and KEEP the title — only
+# a later real branch change should re-name. Without this, last_branch="" would
+# look like a branch change and clobber the existing title on the very first prompt.
+if [ "$state_exists" = 0 ] && [ -n "$session_title" ]; then
+  mkdir -p "$branch_dir" 2>/dev/null && {
+    tmp="${sfile}.tmp.$$"
+    jq -cn --arg b "$branch" '{last_branch:$b}' >"$tmp" 2>/dev/null \
+      && { mv -f "$tmp" "$sfile" 2>/dev/null || rm -f "$tmp" 2>/dev/null; }
+  }
+  exit 0
+fi
 
 # No-op when the session already shows the name we'd emit (idempotent — also
 # prevents a re-emit loop if the state file can't be persisted: emit_title set the

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -22,8 +22,8 @@
 #      branch change). Names come from the branch / repo dir — NEVER the prompt
 #      text, which propagates to the pane title + OS notifications and may carry
 #      secrets. Per-session state (session_id keyed, dedicated dir) holds the last
-#      branch + last emitted name. When `wt switch` IS used the cwd stays at the
-#      repo root, so issue worktrees are named by Path 1, not here.
+#      branch seen. When `wt switch` IS used the cwd stays at the repo root, so
+#      issue worktrees are named by Path 1, not here.
 #
 # `sessionTitle` is a documented hookSpecificOutput field for UserPromptSubmit
 # (Claude Code hooks reference), verified live. UserPromptSubmit stdout is
@@ -101,8 +101,9 @@ desired="$(printf '%s' "$desired" | tr -d '\000-\037' | head -c 80 | { iconv -f 
 [ -n "$desired" ] || exit 0
 
 # Per-session state (session_id keyed) in a DEDICATED dir, separate from the
-# pane-issue dir. Holds the last branch seen and last name emitted, so we can
-# re-name on branch change and tell our own name apart from a manual /rename.
+# pane-issue dir. Holds the last branch seen, so we can re-name on branch change.
+# (Our name vs a same-branch manual /rename is told apart by the idempotency
+# check below — session_title == desired — so no "last emitted" field is needed.)
 branch_dir="${home}/.claude/state/session-branch"
 sfile="${branch_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').json"
 last_branch=""
@@ -130,7 +131,7 @@ fi
 mkdir -p "$branch_dir" 2>/dev/null || exit 0
 find "$branch_dir" -maxdepth 1 -type f -mmin +43200 -delete 2>/dev/null || true
 tmp="${sfile}.tmp.$$"
-if jq -cn --arg b "$branch" --arg e "$desired" '{last_branch:$b,last_emitted:$e}' >"$tmp" 2>/dev/null; then
+if jq -cn --arg b "$branch" '{last_branch:$b}' >"$tmp" 2>/dev/null; then
   mv -f "$tmp" "$sfile" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 fi
 emit_title "$desired"

--- a/canonical/hooks/scripts/session-name.sh
+++ b/canonical/hooks/scripts/session-name.sh
@@ -10,13 +10,20 @@
 #      for this tmux pane (on `wt switch`), title the session with it, once per
 #      switch (the "pending" flag is consumed). An issue pane is handled here
 #      and NEVER falls through to the fallback below (which would clobber it).
-#   2. Fallback (unnamed, non-issue): Claude's built-in auto-naming only fires
-#      on plan-accept or `/rename`, so a plain session can stay nameless. Name
-#      it after the repository directory (payload cwd) — NOT the prompt text:
-#      the title propagates to the tmux pane title and OS notifications, so
-#      prompt content (which may contain secrets) must not leak there. A
-#      per-session marker in a dedicated dir (not touched by wt-pane-issue.sh's
-#      pane-issue GC) makes this set-once.
+#   2. Branch-aware (non-wt sessions): Claude's built-in auto-naming only fires
+#      on plan-accept or `/rename`, so a plain session can stay nameless. Name it
+#      after the current git branch of the launch dir (payload cwd): an issue
+#      branch "{prefix}/#<issue>_<desc>" becomes "#<issue> <slug>" (mirroring
+#      wt-pane-issue.sh), the default branch / non-git / detached HEAD falls back
+#      to the repository directory name, and any other branch uses the branch
+#      name. When the branch CHANGES the session is RE-NAMED — wt-equivalent: it
+#      matches the per-switch rename wt-pane-issue.sh drives, and overwrites even
+#      a manual /rename (a same-branch manual /rename is respected until the next
+#      branch change). Names come from the branch / repo dir — NEVER the prompt
+#      text, which propagates to the pane title + OS notifications and may carry
+#      secrets. Per-session state (session_id keyed, dedicated dir) holds the last
+#      branch + last emitted name. When `wt switch` IS used the cwd stays at the
+#      repo root, so issue worktrees are named by Path 1, not here.
 #
 # `sessionTitle` is a documented hookSpecificOutput field for UserPromptSubmit
 # (Claude Code hooks reference), verified live. UserPromptSubmit stdout is
@@ -33,14 +40,12 @@ command -v jq >/dev/null 2>&1 || exit 0
 state_dir="${home}/.claude/state/pane-issue"
 
 # Emit a sessionTitle and exit. Nothing but this JSON reaches stdout; on jq
-# failure emit nothing. jq --arg JSON-escapes the title. With a marker path
-# ($2), touch it only on a successful emit so the fallback stays set-once.
+# failure emit nothing. jq --arg JSON-escapes the title.
 emit_title() {
   local out
   out="$(jq -cn --arg t "$1" \
     '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",sessionTitle:$t}}' 2>/dev/null)" || exit 0
   [ -n "$out" ] || exit 0
-  if [ -n "${2:-}" ]; then : > "$2" 2>/dev/null || true; fi
   printf '%s' "$out"
   exit 0
 }
@@ -67,37 +72,65 @@ if [ -n "$pane" ]; then
   fi
 fi
 
-# --- 2) Fallback: name an unnamed, non-issue session after its repository ---
-# Respect an existing name (manual /rename, plan-accept) and plan mode.
-[ -z "$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)" ] || exit 0
+# --- 2) Branch-aware naming for non-wt sessions (issue worktrees handled above) ---
+# Respect plan mode and a manual /rename in progress (slash-prefixed prompt). The
+# prompt's first char is all we inspect; the prompt text is never used as a name.
 [ "$(printf '%s' "$payload" | jq -r '.permission_mode // ""' 2>/dev/null || true)" != "plan" ] || exit 0
-
-# Don't preempt a manual /rename: skip when the prompt is a slash command. (We
-# only inspect the first character; the prompt text is never used as the name.)
 case "$(printf '%s' "$payload" | jq -r '.prompt // ""' 2>/dev/null || true)" in /*) exit 0 ;; esac
 
-# Set-once via a per-session marker (session_id keyed) in a DEDICATED dir so the
-# pane-issue GC in wt-pane-issue.sh can't delete it. A long-window GC here bounds
-# growth without clobbering live sessions.
 sid="$(printf '%s' "$payload" | jq -r '.session_id // ""' 2>/dev/null || true)"
 [ -n "$sid" ] || exit 0
-named_dir="${home}/.claude/state/session-named"
-marker="${named_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').named"
-# Already fallback-named this session → short-circuit before any dir scan
-# (repeat turns when session_title keeps coming through empty hit this).
-[ -f "$marker" ] && exit 0
-
-# Name = repository directory (payload cwd is the launch repo root). Using the
-# repo name — not prompt text — keeps secrets out of the pane title / OS
-# notifications. Strip control chars and keep it short / valid UTF-8.
 cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null || true)"
 [ -n "$cwd" ] || exit 0
-fallback="$(basename "$cwd" 2>/dev/null || true)"
-fallback="$(printf '%s' "$fallback" | tr -d '\000-\037' | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
-[ -n "$fallback" ] || exit 0
 
-# About to create a marker — run the opportunistic stale-marker GC now (not on
-# every prompt; the marker check above already short-circuited repeat turns).
-mkdir -p "$named_dir" 2>/dev/null || exit 0
-find "$named_dir" -maxdepth 1 -type f -mmin +43200 -delete 2>/dev/null || true
-emit_title "$fallback" "$marker"
+# Current branch of the launch dir; empty for a non-git dir or detached HEAD.
+branch="$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || true)"
+
+# Desired name from the branch (see header): issue branch -> "#<issue> <slug>"
+# (mirror wt-pane-issue.sh), default/non-git -> repo dir name, else branch name.
+if [[ "$branch" =~ ^[a-z]+/#([0-9]+)_(.+)$ ]]; then
+  slug="${BASH_REMATCH[2]//_/-}"
+  desired="#${BASH_REMATCH[1]} ${slug:0:48}"
+elif [ -z "$branch" ] || [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
+  desired="$(basename "$cwd" 2>/dev/null || true)"
+else
+  desired="$branch"
+fi
+# Strip control chars, cap length, keep valid UTF-8 (title -> pane title / notifications).
+desired="$(printf '%s' "$desired" | tr -d '\000-\037' | head -c 80 | { iconv -f UTF-8 -t UTF-8 -c 2>/dev/null || cat; })"
+[ -n "$desired" ] || exit 0
+
+# Per-session state (session_id keyed) in a DEDICATED dir, separate from the
+# pane-issue dir. Holds the last branch seen and last name emitted, so we can
+# re-name on branch change and tell our own name apart from a manual /rename.
+branch_dir="${home}/.claude/state/session-branch"
+sfile="${branch_dir}/$(printf '%s' "$sid" | tr -c 'A-Za-z0-9' '_').json"
+last_branch=""
+if [ -f "$sfile" ]; then
+  last_branch="$(jq -r '.last_branch // ""' "$sfile" 2>/dev/null || true)"
+fi
+session_title="$(printf '%s' "$payload" | jq -r '.session_title // ""' 2>/dev/null || true)"
+
+# Idempotent: if the session already shows the name we'd emit, there is nothing
+# to do. This also prevents a re-emit-every-prompt loop when the state file can't
+# be persisted (quota/read-only/NFS): emit_title still set the name, so the next
+# prompt short-circuits here even though last_branch was never written.
+[ "$session_title" = "$desired" ] && exit 0
+
+# (Re)name when the branch changed (wt-equivalent: overwrites even a manual
+# /rename, like wt re-naming on every switch) or when the session is unnamed.
+# Otherwise leave it (a same-branch manual /rename — non-empty and, per the guard
+# above, different from our name).
+if [ "$branch" = "$last_branch" ] && [ -n "$session_title" ]; then
+  exit 0
+fi
+
+# About to (re)name — run the opportunistic stale-state GC now (only on a naming
+# event, not every prompt). Long window bounds growth without clobbering sessions.
+mkdir -p "$branch_dir" 2>/dev/null || exit 0
+find "$branch_dir" -maxdepth 1 -type f -mmin +43200 -delete 2>/dev/null || true
+tmp="${sfile}.tmp.$$"
+if jq -cn --arg b "$branch" --arg e "$desired" '{last_branch:$b,last_emitted:$e}' >"$tmp" 2>/dev/null; then
+  mv -f "$tmp" "$sfile" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+fi
+emit_title "$desired"


### PR DESCRIPTION
## 概要

非 wt セッションのセッション命名を、`cwd` の現在 git ブランチ名ベースに拡張し、**ブランチ変化で再命名**（wt 同等）するようにした。`canonical/hooks/scripts/session-name.sh` の Path2 を「リポ名フォールバック（set-once）」から「ブランチ認識 + 再命名」へ置換。Path1（wt の pane-issue）は不変。

## 背景

#126（PR #127）で非 wt の無名セッションはリポ名にフォールバックしていたが、`wt switch` を使わず `git switch -c` した場合もブランチ名で命名したい。`wt switch` は cwd を動かさない（#124）が、wt 非使用時は cwd が実作業ディレクトリなので `git -C "$cwd"` が実ブランチを返す。

実機検証で **命名済みセッションへの `sessionTitle` 再emit が効き、emit 値が次プロンプトの `session_title` に byte 厳密一致で戻る** ことを確認 → Claude 側 hook 単独でブランチ追従・再命名が可能（グローバル git 設定 `core.hooksPath` は不要）。

## 変更内容

- `canonical/hooks/scripts/session-name.sh` Path2:
  - `git symbolic-ref --short HEAD` で現在ブランチを取得し命名
    - issue規約 `^[a-z]+/#([0-9]+)_(.+)$` → `#<issue> <slug>`
    - `master` / `main` / 空（非git・detached）→ リポ名（`basename cwd`）
    - その他 → ブランチ名
  - per-session state `state/session-branch/<sid>.json`（`last_branch`/`last_emitted`）で **ブランチ変化時に再命名**。同一ブランチ内の手動 `/rename` は次のブランチ変化まで尊重
  - **冪等ガード**（既に出す名前なら no-op）で state 永続化失敗時の再emitループを防止
  - prompt 文字列は不使用（秘密漏洩防止）、stdout は JSON のみ
- `canonical/hooks/README.md` / `canonical/CATALOG.md` を新挙動に更新

## 検証

- `shellcheck` PASS
- payload 投入テスト **11シナリオ PASS**（issue / 非issue / master / ブランチ変化 / 同一ブランチ手動rename尊重 / plan / slash / 非git / detached / 冪等）
- 再命名可否は本番 settings に一時診断 hook を pane 限定注入して実機確認（撤去済み）

## セカンドオピニオン

`so-compare`（Codex / Claude）で2者レビュー。両者とも核心ロジック（手動rename尊重 / wt優先 / stdout非汚染）は問題なしと評価。指摘を反映:

- [x] state 永続化失敗時の再emitループ → 冪等ガード追加
- [x] ドキュメント（README/CATALOG）未更新 → 更新
- [x] ブランチ名が UI/通知に出る点 → README に留意事項として明記
- 見送り: GC 期間差（pane-issue 24h vs session-branch 30d。lifecycle が別物で意図的）、jq 複数呼び出し（既存スタイル踏襲・体感影響なし）

## 配備

マージ後に `./scripts/sync.sh claude`（または `./scripts/sync/sync-claude.sh`）で `~/.claude/hooks/session-name.sh` へ反映。

## 影響・留意

- グローバル hook ゆえ全リポ・全セッションで発火。非 wt セッションは毎プロンプト `git symbolic-ref`（ローカル操作・軽微）。wt issue セッションは Path1 で早期 return し git 呼び出し負担なし
- **ブランチ名そのものが Claude UI / tmux pane title / OS 通知に表示される**。顧客名・内部識別子をブランチ名に含める運用では露出面が増える
- 既知の境界: `wt switch` 中の非issueブランチは cwd が repo root のまま（wt は cwd 非追従）なので、Path2 ではリポ名になる。issue worktree は従来どおり Path1 が `#<issue>` で命名

## Refs

- Refs #131
- Refs #124（命名基盤）
- Refs #126（リポ名フォールバック。本 PR はその拡張）
