### PR TITLE
docs(wezterm-ai-mode): Phase 2 dotfiles 統合の完了を反映

### DIFF
--- a/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
+++ b/projects/wezterm-ai-mode/docs/VERIFICATION_MATRIX.md
@@ -30,7 +30,7 @@ use_when:
 | A-1-1 | ソケット自動検出（`gui-sock-*`） | PoC 完了 | PASSED | PoC-01 |
 | A-1-2 | ペイン操作（split / send / list / kill） | PoC 完了 | PASSED（タイミング制約あり） | PoC-02 |
 | A-1-3 | 出力キャプチャ（`get-text`、tmux 内） | PoC 完了 | PASSED | PoC-03 |
-| A-1-4 | 通知経路（user-var 送信 → Lua / toast） | PoC 部分 | PARTIAL（Lua 手動適用要） | PoC-04 |
+| A-1-4 | 通知経路（user-var 送信 → Lua / toast） | 実施済み | PASSED（Phase 2 #86: dotfiles に Lua ハンドラ統合。live toast を GUI ログで確認） | PoC-04, #86, [episode](episodes/2026-06-16-phase2-dotfiles-lua-integration.md), dotfiles PR #20 |
 
 ### A-2. 本プロジェクト（`wez` 統合 CLI・Phase 1）
 
@@ -38,7 +38,7 @@ use_when:
 |----|---------|------|------|------|
 | A-2-1 | `wez discover` 単体・全サブコマンド前提 | 実施済み | PASSED | Issue #28, E2E 9/9 パス |
 | A-2-2 | `wez pane`（list / split / send / capture / kill） | 実施済み | PASSED | Issue #29, E2E 12/12 パス |
-| A-2-3 | `wez notify`（user-var 送信 + Lua 統合方針 ADR） | 実施済み | PASSED（CLI 層。toast は Phase 2） | Issue #30, E2E 12/12 パス, ADR-006/007 |
+| A-2-3 | `wez notify`（user-var 送信 + Lua 統合方針 ADR） | 実施済み | PASSED（CLI 層 + Phase 2 #86 で toast 開通） | Issue #30, E2E 12/12 パス, ADR-006/007, #86 |
 | A-2-4 | 複数 WezTerm インスタンス時のソケット選択 | 設計済み | DESIGNED | ADR-002: mtime+verify ハイブリッド方式。単一インスタンスで E2E 検証済み |
 | A-2-5 | 新ペイン tmux auto-attach 後のコマンド送信（ポーリング等） | 実施済み | PASSED（--wait-ready） | ADR-003: ポーリング方式採用。E2E で send → capture 正常動作確認 |
 | A-2-6 | 3ツール横断 7ステップ統合フロー（discover→kill） | 実施済み | PASSED | Issue #31, [E2E エピソード](episodes/2026-05-13-phase1-e2e.md), #20 コメント群（Cursor/CC/Codex 全成功） |

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-006-lua-integration-policy.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-006-lua-integration-policy.md
@@ -19,7 +19,7 @@ tags: [lua, wezterm, notification, phase2, architecture]
 
 ## ステータス
 
-Accepted（Phase 2 実装完了 — 2026-06-16, dotfiles PR #20）
+Accepted（Phase 2 実装済み — 2026-06-16, dotfiles PR #20）
 
 ## コンテキスト
 
@@ -49,12 +49,3 @@ Accepted（Phase 2 実装完了 — 2026-06-16, dotfiles PR #20）
 - Phase 1 の `wez notify` はユーザー観点で「無音」（user-var は送信されるが toast は出ない）
 - `--help` と README に「toast 表示には `.wezterm.lua` に Lua ハンドラが必要（Phase 2）」と明記
 - Phase 2 の scope: Lua ハンドラの dotfiles 統合、`gmatch` パーサ修正、`allow-passthrough` 対応
-
-### Phase 2 完了（2026-06-16）
-
-Issue #86 / [dotfiles PR #20](https://github.com/stlwolf/dotfiles/pull/20) で Phase 2 を実装・マージ。本 ADR の先送り判断（選択肢 C: dotfiles 統合）どおり実装した。
-
-- `.wezterm.lua`: `user-var-changed` ハンドラをインライン統合（既存ハンドラと同スタイル）。`gmatch('[^|]+')` の空セグメント問題（DJ-3）は `string.match('^([^|]*)|([^|]*)|([^|]*)$')` で修正し、match 失敗時は生値を title に使うフォールバックを追加。
-- `.bashrc`: AI IDE 検出時（`is_ai_ide()`）に `WEZTERM_UNIX_SOCKET` を自動 export（AI IDE 統合ターミナルへ socket が伝搬しない stale socket 問題＝課題A の緩和）。
-- `allow-passthrough`: dotfiles #16 で既に対応済のため #86 スコープ外。TTY direct write 採用（ADR-007 DJ-1）により原理上も不要。
-- 実機検証: live toast の発火・パースを GUI ログで確認し、VERIFICATION_MATRIX A-1-4 を PASSED に更新。詳細は [episode](../episodes/2026-06-16-phase2-dotfiles-lua-integration.md)。

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-006-lua-integration-policy.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-006-lua-integration-policy.md
@@ -19,7 +19,7 @@ tags: [lua, wezterm, notification, phase2, architecture]
 
 ## ステータス
 
