### PR TITLE
feat(skills): episode-retrospective スキルを新設し closure gate を導入

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -7,7 +7,7 @@
 - **Rules**: English — ルール/原則はモデルの学習分布（CS 概念体系が英語ベース）と一致させるため英語で記述。断定的・厳格・端的な表現を使う
 - **Skills**: Japanese — スキルはドメイン知識・コンテキストを含むため、ユーザーの思考言語（日本語）で記述。description（frontmatter）も日本語
 
-## Skills (22)
+## Skills (23)
 
 | 名前 | 説明 | パス | depends |
 |------|------|------|---------|
@@ -19,6 +19,7 @@
 | conventional-commits | コミットメッセージをConventional Commits規約に従って生成する | `skills/conventional-commits/SKILL.md` | — |
 | delegate-task | 親子 Claude Code セッション間の委譲操作（delegate / send / list / report）を自然言語から判断して実行する。tmux 環境前提 | `skills/delegate-task/SKILL.md` | — |
 | diff-audit | PR diff全体を原則ベースでレビューする。4つの問いを軸に、チェックリスト外の問題も含めて拾う。既知パターンは各問いのヒントとして残す | `skills/diff-audit/SKILL.md` | — |
+| episode-retrospective | Episode closure 時の構造化振り返り（closure gate checklist・出力型×消費チャネル・tier 判定） | `skills/episode-retrospective/SKILL.md` | skill: spec-card, skill: so-compare |
 | implementer-contract | サブエージェントへの実装委譲時の返却契約（ステータスenum・報告フォーマット・スコープ外報告） | `skills/implementer-contract/SKILL.md` | — |
 | issue-conventions | Issue作成の規約を適用する | `skills/issue-conventions/SKILL.md` | — |
 | kickoff-to-plan | Kickoff Documentを実行可能なプランに忠実変換する | `skills/kickoff-to-plan/SKILL.md` | skill: adversarial-review |

