### PR TITLE
feat(review): copilot-review-response に再レビュー再リクエストの任意ステップを追加

### DIFF
--- a/canonical/commands/review/copilot-review-response.md
+++ b/canonical/commands/review/copilot-review-response.md
@@ -1,6 +1,6 @@
 ---
 name: copilot-review-response
-description: 自分のPRに対するCopilotのレビューコメントを、未返信スレッドのみ対象に取得し、対応可否を検討・修正・「対応した／対応しない」の返信まで行う。
+description: 自分のPRに対するCopilotのレビューコメントを、未返信スレッドのみ対象に取得し、対応可否を検討・修正・「対応した／対応しない」の返信まで行う。明示的な指示があれば再レビューの再リクエスト（gh pr edit --add-reviewer @copilot）も行う。
 ---
 
 # Copilot Review Response
@@ -54,6 +54,10 @@ flowchart TD
     J -->|Yes| D
     J -->|No| K[コミットとプッシュ]
     K --> L["Step6: 各スレッドへ返信必須"]
+    L --> M{明示的な再リクエスト指示あり？}
+    M -->|なし| Z([終了])
+    M -->|あり| N["Step7（任意）: 再リクエスト @copilot"]
+    N --> B
 ```
 
 ## 前提条件確認
@@ -211,6 +215,30 @@ gh api repos/${REPO}/pulls/${PR_NUM}/comments \
 - 理由: Remi 導入後は `/usr/bin/php81` が利用できるため
 - 補足: alternatives はデフォルトの `/usr/bin/php` のみ切り替え対象で、バージョン固有バイナリには影響しない
 ```
+
+## Step 7（任意・既定では実行しない）: 再レビューの再リクエスト
+
+**既定はここに進まない。** Step 6 で評価対象スレッドに返信したらフローは完了。自動で再リクエストはせず、未返信 0 までの自動ポーリングもしない。「もう一回回すか／止めるか」の判断は人が持つ（指摘の価値が薄れてきたら止めてよい）。
+
+**実行条件**: ユーザーから **明示的な再リクエスト指示**があった場合のみ。例: 「もう一回（レビュー）回して」「再レビュー」「Copilot にもう一度」など、Copilot に再度レビューさせる意図が明確な指示。
+
+指示があったら、対応コミットを push 済みであることを確認のうえ、Copilot を再度レビュアーに追加して再レビューを起動する。
+
+```bash
+PR_NUM="<対象PR>"
+
+# 推奨（gh 2.88.0+。トークンは @copilot：小文字・@付き。bare な Copilot は不可）
+gh pr edit "$PR_NUM" --add-reviewer @copilot
+
+# フォールバック（gh が 2.88.0 未満、または上記が通らない場合。gh バージョン非依存）
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+gh api -X POST "repos/${REPO}/pulls/${PR_NUM}/requested_reviewers" \
+  -f "reviewers[]=copilot-pull-request-reviewer[bot]"
+```
+
+再レビューは非同期で返る。コメントが付いたら **Step 1 から同じフロー**（未返信スレッドのみ対応 → 返信）を 1 ラウンド回し、**また Step 7 の手前で止まる**。続けるかは再度ユーザーの指示を待つ。
+
+**注**: 既にレビュー済みのレビュアーへの「再依頼」は公式 API/CLI で未対応との議論があるが、`--add-reviewer @copilot`（または bot slug の再 POST）で実運用上は新規レビューが起動する。`@copilot` 公式経路の実 PR での挙動は環境により要確認。
 
 ## 安全規律
 


### PR DESCRIPTION
## 目的

`copilot-review-response` は返信専用で、再レビューの再リクエスト手順を持たなかった（返信 ≠ 再リクエスト）。再リクエストはメモ依存でセッションごとに発火が揺らいでいたため、明示キュー駆動の任意ステップとしてコマンドに正本化する。`gh` を 2.93.0（>= 2.88.0）へ更新し、公式の `gh pr edit --add-reviewer @copilot` が使えるようになったのが契機。

## 変更内容

- `canonical/commands/review/copilot-review-response.md` に **Step 7（任意・既定では実行しない）: 再レビューの再リクエスト** を追加
  - 既定は返信（Step 6）して終了。自動再リクエスト・未返信 0 までの自動ポーリングはしない
  - 明示キュー（「もう一回」「再レビュー」「Copilot にもう一度」等）の時だけ `gh pr edit <num> --add-reviewer @copilot` を実行
  - 古い gh 向けに bot-slug REST フォールバックを併記
  - 「回す／止める」の判断は人に残す
- mermaid フローに任意分岐、description に再リクエストの記述を追記

## 影響範囲

- コマンド定義（Markdown）のみ。コードや既存ステップの削除なし
- 反映は master マージ後に `sync.sh` で `~/.claude` へ配布されてから（worktree からは sync しない）
- 関連メモ（リポ外）も実態に合わせ更新済み: `feedback_review_loop_autonomy`（1 ラウンド自律・再リクエストは明示キュー時のみ）/ `reference_copilot_review_request_cli`（gh 2.93.0 対応）

## 未確認 / リスク

- `@copilot` 公式経路の実 PR 依頼での挙動は未実測（コマンド・メモに「要確認」と明記）。次の実依頼が初実測になる

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
