### PR TITLE
docs(rules): add exhaustion-before-conclusion rule

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -64,7 +64,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | playwright-agent | Playwright MCPでブラウザ操作を実行し、結果を要約して報告するエージェント | `agents/playwright-agent.md` |
 | vendor-inspector | Dependency and vendor code deep-reading agent. Investigates local vendor/, node_modules/, and external repository code | `agents/vendor-inspector.md` |
 
-## Rules (12)
+## Rules (13)
 
 | Name | Description | Path |
 |------|-------------|------|
@@ -73,6 +73,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | decision-pacing-rule | Separate problem reporting from action proposals; include "do nothing / defer" as an option | `rules/decision-pacing-rule.md` |
 | evidence-verification-rule | Concretizes Evidence First into a checkable protocol: claim-level verification status (verified/unverified-summary/speculation) + source, and risk-proportional consumer spot-check | `rules/evidence-verification-rule.md` |
 | execution-policy-rule | Read-only before mutations; gates/checkpoints as TODO items; execution obligations | `rules/execution-policy-rule.md` |
+| exhaustion-before-conclusion-rule | Complements Evidence First with exploration breadth: do not conclude while reachable paths or options remain unexamined. Illustrated by design (option) / bug-investigation (code-path) cases; planned mechanisms #77/#78 + soft floor #161; includes a minimal high-stakes discipline | `rules/exhaustion-before-conclusion-rule.md` |
 | implementation-gate-rule | Propose a planning phase before any code change; agent MUST NOT self-apply exceptions | `rules/implementation-gate-rule.md` |
 | implementation-principles-rule | Address root causes over hacky fixes; verify no existing behavior is broken | `rules/implementation-principles-rule.md` |
 | input-style-rule | Handle voice-input typos and fragments; prioritize intent over polish | `rules/input-style-rule.md` |

--- a/canonical/rules/exhaustion-before-conclusion-rule.md
+++ b/canonical/rules/exhaustion-before-conclusion-rule.md
@@ -1,6 +1,6 @@
 # Exhaustion Before Conclusion
 
-Complements `behavioral-rule.md` §1 Evidence First. Evidence First governs the *quality* of grounding (prefer primary sources). This rule governs the *breadth* of exploration: do not conclude while reachable paths or options remain unexamined. (Claim-level verification is `evidence-verification-rule`; this rule is about exploration breadth, not source checking.)
+Complements `behavioral-rule.md` §1 Evidence First. Evidence First governs the *quality* of grounding (prefer primary sources). This rule governs the *breadth* of exploration: do not conclude while reachable paths or options remain unexamined. (Claim-level verification is `evidence-verification-rule.md`; this rule is about exploration breadth, not source checking.)
 
 ## Principle
 
