### PR TITLE
docs(codex): summarize exploration rules in AGENTS.md

### DIFF
--- a/canonical/codex/AGENTS.md
+++ b/canonical/codex/AGENTS.md
@@ -9,7 +9,7 @@ alwaysApply: false
 This file defines the behavioral guardrails applied to every Codex session.
 Purpose: lock in the minimal set of always-on principles while keeping heavy procedures out of the permanent context.
 
-The canonical source is `canonical/rules/*.md` (11 files). This file is a keyword-level summary.
+The canonical source is `canonical/rules/*.md` (14 files). This file is a keyword-level summary.
 For detailed rules (exception conditions, specific procedures), read the canonical source.
 Consistency check: `./scripts/check-codex-guardrails.sh`
 
@@ -33,6 +33,8 @@ Use `collaboration_mode: ask-for-direction` unless the user explicitly requests 
 11. Input Handling — Voice-input typos and fragments are common. Prioritize intent over surface polish.
 12. Skill-First Operations — Load and follow the corresponding skill before executing routine dev operations (branching, commits, PRs, issues). Do NOT skip skill loading.
 13. Subagent Strategy — Delegate investigation and parallel analysis to subagents. One task per subagent. Enforce `implementer-contract` skill for implementation delegation.
+14. Exhaustion Before Conclusion — Do not conclude while reachable paths or options remain unexamined. Complements Evidence First: exploration breadth vs grounding quality.
+15. Reframe on Stall — When exploration stalls (no material new information, only lateral repetition), consider a zero-base rebuild before continuing. The soft floor under Exhaustion Before Conclusion.
 
 ## Planning Phase
 


### PR DESCRIPTION
## 目的

#75 / #161 で追加した2ルール（Exhaustion Before Conclusion / Reframe on Stall）を Codex にも届ける。Codex はルールを `canonical/codex/AGENTS.md`（キーワード要約・手動メンテ）経由で受け取るため、ここに要約が無いと sync しても Codex セッションに反映されない。

## 背景

Wave 1 マージ後の sync で判明：`~/.claude/rules` には2ルールが symlink 配備されるが、Codex 向けは AGENTS.md 経由のため未反映、かつ件数注記が `11 files`（実際14）と stale だった。

## 変更内容

- `canonical/codex/AGENTS.md`
  - Core Principles に追記: `14. Exhaustion Before Conclusion` / `15. Reframe on Stall`
  - canonical source 件数 `11 → 14`
- `./scripts/check-codex-guardrails.sh` pass

## スコープ外（観察・別途判断）

- `evidence-verification-rule` と `workflow-awareness-rule` も AGENTS.md に未要約（pre-existing drift）。always-on 要約に含めるかは curation 判断のため本 PR では触れない。
- Cursor は canonical/rules をファイル配信しない設計（`*.mdc` のみ）。新ルールは Cursor へは届かない（全 canonical rules で同様・別論点）。

Refs #75
Refs #161
