### PR TITLE
docs(rules): add reframe-on-stall rule

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -64,7 +64,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | playwright-agent | Playwright MCPでブラウザ操作を実行し、結果を要約して報告するエージェント | `agents/playwright-agent.md` |
 | vendor-inspector | Dependency and vendor code deep-reading agent. Investigates local vendor/, node_modules/, and external repository code | `agents/vendor-inspector.md` |
 
-## Rules (13)
+## Rules (14)
 
 | Name | Description | Path |
 |------|-------------|------|
@@ -78,6 +78,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | implementation-principles-rule | Address root causes over hacky fixes; verify no existing behavior is broken | `rules/implementation-principles-rule.md` |
 | input-style-rule | Handle voice-input typos and fragments; prioritize intent over polish | `rules/input-style-rule.md` |
 | output-format-rule | Conclusion → evidence → steps → risks → links output structure | `rules/output-format-rule.md` |
+| reframe-on-stall-rule | Always-on soft floor under exhaustion-before-conclusion: when exploration stalls (no material new information, lateral repetition), consider a zero-base rebuild before continuing. Qualitative trigger via observable signs (not a count); reconcile against discarded premises; low-risk carve-out; model-dependent (hard gate #77 backs high-stakes once it lands) | `rules/reframe-on-stall-rule.md` |
 | skill-first-operations-rule | Load and follow skills for routine dev operations; do NOT skip skill loading | `rules/skill-first-operations-rule.md` |
 | subagent-strategy-rule | Subagent delegation: custom agents first, one task per subagent, implementer-contract; routing gate (new thread escalation signal, PR-unit) | `rules/subagent-strategy-rule.md` |
 | workflow-awareness-rule | GitHub Flow; autonomously start branching for issue-driven work | `rules/workflow-awareness-rule.md` |

--- a/canonical/rules/reframe-on-stall-rule.md
+++ b/canonical/rules/reframe-on-stall-rule.md
@@ -32,7 +32,7 @@ A rebuild is not a reset:
 ## Scope
 
 - Applies to costly, stuck exploration. It does not apply to small, low-risk work — a zero-base rebuild is expensive; do not reframe a two-line fix (consistent with `behavioral-rule.md` §4 Minimal Scope).
-- If a reframe changes scope, cost, or direction, surface it as an option rather than silently pivoting, unless autonomous exploration was requested (`decision-pacing-rule` / `implementation-gate-rule`).
+- If a reframe changes scope, cost, or direction, surface it as an option rather than silently pivoting, unless autonomous exploration was requested (`decision-pacing-rule.md` / `implementation-gate-rule.md`).
 
 ## Limits
 

--- a/canonical/rules/reframe-on-stall-rule.md
+++ b/canonical/rules/reframe-on-stall-rule.md
@@ -1,0 +1,56 @@
+# Reframe on Stall
+
+Complements `behavioral-rule.md` §1 Evidence First and serves as the always-on soft floor under `exhaustion-before-conclusion-rule.md`. Where that rule says "do not conclude too early," this one says "do not keep grinding the same way."
+
+## Principle
+
+> When exploration stalls — your last moves return no material new information, only lateral repetition at the same level — do not just continue. Before the next same-direction attempt, explicitly consider rebuilding from zero (a zero-base reframe) once.
+
+This is a default stance, on every session — not a tool to invoke or a hook to fire.
+
+## Trigger: a stall, judged by observable signs (not a step count)
+
+Do not use a count threshold ("after N tries"): a count is context-blind — three repetitions on a triviality is not a stall, and a single lateral move on a hard problem can already be the cue. A single no-new-information move can be the cue; repetition strengthens the signal but is not required.
+
+"Am I stuck?" is the judgment a model is worst at, so prefer observable signs of the last move's result over a feeling:
+
+- Did the error / failure change, or repeat unchanged?
+- Did a hypothesis get ruled in or out?
+- Did the set of live options shrink?
+- Did the next action change as a result?
+
+If none of these moved — including a reasoning step that only restated the problem (a stall need not involve a tool call) — that is the cue to reframe. Materiality matters: piling up confirming detail that does not change the conclusion is a stall even though it is technically new information. Where no observable sign applies, this falls back to a soft "was that just a lateral move?" judgment — and that judgment is itself model-dependent and unreliable (see Limits).
+
+## Reframe, then reconcile
+
+A rebuild is not a reset:
+
+- Before rebuilding, note in one line the premises, hypotheses, and known facts you are discarding — otherwise there is nothing to reconcile against afterward (especially once context is compressed).
+- After the zero-base pass, reconcile it against that note: convergence (it lands where the old path did) raises confidence but is not proof — both passes can share a blind spot; divergence means the old path missed something — record what.
+- If the rebuild also stalls, surface it / escalate rather than loop.
+
+## Scope
+
+- Applies to costly, stuck exploration. It does not apply to small, low-risk work — a zero-base rebuild is expensive; do not reframe a two-line fix (consistent with `behavioral-rule.md` §4 Minimal Scope).
+- If a reframe changes scope, cost, or direction, surface it as an option rather than silently pivoting, unless autonomous exploration was requested (`decision-pacing-rule` / `implementation-gate-rule`).
+
+## Limits
+
+- Adherence is model-dependent; there is no firing guarantee. This raises the floor — it does not close the gap. The trigger judgment itself ("was that material new information?") is partly self-evaluation and unreliable where no observable sign applies. Over-firing (reframing where grinding was right) and under-firing (missing the stall) both remain.
+- High-stakes or irreversible conclusions are not left to this soft reflex. A hard gate (count + script + human) is planned for the design-decision domain (#77) and is not yet implemented — until it lands, rely on `exhaustion-before-conclusion-rule.md`'s minimal discipline plus human confirmation for such conclusions.
+
+## Relationship
+
+- `exhaustion-before-conclusion-rule.md` — the umbrella. Its discipline is conclusion-time (may you commit while reachable paths or options are unexamined?); this rule is mid-exploration (what is the next move when the frame stalls?). They can co-fire — e.g. when you are about to jump to an external hypothesis while stuck. This rule is the permanent always-on floor; that rule's "Minimal discipline" is the interim floor until the hard mechanisms (#77 / #78) land.
+- `persistent-exploration` (skill) — the related anti-give-up reflex (do not quit before trying alternatives). The two can both apply and chain: try other approaches; if those also stall, rebuild the frame.
+
+## Example (illustrative)
+
+A bug investigation retries the same request three ways and gets the same error each time — no new information, lateral moves: a stall. The reframe is not a fourth variant of the request but a zero-base question re-derived from scratch — "what if the request is not the problem at all?" — then reconciled against the discarded "it is the request" premise.
+
+## References
+
+- `exhaustion-before-conclusion-rule.md` — umbrella principle; this rule is its always-on soft floor
+- `behavioral-rule.md` §1 Evidence First
+- `docs/specs/2026-04-23-discussion-exploration-process-design.md` — canonical design discussion
+- `canonical/skills/persistent-exploration/SKILL.md` — the related anti-give-up reflex


### PR DESCRIPTION
## 目的

canonical の behavioral rule として **Reframe on Stall**（空転検知時に作り直し・ゼロベース観点を自発適用）を追加する。探索原則クラスタの #75（Exhaustion Before Conclusion）の下に敷く常時オンの軟らかい床。

## 変更内容

- 新規 `canonical/rules/reframe-on-stall-rule.md`（英語＝Rules 規約）
  - Principle: 空転（material な新情報ゼロ・同レベルの横移動反復）→ 続行前に「ゼロから組み直す」を一度明示検討
  - Trigger: 観測可能な印（エラー変化/仮説の白黒/選択肢減少/次手の変化）優先、印が無ければ soft 判断にフォールバック（モデル依存と明記）。**count 閾値は使わない**
  - Reframe→reconcile: 組み直す前に捨てる前提を外部化して突合（一致＝確信↑だが証明でない／不一致＝見落とし／組み直しも空転なら surface）
  - Scope: 低リスク carve-out（2行修正で reframe するな・Minimal Scope）。scope/方向が変わる reframe は option 提示
  - Limits: モデル依存・発火保証なし・トリガー判断自体も不確実。高リスクは #77（未実装）が下支え予定＝当面 #75 minimal discipline ＋人間確認
  - Relationship: #75（結論時）と co-fire しうる／恒久 floor vs #75 の暫定 floor。persistent-exploration は関連反射として軽く接続
- `canonical/CATALOG.md`: Rules `(13)→(14)`

## レビュー

- so-compare（Codex gpt-5.5 / Claude opus・high, 2者合意）: トリガーの自己評価依存・persistent との排他誤り・#75 境界 no-overlap 誤り・突合の前提外部化欠落・count 矛盾・低リスク carve-out 欠落・Limits の #77 over-claim → 全反映。persistent は実効未知のため一軸断定を避け軽量化

## 影響範囲

- doc のみ。canonical ルールに1件追加（sync で各ツールへ配布）。挙動変更なし

Refs #161