@@ -50,6 +50,6 @@ This does not apply to small, low-risk decisions — avoid analysis paralysis (s
 
 - `behavioral-rule.md` §1 Evidence First — complemented principle (quality of grounding vs breadth of exploration)
 - `evidence-verification-rule.md` — sibling under Evidence First; claim-level verification status, orthogonal to this rule's exploration breadth
-- `docs/specs/2026-04-23-discussion-exploration-process-design.md` — canonical design discussion (§3.4 convergence is not the model's call; §6 "one name covers two problems" caveat)
+- `docs/specs/2026-04-23-discussion-exploration-process-design.md` — canonical design discussion (§3.4: convergence is not the model's call; §6 caveat that one principle name spans two distinct problems)
 - `docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md` — sibling discussion
 - `projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md` — worked design-decision example

--- a/canonical/rules/exhaustion-before-conclusion-rule.md
+++ b/canonical/rules/exhaustion-before-conclusion-rule.md
@@ -1,0 +1,55 @@
+# Exhaustion Before Conclusion
+
+Complements `behavioral-rule.md` §1 Evidence First. Evidence First governs the *quality* of grounding (prefer primary sources). This rule governs the *breadth* of exploration: do not conclude while reachable paths or options remain unexamined. (Claim-level verification is `evidence-verification-rule`; this rule is about exploration breadth, not source checking.)
+
+## Principle
+
+> Do not conclude while known reachable paths or options remain unexamined.
+
+The design discussion phrases it as "do not jump to a conclusion before exhaustiveness is guaranteed" — operationalized as *structural suppression of early convergence*, not literal 100% coverage (see Scope).
+
+Why it is needed: LLMs carry an early-convergence bias — latching onto a plausible local optimum, externalizing judgment ("it depends on the requirements") to cut exploration short, and emitting superficial diversity (N variants of one category). Exploration *quality* is probabilistic (model-dependent), but exploration *structure* can be enforced deterministically. This rule sets that default stance.
+
+## Where it shows up (illustrative)
+
+The same failure structure recurs across domains. The two cases below are illustrative examples, not verification-grade proof — the principle rests on the reasoning above. The pattern is the point; it need not be these specific cases.
+
+| Bug investigation (code-path exhaustion) | Design decision (option exhaustion) |
+|---|---|
+| Jump to an external hypothesis while a code-path segment from input to output is still unread | Commit while an unexplored alternative remains in the option set |
+| "Read the whole path before moving to external hypotheses" | "Explore alternatives from zero before committing" |
+| Externalize each hypothesis to make spinning (same-level lateral moves) visible | Externalize the option set to make exploration coverage visible |
+
+- Design-decision example: the wez notify `option C` (TTY direct write) surfaced only after an ad-hoc zero-base re-review, when a commit on options A/B was already near. Worked example in this repo: `projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md`.
+- Bug-investigation example: an error investigation that jumped to an external hypothesis (infra difference) while an input→output code path was still unread — 6 steps for what 2 would have. From a separate project (external, ref omitted); cited as illustration only, not inspectable here.
+
+## Application
+
+The reachable space splits in two, so the planned mechanisms split into two tracks while the principle stays single:
+
+- Design-decision domain (unexplored options): a hard mechanism to force zero-base exploration before committing — design tracked in #77 (planned, not yet implemented).
+- Bug-investigation domain (unread code paths): a hard mechanism to externalize hypotheses and make spinning visible — design tracked in #78 (planned, not yet implemented).
+- An always-on soft floor (reframe / zero-base on detecting spin) — planned as a separate rule, #161 (not yet landed).
+
+## Minimal discipline (until the mechanisms land)
+
+The mechanisms above do not exist yet. At high-stakes conclusions — committing a design, asserting a root cause, or jumping to an external hypothesis — apply this floor directly:
+
+- Do not self-declare "explored enough" without a stated reason. The model is biased to announce sufficiency; the design discussion is explicit that convergence must not be left to the model's own judgment.
+- Decide the stopping condition before exploring, not when you feel done.
+- At conclusion, state briefly what was read, what was explored, and what reachable area was left unexamined.
+
+This does not apply to small, low-risk decisions — avoid analysis paralysis (see Scope).
+
+## Scope
+
+- Aim to lift exploration quality from the ~50% "jump early" level to ~80%. Do not aim for 100%.
+- The remaining ~20% is edge cases — the "handle it once it shows up" level, even for humans. Do not over-enforce exhaustiveness (consistent with `behavioral-rule.md` §4 Minimal Scope).
+
+## References
+
+- `behavioral-rule.md` §1 Evidence First — complemented principle (quality of grounding vs breadth of exploration)
+- `evidence-verification-rule.md` — sibling under Evidence First; claim-level verification status, orthogonal to this rule's exploration breadth
+- `docs/specs/2026-04-23-discussion-exploration-process-design.md` — canonical design discussion (§3.4 convergence is not the model's call; §6 "one name covers two problems" caveat)
+- `docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md` — sibling discussion
+- `projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md` — worked design-decision example


### PR DESCRIPTION
## 目的

canonical の行動原則として **Exhaustion Before Conclusion**（網羅性が保証される前に結論へ飛ぶな）を追加する。探索原則クラスタ（#75 / #76 / #77 / #78 / #161）の傘＝root 原則。

## 変更内容

- 新規 `canonical/rules/exhaustion-before-conclusion-rule.md`（英語＝Rules 規約）
  - Evidence First を **complement**（根拠の質 vs 探索の幅）。`evidence-verification-rule` との直交を明記
  - Principle を Scope（80% 狙い・非 100%）と一致させ、`guaranteed`/`exhaust` の過剰表現を緩和
  - 2ドメイン（設計＝選択肢 / バグ調査＝コードパス）は **参考例（illustration）** として提示。原則の正当性は推論で立て、例示は証明扱いしない。バグ調査側は外部・ref 省略（検証不能）と正直に明記
  - **Minimal discipline**（高リスク結論限定の歯）: 収束を根拠なく自己宣言しない / 停止条件を先に置く / 結論時に未探索範囲を明示（正本 §3.4「収束はモデルの判断に委ねない」を反映）
  - 硬い機構 #77 / #78・軟らかい床 #161 は **planned** として参照（dangling 回避）
- `canonical/CATALOG.md`: Rules `(12)→(13)`、1行追加

## レビュー

- so-compare（Codex gpt-5.5 / Claude opus・high）で反証レビュー → 指摘（過剰表現・over-claim・dangling 参照・歯の不在）を全反映。2者合意。

## 影響範囲

- doc のみ。全プロジェクトへ配布される canonical ルールに1件追加（sync で各ツールへ）。挙動変更なし。

Refs #75
