### PR TITLE
feat(so-compare): Claude/Codex のモデルと Claude エフォートを指定可能にする

### DIFF
--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -35,6 +35,9 @@ so-compare [OPTIONS] "プロンプト"
 | `--cursor` | Cursor CLI (agent) も実行（デフォルト: 無効） | 無効 |
 | `--cursor-only` | Cursor のみ実行 | 両方実行 |
 | `--cursor-model MODEL` | Cursor で使用するモデル | `auto` |
+| `--claude-model MODEL` | Claude で使用するモデル（エイリアス `opus`/`sonnet`/`haiku` 可） | CLI 既定 |
+| `--codex-model MODEL` | Codex で使用するモデル | CLI 既定 |
+| `--claude-effort LEVEL` | Claude のエフォート（`low`/`medium`/`high`/`xhigh`/`max`） | CLI 既定 |
 | `--prev DIR` | 前回出力を追記（イテレーション用） | なし |
 
 ### 環境変数
@@ -44,6 +47,9 @@ so-compare [OPTIONS] "プロンプト"
 | `SO_TIMEOUT` | 各ツールのタイムアウト秒数 | `240` |
 | `PREV_MAX_BYTES` | `--prev` で追記する回答の上限バイト数 | `4000` |
 | `SO_CURSOR_MODEL` | Cursor のデフォルトモデル（`--cursor-model` で上書き可） | `auto` |
+| `SO_CLAUDE_MODEL` | Claude のデフォルトモデル（`--claude-model` で上書き可） | CLI 既定 |
+| `SO_CODEX_MODEL` | Codex のデフォルトモデル（`--codex-model` で上書き可） | CLI 既定 |
+| `SO_CLAUDE_EFFORT` | Claude のデフォルトエフォート（`--claude-effort` で上書き可） | CLI 既定 |
 
 ### 基本パターン
 
@@ -68,7 +74,29 @@ so-compare --cursor --cursor-model composer-1.5 -w "$(pwd)" "プロンプト"
 
 # Cursor のみ
 so-compare --cursor-only -w "$(pwd)" "プロンプト"
+
+# Claude を上位モデル + 高エフォートで（設計判断など重い SO）
+so-compare --claude-model opus --claude-effort high -w "$(pwd)" "この設計方針を検証してください"
+
+# Codex のモデル指定
+so-compare --codex-model gpt-5.5 -w "$(pwd)" "プロンプト"
 ```
+
+## モデル / エフォート選択ガイド
+
+セカンドオピニオンを投げるエージェント向けの選択指針。**動的なモデル一覧コマンドが実在するのは Cursor のみ**（`agent models`）。Claude / Codex は以下を目安にする。
+
+- **Claude**: エイリアス `opus` / `sonnet` / `haiku` で指定する。**エイリアスはそのティアの最新を指す**ため、バージョン ID（`claude-opus-4-8` 等）を追いかける必要はない（フル ID も透過で渡せる）。エフォートは `--claude-effort` に `low`/`medium`/`high`/`xhigh`/`max`
+- **Codex**: 既定モデルは `~/.codex/config.toml` の `model`。任意のモデル名はそのまま透過で渡る
+- **Cursor**: `agent models` で「アカウントで使えるモデル一覧」を取得できる。`--cursor-model` に渡す
+
+### 使い分けの目安
+
+- 設計判断・反証など重い SO → Claude を `--claude-model opus --claude-effort high`（必要なら `max`）に上げる
+- 軽い確認 → 既定モデルのまま（フラグ未指定＝従来挙動）
+- 指定したモデル名が無効・未契約の場合、そのレーンはエラー（`error` / `error_partial`）として結果サマリに現れる
+
+未指定なら各 CLI の既定モデルで動作し、従来と挙動は変わらない。
 
 ## 出力ディレクトリ構成
 
@@ -77,13 +105,13 @@ tmp/so-YYYYMMDD-HHMMSS/
 ├── prompt.txt          # 最終プロンプト全文
 ├── codex-stdout.txt    # Codex の回答
 ├── codex-stderr.txt    # Codex の stderr
-├── codex-meta.txt      # メタデータ（tool, exit_code, elapsed_seconds, stdout_lines, stdout_bytes）
+├── codex-meta.txt      # メタデータ（tool, model_requested, exit_code, elapsed_seconds, stdout_lines, stdout_bytes）
 ├── claude-stdout.txt   # Claude の回答
 ├── claude-stderr.txt   # Claude の stderr
-├── claude-meta.txt     # メタデータ
+├── claude-meta.txt     # メタデータ（model_requested, effort_requested を含む）
 ├── cursor-stdout.txt   # Cursor の回答（--cursor 時のみ）
 ├── cursor-stderr.txt   # Cursor の stderr（--cursor 時のみ）
-└── cursor-meta.txt     # メタデータ（--cursor 時のみ）
+└── cursor-meta.txt     # メタデータ（model_requested 含む。--cursor 時のみ）
 ```
 
 ## 結果読み込み手順