--- a/canonical/skills/episode-retrospective/SKILL.md
+++ b/canonical/skills/episode-retrospective/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: episode-retrospective
+description: Episode の closure 時に構造化振り返りを適用する。closure gate checklist（消費者明示・routing・status 確定）、出力型×消費チャネルの内容プロンプト、tier 判定（opt-out / standard / heavy）を含む。Episode を閉じるとき、Decision/ADR への昇格を検討するときに使用する。
+---
+
+# Episode Retrospective — closure 時の構造化振り返り
+
+## いつ使うか
+
+- Episode を closure する（作業を畳み、status を確定する）とき
+- Episode から Decision / ADR への昇格を検討するとき
+- branch-finish / PR 作成の直前で「episode を閉じたか」を確認するとき
+
+## いつ使わないか
+
+- Episode 本文（追記ログ）の書き方 — 本文はフリーフォーム + 性質ガイドのまま（`document-format.md` §7）。**本スキルは本文に構造を課さない**（書きアンカー保護、design-principles §5）
+- frontmatter / ULID / 命名規則 — `spec-card` が担う（本スキルは重複させない）
+- kickoff / plan / discussion の closure — 対象は episode のみ
+
+## 設計根拠（要約）
+
+episode 品質監査（52 件全数採点、`docs/research/2026-06-10-episode-quality-audit.md`）の主要結果:
+
+- 最大の穴は **closure 軸**（平均 1.12/2、満点率 19%）。振り返り枠組み（KPT/YWT）の選択は主要因ではない
+- **closure は「次の消費者」が存在するときだけ書かれる**（法則 L1）。明示ゲートで代替可能
+- 「後で追記」型の先送りは観測範囲で **100% 不履行**（法則 L4）
+- テンプレートは過去向き軸の床を上げるが、未来向き軸を作らない（法則 L2）。構造の足しすぎは蒸留を下げる
+
+よって本スキルの重心は「枠組みの精緻さ」ではなく **closure gate**（消費者明示 + routing + status 確定）に置く。セクションは感想カテゴリでなく「**何を出力し、誰が消費するか**」で定義する（Issue #113 オーナー設計判断、2026-06-10）。
+
+## Step 1: tier 判定
+
+closure 開始時にまず tier を判定する。判定は印象でなく下のトリガ列で行い、**heavy → opt-out → standard の順で評価する**（heavy トリガに 1 つでも該当すれば、失格条件や消費者の有無にかかわらず heavy。opt-out に到達するのは heavy トリガゼロのときだけ）。
+
+### heavy トリガ（1 つでも該当すれば heavy）
+
+- [ ] 実行中に失敗・撤回・方針転回があった
+- [ ] SO / peer-review / Copilot 等の外部レビューレーンを使った
+- [ ] 学習・調査・feasibility 検証が主成果（実装より知見が成果物）
+- [ ] 非自明な設計判断（選択肢を比較して棄却した）がある
+- [ ] Decision / skill / rule への昇格候補がありそう
+
+### opt-out 失格条件（1 つでも該当すれば opt-out 不可）
+
+- [ ] 行き先未定の follow-up が存在する
+- [ ] 実行ログ（会話・episode 追記）に失敗・指摘・撤回が残っている
+- [ ] 外部レビューを実施した
+- [ ] 昇格候補（Decision / skill / rule / negative knowledge)がある
+
+判定結果:
+
+| tier | 条件 | 要求 |
+|------|------|------|
+| heavy | heavy トリガ 1 つ以上 | Step 2 + Step 3 + Step 4（外部チェック） |
+| opt-out | heavy トリガなし + 失格条件ゼロ + 消費者なし | 下記の opt-out 定型 1 行のみ |
+| standard | 上記以外（失格条件への該当は opt-out を塞ぐだけで heavy にはしない） | Step 2 + Step 3（自己申告で可） |
+
+### opt-out 定型
+
+opt-out は「書かない」ではなく「消費者ゲート判断を明示した正当な closure」。次の 1 行を episode 末尾（episode 未作成なら PR 本文）に残し、status を確定する:
+
+```markdown
+振り返り不要: <理由> / 次の消費者: なし / follow-up: なし / status: <stable または deprecated>
+```
+
+## Step 2: closure gate checklist（standard / heavy で必須。opt-out は Step 1 の定型 1 行が本 checklist を代替）
+
+手段指示の構造化セクション（design-principles §4）。**4 項目 + 条件付き 2 項目**。これを満たさない closure は不完全。
+
+- [ ] **Context / なぜ**: episode 冒頭に「なぜこの作業が始まったか」が 1〜2 文で自己完結しているか（リンク先参照のみは不可。腐敗保険）
+- [ ] **次の消費者**: この episode を次に読むのは誰か / どのタスクか を明示。書けなければ「消費者なし」と明示（opt-out の線引きに使う）
+- [ ] **follow-up routing**: すべての残課題に行き先を付与 — Issue / ADR / 別 doc / 「追わない」宣言のいずれか。**行き先なしの箇条書きは禁止**。他文書で発見した欠陥も routing 対象（反映 or 前方参照 or 追わない理由 = back-propagation）
+- [ ] **status 確定**: frontmatter の status を draft → stable / deprecated へ。据え置く場合は理由を 1 行。達成度（達成 / 部分 / 未達）を 1 語添える
+- [ ] **（条件付き）evidence anchor**: 本文が `tmp/` 等の揮発パスや別リポの匿名化情報を参照している場合、要点（数値・結論・hash）を本文へ転記、または永続する代替アンカーを置いたか
+- [ ] **（条件付き）SO 証跡リンク**: 外部チェック（Step 4）を実施した場合、その出力パスまたは要約を episode にリンクしたか
+
+## Step 3: 内容セクション — 出力型 × 消費チャネル
+
+該当する出力型だけ書く（全部埋める義務はない。空欄の機械的穴埋めは蒸留を下げる — 監査 L2）。各型は「誰が消費するか」で定義されている。書く前に「この episode から何が出たか」を型に照らして確認する目的のチェックリストであり、空でも見出しを立てる必要はない。
+
+| 出力型 | 消費チャネル | 書く内容 |
+|--------|-------------|---------|
+| 事実・失敗 | 失敗分類・再発防止（→ #60） | 何が起き、何が失敗したか。実行ログに残る失敗を選択的に省略しない |
+| 決定と根拠 | 判断の再利用・Decision 昇格 | 選択肢・採否・**棄却した案と棄却理由**。コードや diff から復元できない「なぜ」 |
+| わかったこと（W） | ナレッジ・次タスク参照 | 検証で判明した事実・技術的知見 |
+| 原則（Pattern / Anti-pattern 対) | negative knowledge 注入（→ #62） | 転用可能な対構造。NG/OK ペア形式可 |
+| 行動変更 | hook / skill / チェックリスト化 | **トリガ・機構・着地先アーティファクト名を必須**。機構未確定の「検討する」は残課題（routing 対象）へ降格 |
+| 蒸留シグナル | 昇格パイプライン | 昇格候補の明示: Decision / skill / rule / #62 / **なし**（「なし」も明示する） |
+| 残課題 | routing（Step 2 で行き先付与） | 未解決・未検証。証明できなかったことは証明できなかったと書く（対称な honesty） |
+
+### 任意の皮: KPT / YWT
+
+人間レビュー用の読み物として、上記の内容を KPT（Keep / Problem / Try）+ Open Questions や YWT で**再構成してもよい**。皮は骨格の代替ではない — Keep に「わかったこと」を仮装させない、Problem の空欄/形骸化は皮では検知できない（自己検出率 0 の実証あり）ことに注意。
+
+## Step 4: heavy tier の外部チェック
+
+自己評価は甘い（別リポ実証: Problem 自己検出率 0、選択的省略あり）。heavy では外部チェックを最低 1 回入れる。
+
+- 既定: `so-compare` で振り返りの focused check。確認対象は **失敗セクションの選択的省略 / routing の網羅 / evidence anchor / back-propagation** のみに絞る（全文レビューにしない — 摩擦が高いと skip される）
+- 委譲採点 + spot-check は監査級の規模（多数 episode の横断評価）に限定
+- SO 出力パスを episode にリンクする（Step 2 の条件付き項目。証跡の有無が PR レビューで機械的に確認できる）
+
+### プロンプト例
+
+```bash
+so-compare -w "$(pwd)" "episode <path> の closure 振り返りを検証: (1) 実行ログにある失敗・撤回・指摘が事実・失敗セクションから選択的に省略されていないか (2) 全 follow-up に行き先があるか (3) 揮発パス参照が残っていないか (4) 他文書の欠陥への back-propagation 漏れはないか"
+```
+
+## 制約と既知の限界
+
+- **本スキルは助言であり同期ゲートではない**。「skill があっても closure を忘れる」問題（監査 R4）は branch-finish / PR フロー側の同期ゲートで対処する（別 Issue）。本スキルの遵守はトリガされたときのみ機能する
+- 実行ログマーカー（つまずき / 指摘 / 撤回）× 失敗セクションの機械突合は将来機構（書き込み時ガイドラインとセットで成立。#149 B 検証の defer 解除後）。現時点では Step 1 失格条件・Step 4 SO が代替
+- 後追い再構成の episode（リアルタイム追記でないもの）は冒頭に `reconstructed` と明示する。リアルタイム追記ログと同じ証拠価値を持たないため、形式比較のデータとして同列に扱わない
+
+## 効果測定（#113 完了条件のデータ取得経路）
+
+「KPT で十分か別形式か」は 2 事例 + オーナー判断（出力型×消費チャネル骨格の採用、KPT は皮へ）で回答済み。以後の測定経路:
+
+- 監査 rubric の軸5（closure）・軸3（証拠接続）で導入前後の episode を比較（before 値: 軸5 = 1.12 / 軸3 = 1.35）
+- opt-out 率を追跡（乱用の可視化。opt-out が多数派になったら失格条件を再設計）
+- 実適用 episode に**形式メモ**を 3〜4 行残す: チャネル骨格で拾えたもの / 拾えなかったもの / 皮（KPT/YWT）を使ったか / 摩擦
+
+## 既存スキル・ドキュメントとの関係
+
+- **`spec-card`**: frontmatter / ULID / 命名 / status enum の正本。本スキルは closure の中身を担い、形式は spec-card に従う
+- **`document-format.md` §7 Episode**: 本文フリーフォーム + 性質ガイドの定義。本スキルは末尾の構造化 FB セクションの実装
+- **`branch-finish`**: ブランチ完了判定フローの一部として closure 確認に使える（同期ゲート化は別 Issue）
+- **`evidence-verification-rule`**: 自己確認は検証ではない — Step 4 外部チェックの根拠
+- **Issue #60 / #62**: 出力型の消費チャネル先（失敗分類 / negative knowledge 注入）。注入側フォーマットは #62 で設計