-Accepted
+Accepted（Phase 2 実装完了 — 2026-06-16, dotfiles PR #20）
 
 ## コンテキスト
 
@@ -49,3 +49,12 @@ Accepted
 - Phase 1 の `wez notify` はユーザー観点で「無音」（user-var は送信されるが toast は出ない）
 - `--help` と README に「toast 表示には `.wezterm.lua` に Lua ハンドラが必要（Phase 2）」と明記
 - Phase 2 の scope: Lua ハンドラの dotfiles 統合、`gmatch` パーサ修正、`allow-passthrough` 対応
+
+### Phase 2 完了（2026-06-16）
+
+Issue #86 / [dotfiles PR #20](https://github.com/stlwolf/dotfiles/pull/20) で Phase 2 を実装・マージ。本 ADR の先送り判断（選択肢 C: dotfiles 統合）どおり実装した。
+
+- `.wezterm.lua`: `user-var-changed` ハンドラをインライン統合（既存ハンドラと同スタイル）。`gmatch('[^|]+')` の空セグメント問題（DJ-3）は `string.match('^([^|]*)|([^|]*)|([^|]*)$')` で修正し、match 失敗時は生値を title に使うフォールバックを追加。
+- `.bashrc`: AI IDE 検出時（`is_ai_ide()`）に `WEZTERM_UNIX_SOCKET` を自動 export（AI IDE 統合ターミナルへ socket が伝搬しない stale socket 問題＝課題A の緩和）。
+- `allow-passthrough`: dotfiles #16 で既に対応済のため #86 スコープ外。TTY direct write 採用（ADR-007 DJ-1）により原理上も不要。
+- 実機検証: live toast の発火・パースを GUI ログで確認し、VERIFICATION_MATRIX A-1-4 を PASSED に更新。詳細は [episode](../episodes/2026-06-16-phase2-dotfiles-lua-integration.md)。

