### PR TITLE
feat: record resolved Codex model in so-compare metadata

### DIFF
--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -106,7 +106,7 @@ tmp/so-YYYYMMDD-HHMMSS/
 ├── prompt.txt          # 最終プロンプト全文
 ├── codex-stdout.txt    # Codex の回答
 ├── codex-stderr.txt    # Codex の stderr
-├── codex-meta.txt      # メタデータ（tool, model_requested, exit_code, timeout_status, elapsed_seconds, stdout_lines, stdout_bytes）
+├── codex-meta.txt      # メタデータ（tool, model_requested, model_resolved, exit_code, timeout_status, elapsed_seconds, stdout_lines, stdout_bytes）
 ├── claude-stdout.txt   # Claude の回答
 ├── claude-stderr.txt   # Claude の stderr
 ├── claude-meta.txt     # メタデータ（model_requested, effort_requested を含む）

--- a/scripts/so-compare.sh
+++ b/scripts/so-compare.sh
@@ -313,6 +313,43 @@ classify_result() {
     fi
 }
 
+resolve_codex_model() {
+    local requested="$1"
+    if [[ -n "$requested" ]]; then
+        printf '%s\n' "$requested"
+        return 0
+    fi
+
+    local config_path="${CODEX_HOME:-$HOME/.codex}/config.toml"
+    local resolved=""
+    if [[ -f "$config_path" ]]; then
+        resolved="$(
+            awk '
+                /^[[:space:]]*\[/ { exit }
+                /^[[:space:]]*model[[:space:]]*=/ {
+                    sub(/^[[:space:]]*model[[:space:]]*=[[:space:]]*/, "")
+                    sub(/[[:space:]]*(#.*)?$/, "")
+                    if ($0 ~ /^".*"$/) {
+                        sub(/^"/, "")
+                        sub(/"$/, "")
+                    } else if ($0 ~ /^\047.*\047$/) {
+                        sub(/^\047/, "")
+                        sub(/\047$/, "")
+                    }
+                    print
+                    exit
+                }
+            ' "$config_path"
+        )"
+    fi
+
+    if [[ -n "$resolved" ]]; then
+        printf '%s\n' "$resolved"
+    else
+        printf 'unknown\n'
+    fi
+}
+
 # --- 実行関数 ---
 # shellcheck disable=SC2120  # 引数はリトライ時に渡される（初回はデフォルト値を使用）
 run_codex() {
@@ -341,12 +378,15 @@ run_codex() {
 
     local timeout_status
     timeout_status=$(classify_result "codex" "$exit_code")
+    local model_resolved
+    model_resolved="$(resolve_codex_model "$CODEX_MODEL")"
 
     echo "[Codex] 完了 (${elapsed}秒, exit=${exit_code}, status=${timeout_status})"
 
     {
         echo "tool=codex"
         echo "model_requested=${CODEX_MODEL:-default}"
+        echo "model_resolved=$model_resolved"
         echo "exit_code=$exit_code"
         echo "timeout_status=$timeout_status"
         echo "elapsed_seconds=$elapsed"


### PR DESCRIPTION
## Purpose

Record the Codex model that `so-compare` resolves at runtime so default-model runs are easier to reproduce.

Refs #146

## Changes

- Add `model_resolved=` to `codex-meta.txt`.
- Resolve explicit `--codex-model` / `SO_CODEX_MODEL` values directly.
- Resolve default Codex runs from `${CODEX_HOME:-$HOME/.codex}/config.toml`, falling back to `unknown`.
- Update the `so-compare` skill output-file documentation.

## Validation

- `bash -n scripts/so-compare.sh`
- `shellcheck scripts/so-compare.sh`
- fake `codex` smoke: default model produced `model_resolved=gpt-5.5`
- fake `codex` smoke: `--codex-model test-model` produced `model_resolved=test-model`
- `git diff --check`
- `so-compare` artifact review: Codex `pass`, Claude `pass` (blockers: none)