--- a/canonical/skills/spec-card/SKILL.md
+++ b/canonical/skills/spec-card/SKILL.md
@@ -39,7 +39,7 @@ description: 蒸留パイプライン文書（kickoff/episode/decision/discussio
 | `discussion` | 探索・ブレスト・調査メモ | 最小（frontmatter のみ） |
 | `kickoff` | スコープ確定・方針の言語化 | 重い（セクションテンプレートあり） |
 | `plan` | 実行可能な粒度まで分解 | 重い（kickoff-to-plan 出力と整合） |
-| `episode` | 実行記録・作業ログ | 中間（本文フリーフォーム + 性質ガイド） |
+| `episode` | 実行記録・作業ログ | 中間（本文フリーフォーム + 性質ガイド）。closure 時は `episode-retrospective` skill を参照 |
 | `decision` | 意思決定の蒸留・ADR | 重い（コンテキスト / 決定 / 根拠 / 結果） |
 
 ### ファイル命名

--- a/docs/episodes/2026-06-10-episode-113-retrospective-skill.md
+++ b/docs/episodes/2026-06-10-episode-113-retrospective-skill.md
@@ -1,0 +1,94 @@
+---
+id: "01KTS0260KD29DP2J7HPKJWRTV"
+title: "Issue #113 episode-retrospective skill 新設 — ゼロベース設計と SO ゲートの記録"
+date: 2026-06-10
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/113"
+    reason: "本作業の対象 Issue（Episode closure 時の構造化振り返りスキル新設）"
+  - type: evidence_for
+    ref: "docs/research/2026-06-10-episode-quality-audit.md"
+    reason: "設計の主根拠（52 episode 全数監査・法則 L1〜L8・提言 R1）"
+  - type: design_context
+    ref: "docs/episodes/2026-06-10-episode-149-audit-meta.md"
+    reason: "skill 出力の実質プロトタイプ（自己適用 1 例目）。本 episode は 2 例目"
+  - type: integration_target
+    ref: "canonical/skills/episode-retrospective/SKILL.md"
+    reason: "本作業の成果物"
+tags: [episode, retrospective, skill, closure, issue-113, zero-base, so-gate]
+---
+
+# Issue #113 episode-retrospective skill 新設 — ゼロベース設計と SO ゲートの記録
+
+## Context / なぜ
+
+Episode の closure 品質（消費者明示・routing・status 確定）が全コーパスで最弱という監査結果（#149 → PR #153）を受け、closure 時の構造化振り返りを skill 化する Issue #113 を、フレッシュスレッドがゼロベース原則（先行議論を読む前に一次原理から設計 → 突合）で担当した。
+
+## 次の消費者
+
+- **#62（negative knowledge 注入側）の設計者**: 本 skill の出力型「原則」「蒸留シグナル」が注入フォーマットの入力契約になる。closure 側のフィールドから逆算すること
+- **R4 同期ゲート（branch-finish / PR フロー組込み）の実装者**: 本 skill が「助言であり同期ゲートではない」と明記した制約の解消が仕事になる
+- **次に episode を closure する全エージェント**: skill 本体が直接の消費物
+
+## 作業の流れ（要約）
+
+1. **ゼロベース設計**: #113 コメント群・PR #153 を読む前に、一次原理（価値=消費される / 負の知 > 正の知 / 「なぜ」はコードから不可視）から設計案を起草し、突合基準線として確定
+2. **突合**: #113 本文 + コメント 8 件 + 監査ノート + 149-audit-meta を読み、一致・不一致を記録
+3. **オーナーゲート 3 分岐**: ①骨格 = 出力型×消費チャネル + KPT は皮 ②失敗捕捉 = tier 別外部チェック ③監査 R2 を同 PR に含める
+4. **プラン SO（Codex + Claude opus/high）**: 両者が独立に同じ 4 欠陥を指摘 → プラン v2 へ反映してオーナー承認
+5. **実装**: SKILL.md 新設 / spec-card routing 行 / document-format.md R2 編集 / CATALOG 追加
+6. **実装後 SO（Codex + Claude opus/high）**: should-fix 3 件（tier 判定順の論理穴 / document-format との任意・必須衝突 / 本 episode 自身の closure 未完遂）を捕捉 → 全件反映して closure（要点は closure 節に転記）
+
+## 決定と根拠
+
+- **骨格 = closure gate checklist + 出力型×消費チャネルの内容プロンプト + 任意の KPT/YWT 皮**。監査 R1-4 の「KPT+YWT ハイブリッド」は採用せず格下げ。根拠: 監査の主結果（枠組み選択は主要因でない、穴は closure 軸）+ オーナー 2026-06-10 コメント（振り返り枠は感想カテゴリでなく出力型×消費チャネルで定義）。マージ済み提言からの意図的逸脱として記録する
+- **内容セクションは必須テンプレにしない**（該当時のみ・空欄穴埋め禁止）。棄却案 = 全セクション必須のフルテンプレ。根拠: 監査 L2/L3（2026-05 のテンプレ化が蒸留を 1.82 → 1.32 に下げた）と design-principles §4（手段指示は構造化セクション限定）
+- **opt-out を正当な closure として定型化 + 客観的失格条件**。棄却案 = フル振り返りか無かの二択。根拠: オーナー実運用観察「振り返るほどでもない closure が普通にある。摩擦 = skip = episode ごと消える」
+- **heavy tier 判定は印象でなくトリガ列挙**。棄却案 = エージェントの自己判定。根拠: 別リポ実証で自己評価は 3 観点中 2 つで甘い（Problem 自己検出率 0）
+- **R1-5（back-propagation）は routing に内包、R1-6（evidence anchor）は条件付き必須**。棄却案 = 独立セクション化（低頻度事象に常設セクションは過剰）
+
+## 事実・失敗
+
+- ゼロベース案は「どのセクション集合が最適か」に注力したが、監査が示す本丸（closure gate）から見れば重心がずれていた。突合で修正
+- プラン v1 は監査 R1 の優先順 5・6（back-propagation / evidence anchor）を取りこぼした。SO（Codex・Claude 両方）が独立に指摘
+- プラン v1 の Step 1 精読範囲（design-principles §2/§3/§5）から、テンプレ化リスクの中核を握る **§4 を漏らした**。Claude SO が捕捉。「参照すべき節を自分で選ぶと、設計に都合の悪い節が落ちる」の実例
+- ゼロベース基準線にあった「決定と根拠」「蒸留シグナル」を、チャネル骨格への変換時に自分で落とした（オーナーコメントの表にも軸2 相当が無く、一般化の過程で揃って脱落）。SO が基準線との突合で検出 — **基準線を文書として固定していたから検出できた**
+- SKILL.md 初版の tier 判定に論理穴: heavy トリガ該当かつ失格条件ゼロの episode が opt-out 可能に読めた（判定順が未定義）。プラン SO・自己適用でも見逃し、**実装後 SO（Claude レーン）が捕捉** → 「heavy → opt-out → standard」の評価順を明文化して修正
+- 本 episode 自身が初版で「実装後 SO は後で追記」というプレースホルダを含み、両 SO レーンに**自スキルの L4 禁則（後で追記は 100% 不履行）そのもの**と指摘された。プロセス上は SO 反映後に closure する設計だったが、書き方が dangling だった → 本反映で解消
+
+## わかったこと
+
+- ゼロベース → 突合は、先行議論と独立に収束した点（消費者ゲート = 監査 L1）に corroboration 価値を与える。一方で先行議論の方が成熟している領域では「自分の案の何が劣るか」の検出器として機能する。どちらに転んでも収穫がある
+- SO 2 レーンが独立に同じ欠陥群を突いたとき、その指摘は採用してよい確度が高い（プラン SO では 4 欠陥すべてが両レーン一致）
+- `gh issue view` がコメント非表示デフォルトであることが、封印付きゼロベースの実装を容易にする（149-audit-meta の知見を本作業でも再確認）
+
+## 蒸留シグナル
+
+- **skill 候補**: 「封印付きゼロベース手順」（基準線を文書固定 → 読む → 突合記録）は #149 と本作業で 2 例目。3 例目が出たら手順スキル化を検討 → 行き先: 追わない（次の該当タスクで再評価）
+- Decision / rule 昇格候補: なし（本作業の決定は SKILL.md 本文に正本化済み）
+
+## 残課題（routing 済み）
+
+- rubric before/after 測定（軸5・軸3）の実施 → 行き先: 別doc（skill 本文「効果測定」節が経路の正本。実施トリガ = 導入後 episode の蓄積）
+- R4 同期ゲート（branch-finish / PR フローへの closure チェック組込み）→ 行き先: Issue #156（本作業で起票）
+- 実行ログマーカー × 失敗セクションの機械突合 → 行き先: 追わない宣言（監査 R3 の defer をオーナー受諾済み。再判断トリガ = #149 B 検証 + 対照群の追記型移行データ）
+- `.oe/` の手元ノート（ゼロベース基準線・SO 出力）は gitignore 対象の揮発パスのため、要点を本 episode に転記済み（evidence anchor 自己適用）
+
+## 形式メモ（skill 効果測定用）
+
+- チャネル骨格で拾えたもの: 決定と根拠（5 件）・失敗（4 件）・蒸留シグナル（明示「なし」含む）が自然に埋まった。「次の消費者」が routing の書き方を具体化した
+- 拾えなかったもの: 特になし。ただし「わかったこと」と「原則」の境界は曖昧（本 episode では原則セクションを立てず、わかったことに寄せた）
+- 皮（KPT/YWT）: 使わず。骨格のみで人間可読性は維持できている感触
+- 摩擦: tier 判定と失格条件チェックは数十秒で済む。形式メモ自体が最も「書かされている」感がある（3 例目以降で要否再評価）
+
+## closure（gate checklist 自己適用）
+
+- tier: **heavy**（外部レビューレーン使用・非自明な設計判断・失敗あり）
+- 次の消費者: 明示済み（上記）
+- follow-up routing: 全件行き先付与済み（上記。行き先 = #156 / 別doc / 追わない宣言）
+- status: **stable** で確定（達成度: 達成）
+- SO 証跡（出力は gitignore 対象の `tmp/` のため要点を転記 — evidence anchor 自己適用）:
+  - プラン SO = `tmp/so-20260610-232846/`（Codex 102s / Claude opus-high 354s、両者成功）。両レーン一致の 4 欠陥: R1-5/6 脱落・出力型 2 欠落（決定と根拠 / 蒸留シグナル）・opt-out 無防備・heavy チェック形骸化リスク → プラン v2 に全件反映
+  - 実装後 SO = `tmp/so-20260610-235008/`（Codex 201s / Claude opus-high 238s、両者成功）。should-fix 3 件: ①tier 判定順の論理穴（heavy 優先を明文化）②document-format FB「任意」と skill gate「必須」の衝突（必須 2 項目の注記を追加）③本 episode の closure 未完遂（status 確定・routing 修正・本転記で解消）。Codex の「新規ファイル未追跡」指摘はコミット順序の問題として PR 作成時に解消