--- a/projects/wezterm-ai-mode/docs/episodes/2026-06-16-phase2-dotfiles-lua-integration.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-06-16-phase2-dotfiles-lua-integration.md
@@ -1,0 +1,99 @@
+---
+id: "01KV5YVP42FKC3HSH7WY6MGKM0"
+title: "Phase 2 dotfiles 統合（Lua ハンドラ + bashrc socket export）（Issue #86）"
+date: 2026-06-16
+type: episode
+status: stable
+related:
+  - type: implements
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/86"
+    reason: "Phase 2: dotfiles 統合で wez notify の toast を開通"
+  - type: depends_on
+    ref: ../decisions/ADR-006-lua-integration-policy.md
+    reason: "Phase 2 先送り判断（選択肢 C: dotfiles 統合）の実装"
+  - type: depends_on
+    ref: ../decisions/ADR-007-notify-design-decisions.md
+    reason: "DJ-3（gmatch 空セグメント問題）の修正を実装"
+  - type: evidence_for
+    ref: ../VERIFICATION_MATRIX.md
+    reason: "A-1-4 を PARTIAL → PASSED に更新した根拠"
+tags: [phase2, dotfiles, wezterm, lua, notify, socket, copilot-review]
+---
+
+# Phase 2 dotfiles 統合（Lua ハンドラ + bashrc socket export）（Issue #86）
+
+## 概要 / なぜ
+
+Phase 1 で `wez notify` の CLI（OSC 1337 SetUserVar 送信）は完成していたが、toast 表示には `.wezterm.lua` 側の `user-var-changed` → `toast_notification` ハンドラが必要で、ユーザー観点では「無音」だった（ADR-006 が Phase 2 へ先送り）。本 episode は Issue #86 として、dotfiles リポジトリ（`stlwolf/dotfiles`）に Lua ハンドラと socket 自動 export を統合し、toast を開通させた記録。
+
+実装は dotfiles 側で完結（[PR #20](https://github.com/stlwolf/dotfiles/pull/20)、squash merge `0eb96e7`）。hub 側はこの episode + VERIFICATION_MATRIX `A-1-4` + ADR-006 の更新のみ。
+
+tier: **standard**。`episode-retrospective` Step 1 では heavy トリガ（外部レビューレーン=Copilot 使用 / 方針転回 / 非自明な設計判断）に該当するが、owner 判断で standard を採用（理由は §6）。
+
+## 1. 実装内容（dotfiles）
+
+### `.wezterm.lua`（feat, `adcb13a` → 改善 `99c3067`/`97e4411`）
+
+`return config` 直前に既存イベントハンドラと同じインラインスタイルで追加:
+
+- パーサは `string.match('^([^|]*)|([^|]*)|([^|]*)$')` で `title|body|timeout` を固定3フィールド抽出。PoC の `gmatch('[^|]+')` は**空 body セグメントで timeout が body にずれる**問題（ADR-007 DJ-3）があったため修正（Lua の `|` はリテラルで alternation ではない点が固定3フィールド抽出の前提）。
+- match 失敗時は生 `value` を title に使うフォールバック（将来の区切り変更=DJ-3 や手動送信に備える）。
+- 空 body 時は toast メッセージを `title` のみに（末尾 `: ` を残さない）。
+- `ai_notify` / `ai_status` の分岐は `if/elseif`（`name` は排他）。
+
+### `.bashrc`（feat, `adcb13a` → 改善 `99c3067`/`97e4411`）
+
+`is_ai_ide()` の Homebrew ブロック内で、`WEZTERM_UNIX_SOCKET` 未設定時のみ `~/.local/share/wezterm/gui-sock-*` の mtime 最新を自動 export。AI IDE 統合ターミナルへ socket が伝搬しない **stale socket 問題（課題A）** の緩和。socket 探索は `for` + `-nt` 比較ループ（`ls` を使わず ShellCheck SC2012 を回避）、存在チェックは `-S`（socket file。stale な通常ファイルを掴まない）。未設定時のみ・socket 無しなら no-op。
+
+### `.gitignore`（chore, `09a3f7f`）
+
+`tmp/` と `.antigravitycli/` を ignore 化（リポ衛生。#86 とは別論理コミット）。
+
+## 2. 決定と根拠（選択肢比較）
+
+| 論点 | 採用 | 棄却 / 理由 |
+|------|------|------------|
+| ブランチ運用 | **通常ブランチ（main checkout）** | wt worktree を棄却。dotfiles は symlink デプロイ（`~/.wezterm.lua` → main checkout）で、別ディレクトリの worktree 編集は**ライブ設定に反映されず**、`make validate`（`$HOME/<f>` が `$(PWD)` を指すか検査）も main からでないと成立しない |
+| dirty tree の隔離 | **`.wezterm.lua` 1行だけ stash → 作業 → マージ後 pop** | 作業ツリーに無関係な未コミット変更（うち `.wezterm.lua` 1行）が同居。衝突するファイルだけ退避し、#86 コミットを純粋化。他ファイルは `git add` で触れない |
+| socket 選択 | **bash `-nt` ループ + `-S`** | `ls -t \| head -1` を棄却（Copilot 指摘 SC2012、非ソケット混入リスク） |
+| パーサ堅牢化 | **match 失敗時フォールバック** | 全 nil → `'AI Mode'` への潰れ（内容消失・デバッグ困難）を回避 |
+| セカンドオピニオン | **SO なし** | コードは spec 転記 + ADR-007 で peer-review 済のため SO の上積みが薄い。代わりに live toast 実機検証 + 一次情報（WezTerm user-var 仕様）で代替（evidence-verification-rule） |
+
+## 3. わかったこと（W）
+
+- **symlink デプロイ × worktree の非両立**: 配備が固定パスへの symlink の場合、別ディレクトリ worktree での編集はライブに反映されず、ライブ検証・`make validate` が成立しない。symlink デプロイのリポは「main checkout で作業 + dirty tree は部分 stash で隔離」が筋。
+- **WezTerm は user-var 値を base64 デコードしてから Lua ハンドラに渡す**: CLI は base64 エンコード送信、ハンドラ受領時は復号済み文字列（live で実証。`ai_notify: test - hello` がログに出た）。PoC が `local decoded = value` と命名していた前提が正しいと確認。
+- **`make lint` はハードフェイルしない**: ベースラインで多数の warning 既出・recipe が常に exit 0。新規 finding を出さないことが実質ゲート（SC2012 を残さない判断の根拠）。
+
+## 4. Copilot レビュー（外部レビューレーン）
+
+push のたびに Copilot が新 diff を再レビューし、計 **2 ラウンド・5 スレッド**を対応（全件「対応した」で返信）:
+
+- **R1**（`99c3067`）: socket 選択を `-nt` 化（SC2012 解消） / パーサ match 失敗時フォールバック追加。
+- **R2**（`97e4411`）: 存在チェック `-e`→`-S`（非ソケット回避） / 空 body 時 toast を title のみに / `if`→`elseif` 統合。
+
+傾向: 各ラウンドは概ねスタイル/堅牢性の小粒で、ラウンドを追うごとに**収穫逓減**。R2 完了時点で未返信ゼロ、owner 判断でマージ。
+
+## 5. 検証エビデンス（揮発ログの転記）
+
+live toast は `~/.local/share/wezterm/wezterm-gui-log-*.txt`（揮発・ローカル）に出た以下を確認:
+
+```text
+lua: ai_notify: test - hello          # 通常
+lua: ai_notify: title only -          # 空 body（DJ-3 修正の実証。body が空のままずれない）
+lua: ai_notify: rawtest-nopipe -      # パイプ無し生値（フォールバック発火）
+lua: ai_status: running               # elseif 分岐
+```
+
+- shellcheck: `.bashrc` の新規 finding は SC2012(info) のみ → `-nt` 化で **SC2012 ゼロ**（ベースライン一致）。
+- socket ロジック（シェル）: 未設定→最新 export / 既設定→非上書き / socket 無し→ no-op / 非ソケットの同名ファイル→スキップ。
+- `make validate`: `OK: .bashrc` / `OK: .wezterm.lua`。
+- dotfiles コミット: `adcb13a`（feat）/ `09a3f7f`（chore）/ `99c3067`（fix R1）/ `97e4411`（fix R2）→ squash merge `0eb96e7`（PR #20）。
+
+## 6. 振り返り（closure）
+
+- **次の消費者**: Phase 3（`wez agent` 連携）設計時に Lua ハンドラ / socket export を前提として参照する人。dotfiles の `wez notify` 周りを再訪する人。
+- **follow-up routing**: 残課題なし（#86 完了）。`allow-passthrough` は dotfiles #16 で既済のため #86 から除外（追わない）。ローカル `master` の sync とブランチ掃除は owner 環境の運用（追わない）。
+- **蒸留シグナル（昇格候補）**: 「symlink デプロイのリポは worktree 不可・main checkout + 部分 stash で隔離」は転用可能な pattern。今回は episode に留め、Decision/skill 昇格は**なし**（単一事例。再発したら negative knowledge #62 へ）。
+- **tier 逸脱の明示**: heavy トリガ（Copilot レーン・wt→通常ブランチの方針転回・複数の設計判断）に該当するが、owner が standard を選択。理由は本タスク全体で SO を使わない方針（heavy の Step 4 外部チェックと整合しない）で、self-reported closure とする。
+- **status**: stable（達成 — toast 開通を実機確認、hub docs 反映済み）。


### PR DESCRIPTION
## 概要

Issue #86（Phase 2 dotfiles 統合）の **hub 側反映**。dotfiles の実装・マージ（[stlwolf/dotfiles PR #20](https://github.com/stlwolf/dotfiles/pull/20)、squash `0eb96e7`）を受けて、検証マトリクス・ADR・episode を更新する。コード変更はなく、ドキュメントのみ。

Refs #86

## 変更内容

- **VERIFICATION_MATRIX**: `A-1-4`（通知経路 Lua/toast）を `PARTIAL（Lua 手動適用要）` → `PASSED`（live toast 実機確認）。`A-2-3` の「toast は Phase 2」注記を「#86 で開通」に更新。
- **ADR-006**: ステータスに「Phase 2 実装完了」を追記し、「結果」に Phase 2 完了サマリを追加（先送り判断 = 選択肢 C どおり dotfiles に統合）。
- **episode 新規**（`2026-06-16-phase2-dotfiles-lua-integration.md`、standard tier・closure gate 充足）: 実装内容、設計判断（symlink × worktree 非両立 / 隔離 stash / `-nt` / パーサ fallback）、Copilot 2 ラウンド、検証エビデンス（live toast ログ・コミット）を記録。

## 検証

- dotfiles 側で実機検証済み（live toast: `ai_notify: test - hello` / 空 body / fallback / `ai_status`、shellcheck SC2012 ゼロ、`make validate` / `make lint`）。
- 本 PR は hub 側ドキュメントのみの変更（コード変更なし）。

## やらないこと

- dotfiles 側はマージ済み（別リポ #20）。本 PR は hub のドキュメント反映のみ。
