### PR TITLE
feat: pass claude args through oe-delegate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tmp/
 .specstory/
 .playwright-mcp/
 .thread-exports/
+.oe/

--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -51,6 +51,12 @@ BIN="$REPO/projects/orchestration-engine/bin"
 "$BIN/oe-delegate" -w "$REPO" --label "#N" "Issue #N の内容を gh issue view N で確認して作業を進めて。リポジトリ: $REPO"
 ```
 
+**子 Claude に起動オプションを渡す** — 自律調査で権限プロンプト停止を避けたい場合
+
+```bash
+"$BIN/oe-delegate" -w "$REPO" --label "#N" --claude-arg --permission-mode --claude-arg auto "Issue #N の内容を確認して調査して。リポジトリ: $REPO"
+```
+
 **キックオフ doc を渡す（4層ドキュメント方式 / リッチな事前情報）**
 
 ```bash
@@ -58,7 +64,7 @@ BIN="$REPO/projects/orchestration-engine/bin"
 ```
 
 - `--kickoff <path>` は子へ `"<path> を読んで進めて。"` を付加し、子が読めるよう doc のディレクトリを `--add-dir` で開示する
-- doc が無い軽いケースは、親で組み立てた内容を **workspace 配下**（例 `<workspace>/.oe/kickoff-*.md`）に書いてから `--kickoff` で渡す（`/tmp` は対話型 claude が読めないので避ける）
+- doc が無い軽いケースは、親で組み立てた内容を **workspace 配下**（例 `<workspace>/.oe/kickoff-*.md`）に書いてから `--kickoff` で渡す（`/tmp` は対話型 claude が読めないので避ける）。`.oe/` はこのリポジトリでは gitignore 済み。
 
 **実装委譲（implementer-contract 併用）**
 

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -37,11 +37,12 @@ oe-capture <pane_id> [--session-id <id>] [--lines <N>]
 子 Claude を `tmux split-window` で起動し、タスク（または kickoff doc）をキック（spawn + send の合成）。
 
 ```bash
-oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--] <task>
+oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
 ```
 
 - `--kickoff <path>` … `"<path> を読んで進めて。"` を送り、doc のディレクトリを `--add-dir` で子に開示
 - `--label <#N|name>` … registry 登録ラベル（後で `oe-send <label>` で指す）
+- `--claude-arg <arg>` … 子 Claude 起動時に追加引数を渡す（repeatable）。例: `--claude-arg --permission-mode --claude-arg auto`
 - tmux 内必須（`TMUX_PANE` から親ペイン取得、`PARENT_TMUX_PANE` を子へ継承）
 
 関連 lib: `delegate-registry.sh`（キック注入は `oe-send` 経由）

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # oe-delegate — 子 Claude セッションを起動し、タスクをキックする
 #
-# usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--] <task>
+# usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
 #
 # 子ペインを tmux split-window で起動し、キックは bin/oe-send 経由で注入する
 # （spawn + send の合成）。delegate は委譲（起動とキック）に専念し、戻し（report）の処理は
@@ -17,7 +17,7 @@ source "${BIN_DIR}/../lib/delegate-registry.sh"
 
 usage() {
   cat >&2 <<'EOF'
-usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--] <task>
+usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
 
   <task>              子 Claude セッションへ送るタスク（1行テキスト・改行不可）
                       --kickoff があれば省略可
@@ -26,6 +26,8 @@ usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--] <t
                       子から読めるよう doc のディレクトリを --add-dir で開示する
   --label <#N|name>   子を registry に登録する際のラベル（後で oe-send <label> で指す）。
                       省略時はラベル無しで登録（wt switch 後は pane-issue の #N で解決可）
+  --claude-arg <arg>  子 Claude 起動時に渡す追加引数（repeatable）。
+                      例: --claude-arg --permission-mode --claude-arg auto
   -h, --help          このヘルプを表示
 
 環境変数:
@@ -40,6 +42,7 @@ EOF
 WORKSPACE="$(pwd)"
 KICKOFF=""
 LABEL=""
+CLAUDE_ARGS=()
 while [[ "${1:-}" == -* ]]; do
   case "$1" in
     -w|--workspace)