--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -38,6 +38,7 @@ so-compare [OPTIONS] "プロンプト"
 | `--claude-model MODEL` | Claude で使用するモデル（エイリアス `opus`/`sonnet`/`haiku` 可） | CLI 既定 |
 | `--codex-model MODEL` | Codex で使用するモデル | CLI 既定 |
 | `--claude-effort LEVEL` | Claude のエフォート（`low`/`medium`/`high`/`xhigh`/`max`） | CLI 既定 |
+| `--claude-web` | Claude Code に WebFetch を許可（`-p` で外部URL参照を要するタスク用） | 無効 |
 | `--prev DIR` | 前回出力を追記（イテレーション用） | なし |
 
 ### 環境変数
@@ -105,7 +106,7 @@ tmp/so-YYYYMMDD-HHMMSS/
 ├── prompt.txt          # 最終プロンプト全文
 ├── codex-stdout.txt    # Codex の回答
 ├── codex-stderr.txt    # Codex の stderr
-├── codex-meta.txt      # メタデータ（tool, model_requested, exit_code, elapsed_seconds, stdout_lines, stdout_bytes）
+├── codex-meta.txt      # メタデータ（tool, model_requested, exit_code, timeout_status, elapsed_seconds, stdout_lines, stdout_bytes）
 ├── claude-stdout.txt   # Claude の回答
 ├── claude-stderr.txt   # Claude の stderr
 ├── claude-meta.txt     # メタデータ（model_requested, effort_requested を含む）

--- a/scripts/so-compare.sh
+++ b/scripts/so-compare.sh
@@ -23,6 +23,9 @@ Options:
   --cursor       Cursor CLI (agent) も実行（デフォルト: 無効）
   --cursor-only  Cursor のみ実行
   --cursor-model MODEL  Cursor で使用するモデル（デフォルト: auto）
+  --claude-model MODEL  Claude で使用するモデル（エイリアス opus/sonnet/haiku 可。デフォルト: CLI 既定）
+  --codex-model MODEL   Codex で使用するモデル（デフォルト: CLI 既定）
+  --claude-effort LEVEL Claude のエフォート level（low/medium/high/xhigh/max。デフォルト: CLI 既定）
   --claude-web   Claude Code に WebFetch を許可（-p モードで外部URL参照を要するタスク用）
   --prev DIR     前回の so-compare 出力ディレクトリ
                  回答をプロンプトに追記（上限: PREV_MAX_BYTES, デフォルト4000）
@@ -32,6 +35,9 @@ Environment:
   PREV_MAX_BYTES   --prev で追記する回答の上限バイト数（デフォルト: 4000）
   SO_TIMEOUT       各ツールのタイムアウト秒数（整数、デフォルト: 240）
   SO_CURSOR_MODEL  Cursor のデフォルトモデル（デフォルト: auto。--cursor-model で上書き可）
