### PR TITLE
fix(engine): oe-send の Enter 吸収を観測ベース finalize で回復する

### DIFF
--- a/projects/orchestration-engine/docs/episodes/2026-06-09-episode-oe-send-finalize-ingestion.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-09-episode-oe-send-finalize-ingestion.md
@@ -1,0 +1,84 @@
+---
+id: "01KTPB0D98JFNVHJAC9W9GZP50"
+title: "oe-send 送信信頼化 — Enter 吸収の観測ベース finalize 回復（#144 駆動層記録）"
+date: 2026-06-09
+type: episode
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/144"
+    reason: "本サイクルの傘 Issue（Enter 吸収・stage 不達の根治調査）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/plans/2026-06-09-plan-oe-send-ingestion-rootfix.md"
+    reason: "本 episode の実行計画（so-gate v1→v5 を経た実装着手版）"
+  - type: source_material
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/148"
+    reason: "実装 PR"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/episodes/2026-06-08-episode-oe-delegate-redesign.md"
+    reason: "症状の出自（#142 dogfood）。本件はそのフォローアップ（入力側）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
+    reason: "対話 TUI は入出力とも本質的に脆い、という共通洞察"
+tags: [orchestration, oe-send, delegate-send, tmux, ingestion, enter-absorption, finalize, so-gate, episode]
+---
+
+# oe-send 送信信頼化 — Enter 吸収の観測ベース finalize 回復（#144 駆動層記録）
+
+> findings → so-gate v1 → 診断スパイク → so-gate v2/v3/v4/v5 → 実装 → dogfood → Copilot レビュー対応、という1サイクル。**方針が二度転回**（bracketed-paste → 原子送信 c2 → transport据え置き+finalize）し、so-gate が**実バグを複数捕捉**した記録。
+
+## Context / なぜ
+
+#142 dogfood で、`oe_send_line`（tmux `send-keys` → Claude Code 対話 TUI への1行注入）の**自動 Enter が間欠的に「吸収」され submit されない**ことが顕在化（緩和A=0.3s delay のみで未根治）。オーナー判定: 明示 `--no-enter` は仕様だが「自動のはずが届かない」はバグ＝信頼化対象。
+
+## 駆動層の流れと、各ゲートが何を捕まえたか
+
+### 診断スパイク（実機 throwaway claude 2.1.169 / tmux 3.5a）
+- **clean throwaway では2症状とも再現不能**（Enter 吸収 12/12 submit、stage 不達 20/20 着弾）。→ 比較失敗率の計測は不能＝**機構は論証で選ぶ**しかない。
+- `pipe-pane` 観測: idle/通常処理中は `?2004h`（bracketed paste mode）維持、`?2004l` は claude 終了時のみ。
+- **claude の paste 検知は bracket ベース**（raw send の CR は keystroke として submit）→ bracket を送らない baseline の Enter 吸収は **①paste 誤検知では説明できない**（clean 観測の範囲）。残る有力は **②原子性レース**（text と Enter が別 write）だが、再現できないため**断定不可**。
+
+### so-gate（Codex / Claude を5回・各 SO_TIMEOUT=600）
+- **v1**: 初案 bracketed-paste(a) → `paste-buffer -p` は受け手の `?2004h` 依存で**サイレント劣化**（man tmux で確認）→ 撤回。
+- **v2**: c2（単一 paste・原子送信）主軸 + 冪等 finalize → ②過剰主張・finalize 冪等の二重 submit を指摘。
+- **v3**: finalize「安定」定義が**論理反転**（idle+staged の本命で撃たず、processing+staged の危険ケースで撃つ）を捕捉。c2 は緩和A の 0.3s 防御ギャップを除去する賭けで、paste 検知が timing 型なら負荷下で悪化し得る（検証不可）と指摘 → **transport を据え置く決定**。
+- **v4**: **B1**（baseline/edge が発火に無効＋「子ビジー→後に staged_idle」で二重 submit 経路）。**B2**（吸収＝消費 と 遅延配送 を per-event で区別できず、finalize は遅延型なら間欠未submit を間欠**二重**submit に変換し得る＝**純便益の符号は settle 窓次第**）。
+- **v5**: settle 窓が staged_idle 発火を実際にゲートするか未確定／`base_staged` 過剰主張／payload literal 判定未定義 → 確定して3者合意。
+
+### 実装 + dogfood + Copilot
+- 実装: transport 据え置き（send-keys -l → sleep → Enter）の後段に**観測ベース finalize**を追加。状態機械: 送信前 baseline → quiescence poll（settle 窓終端まで）→ `submitted/staged_idle/stage_miss_suspect/unknown` 分類で **staged_idle のみ Enter を1回再送**。保守的発火（不確実なら撃たない）・rc 透過・`OE_SEND_FINALIZE=0` で無効。
+- ユニット: `capture-pane` 時系列モックで分岐 a〜j・単発ガード・回帰を assert（28/28 PASS）。**モックがサブシェル越しの index 伝播で躓いた**（lib は `$(tmux capture-pane)` で読むため変数カウンタが親に伝播しない）→ index/コール数を**ファイルベース**に変更して解消。
+- dogfood: FIRE 経路（手動 stage → finalize が約4s=窓使い切りで submit）と happy path（単一 submit・早期 exit 1s・二重 submit なし）を実機確認。**実 TUI の scrape×fire 整合**（ユニットで検証不能な領域）を裏取り。
+- Copilot（PR #148）: 4件とも妥当 → 全対応（入力欄行頭アンカー・stage_miss を空時のみ・baseline capture 失敗時は finalize 無効化・終端 capture も stable 連鎖に含める）。
+
+## 確定した設計と、その射程
+
+- **transport は賭けない**（機構未確定ゆえ）。緩和A の防御ギャップは第一線として維持。
+- **finalize は「観測可能な staged_idle の after-the-fact 回復」に射程限定**。一次発生は減らさない。
+- **settle 窓 = 中心安全パラメータ**: 「妥当な遅延の最悪値より長く待ち、なお staged なら真の吸収」。遅延配送なら窓内に着弾→submitted で撃たない、で安全側へ。
+
+## 残リスク（対称な honesty・episode/PR に明記）
+
+- **根治の証明は不可**（再現不能）。確率を下げる施策。
+- **finalize の新リスク（二重 submit）も間欠で clean dogfood に出ない**。「fix が効いた証明不可」かつ「新バグ不在も証明不可」。
+- **吸収が負荷相関なら実効回復は小さい可能性**（子ビジー時は撃たない＝busy レジームは回復対象外）。
+- settle 窓 3s は provisional（遅延分布を測れず）。`esc to interrupt` は version 依存 magic string。
+
+## 振り返り
+
+### 効いたこと
+- **再現不能を早期に確定**し、「計測でなく論証で選ぶ／過信しない」へ舵を切れた。スパイクが「①は bracket ベースで除外・②が最有力だが断定不可」まで切り分けた。
+- **so-gate を5回**当てたのが効いた。特に **v3 の論理反転・v4 の B1（二重 submit 経路）・B2（純便益の符号）** は静的レビューでしか出ない実バグ/盲点で、実装前に潰せた。方針も2度（a→c2→据え置き+finalize）反証で正された。
+- **dogfood が実 TUI scrape×fire を裏取り**（ユニットの mock では原理的に検証不能な領域）。
+- **Copilot が4件の堅牢化**を追加で捕捉（baseline 失敗時の誤発火など実害寄り）。
+
+### 学び（次に活かす）
+- **間欠・受け手依存のバグは「根治」でなく「best-effort 回復 + 対称な honesty」が誠実**。証明不可を隠さず、純便益の符号が条件依存であることを明記した。
+- **不確実性が高いほど『賭けない』が強い**: transport 変更は検証不能な悪化リスクがあり見送り、観測ベースの保守的回復に寄せた。
+- **テスト mock とサブシェル**: lib が `$(...)` で読む値はモックの変数カウンタが伝播しない。状態はファイルで持つ。
+- so-gate は「合意」より**反証で実バグを出す**ことに価値があった（5回中ほぼ毎回 blocking を捕捉）。
+
+### follow-up
+- settle 窓 3s の長期 calibration（負荷時に伸ばす判断基準）。
+- ②/③ の deterministic 再現環境（「整形崩れセッション」の人工再現）は未達＝根本の機構特定は保留。
+- `oe-capture` の pane-id 2系統・出力チャネル統一 → #114。

