### PR TITLE
feat(engine): oe-delegate / oe-report — 親子スレッド協調スクリプトを追加

### DIFF
--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -3,8 +3,8 @@
 #
 # usage: oe-delegate [-w WORKSPACE] <task>
 #
-# 親ペイン ID ($TMUX_PANE) を /tmp/oe-parent-{child_pane_id} に書き出し、
-# oe-report が子セッション内から自動検出できるようにする。
+# 親ペイン ID を PARENT_TMUX_PANE 環境変数として子プロセスに渡す（優先）。
+# /tmp/oe-parent-{child_pane_id} への書き出しは手動利用向けのフォールバック。
 # Phase 5 HitL 統合はスコープ外（Issue #138）。
 
 set -euo pipefail
@@ -22,6 +22,7 @@ usage: oe-delegate [-w WORKSPACE] <task>
 環境変数:
   OE_DELEGATE_WAIT_SEC  claude 起動待ちの秒数（デフォルト: 4）
   TMUX_PANE             tmux 内で自動設定される親ペイン ID（必須）
+  PARENT_TMUX_PANE      子プロセスへ自動で渡される（設定不要）
 
 子セッション内での申し送り:
   oe-report "サマリー"           # 申し送り: ...
@@ -51,12 +52,11 @@ PARENT_PANE="${TMUX_PANE:-}"
   exit 1
 }
 
-# 子ペインを作成し claude を起動
-CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -c "$WORKSPACE" "claude")"
+# 子ペインを作成し claude を起動（PARENT_TMUX_PANE を env として渡す）
+CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -c "$WORKSPACE" "PARENT_TMUX_PANE=$PARENT_PANE claude")"
 echo "oe-delegate: child pane ${CHILD_PANE} started (parent: ${PARENT_PANE}, workspace: ${WORKSPACE})" >&2
 
-# 親ペイン ID を tmp ファイルへ書き出し（oe-report が自動検出するため）
-# ファイル名は子ペイン ID から % を除去したもの
+# 親ペイン ID を tmp ファイルへ書き出し（手動利用向けフォールバック）
 PARENT_FILE="/tmp/oe-parent-${CHILD_PANE#%}"
 printf '%s\n' "$PARENT_PANE" > "$PARENT_FILE"
 
@@ -64,8 +64,15 @@ printf '%s\n' "$PARENT_PANE" > "$PARENT_FILE"
 WAIT_SEC="${OE_DELEGATE_WAIT_SEC:-4}"
 sleep "$WAIT_SEC"
 
+# 子ペインの生存確認
+tmux list-panes -a -F "#{pane_id}" | grep -qF "$CHILD_PANE" || {
+  echo "oe-delegate: child pane $CHILD_PANE exited during startup" >&2
+  exit 1
+}
+
 # タスクを注入（oe-report の場所を末尾に付記）
 INJECT="${TASK}. 完了後は ${BIN_DIR}/oe-report \"サマリー\" を実行して申し送りを送ること。レビュー依頼は ${BIN_DIR}/oe-report --review \"サマリー\"。"