@@ -51,6 +54,13 @@ while [[ "${1:-}" == -* ]]; do
     --label)
       [[ $# -ge 2 ]] || { echo "oe-delegate: --label requires a value" >&2; exit 2; }
       LABEL="$2"; shift 2 ;;
+    --claude-arg)
+      [[ $# -ge 2 ]] || { echo "oe-delegate: --claude-arg requires a value" >&2; exit 2; }
+      if [[ "$2" == *$'\n'* || "$2" == *$'\r'* ]]; then
+        echo "oe-delegate: --claude-arg value must be a single argument (no newline)" >&2
+        exit 2
+      fi
+      CLAUDE_ARGS+=("$2"); shift 2 ;;
     -h|--help) usage ;;
     --) shift; break ;;
     *) echo "oe-delegate: unknown option: $1" >&2; usage ;;
@@ -81,7 +91,6 @@ PARENT_PANE="${TMUX_PANE:-}"
 # --add-dir で開示する。spawn.sh の envelope は claude -p + --add-dir /tmp で読ませているが、
 # こちらは素の対話型 claude のため明示開示が要る（so 指摘）。
 KICKOFF_ABS=""
-ADD_DIR_OPT=""
 if [[ -n "$KICKOFF" ]]; then
   [[ -f "$KICKOFF" ]] || { echo "oe-delegate: --kickoff file not found: ${KICKOFF}" >&2; exit 2; }
   case "$KICKOFF" in
@@ -89,11 +98,30 @@ if [[ -n "$KICKOFF" ]]; then
   esac
   kdir="$(cd "$(dirname "$KICKOFF")" && pwd)"
   KICKOFF_ABS="${kdir}/$(basename "$KICKOFF")"
-  ADD_DIR_OPT=" --add-dir '${kdir}'"
 fi
 
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+build_child_command() {
+  local cmd
+  cmd="PARENT_TMUX_PANE=$(shell_quote "$PARENT_PANE") claude"
+  local arg
+  for arg in "${CLAUDE_ARGS[@]}"; do
+    cmd="${cmd} $(shell_quote "$arg")"
+  done
+  if [[ -n "$KICKOFF" ]]; then
+    cmd="${cmd} --add-dir $(shell_quote "$kdir")"
+  fi
+  printf '%s\n' "$cmd"
+}
+
 # 子ペインを作成し claude を起動（PARENT_TMUX_PANE を env として渡す）
-CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -c "$WORKSPACE" "PARENT_TMUX_PANE=${PARENT_PANE} claude${ADD_DIR_OPT}")"
+CHILD_COMMAND="$(build_child_command)"
+CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -c "$WORKSPACE" "$CHILD_COMMAND")"
 echo "oe-delegate: child pane ${CHILD_PANE} started (parent: ${PARENT_PANE}, workspace: ${WORKSPACE})" >&2
 
 # claude 起動待ち

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_delegate.sh — oe-delegate の CLI 引数と spawn command を検証する
+#
+# 実 tmux / Claude は起動せず、PATH 先頭の tmux mock で split-window と send-keys を記録する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/logs" "$_TMP_DIR/state" "$_TMP_DIR/pane-issue" "$_TMP_DIR/ws/.oe"
+
+cat > "$_TMP_DIR/bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir="${OE_DELEGATE_TEST_LOG_DIR:?}"
+
+if [[ "${1:-}" == "split-window" ]]; then
+  last=""
+  while [[ $# -gt 0 ]]; do
+    last="$1"
+    shift
+  done
+  printf '%s\n' "$last" >> "${log_dir}/split-command.log"
+  printf '%%9\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "list-panes" ]]; then
+  printf '%%1\n%%9\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "send-keys" ]]; then
+  printf '%s\n' "$*" >> "${log_dir}/send-keys.log"
+  exit 0
+fi
+
+if [[ "${1:-}" == "display-message" ]]; then
+  printf 'mock-pane\n'
+  exit 0
+fi
+
+echo "unexpected tmux call: $*" >&2
+exit 1
+EOF
+chmod +x "$_TMP_DIR/bin/tmux"
+
+export PATH="${_TMP_DIR}/bin:${PATH}"
+export TMUX="/tmp/mock-tmux,12345,0"
+export TMUX_PANE="%1"
+export OE_DELEGATE_TEST_LOG_DIR="${_TMP_DIR}/logs"
+export OE_DELEGATE_STATE_DIR="${_TMP_DIR}/state"
+export OE_PANE_ISSUE_DIR="${_TMP_DIR}/pane-issue"
+export OE_DELEGATE_WAIT_SEC=0
+export OE_SEND_FINALIZE=0
+export OE_SEND_ENTER_DELAY=0
+
+PASS=0
+FAIL=0
+
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (want='$expected' got='$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+reset_logs() {
+  rm -f "$_TMP_DIR/logs/"*.log
+}
+
+run_delegate() {
+  bash "$PROJECT_DIR/bin/oe-delegate" "$@" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log"
+}
+
+echo "[1] default spawn command"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --label "#152" "default task"
+ck "default child command" "PARENT_TMUX_PANE='%1' claude" "$(cat "$_TMP_DIR/logs/split-command.log")"
+ck "task sent to child pane" "yes" "$(grep -q -- 'send-keys -l -t %9 -- default task' "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+ck "Enter sent" "yes" "$(grep -q -- 'send-keys -t %9 Enter' "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+
+echo "[2] --claude-arg is repeatable and preserves one arg per flag"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg --permission-mode --claude-arg auto "arg task"
+ck "claude args in child command" "PARENT_TMUX_PANE='%1' claude '--permission-mode' 'auto'" "$(cat "$_TMP_DIR/logs/split-command.log")"
+
+echo "[3] --claude-arg combines with --kickoff add-dir"
+reset_logs
+kickoff="${_TMP_DIR}/ws/.oe/kickoff.md"
+printf '%s\n' '# kickoff' > "$kickoff"
+run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg --permission-mode --claude-arg auto --kickoff "$kickoff" "kickoff task"
+expected_cmd="PARENT_TMUX_PANE='%1' claude '--permission-mode' 'auto' --add-dir '${_TMP_DIR}/ws/.oe'"
+ck "kickoff add-dir follows claude args" "$expected_cmd" "$(cat "$_TMP_DIR/logs/split-command.log")"
+ck "kickoff path sent" "yes" "$(grep -qF -- "$kickoff を読んで進めて。 kickoff task" "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+
+echo "[4] --claude-arg shell-quotes single quotes"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg "foo'bar" "quote task"
+ck "single quote escaped in child command" "PARENT_TMUX_PANE='%1' claude 'foo'\\''bar'" "$(cat "$_TMP_DIR/logs/split-command.log")"
+
+echo "[5] --claude-arg preserves spaces and shell metacharacters"
+reset_logs
+meta_arg="a b;"'$'"(x)"
+run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg "$meta_arg" "meta task"
+ck "spaces/metacharacters quoted in child command" "PARENT_TMUX_PANE='%1' claude 'a b;\$(x)'" "$(cat "$_TMP_DIR/logs/split-command.log")"
+
+echo "[6] --claude-arg requires a value"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "missing claude arg rc=2" "2" "$rc"
+ck "missing claude arg does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[7] --claude-arg rejects LF before spawn"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg $'bad\narg' "task" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "LF claude arg rc=2" "2" "$rc"
+ck "LF claude arg does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[8] --claude-arg rejects CR before spawn"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg $'bad\rarg' "task" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "CR claude arg rc=2" "2" "$rc"
+ck "CR claude arg does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Purpose

Allow `oe-delegate` to pass startup options through to the child Claude session, especially `--permission-mode auto`, and stop local `.oe/` kickoff docs from appearing as untracked files.

Refs #152

## Changes

- Add repeatable `--claude-arg <arg>` support to `projects/orchestration-engine/bin/oe-delegate`.
- Shell-quote child Claude startup args when building the `tmux split-window` command.
- Reject LF/CR in `--claude-arg` values before spawning a child pane.
- Keep existing `--kickoff`, `--label`, registry, and `oe-send` injection flow intact.
- Add `.oe/` to `.gitignore`.
- Update `delegate-task` skill and `bin/README.md` usage docs.
- Add `projects/orchestration-engine/tests/test_oe_delegate.sh` with tmux-mocked coverage.

## Validation

- `bash -n projects/orchestration-engine/bin/oe-delegate projects/orchestration-engine/tests/test_oe_delegate.sh`
- `shellcheck projects/orchestration-engine/bin/oe-delegate projects/orchestration-engine/tests/test_oe_delegate.sh`
- `bash projects/orchestration-engine/tests/test_oe_delegate.sh`
- `bash projects/orchestration-engine/tests/test_delegate_send.sh`
- `bash projects/orchestration-engine/tests/test_delegate_registry.sh`
- `git diff --check`

## Second Opinion

- `so-compare` artifact review: Codex `pass`, blockers none.
- Claude lane timed out with no output on initial run and retry.
- Codex follow-up after test additions reported only the then-untracked test file; resolved by staging and committing the file.