--- a/projects/orchestration-engine/docs/plans/2026-06-09-plan-oe-send-ingestion-rootfix.md
+++ b/projects/orchestration-engine/docs/plans/2026-06-09-plan-oe-send-ingestion-rootfix.md
@@ -1,0 +1,143 @@
+---
+id: "01KTNXQCK8YSZ8R1FPDJCMZ4KH"
+title: "oe_send_line 送信信頼化計画 — transport 据え置き + 観測ベース finalize（staged_idle 回復）"
+date: 2026-06-09
+type: plan
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/144"
+    reason: "本計画の傘 Issue（Enter 吸収・stage 不達の根治調査）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-06-08-episode-oe-delegate-redesign.md"
+    reason: "症状・dogfood・緩和A導入の出自（#142）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
+    reason: "対話 TUI は入出力とも本質的に脆い、という共通洞察（本件は入力側）"
+  - type: design_context
+    ref: "projects/wezterm-ai-mode/lib/pane.sh"
+    reason: "単一書き込み送信の先行事例（c2 として検討→ギャップ除去リスクで見送り）"
+tags: [orchestration, oe-send, delegate-send, tmux, ingestion, enter-absorption, finalize, plan]
+---
+
+# oe_send_line 送信信頼化計画 — transport 据え置き + 観測ベース finalize（staged_idle 回復）
+
+> 駆動層: findings → so-gate v1 → 診断スパイク → so-gate v2/v3/v4/v5 → **本書（v5 最終指摘反映＝実装着手版）** → 承認 → 実装。so-gate v5 で 3者合意（approach 一致・未解決 critical risk 無し・残点は同 PR 吸収可）。
+
+## 1. Context / 問題
+
+`oe_send_line`（`lib/delegate-send.sh`、`bin/oe-send`/`bin/oe-delegate` が使用）は tmux `send-keys` で Claude Code 対話 TUI へ1行注入する transport。#142 dogfood で2症状が**間欠的**に顕在化:
+
+- **Enter 吸収**: テキストは入力欄に staged されるが Enter が効かず未 submit。手動 Enter で submit。
+- **stage 不達**: 稀にテキスト自体が入力欄に残らない。
+
+現状は緩和策A（Enter 前 `sleep ${OE_SEND_ENTER_DELAY:-0.3}`）のみ。オーナー判定: 明示 `--no-enter`（ステージのみ）は仕様 OK だが「自動(Enter)のはずが届かない」のはバグ＝信頼化対象。
+
+## 2. so-gate の経緯（v1→v5 で五度の反証）
+
+- **v1**: bracketed-paste(a) 主軸 → `?2004h` 依存劣化で撤回。
+- **v2**: c2（単一 paste）主軸 + 冪等 finalize → ②過剰主張・finalize 冪等の二重 submit を指摘。
+- **v3**: finalize「安定」定義が論理反転を捕捉。c2 は `sleep 0.3` 防御ギャップ除去で①timing 型なら負荷下悪化（検証不可）。
+- **v4**: B1（baseline/edge が発火に無効＋子ビジー→staged_idle 二重 submit 経路）／B2（吸収 vs 遅延配送を区別不能＝finalize 純便益の符号は settle 窓次第）。
+- **v5**: 主要 blocking は解消。残: settle 窓が staged_idle 発火を実際にゲートするか未確定／`base_staged` 過剰主張／payload literal 判定未定義 → **本書で確定**（3者合意）。
+- **決定**: transport 据え置き継続。finalize は **settle 窓を発火ゲートに使う**形へ確定し、射程を「**観測可能な staged_idle の after-the-fact 回復**」に honest 限定。
+
+## 3. 診断スパイク（2026-06-09 実機・throwaway claude 2.1.169 / tmux 3.5a）
+
+clean throwaway claude を spawn し `pipe-pane` でエスケープ列を観測。生ログ `/tmp/oe-spike-144/`（揮発）。
+
+| # | 検証項目 | 結果 | status |
+|---|---------|------|--------|
+| S1 | submit 信号と画面領域 | 入力欄＝`❯` 行（`tail -1`）。**"esc to interrupt" は `❯` 行と別行（最下部 status 行）**＝scrape は2領域。`C-u` reset 可 | verified（実機 capture） |
+| S2/S3 | bracketed paste mode | idle/通常処理中 `?2004h` 維持、`?2004l` は claude 終了時のみ | verified（pipe-pane ログ） |
+| S7 | baseline 再現（Enter 吸収） | delay=0・長め payload・12回 → 12/12 submit・absorbed 0 | verified（実機・clean idle） |
+| S8 | baseline 再現（stage 不達） | literal 20回 → 20/20 着弾・miss 0 | verified（実機・clean idle） |
+| S6 | paste 検知の方式 | clean idle では raw send の CR は keystroke として submit | unverified-summary（推論。負荷時/modal の timing 未観測） |
+
+**結論**:
+- clean throwaway では2症状とも**再現不能**＝比較失敗率の計測は不能、機構は論証で選ぶ。[verified（再現試行）]
+- **① 完全除外は主張しない**（前提 S6 が unverified、負荷時 timing 型併用は否定不可）。[unverified-summary]
+- **② も断定不可**（再現できず、race が claude 内部なら transport 変更で閉じない）。[unverified-summary]
+- → **transport を変える根拠は確証に至らない**ため据え置き、finalize を主柱に（射程は staged_idle 回復に限定）。
+
+## 4. 決定した方向（実装着手版・承認待ち）
+
+- **transport 据え置き**: `send-keys -l text` → `sleep ${OE_SEND_ENTER_DELAY:-0.3}` → `send-keys Enter`。緩和A の 0.3s ギャップは第一線防御として維持。c2/`;` は 0.3s 除去の賭け＋global buffer 副作用で見送り。
+- **観測ベース finalize を主柱（既定ON・保守的）**: 既存送信は変えず後段に検証層を追加。**射程は「観測可能な staged_idle（＝settle 窓終端まで入力欄に残る吸収）の after-the-fact 回復」に限定**。一次発生は減らさない。「機構非依存に救う」とは主張しない（**吸収＝Enter が消費される場合に救う／遅延配送型では settle 窓が短いと二重化し得る**）。
+- **settle 窓 = 中心安全パラメータ**（v4 B2/B4・v5 確定）: 「妥当な配送/描画遅延の最悪値より長く待ち、窓終端までなお staged なら真の吸収」とみなし**窓が発火を実際にゲートする**設計。窓を伸ばす＝二重 submit に安全だが回復が遅延、のトレードオフを明示（§7）。
+
+## 5. 実装計画（`lib/delegate-send.sh` 中心・1論理変更=1PR）
+
+### 5.1 観測ベース finalize（状態機械・主柱）
+既存送信ロジックは不変。`send_enter≠0`（auto）かつ `OE_SEND_FINALIZE≠0` の時のみ後段で実行。
+
+**送信前 baseline capture**（ガード・v4 B1/N2）:
+- [ ] `base_proc` = 処理インジケータ領域に "esc to interrupt" が**既に出ているか**（子が送信前からビジーか）。
+- [ ] `base_staged` = 入力欄領域に**既存の内容があるか**。
+
+**scrape は2領域を別々に抽出**（v4 B3・S1）:
+- [ ] 入力欄領域（`❯` 行＝payload 有無・空判定）と 処理インジケータ領域（最下部 status＝"esc to interrupt" 検知）を別関数で。入力欄限定にして processing 検知を落とさない。
+- [ ] payload 一致判定は**リテラル部分一致**（`grep -F` 等・正規表現解釈しない＝メタ文字 payload で誤判定しない・so v5）。
+
+**poll（窓が staged_idle 発火を実際にゲートする・v5 最重要確定）**:
+- [ ] 送信後、間隔 `OE_SEND_FINALIZE_INTERVAL`（既定 0.3s）で `OE_SEND_FINALIZE_TIMEOUT`（既定 3s・**中心安全パラメータ＝発火をゲートする窓**。負荷時は伸ばす）まで poll。
+- [ ] **早期 exit は submit 確証時のみ**（happy path に全窓を課さない）: payload を一度 staged 観測後に入力欄が空、または処理インジケータが **edge**（`base_proc=false`→present）で出現 → `submitted` 確定で即 exit。
+- [ ] **`staged_idle` 発火は早期 exit しない**: payload が**窓終端まで quiescent に staged 継続**（直近 K 読み不変＝`OE_SEND_FINALIZE_STABLE` 既定3、かつ全窓 staged）の時のみ。K=終端安定の最小読み数、TIMEOUT=真の安全窓 → 遅延配送の Enter は窓内に着弾→submitted→撃たない、で安全側（v4 B2）。
+- [ ] quiescence 比較は**入力欄領域の実揮発要素**（カーソル/placeholder 等）を正規化（status 領域のタイマー "Crunched 4m15s" は別領域＝混同しない・v4 N1/Nit）。
+
+**安定状態の分類と発火**（finalize 追加 Enter は **1 呼び出しにつき最大1回**）:
+- [ ] `submitted`（payload を staged 観測後に消失 or edge processing） → **撃たない**。
+- [ ] `staged_idle`（payload が**窓終端まで** quiescent に staged・processing でない・**かつ `base_proc=false`・かつ `base_staged=false`**） → **Enter を1回**（吸収の回復・本命）。
+- [ ] `stage_miss_suspect`（payload を一度も staged 観測せず入力欄が空・edge processing 無し） → **warn のみ・撃たない**（§5.2）。
+- [ ] `unknown`（窓内に終端安定せず／折返しで payload 不可読／capture-pane 失敗（v4 N5）／`base_proc=true`／**`base_staged=true`＝無条件 unknown**） → **撃たない**（保守）。
+- [ ] 発火後ループしない。
+
+**明記事項**:
+- [ ] 「冪等」「受け手非依存」「確実に防ぐ」は使わない。実態は **Claude TUI screen scrape ベース・best-effort・保守的**。
+- [ ] **finalize は全ブランチで transport の rc を変えない**（capture-pane 失敗・unknown 含む）。rc を漏らすと呼び出し側が再送→二重 submit（v4・so v5）。
+- [ ] **`base_staged` の射程**: `base_staged=true` は finalize を撃たないだけ。**元 Enter（transport 本体）が既存内容ごと submit する挙動は finalize では防げない**（transport レベルの既存条件＝射程外）。「finalize による追加誤 submit を足さない」までが正確（so v5）。
+- [ ] "esc to interrupt" は claude 2.1.169 観測の **version 依存 magic string** → 定数化＋バージョン注記。
+- [ ] 残存 race: 配送遅延 > settle 窓のとき finalize 発火後に元 Enter 着弾＝二重 submit が病的負荷下で残る（§7）。
+- [ ] `OE_SEND_FINALIZE=0` で finalize 層を完全無効（capture も追加 Enter も stage_miss warn もしない）。
+
+### 5.2 stage 不達の warn（観測性のみ・rc 不変・v4 N4）
+- [ ] `stage_miss_suspect`（§5.1）で **warn ログのみ**・**rc は変えない**（false positive で非0→呼び出し側再送→二重 submit を防ぐ）。
+- [ ] **warn の限界を明記**: benign 高速 submit も "neither" に見え false-positive・子ビジー+吸収+staged は warn が出ず無言ロス。観測補助であり信頼判定でない。`unknown` とはログ上区別。
+
+### 5.3 既存契約の維持
+- [ ] transport（send-keys 順序）・`--no-enter`（ステージのみ・finalize 不発火）・改行 fail-fast・tmux 不在・pane 生存チェックは不変。`OE_SEND_ENTER_DELAY` 維持（obsolete でない）。
+- [ ] baseline capture / finalize は **auto（`send_enter≠0`）時のみ**。finalize は **rc を変えない**（§5.1 再掲・全ブランチ）。
+
+### 5.4 テスト
+- [ ] tmux モックに `capture-pane`（**時系列の戻り値を差替え可能に**＝配列/カウンタで連続 capture をモック・stderr warn とラベル取得口も用意・so v5）を追加し、**finalize 分岐の計算ラベルを assert**（v4 T1: 発火有無でなく `submitted/staged_idle/stage_miss_suspect/unknown` のラベルを検証）:
+  - (a) staged 観測後に空＝submitted→撃たない / (b) staged_idle（base_proc=false・窓終端まで staged）→1回 / (c) **baseline busy→後に staged_idle**＝unknown→**撃たない**（v4 T2・B1） / (d) processing edge→撃たない / (e) payload 不在・未staged＝stage_miss_suspect→warn のみ rc 不変 / (f) 折返し部分不一致＝unknown→撃たない / (g) **既存 base_staged 有**＝無条件 unknown→撃たない（v4 N2） / (h) capture-pane 失敗＝unknown→撃たない・**rc 不変**（v4 N5） / (i) **K 安定後に遅延 submit**（staged×K → empty）＝**窓終端まで staged 継続せず submitted**→撃たない（so v5・読み①/②識別の決定的ケース） / (j) **正規表現メタ文字 payload** のリテラル一致（`grep -F`）で誤判定しない。
+  - **finalize 単発ガード**: **1 回の `oe_send_line` 呼び出し内で finalize 追加 Enter は最大1回**（呼び出しごとの元 Enter は当然必要・so v5 で文言修正）。**注記: プロセス内ガードの確認に過ぎず、元Enter×finalizeEnter の実 race は mock で検証不能**。
+  - `OE_SEND_FINALIZE=0` で capture・追加 Enter・stage_miss warn が一切発生しないこと。
+  - 揮発文字正規化（入力欄領域の揮発要素混入でも quiescence 到達）（v4 N1）。
+  - 既存ガード（改行 reject / dead pane / list-panes fail / pane 必須 / `--no-enter` で Enter 撃たない）の回帰。
+- [ ] `shellcheck` clean。
+- [ ] **テストの限界**: mock は発行と分岐ラベルを見るだけ。実 submit・実 race・二重 submit 不在・scrape 領域×processing の実レイアウト整合は**原理的にユニット検証不能＝dogfood 専管**（v4 B3）。
+
+## 6. ゲート / 検証（実行義務・interleave）
+- [ ] `shellcheck` + `tests/test_delegate_send.sh` を**PR 前に実走**（test plan 実行）。
+- [ ] dogfood（実機 gate）: finalize が staged_idle 吸収を救う・子ビジー時に撃たない・happy path で早期 exit・`--no-enter` 不変。**狭幅/日本語/正規表現メタ文字 payload**・**settle 窓(3s)の calibration**（K×INTERVAL≪TIMEOUT の罠を避ける・3s 維持/延長の判断基準を記録）。間欠ゆえ「消去の証明」でなく**回帰なし + 機構論証**で評価。
+- [ ] PR 作成 → Copilot レビュー対応。
+- [ ] episode 追記（`2026-06-08-...redesign.md` 末尾 or #144 独立 episode を分量で判断）。
+
+## 7. リスク / Open questions（対称な honesty）
+- **根治の証明は不可** [verified（再現不能）]。observed staged_idle 吸収を best-effort 回復し**確率を下げる**もの。一次発生は減らさない（transport 据え置き）。
+- **finalize の純便益の符号は settle 窓に依存** [unverified-summary]（v4 B2）: 吸収（消費）なら正、遅延配送型なら窓が短いと二重 submit に反転。窓を**発火ゲート**にして安全側へ寄せるが、配送遅延 > 窓の病的ケースは irreducible。
+- **吸収が負荷相関なら finalize の実効回復は小さい可能性** [unverified-summary]（so v5）: S7/S8 は clean idle で吸収を再現できず＝吸収は負荷/timing 相関の疑い。一方 finalize は `base_proc=true`（子ビジー）を撃たない＝**吸収が最も起きやすいと疑われる busy レジームを回復も警告もせず素通り**。回復対象は idle-baseline の吸収に限られる。
+- **finalize の新リスク（二重 submit）も間欠で clean dogfood に出ない**。「fix が効いた証明不可」かつ「新バグ不在も証明不可」を episode/PR に**対称に明記**。
+- **settle 窓 3s は provisional**（再現不能で遅延分布を測れず）。dogfood calibration をゲート化（§6）。
+- **"esc to interrupt" magic string** は claude バージョン依存（定数化で保守）。
+- **modal 状態未検証**（権限プロンプト/plan-wait の入力受付）＝③readiness。子ビジー扱いで撃たず stage 残存（warn で観測）。
+- **再現不能の根本未解決**: ① timing 型併用の有無 / race の所在（pty か claude 内部か）は buggy 再現なしには解決不能。
+
+## 8. スコープ外
+- transport の変更（c2 / `;` バッチ）＝再現不能下では賭けない（見送り）。
+- `oe-capture` の出力チャネル・pane-id 2系統統一 → #114。
+- 明示 `--no-enter`（ステージのみ）はバグでなく仕様。
+- stage 不達の**自動 fix**（検知 warn §5.2 はスコープイン、fix はスコープ外）。
+- 一次発生（Enter 吸収そのもの）の削減＝transport 据え置きにより射程外。
+- ②/③ の deterministic 再現環境の構築。

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -57,8 +57,10 @@ _oe_send_finalize() {
   # 既存条件で finalize では防げない）。finalize による「追加の」誤 submit を足さないため撃たない。
   [[ "$base_staged" == "1" ]] && return 0
 
+  # ceil(timeout/interval)。floor だと割り切れない時に総待機が TIMEOUT 未満になり安全窓を
+  # 満たさない（例 timeout=1/interval=0.3 → 0.9s）。最低 TIMEOUT は待つ（Copilot 指摘）。
   local max_iter
-  max_iter="$(awk -v t="$timeout" -v i="$interval" 'BEGIN{ if(i+0<=0) i=0.3; n=int((t+0)/(i+0)); if(n<1)n=1; print n }')"
+  max_iter="$(awk -v t="$timeout" -v i="$interval" 'BEGIN{ if(i+0<=0) i=0.3; n=int((t+0)/(i+0)); if(n*(i+0) < (t+0)) n++; if(n<1)n=1; print n }')"
 
   local i cap input proc staged norm prev="" stable=0 saw_staged=0
   for ((i=0; i<max_iter; i++)); do

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -21,7 +21,8 @@
 #   capture-pane の出力から入力欄行（最下部の `❯` 行）を1行返す。
 #   送信済みメッセージの echo も `❯` で始まるが画面上方に出るため tail -1 が入力欄。
 _oe_send_inputline() {
-  printf '%s\n' "$1" | grep '❯' | tail -n 1
+  # 入力欄プロンプトは行頭（先頭空白許容）の `❯`。行中に現れる `❯` を誤って拾わない（Copilot 指摘）。
+  printf '%s\n' "$1" | grep '^[[:space:]]*❯' | tail -n 1
 }
 
 # _oe_send_has_content <input-line>
@@ -78,20 +79,24 @@ _oe_send_finalize() {
     sleep "$interval"
   done
 
-  # 窓終端の最終判定（再 capture）
+  # 窓終端の最終判定（再 capture）。終端 capture も stable 連鎖に含める＝終端で入力欄が
+  # 変化していたら「終端安定」とみなさない（直前まで stable でも staged_idle 発火しない・Copilot 指摘）。
   cap="$(tmux capture-pane -p -t "$pane" 2>/dev/null)" || return 0
   input="$(_oe_send_inputline "$cap")"
   if printf '%s\n' "$cap" | tail -n 3 | grep -qF -- "$marker"; then proc=1; else proc=0; fi
   if printf '%s' "$input" | grep -qF -- "$payload"; then staged=1; else staged=0; fi
   [[ "$staged" == "1" ]] && saw_staged=1
+  norm="$(printf '%s' "$input" | sed 's/[[:space:]]*$//')"
+  if [[ "$norm" == "$prev" ]]; then stable=$((stable+1)); else stable=1; fi
 
   # staged_idle: 窓終端までなお staged・processing でない・baseline idle・終端安定 → 1回撃つ
   if [[ "$staged" == "1" && "$proc" == "0" && "$base_proc" == "0" && "$stable" -ge "$stable_need" ]]; then
     tmux send-keys -t "$pane" Enter
     return 0
   fi
-  # stage_miss_suspect: 一度も staged 観測せず空 → warn のみ（観測補助・rc は変えない）
-  if [[ "$saw_staged" == "0" && "$staged" == "0" ]]; then
+  # stage_miss_suspect: 一度も staged 観測せず、入力欄が空のとき → warn のみ（観測補助・rc は変えない）。
+  # 入力欄に内容が残る（折返し/省略で payload と完全一致しない）ケースは unknown 扱いで warn しない（Copilot 指摘）。
+  if [[ "$saw_staged" == "0" && "$staged" == "0" ]] && ! _oe_send_has_content "$input"; then
     echo "oe_send_line: finalize: payload not observed staged or submitted on ${pane} (possible stage miss / fast submit)" >&2
     return 0
   fi
@@ -145,11 +150,16 @@ oe_send_line() {
   local fin_on=0 base_proc=0 base_staged=0
   if [[ "$send_enter" != "0" && "${OE_SEND_FINALIZE:-1}" != "0" ]]; then
     fin_on=1
-    local bcap binput bmarker="${OE_SEND_PROC_MARKER:-esc to interrupt}"
-    bcap="$(tmux capture-pane -p -t "$pane" 2>/dev/null)" || bcap=""
-    if printf '%s\n' "$bcap" | tail -n 3 | grep -qF -- "$bmarker"; then base_proc=1; fi
-    binput="$(_oe_send_inputline "$bcap")"
-    if _oe_send_has_content "$binput"; then base_staged=1; fi
+    local bcap binput brc bmarker="${OE_SEND_PROC_MARKER:-esc to interrupt}"
+    bcap="$(tmux capture-pane -p -t "$pane" 2>/dev/null)"; brc=$?
+    if [[ "$brc" -ne 0 ]]; then
+      # baseline が取れない＝送信前状態が不明 → finalize 無効化（idle と誤認して撃つのを防ぐ・Copilot 指摘）。
+      fin_on=0
+    else
+      if printf '%s\n' "$bcap" | tail -n 3 | grep -qF -- "$bmarker"; then base_proc=1; fi
+      binput="$(_oe_send_inputline "$bcap")"
+      if _oe_send_has_content "$binput"; then base_staged=1; fi
+    fi
   fi
 
   # -- で text のオプション誤解釈を防ぐ。-l はリテラル送信。Enter は別途発火（任意）。

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -7,12 +7,105 @@
 # 既存 lib/spawn.sh の oe_spawn_send（wez・claude -p・非対話・envelope 経由）とは
 # 別系統。こちらは対話セッションへ tmux send-keys で注入する transport。
 # bin/oe-send / bin/oe-delegate が使う。将来 bin/oe-report も無改修で乗れるよう独立。
+#
+# 送信信頼化（Issue #144）: tmux send-keys → Claude Code TUI の取り込みは間欠的に
+# 不安定で、自動 Enter が「吸収」され submit されないことがある（dogfood で確認）。
+# transport（send-keys -l → sleep → Enter）は据え置き、送信後に「観測ベースの finalize」を
+# 後段で走らせ、入力欄に payload が staged のまま残る吸収を after-the-fact で1回だけ回復する。
+# finalize は Claude TUI の screen scrape ベースの best-effort・保守的判定で、transport の
+# rc を一切変えない。設計経緯は docs/plans/2026-06-09-plan-oe-send-ingestion-rootfix.md。
+
+# --- finalize 内部ヘルパー（source 専用・oe_ 接頭辞でネームスペース汚染を最小化） ---
+
+# _oe_send_inputline <capture-text>
+#   capture-pane の出力から入力欄行（最下部の `❯` 行）を1行返す。
+#   送信済みメッセージの echo も `❯` で始まるが画面上方に出るため tail -1 が入力欄。
+_oe_send_inputline() {
+  printf '%s\n' "$1" | grep '❯' | tail -n 1
+}
+
+# _oe_send_has_content <input-line>
+#   入力欄行にプレースホルダでない既存内容があれば 0。空 or `Try "..."`（候補表示）は 1。
+#   plain capture では色が落ちるためプレースホルダ判定はヒューリスティック（best-effort）。
+_oe_send_has_content() {
+  local line="${1#*❯}"
+  line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [[ -n "$line" ]] || return 1
+  case "$line" in
+    'Try "'*) return 1 ;;  # 空入力時のプレースホルダ候補 → 内容なし扱い
+  esac
+  return 0
+}
+
+# _oe_send_finalize <pane> <payload> <base_proc> <base_staged>
+#   自動送信（Enter 発火）後に呼ぶ。入力欄に payload が staged のまま残る Enter 吸収を
+#   settle 窓終端まで観測し、なお staged なら Enter を1回だけ再送して回復する。
+#   - settle 窓 = 中心安全パラメータ。遅延配送の Enter は窓内に着弾→submitted 判定で撃たない。
+#   - 受け手状態に依存する best-effort。二重 submit を「確実に」防ぐとは主張しない（窓 < 遅延の
+#     病的負荷下では残存）。常に 0 を返し transport の rc を変えない（誤再送→二重 submit 防止）。
+_oe_send_finalize() {
+  local pane="$1" payload="$2" base_proc="$3" base_staged="$4"
+  local interval="${OE_SEND_FINALIZE_INTERVAL:-0.3}"
+  local stable_need="${OE_SEND_FINALIZE_STABLE:-3}"
+  local timeout="${OE_SEND_FINALIZE_TIMEOUT:-3}"
+  local marker="${OE_SEND_PROC_MARKER:-esc to interrupt}"
+
+  # payload 空（直呼び等）は literal 一致が全マッチになり誤発火するため撃たない。
+  [[ -z "$payload" ]] && return 0
+  # 送信前から入力欄に内容あり = 元 Enter が既存内容ごと submit し得る（transport レベルの
+  # 既存条件で finalize では防げない）。finalize による「追加の」誤 submit を足さないため撃たない。
+  [[ "$base_staged" == "1" ]] && return 0
+
+  local max_iter
+  max_iter="$(awk -v t="$timeout" -v i="$interval" 'BEGIN{ if(i+0<=0) i=0.3; n=int((t+0)/(i+0)); if(n<1)n=1; print n }')"
+
+  local i cap input proc staged norm prev="" stable=0 saw_staged=0
+  for ((i=0; i<max_iter; i++)); do
+    cap="$(tmux capture-pane -p -t "$pane" 2>/dev/null)" || return 0  # capture 失敗 = unknown → 撃たない
+    input="$(_oe_send_inputline "$cap")"
+    if printf '%s\n' "$cap" | tail -n 3 | grep -qF -- "$marker"; then proc=1; else proc=0; fi
+    if printf '%s' "$input" | grep -qF -- "$payload"; then staged=1; else staged=0; fi
+    [[ "$staged" == "1" ]] && saw_staged=1
+
+    # submit 確証 → 早期 exit（撃たない）: payload が staged 観測後に消えた / 処理が edge で開始
+    [[ "$saw_staged" == "1" && "$staged" == "0" ]] && return 0
+    [[ "$proc" == "1" && "$base_proc" == "0" ]] && return 0
+
+    # quiescence（入力欄の末尾揮発を正規化して連続不変を数える）。staged_idle は窓終端まで待つ。
+    norm="$(printf '%s' "$input" | sed 's/[[:space:]]*$//')"
+    if [[ "$norm" == "$prev" ]]; then stable=$((stable+1)); else stable=1; fi
+    prev="$norm"
+    sleep "$interval"
+  done
+
+  # 窓終端の最終判定（再 capture）
+  cap="$(tmux capture-pane -p -t "$pane" 2>/dev/null)" || return 0
+  input="$(_oe_send_inputline "$cap")"
+  if printf '%s\n' "$cap" | tail -n 3 | grep -qF -- "$marker"; then proc=1; else proc=0; fi
+  if printf '%s' "$input" | grep -qF -- "$payload"; then staged=1; else staged=0; fi
+  [[ "$staged" == "1" ]] && saw_staged=1
+
+  # staged_idle: 窓終端までなお staged・processing でない・baseline idle・終端安定 → 1回撃つ
+  if [[ "$staged" == "1" && "$proc" == "0" && "$base_proc" == "0" && "$stable" -ge "$stable_need" ]]; then
+    tmux send-keys -t "$pane" Enter
+    return 0
+  fi
+  # stage_miss_suspect: 一度も staged 観測せず空 → warn のみ（観測補助・rc は変えない）
+  if [[ "$saw_staged" == "0" && "$staged" == "0" ]]; then
+    echo "oe_send_line: finalize: payload not observed staged or submitted on ${pane} (possible stage miss / fast submit)" >&2
+    return 0
+  fi
+  # それ以外（base_proc=1・非安定・折返し等）= unknown → 撃たない
+  return 0
+}
 
 # oe_send_line <pane_id> <text> [send_enter]
 #   <text> に改行（LF / CR）が含まれていれば送信せず非 0 で失敗する（途中送信の根本封じ）。
 #   対象ペインが存在しなければ非 0 で失敗する（死んだペインへの無言送信を防ぐ）。
 #   send_enter（既定 "1"）が "0" のときは Enter を発火せずテキスト投入のみ（ステージ）。
 #   成功時は tmux send-keys -l でリテラル注入し、既定では続けて Enter を発火する。
+#   自動送信時は送信後に観測ベース finalize（Enter 吸収の after-the-fact 回復）を走らせる
+#   （`OE_SEND_FINALIZE=0` で無効化可。finalize は rc を変えない best-effort）。
 oe_send_line() {
   local pane="${1:-}"
   local text="${2:-}"
@@ -46,7 +139,21 @@ oe_send_line() {
     echo "oe_send_line: target pane not found: ${pane}" >&2
     return 1
   fi
+
+  # finalize 用の送信前 baseline（自動送信 かつ finalize 有効時のみ）。
+  # base_proc: 送信前から処理中か（子がビジー）／ base_staged: 入力欄に既存内容があるか。
+  local fin_on=0 base_proc=0 base_staged=0
+  if [[ "$send_enter" != "0" && "${OE_SEND_FINALIZE:-1}" != "0" ]]; then
+    fin_on=1
+    local bcap binput bmarker="${OE_SEND_PROC_MARKER:-esc to interrupt}"
+    bcap="$(tmux capture-pane -p -t "$pane" 2>/dev/null)" || bcap=""
+    if printf '%s\n' "$bcap" | tail -n 3 | grep -qF -- "$bmarker"; then base_proc=1; fi
+    binput="$(_oe_send_inputline "$bcap")"
+    if _oe_send_has_content "$binput"; then base_staged=1; fi
+  fi
+
   # -- で text のオプション誤解釈を防ぐ。-l はリテラル送信。Enter は別途発火（任意）。
+  # transport は据え置き（#144: 機構未確定ゆえ送信経路は賭けない）。
   tmux send-keys -l -t "$pane" -- "$text"
   if [[ "$send_enter" != "0" ]]; then
     # リテラル送信の直後に Enter を撃つと、Claude Code TUI の paste 検知で Enter が
@@ -54,5 +161,9 @@ oe_send_line() {
     # 小休止で paste 検知窓を閉じてから Enter を撃つ。OE_SEND_ENTER_DELAY で上書き可。
     sleep "${OE_SEND_ENTER_DELAY:-0.3}"
     tmux send-keys -t "$pane" Enter
+    # 観測ベース finalize（best-effort・rc を変えない）。Enter 吸収の after-the-fact 回復。
+    if [[ "$fin_on" == "1" ]]; then
+      _oe_send_finalize "$pane" "$text" "$base_proc" "$base_staged" || true
+    fi
   fi
 }

--- a/projects/orchestration-engine/tests/test_delegate_send.sh
+++ b/projects/orchestration-engine/tests/test_delegate_send.sh
@@ -3,6 +3,13 @@
 #
 # 改行拒否・pane 検証・list-panes 失敗の環境エラー区別・Enter 発火/--no-enter を
 # tmux 関数モックで自動検証する（Issue #142 / Copilot 指摘）。実 tmux サーバ不要。
+#
+# Issue #144: 観測ベース finalize（Enter 吸収の after-the-fact 回復）の分岐を、
+# capture-pane を時系列モック化して発火/不発火・warn で検証する。
+# 注: lib は capture を `$(tmux capture-pane)` のサブシェルで読むため、モックの capture
+# インデックス/呼び出し数は「ファイル」で持つ（サブシェルの変数代入は親に伝播しないため）。
+# 注: mock は tmux 発行と finalize 分岐を見るだけ。実 submit・実 race・二重 submit 不在・
+# scrape 領域×レイアウト整合は原理的にユニット検証不能＝dogfood 専管。
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -10,19 +17,38 @@ LIB="${SCRIPT_DIR}/../lib/delegate-send.sh"
 
 export OE_SEND_ENTER_DELAY=0   # テスト高速化（Enter 前の小休止を 0 に）
 
+# --- サブシェル越しに持つ状態（capture の連続返却とコール数） ---
+CAP_IDXFILE="$(mktemp)";   echo 0 > "$CAP_IDXFILE"
+CAP_CALLSFILE="$(mktemp)"; echo 0 > "$CAP_CALLSFILE"
+ERRFILE="$(mktemp)"
+trap 'rm -f "$CAP_IDXFILE" "$CAP_CALLSFILE" "$ERRFILE"' EXIT
+
 # --- モック tmux: list-panes は MOCK_LIVE_PANES、send-keys は MOCK_SENDKEYS_LOG に記録 ---
+# capture-pane は MOCK_CAP_SEQ（配列・各要素が1画面分）を順に返し、尽きたら最後を反復。
+# インデックス/コール数はファイル（CAP_IDXFILE/CAP_CALLSFILE）に持つ＝サブシェル越しでも進む。
 MOCK_LIVE_PANES="%5 %7"
 MOCK_SENDKEYS_LOG=""
+MOCK_CAP_SEQ=()
 tmux() {
   case "${1:-} ${2:-}" in
     "list-panes -a"|"list-panes"*)
       if [[ -n "${MOCK_TMUX_FAIL:-}" ]]; then echo "no server running on socket" >&2; return 1; fi
       # shellcheck disable=SC2086
       printf '%s\n' $MOCK_LIVE_PANES ;;
+    "capture-pane"*)
+      local c; c="$(cat "$CAP_CALLSFILE")"; echo $((c+1)) > "$CAP_CALLSFILE"
+      if [[ "${MOCK_CAP_FAIL:-}" == "1" ]]; then return 1; fi
+      local n="${#MOCK_CAP_SEQ[@]}"; [[ "$n" -eq 0 ]] && return 0
+      local idx; idx="$(cat "$CAP_IDXFILE")"
+      local use="$idx"; [[ "$use" -ge "$n" ]] && use=$((n-1))
+      printf '%s\n' "${MOCK_CAP_SEQ[$use]}"
+      echo $((idx+1)) > "$CAP_IDXFILE" ;;
     "send-keys"*) MOCK_SENDKEYS_LOG+="tmux $*"$'\n' ;;
     *) return 0 ;;
   esac
 }