+  SO_CLAUDE_MODEL  Claude のデフォルトモデル（--claude-model で上書き可）
+  SO_CODEX_MODEL   Codex のデフォルトモデル（--codex-model で上書き可）
+  SO_CLAUDE_EFFORT Claude のデフォルトエフォート（--claude-effort で上書き可）
 
 Exit codes:
   0  全プロバイダ成功
@@ -55,6 +61,9 @@ RUN_CLAUDE=true
 RUN_CURSOR=false
 CLAUDE_WEB=false
 CURSOR_MODEL="${SO_CURSOR_MODEL:-auto}"
+CLAUDE_MODEL="${SO_CLAUDE_MODEL:-}"
+CODEX_MODEL="${SO_CODEX_MODEL:-}"
+CLAUDE_EFFORT="${SO_CLAUDE_EFFORT:-}"
 SO_TIMEOUT="${SO_TIMEOUT:-240}"
 SO_RETRY_TIMEOUT_FACTOR=1.5
 
@@ -128,6 +137,21 @@ while [[ $# -gt 0 ]]; do
         --cursor-model)
             require_arg "$1" "${2:-}"
             CURSOR_MODEL="$2"
+            shift 2
+            ;;
+        --claude-model)
+            require_arg "$1" "${2:-}"
+            CLAUDE_MODEL="$2"
+            shift 2
+            ;;
+        --codex-model)
+            require_arg "$1" "${2:-}"
+            CODEX_MODEL="$2"
+            shift 2
+            ;;
+        --claude-effort)
+            require_arg "$1" "${2:-}"
+            CLAUDE_EFFORT="$2"
             shift 2
             ;;
         --claude-web)
@@ -253,6 +277,12 @@ fi
 if $RUN_CURSOR; then
     echo "Cursor: enabled${CURSOR_MODEL:+ (model: $CURSOR_MODEL)}"
 fi
+if $RUN_CODEX && [[ -n "$CODEX_MODEL" ]]; then
+    echo "Codex: model=$CODEX_MODEL"
+fi
+if $RUN_CLAUDE && [[ -n "$CLAUDE_MODEL$CLAUDE_EFFORT" ]]; then
+    echo "Claude:${CLAUDE_MODEL:+ model=$CLAUDE_MODEL}${CLAUDE_EFFORT:+ effort=$CLAUDE_EFFORT}"
+fi
 echo "タイムアウト: ${SO_TIMEOUT}秒"
 echo "プロンプト長: $(echo "$PROMPT" | wc -c | tr -d ' ') bytes"
 echo ""