-tmux send-keys -t "$CHILD_PANE" "$INJECT" Enter
+tmux send-keys -l -t "$CHILD_PANE" "$INJECT"
+tmux send-keys -t "$CHILD_PANE" Enter
 
 echo "oe-delegate: task injected to ${CHILD_PANE}" >&2

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# oe-delegate — 子 Claude セッションを起動し、タスクをキックする
+#
+# usage: oe-delegate [-w WORKSPACE] <task>
+#
+# 親ペイン ID ($TMUX_PANE) を /tmp/oe-parent-{child_pane_id} に書き出し、
+# oe-report が子セッション内から自動検出できるようにする。
+# Phase 5 HitL 統合はスコープ外（Issue #138）。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: oe-delegate [-w WORKSPACE] <task>
+
+  <task>              子 Claude セッションへ送るタスク（1行テキスト）
+  -w, --workspace DIR 子セッションの作業ディレクトリ（デフォルト: カレントディレクトリ）
+  -h, --help          このヘルプを表示
+
+環境変数:
+  OE_DELEGATE_WAIT_SEC  claude 起動待ちの秒数（デフォルト: 4）
+  TMUX_PANE             tmux 内で自動設定される親ペイン ID（必須）
+
+子セッション内での申し送り:
+  oe-report "サマリー"           # 申し送り: ...
+  oe-report --review "サマリー"  # レビュー依頼: ...
+EOF
+  exit 1
+}
+
+WORKSPACE="$(pwd)"
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -w|--workspace)
+      [[ $# -ge 2 ]] || { echo "oe-delegate: --workspace requires a value" >&2; exit 2; }
+      WORKSPACE="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "oe-delegate: unknown option: $1" >&2; usage ;;
+  esac
+done
+
+TASK="${1:-}"
+[[ -n "$TASK" ]] || { echo "oe-delegate: task argument is required" >&2; usage; }
+
+# tmux 内でのみ実行可能
+PARENT_PANE="${TMUX_PANE:-}"
+[[ -n "$PARENT_PANE" ]] || {
+  echo "oe-delegate: TMUX_PANE is not set — must run inside a tmux session" >&2
+  exit 1
+}
+
+# 子ペインを作成し claude を起動
+CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -c "$WORKSPACE" "claude")"
+echo "oe-delegate: child pane ${CHILD_PANE} started (parent: ${PARENT_PANE}, workspace: ${WORKSPACE})" >&2
+
+# 親ペイン ID を tmp ファイルへ書き出し（oe-report が自動検出するため）
+# ファイル名は子ペイン ID から % を除去したもの
+PARENT_FILE="/tmp/oe-parent-${CHILD_PANE#%}"
+printf '%s\n' "$PARENT_PANE" > "$PARENT_FILE"
+
+# claude 起動待ち
+WAIT_SEC="${OE_DELEGATE_WAIT_SEC:-4}"
+sleep "$WAIT_SEC"
+
+# タスクを注入（oe-report の場所を末尾に付記）
+INJECT="${TASK}. 完了後は ${BIN_DIR}/oe-report \"サマリー\" を実行して申し送りを送ること。レビュー依頼は ${BIN_DIR}/oe-report --review \"サマリー\"。"
+tmux send-keys -t "$CHILD_PANE" "$INJECT" Enter
+
+echo "oe-delegate: task injected to ${CHILD_PANE}" >&2

--- a/projects/orchestration-engine/bin/oe-report
+++ b/projects/orchestration-engine/bin/oe-report
@@ -62,4 +62,5 @@ else
   PREFIX="申し送り"
 fi
 
-tmux send-keys -t "$PARENT_PANE" "${PREFIX}: ${MESSAGE}" Enter
+tmux send-keys -l -t "$PARENT_PANE" "${PREFIX}: ${MESSAGE}"
+tmux send-keys -t "$PARENT_PANE" Enter

--- a/projects/orchestration-engine/bin/oe-report
+++ b/projects/orchestration-engine/bin/oe-report
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# oe-report — 親 Claude セッションへ申し送り / レビュー依頼を送る
+#
+# usage: oe-report [--review] <message>
+#
+# 親ペイン ID の解決順:
+#   1. 環境変数 PARENT_TMUX_PANE
+#   2. /tmp/oe-parent-{TMUX_PANE#%} ファイル（oe-delegate が書き出す）
+# どちらもなければエラー終了（exit 1）。
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: oe-report [--review] <message>
+
+  <message>   1行の申し送りテキスト（必須）
+  --review    レビュー依頼として送る（プレフィックスが "レビュー依頼:" になる）
+  -h, --help  このヘルプを表示
+
+親ペイン ID の解決:
+  1. 環境変数 PARENT_TMUX_PANE
+  2. /tmp/oe-parent-{TMUX_PANE#%} ファイル（oe-delegate が書き出す）
+EOF
+  exit 1
+}
+
+REVIEW=0
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    --review) REVIEW=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "oe-report: unknown option: $1" >&2; usage ;;
+  esac
+done
+
+MESSAGE="${1:-}"
+[[ -n "$MESSAGE" ]] || { echo "oe-report: message argument is required" >&2; usage; }
+
+# 親ペイン ID を解決
+PARENT_PANE="${PARENT_TMUX_PANE:-}"
+
+if [[ -z "$PARENT_PANE" ]]; then
+  SELF_PANE="${TMUX_PANE:-}"
+  if [[ -n "$SELF_PANE" ]]; then
+    PARENT_FILE="/tmp/oe-parent-${SELF_PANE#%}"
+    if [[ -f "$PARENT_FILE" ]]; then
+      PARENT_PANE="$(cat "$PARENT_FILE")"
+    fi
+  fi
+fi
+
+[[ -n "$PARENT_PANE" ]] || {
+  echo "oe-report: parent pane not found — set PARENT_TMUX_PANE or run via oe-delegate" >&2
+  exit 1
+}
+
+# メッセージを組み立てて送信
+if [[ "$REVIEW" -eq 1 ]]; then
+  PREFIX="レビュー依頼"
+else
+  PREFIX="申し送り"
+fi
+
+tmux send-keys -t "$PARENT_PANE" "${PREFIX}: ${MESSAGE}" Enter


### PR DESCRIPTION
## 目的

`tmux send-keys` 経由の親子スレッド協調プロトコル（#137 PoC 結果）を実装する。
親 Claude セッションが子セッションを起動してタスクをキックし、子が完了後に親へ申し送りを送る一連のフローを最小スクリプトで実現する。

## 変更内容

### `projects/orchestration-engine/bin/oe-delegate`

親キック用スクリプト。

- `tmux split-window` で新しい Claude セッション（子ペイン）を起動
- 親ペイン ID (`$TMUX_PANE`) を `/tmp/oe-parent-{child_pane_id}` に書き出し
- 固定 `sleep` 後にタスクを `tmux send-keys` で注入（`OE_DELEGATE_WAIT_SEC` で上書き可能）

### `projects/orchestration-engine/bin/oe-report`

子→親申し送り用スクリプト。

- 親ペイン ID を `PARENT_TMUX_PANE` 環境変数 → `/tmp/oe-parent-{TMUX_PANE#%}` の順に解決
- `tmux send-keys -t "$PARENT_PANE" "申し送り: ..." Enter` で親プロンプトに注入
- `--review` フラグで `レビュー依頼:` プレフィックスに切り替え

## 設計決定サマリー

| 項目 | 決定 |
|---|---|
| `$TMUX_PANE` 受け渡し | tmp ファイル `/tmp/oe-parent-{child_pane#%}` — ペインごとに独立し並行委譲が干渉しない |
| 起動待ち | 固定 `sleep 4`（`OE_DELEGATE_WAIT_SEC` で上書き可）— プロンプト出現ポーリングは Phase 5 以降 |
| 申し送りフォーマット | `申し送り: <1行テキスト>` |
| レビュー依頼の区別 | `oe-report --review` → `レビュー依頼: <1行テキスト>` |

## スコープ外

- Phase 5 HitL ゲートへの統合（Issue #138 の実装タスク最終項）

## テスト

- `shellcheck` 問題なし
- `--help` 出力確認
- TMUX_PANE 未設定時・親ペイン未解決時のエラーパス確認
- tmp ファイル経由のペイン解決動作確認

Refs #138
