### PR TITLE
fix(engine): oe-delegate/oe-report に -- デリミタを追加

### DIFF
--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -38,6 +38,7 @@ while [[ "${1:-}" == -* ]]; do
       [[ $# -ge 2 ]] || { echo "oe-delegate: --workspace requires a value" >&2; exit 2; }
       WORKSPACE="$2"; shift 2 ;;
     -h|--help) usage ;;
+    --) shift; break ;;
     *) echo "oe-delegate: unknown option: $1" >&2; usage ;;
   esac
 done

--- a/projects/orchestration-engine/bin/oe-report
+++ b/projects/orchestration-engine/bin/oe-report
@@ -30,6 +30,7 @@ while [[ "${1:-}" == -* ]]; do
   case "$1" in
     --review) REVIEW=1; shift ;;
     -h|--help) usage ;;
+    --) shift; break ;;
     *) echo "oe-report: unknown option: $1" >&2; usage ;;
   esac
 done


### PR DESCRIPTION
## 変更内容

`oe-delegate` / `oe-report` の引数パーサーに `--` デリミタを追加。

`--` を渡すことでオプション解析を終了し、以降の引数（`-` 始まりのタスク文字列やメッセージ）を positional argument として扱えるようになった。

## 変更対象

- `projects/orchestration-engine/bin/oe-delegate` — `while` ループに `--) shift; break ;;` を追加
- `projects/orchestration-engine/bin/oe-report` — 同上

## テスト

- `shellcheck` 両スクリプトともクリア
- `--` デリミタのパース動作を bash インラインでシミュレート確認（`-` 始まり文字列が MESSAGE/TASK に正常セット）

Refs #140