@@ -292,6 +322,9 @@ run_codex() {
     start=$(date +%s)
 
     local codex_args=("exec" "-s" "$SANDBOX_MODE")
+    if [[ -n "$CODEX_MODEL" ]]; then
+        codex_args+=("--model" "$CODEX_MODEL")
+    fi
     if [[ -n "$WORKSPACE" ]]; then
         codex_args+=("-C" "$WORKSPACE")
     fi
@@ -313,6 +346,7 @@ run_codex() {
 
     {
         echo "tool=codex"
+        echo "model_requested=${CODEX_MODEL:-default}"
         echo "exit_code=$exit_code"
         echo "timeout_status=$timeout_status"
         echo "elapsed_seconds=$elapsed"
@@ -329,6 +363,12 @@ run_claude() {
     start=$(date +%s)
 
     local claude_args=("-p")
+    if [[ -n "$CLAUDE_MODEL" ]]; then
+        claude_args+=("--model" "$CLAUDE_MODEL")
+    fi
+    if [[ -n "$CLAUDE_EFFORT" ]]; then
+        claude_args+=("--effort" "$CLAUDE_EFFORT")
+    fi
     if [[ -n "$WORKSPACE" ]]; then
         claude_args+=("--add-dir" "$WORKSPACE")
     fi
@@ -355,6 +395,8 @@ run_claude() {
 
     {
         echo "tool=claude"
+        echo "model_requested=${CLAUDE_MODEL:-default}"
+        echo "effort_requested=${CLAUDE_EFFORT:-default}"
         echo "exit_code=$exit_code"
         echo "timeout_status=$timeout_status"
         echo "elapsed_seconds=$elapsed"
@@ -395,6 +437,7 @@ run_cursor() {
 
     {
         echo "tool=cursor"
+        echo "model_requested=${CURSOR_MODEL:-default}"
         echo "exit_code=$exit_code"
         echo "timeout_status=$timeout_status"
         echo "elapsed_seconds=$elapsed"


### PR DESCRIPTION
## 目的

`so-compare`（セカンドオピニオン比較）で Claude / Codex のモデルと Claude のエフォートを指定できるようにする。これまでモデル指定できるのは Cursor（`--cursor-model`）のみで、Claude / Codex は各 CLI 既定モデル固定という非対称な状態だった。週次のモデル余力がある際に、SO を上位モデル（Opus）・高エフォートで取得できるようにするのが動機。

Refs #145

## 変更内容

`scripts/so-compare.sh`:
- フラグ追加: `--claude-model` / `--codex-model` / `--claude-effort`
- 環境変数追加: `SO_CLAUDE_MODEL` / `SO_CODEX_MODEL` / `SO_CLAUDE_EFFORT`（フラグで上書き可）
- 指定時のみ各 CLI へ透過（既存 `--cursor-model` と同じ `if/then/fi` 形）。codex は `exec -s <mode>` の直後に `--model` を付与
- 実行サマリは指定時のみ表示（空表示ガード）
- `*-meta.txt`（3レーン）に `model_requested`（Claude は `effort_requested` も）を記録

`canonical/skills/so-compare/SKILL.md`:
- オプション表・環境変数表・使用例を更新
- 「モデル / エフォート選択ガイド」を追加（`opus` 等エイリアスは最新ティアに自動追従、Codex 既定は config 依存、Cursor は `agent models`）

## 設計判断

- **effort は Claude のみ**: Codex は CLI フラグが無く `-c model_reasoning_effort` 経由かつ既定 `high` のため対象外
- **`--list-models` は作らない**: 動的なモデル一覧コマンドが実在するのは Cursor のみ。`opus` エイリアスが最新ティアに自動追従するため、SKILL.md の選択ガイドで足りる
- **meta は `model_requested`**: 「要求したモデル」であり「実際に解決されたモデル」ではないことを明示。解決済みモデルの記録は #146 で追跡

## 検証結果

すべてグリーン。実 API 消費はテスト兼 SO の1回のみ（スタブで到達・後方互換・環境変数経路を消費ゼロで確認）。

```text
shellcheck scripts/so-compare.sh        → clean
so-compare --help                       → 新フラグ/環境変数を表示
スタブ（フラグ指定）                     → claude に --model opus --effort max / codex に --model gpt-5.5 が到達
スタブ（未指定）                         → --model/--effort トークンなし（後方互換）
スタブ（環境変数）                       → SO_CLAUDE_MODEL/EFFORT/SO_CODEX_MODEL 反映
実機テスト（--claude-model opus --claude-effort max）
  → 両者成功 / claude-meta に model_requested=opus, effort_requested=max を実記録
```

- [x] `so-compare --help` に新フラグ・新環境変数が表示される
- [x] 各フラグ・環境変数が CLI に到達する
- [x] 未指定時に `--model` / `--effort` トークンが付かない（後方互換）
- [x] `*-meta.txt` に要求モデルが記録される
- [x] `shellcheck` クリーン
- [x] SKILL.md 更新

## セカンドオピニオン（テスト兼）

実装を `--claude-model opus --claude-effort max`（Claude）+ Codex（gpt-5.5）でレビュー。両者とも「ブロッカー級バグ・既存挙動の破壊なし、マージ可能品質」で一致。外部 CLI のフラグ実在性（`claude --effort` 値域、`codex exec --model` 位置、エイリアス=最新ティア）も一次確認済み。唯一の Medium 指摘（meta の追跡性）は `model_requested` へのリネームで対応し、解決済みモデル記録は #146 へ。