--- a/docs/specs/document-format.md
+++ b/docs/specs/document-format.md
@@ -257,7 +257,7 @@ tags: [tags]
 
 性質ガイド（本文の書き方指針）:
 
-> 各 Step の記録は、後から読んだ人がやりとりの流れを追跡できるように書く。特に問題発生→原因特定→対処の連鎖は省略しない。
+> 冒頭に「なぜこの作業が始まったか」を 1〜2 文で自己完結して書く（Context / なぜ。リンク先参照のみにしない）。各 Step の記録は、後から読んだ人がやりとりの流れを追跡できるように書く。特に問題発生→原因特定→対処の連鎖は省略しない。羅列で終わらせず、転用可能な知見・教訓があれば節を立てて残す。
 
 構造化 FB セクション（Episode 末尾、任意）:
 
@@ -266,7 +266,11 @@ tags: [tags]
 - 想定外だった点:
 - 規約遵守状況:
 - ADR 昇格候補:
+- 次の消費者（誰が / どのタスクで読むか）:
+- follow-up の行き先（Issue / ADR / 別doc / 追わない宣言）:
 ```
+
+うち「次の消費者」「follow-up の行き先」は closure 時の必須項目（他は該当時のみ。空欄の機械的穴埋めはしない）。closure（status 確定・振り返り）の手順は `episode-retrospective` skill を参照。
 
 ### Decision / ADR
 
@@ -318,7 +322,8 @@ YYYY-MM-DD-{type}-{topic}.md
 | プロジェクト横断の Decision | `docs/decisions/` |
 | プロジェクト固有の Decision | `projects/{name}/docs/decisions/` |
 | KickOff / Plan | `docs/plans/{issue-or-epic}/` |
-| Episode | プロジェクト固有ディレクトリ（規約は各プロジェクト） |
+| プロジェクト横断の Episode | `docs/episodes/` |
+| プロジェクト固有の Episode | プロジェクト固有ディレクトリ（規約は各プロジェクト） |
 | Discussion | `docs/draft/` または `ideas/` |
 
 ## 9. #19 MVP との接続


### PR DESCRIPTION
## 目的

Episode closure 品質が全コーパスで最弱（監査 #149: 軸5 平均 1.12/2、満点率 19%）であることを受け、closure 時の構造化振り返りを skill 化する。

Refs #113

## 変更内容

### 1. `canonical/skills/episode-retrospective/SKILL.md` 新設（コミット 1）

- **骨格 = closure gate checklist**: 消費者明示・follow-up routing・status 確定（監査 R1-1〜3）+ 条件付き 2 項目（back-propagation / evidence anchor = R1-5/6）
- **内容セクションは出力型×消費チャネルで定義**（7 型、該当時のみ・空欄穴埋め禁止）。KPT/YWT は人間レビュー用の任意の皮へ格下げ（Issue #113 オーナー設計判断 2026-06-10。監査 R1-4「KPT+YWT ハイブリッド」からの意図的逸脱として skill 本文に記録）
- **tier 判定**: heavy → opt-out → standard の評価順。opt-out は失格条件付き定型 1 行（「フル振り返りか無か」の二択回避）、heavy は客観トリガ判定 + so-compare focused check + SO 証跡リンク必須（自己評価の甘さの実証データ対策）
- 助言限定の明記（同期ゲートは #156）、効果測定経路（rubric 軸5/軸3 before/after・opt-out 率・形式メモ・real-time/reconstructed 区別）
- `spec-card` SKILL.md に routing 1 行、CATALOG.md に登録

### 2. `docs/specs/document-format.md` 監査 R2 の軽量編集（コミット 2）

- 性質ガイドに冒頭 Context/なぜ 定型（L7）+ 知見・教訓節への言及（L8）
- FB セクションに「次の消費者」「follow-up の行き先」を追加、closure 時必須 2 項目の注記
- §8 配置表に「プロジェクト横断の Episode: `docs/episodes/`」行を追加（PR #153 で実体新設済みのギャップ解消）
- `status: draft` は維持（stable 昇格は別件）

### 3. `docs/episodes/2026-06-10-episode-113-retrospective-skill.md`（コミット 3）

本作業自体の episode を新 skill の自己適用で記録（149-audit-meta に続く 2 例目）。完了条件「初期テンプレで 1 件以上の Episode を実際に書ける」の充足証跡 + 形式メモ。

## 検証

- [x] markdown 規約チェック（禁止記号・コードブロック言語指定・パスのインラインコード）
- [x] routing 解決確認（spec-card / CATALOG / document-format → `episode-retrospective` の名前・パス一致）
- [x] 既存 episode（149-audit-meta）の gate checklist 適合検証（コア 4/4。「達成度 1 語」のみ本 skill で新設した要求）
- [x] プラン SO（Codex + Claude opus/high、3者合意）: 両レーン一致の 4 欠陥（R1-5/6 脱落・出力型 2 欠落・opt-out 無防備・heavy チェック形骸化リスク）→ プラン v2 に反映してオーナー承認
- [x] 実装後 SO（Codex + Claude opus/high）: should-fix 3 件（tier 判定順の論理穴 / document-format「任意」と skill「必須」の衝突 / episode closure 未完遂）→ 全件反映済み

## 完了条件との対応（#113）

- [x] 新スキル配置 + `spec-card` から routing 可能
- [x] 初期テンプレで 1 件以上の Episode を実際に書ける（自己適用 2 例: 149-audit-meta 適合検証 + 本作業 episode）
- [x] データ取得経路の明示: 「KPT で十分か」は 2 事例 + オーナー判断（出力型×消費チャネル骨格）で回答済みと skill 本文に明記。以後の測定経路 = rubric before/after・opt-out 率・形式メモ

## スコープ外（行き先明示済み）

- 同期ゲート（branch-finish / PR フローへの closure チェック組込み）→ #156（本作業で起票）
- 実行ログマーカー × 失敗セクションの機械突合 → #149 B 検証の defer 解除後（skill 本文に将来機構として記載）
- `document-format.md` の draft → stable 昇格 / #62 注入側フォーマット / RAG 自動投入 → #113 本文どおり別件

## 関連

- [Issue #113](https://github.com/stlwolf/ai-development-hub/issues/113)
- [Issue #156](https://github.com/stlwolf/ai-development-hub/issues/156) — 同期ゲート（本 PR で起票）
- [PR #153](https://github.com/stlwolf/ai-development-hub/pull/153) — 設計根拠の監査ノート

🤖 Generated with [Claude Code](https://claude.com/claude-code)