+# finalize の sleep を無効化（テストは即時）。
+sleep() { :; }
 
 # shellcheck source=../lib/delegate-send.sh
 source "$LIB"
@@ -32,6 +58,9 @@ ck() { # <desc> <expected> <actual>
   if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; pass=$((pass+1));
   else echo "  FAIL: $1 (want='$2' got='$3')"; fail=$((fail+1)); fi
 }
+
+# === 既存テスト（transport）: finalize は無効化して transport の挙動のみ検証 ===
+export OE_SEND_FINALIZE=0
 
 echo "[1] 改行拒否 → rc 2 / send-keys 未呼び出し"
 MOCK_SENDKEYS_LOG=""
@@ -64,6 +93,105 @@ rc=0; oe_send_line "%5" "hello" "0" >/dev/null 2>&1 || rc=$?
 ck "send rc=0" "0" "$rc"
 ck "literal 'hello' を送信" "yes" "$(echo "$MOCK_SENDKEYS_LOG" | grep -q 'hello' && echo yes || echo no)"
 ck "Enter を撃たない" "yes" "$(echo "$MOCK_SENDKEYS_LOG" | grep -q 'Enter' && echo no || echo yes)"
+
+# === Issue #144: 観測ベース finalize の分岐テスト ===
+# 画面ビルダ（入力欄＝`❯` 行・最下部に処理インジケータ "esc to interrupt"）
+scr_staged()  { printf '────── ws ──\n❯ %s\n──────\n  ? for shortcuts' "$1"; }
+scr_empty()   { printf '────── ws ──\n❯ \n──────\n  ? for shortcuts'; }
+scr_proc()    { printf '────── ws ──\n❯ \n──────\n  esc to interrupt'; }
+scr_content() { printf '────── ws ──\n❯ %s\n──────\n  ? for shortcuts' "$1"; }
+
+# finalize を有効化し、窓を小さく（sleep は no-op なので即時）。max_iter=int(5/1)=5。
+export OE_SEND_FINALIZE=1
+export OE_SEND_FINALIZE_INTERVAL=1
+export OE_SEND_FINALIZE_TIMEOUT=5
+export OE_SEND_FINALIZE_STABLE=2
+
+# 各シナリオ: MOCK_CAP_SEQ[0]=送信前 baseline、以降=finalize の poll/最終 capture。
+enter_count() { printf '%s' "$MOCK_SENDKEYS_LOG" | grep -c 'send-keys -t %5 Enter'; }
+cap_calls()   { cat "$CAP_CALLSFILE"; }
+reset_fin() { MOCK_SENDKEYS_LOG=""; echo 0 > "$CAP_IDXFILE"; echo 0 > "$CAP_CALLSFILE"; MOCK_CAP_FAIL=""; }
+
+echo "[7] finalize: staged_idle（窓終端までstaged・baseline idle）→ Enter を1回再送"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY7')" )
+oe_send_line "%5" "PAY7" >/dev/null 2>&1
+ck "Enter は transport+finalize で計2回" "2" "$(enter_count)"
+
+echo "[8] finalize: staged 後に submit（空に遷移）→ 早期 exit・再送しない"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY8')" "$(scr_empty)" )
+oe_send_line "%5" "PAY8" >/dev/null 2>&1
+ck "Enter は transport の1回のみ" "1" "$(enter_count)"
+
+echo "[9] finalize: K安定後に遅延 submit（staged×2→空）→ 再送しない（読み②・二重submit防止）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY9')" "$(scr_staged 'PAY9')" "$(scr_empty)" )
+oe_send_line "%5" "PAY9" >/dev/null 2>&1
+ck "Enter は1回のみ（遅延submitを二重化しない）" "1" "$(enter_count)"
+
+echo "[10] finalize: baseline busy → 後に staged_idle → base_proc=1 で撃たない（B1）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_proc)" "$(scr_staged 'PAY10')" )
+oe_send_line "%5" "PAY10" >/dev/null 2>&1
+ck "baseline busy 時は finalize 撃たない" "1" "$(enter_count)"
+
+echo "[11] finalize: processing が edge で出現 → submit 確証・撃たない"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_proc)" )
+oe_send_line "%5" "PAY11" >/dev/null 2>&1
+ck "edge processing は submitted 扱い・撃たない" "1" "$(enter_count)"
+
+echo "[12] finalize: stage_miss_suspect（一度も staged 観測せず空）→ warn のみ・撃たない・rc 不変"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_empty)" )
+# サブシェル($(...))にすると MOCK_SENDKEYS_LOG が親に伝播しないため、stderr はファイルへ。
+rc=0; oe_send_line "%5" "PAY12" >/dev/null 2>"$ERRFILE" || rc=$?
+ck "stage_miss でも rc=0（rc 透過）" "0" "$rc"
+ck "stage_miss は撃たない（transport の1回のみ）" "1" "$(enter_count)"
+ck "stage_miss warn を出す" "yes" "$(grep -q 'possible stage miss' "$ERRFILE" && echo yes || echo no)"
+
+echo "[13] finalize: base_staged（送信前から入力欄に内容）→ 無条件 unknown・撃たない"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_content 'olddata')" "$(scr_staged 'PAY13')" )
+oe_send_line "%5" "PAY13" >/dev/null 2>&1
+ck "base_staged 時は finalize 撃たない" "1" "$(enter_count)"
+
+echo "[14] finalize: capture-pane 失敗 → unknown・撃たない・rc 不変"
+reset_fin
+MOCK_CAP_FAIL=1
+MOCK_CAP_SEQ=( "$(scr_empty)" )
+rc=0; oe_send_line "%5" "PAY14" >/dev/null 2>&1 || rc=$?
+ck "capture 失敗でも rc=0" "0" "$rc"
+ck "capture 失敗時は finalize 撃たない" "1" "$(enter_count)"
+MOCK_CAP_FAIL=""
+
+echo "[15] finalize: 正規表現メタ文字 payload を grep -F でリテラル一致 → 正しく staged_idle 発火"
+reset_fin
+META='a.*b[x]?'
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged "$META")" )
+oe_send_line "%5" "$META" >/dev/null 2>&1
+ck "メタ文字 payload でも literal 一致で再送" "2" "$(enter_count)"
+
+echo "[16] finalize: OE_SEND_FINALIZE=0 → capture も追加 Enter も発生しない"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_staged 'PAY16')" )
+OE_SEND_FINALIZE=0 oe_send_line "%5" "PAY16" >/dev/null 2>&1
+ck "FINALIZE=0 で capture-pane を呼ばない" "0" "$(cap_calls)"
+ck "FINALIZE=0 で Enter は transport の1回のみ" "1" "$(enter_count)"
+
+echo "[17] finalize: --no-enter（send_enter=0）→ finalize 不発火・capture しない"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_staged 'PAY17')" )
+oe_send_line "%5" "PAY17" "0" >/dev/null 2>&1
+ck "--no-enter で capture-pane を呼ばない" "0" "$(cap_calls)"
+ck "--no-enter で Enter を撃たない" "0" "$(enter_count)"
+
+echo "[18] finalize: staged_idle の finalize Enter は最大1回（単発ガード）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY18')" )
+oe_send_line "%5" "PAY18" >/dev/null 2>&1
+ck "finalize 追加 Enter は1回（計2回）" "2" "$(enter_count)"
 
 echo "=== RESULT: pass=${pass} fail=${fail} ==="
 [[ "$fail" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_delegate_send.sh
+++ b/projects/orchestration-engine/tests/test_delegate_send.sh
@@ -193,5 +193,14 @@ MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY18')" )
 oe_send_line "%5" "PAY18" >/dev/null 2>&1
 ck "finalize 追加 Enter は1回（計2回）" "2" "$(enter_count)"
 
+echo "[19] finalize: max_iter は ceil（floor で総待機が TIMEOUT 未満にならない・Copilot 指摘）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY19')" )
+# TIMEOUT=1/INTERVAL=0.3 → ceil=4（floor なら3）。baseline(1)+poll(4)+最終(1)=6 capture。
+OE_SEND_FINALIZE_TIMEOUT=1 OE_SEND_FINALIZE_INTERVAL=0.3 OE_SEND_FINALIZE_STABLE=2 \
+  oe_send_line "%5" "PAY19" >/dev/null 2>&1
+ck "ceil で capture 回数 = baseline+4+final = 6（floor なら5）" "6" "$(cap_calls)"
+ck "staged_idle で再送（計2回）" "2" "$(enter_count)"
+
 echo "=== RESULT: pass=${pass} fail=${fail} ==="
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## 概要

`oe_send_line`（`bin/oe-send` / `bin/oe-delegate` が使う tmux → Claude Code TUI への1行注入 transport）の **自動 Enter が間欠的に「吸収」され submit されない**問題（#142 dogfood で顕在化）に対し、**送信後に観測ベースの finalize を後段で走らせ、入力欄に payload が staged のまま残る吸収を after-the-fact で1回だけ回復する**。

Refs #144

## 設計判断（so-gate v1→v5 で二度転回）

再現が不能（clean throwaway では2症状とも再現せず＝比較失敗率を計測できない）なため、**機構を確定できない**。この不確実性を前提に:

- **transport は現行据え置き**（`send-keys -l text` → `sleep 0.3` → `send-keys Enter`）。
  - 当初案 bracketed-paste(a) は `paste-buffer -p` が受け手の `?2004h` 依存でサイレント劣化 → 撤回。
  - 次案 c2（単一 paste・原子送信）は現行の `sleep 0.3` 防御ギャップを除去する賭けで、paste 検知がタイミング型なら負荷下で悪化し得る（検証不可）→ 見送り。**送信経路は賭けない**。
- **信頼化の主柱は観測ベース finalize**。Enter 吸収を機構非依存に「観測できる範囲で」回復する。

## 変更内容

- `lib/delegate-send.sh`: `oe_send_line` に finalize 状態機械を追加（既存 transport は不変）。
  - 送信前 baseline capture（`base_proc`=子がビジーか / `base_staged`=既存内容ありか）。
  - 入力欄領域（`❯` 行）と処理インジケータ領域（`esc to interrupt`）を別々に scrape。payload はリテラル一致（`grep -F`）。
  - **settle 窓（既定3s）を発火ゲート**に poll。早期 exit は submit 確証時のみ。`staged_idle` は窓終端までなお staged のときだけ Enter を1回再送（遅延配送の Enter は窓内に着弾→submitted 判定で撃たない）。
  - `submitted` / `staged_idle` / `stage_miss_suspect`（warn のみ）/ `unknown`（撃たない）に分類。`base_proc=true`・`base_staged=true`・capture 失敗・曖昧は**保守的に撃たない**。
  - `OE_SEND_FINALIZE=0` で無効化。`OE_SEND_FINALIZE_INTERVAL/STABLE/TIMEOUT` / `OE_SEND_PROC_MARKER` で調整可。
  - **finalize は全ブランチで transport の rc を変えない**（誤再送→二重 submit を防ぐ）。
- `tests/test_delegate_send.sh`: finalize 分岐テスト（`capture-pane` 時系列モック）を追加（[7]〜[18]）。
- `docs/plans/2026-06-09-plan-oe-send-ingestion-rootfix.md`: 駆動層の計画 doc。

## 検証

- `shellcheck` clean（lib + test）。
- `tests/test_delegate_send.sh`: **28/28 PASS**（既存 transport 回帰 + finalize 分岐 a〜j・単発ガード・FINALIZE=0・--no-enter・capture 失敗・メタ文字リテラル一致）。
- **dogfood（実機 claude 2.1.169）**:
  - FIRE 経路: 手動 stage → `_oe_send_finalize` が staged_idle を検出 → 約4s（3s 窓使い切り）→ **submit 成功**。実 TUI の scrape×fire 整合を確認（ユニットで検証不能な領域）。
  - happy path: 通常 auto 送信は **user 投稿ちょうど1回（二重 submit なし）・早期 exit 約1s・false warn なし**。
- so-gate v1→v5（Codex/Claude）で方針を反証検証し3者合意。診断スパイクの生ログ・so 出力は `tmp/`（gitignore）。

## リスク / Open questions（対称な honesty）

- **根治の証明は不可**（再現不能）。本変更は observed staged_idle 吸収を best-effort 回復し**確率を下げる**もの。一次発生は減らさない（transport 据え置き）。
- **finalize の純便益の符号は settle 窓に依存**: 吸収（Enter が消費される）なら正、遅延配送型なら窓が短いと二重 submit に反転。窓を発火ゲートにして安全側へ寄せるが、配送遅延 > 窓の病的負荷下では二重 submit が残る。**この新リスクも間欠で clean dogfood には出ない**（「fix が効いた証明不可」かつ「新バグ不在も証明不可」）。
- **吸収が負荷相関なら実効回復は小さい可能性**: 子ビジー（`base_proc=true`）時は撃たないため、吸収が最も起きやすいと疑われる busy レジームは回復対象外（warn で観測）。
- `esc to interrupt` は claude バージョン依存の magic string（定数化済み・UI 文言変更で判定劣化）。
- settle 窓 3s は provisional（再現不能で遅延分布を測れず）。運用で calibration 余地。

## スコープ外

- transport の変更（c2 / `;` バッチ）・stage 不達の自動 fix（検知 warn のみ）。
- `oe-capture` の出力チャネル / pane-id 2系統統一 → #114。
