### PR TITLE
feat(so-compare): add --with for explicit provider selection

### DIFF
--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -30,6 +30,7 @@ so-compare [OPTIONS] "プロンプト"
 | `-c FILE...` | コンテキストファイル添付（**非推奨**。`-w` を使うこと） | - |
 | `-o DIR` | 出力ディレクトリ指定 | `tmp/so-YYYYMMDD-HHMMSS` |
 | `-s MODE` | Codex sandbox モード | `read-only` |
+| `--with LIST` | 実行プロバイダを明示指定（`codex,claude,cursor` のカンマ区切り） | なし（未指定時は codex+claude） |
 | `--codex-only` | Codex のみ実行 | 両方実行 |
 | `--claude-only` | Claude のみ実行 | 両方実行 |
 | `--cursor` | Cursor CLI (agent) も実行（デフォルト: 無効） | 無効 |
@@ -66,6 +67,10 @@ so-compare --prev tmp/so-20260304-001234 -w "$(pwd)" "前回の指摘を踏ま�
 
 # Codex のみ（claude-safe 未導入環境）
 so-compare -w "$(pwd)" "プロンプト" --codex-only
+
+# 任意の2社（従来は codex+cursor / claude+cursor が指定不可だった）
+so-compare --with codex,cursor -w "$(pwd)" "プロンプト"
+so-compare --with claude,cursor -w "$(pwd)" "プロンプト"
 
 # Cursor も含めた3者比較
 so-compare --cursor -w "$(pwd)" "この設計方針を検証してください"

--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -30,7 +30,7 @@ so-compare [OPTIONS] "プロンプト"
 | `-c FILE...` | コンテキストファイル添付（**非推奨**。`-w` を使うこと） | - |
 | `-o DIR` | 出力ディレクトリ指定 | `tmp/so-YYYYMMDD-HHMMSS` |
 | `-s MODE` | Codex sandbox モード | `read-only` |
-| `--with LIST` | 実行プロバイダを明示指定（`codex,claude,cursor` のカンマ区切り） | なし（未指定時は codex+claude） |
+| `--with LIST` | 実行プロバイダを明示指定（`codex,claude,cursor` のカンマ区切り）。`--codex-only` / `--claude-only` / `--cursor-only` / `--cursor` と併用不可 | なし（未指定時は codex+claude） |
 | `--codex-only` | Codex のみ実行 | 両方実行 |
 | `--claude-only` | Claude のみ実行 | 両方実行 |
 | `--cursor` | Cursor CLI (agent) も実行（デフォルト: 無効） | 無効 |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,12 +67,17 @@ so-compare.sh --prev tmp/so-YYYYMMDD-HHMMSS -w "$(pwd)" "再評価してくだ�
 # Codex のみ / Claude のみ
 so-compare.sh -w "$(pwd)" "プロンプト" --codex-only
 so-compare.sh -w "$(pwd)" "プロンプト" --claude-only
+
+# 任意のプロバイダ組み合わせ（1〜3社）
+so-compare.sh --with codex,cursor -w "$(pwd)" "プロンプト"
+so-compare.sh --with claude,cursor -w "$(pwd)" "プロンプト"
 ```
 
 主要オプション:
 
 | オプション | 説明 |
 |-----------|------|
+| `--with LIST` | 実行プロバイダ明示（`codex,claude,cursor` のカンマ区切り。レガシー only/cursor フラグと併用不可） |
 | `-w PATH` | ワークスペースパス（推奨。codex に `-C`、claude に `--add-dir` として渡される） |
 | `-c FILE...` | コンテキストファイル添付（非推奨。プロンプト肥大化の原因） |
 | `-f FILE` | プロンプトをファイルから読み込み |

--- a/scripts/so-compare.sh
+++ b/scripts/so-compare.sh
@@ -18,6 +18,9 @@ Options:
   -w PATH        ワークスペースパス（Codex/Claude にパス参照で渡す）
   -o DIR         出力ディレクトリを指定（デフォルト: tmp/so-YYYYMMDD-HHMMSS）
   -s MODE        Codex sandbox モード（デフォルト: read-only）
+  --with LIST    実行プロバイダを明示指定（カンマ区切り: codex,claude,cursor）
+                 例: --with codex,cursor / --with claude,cursor
+                 --codex-only 等のレガシーフラグとは併用不可
   --codex-only   Codex のみ実行
   --claude-only  Claude のみ実行
   --cursor       Cursor CLI (agent) も実行（デフォルト: 無効）
@@ -59,6 +62,9 @@ WORKSPACE=""
 RUN_CODEX=true
 RUN_CLAUDE=true
 RUN_CURSOR=false
+PROVIDERS_RAW=""
+WITH_SPECIFIED=false
+LEGACY_PROVIDER_FLAG=false
 CLAUDE_WEB=false
 CURSOR_MODEL="${SO_CURSOR_MODEL:-auto}"
 CLAUDE_MODEL="${SO_CLAUDE_MODEL:-}"
@@ -83,6 +89,57 @@ require_arg() {
         echo "Error: $1 にはアーギュメントが必要です" >&2
         exit 1
     fi
+}
+
+trim_ws() {
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+apply_providers() {
+    RUN_CODEX=false
+    RUN_CLAUDE=false
+    RUN_CURSOR=false
+    local seen=()
+    local parts=()
+    local raw p s
+
+    IFS=',' read -ra parts <<< "$PROVIDERS_RAW"
+    for raw in "${parts[@]}"; do
+        p=$(trim_ws "$raw")
+        [[ -n "$p" ]] || continue
+        for s in "${seen[@]}"; do
+            if [[ "$s" == "$p" ]]; then
+                echo "Error: プロバイダが重複しています: $p" >&2
+                exit 1
+            fi
+        done
+        seen+=("$p")
+        case "$p" in
+            codex)  RUN_CODEX=true ;;
+            claude) RUN_CLAUDE=true ;;
+            cursor) RUN_CURSOR=true ;;
+            *)
+                echo "Error: 未知のプロバイダ: ${p} (codex / claude / cursor を指定)" >&2
+                exit 1
+                ;;
+        esac
+    done
+    if [[ ${#seen[@]} -eq 0 ]]; then
+        echo "Error: --with に有効なプロバイダが指定されていません" >&2
+        exit 1
+    fi
+}
+
+providers_label() {
+    local labels=()
+    $RUN_CODEX && labels+=(codex)
+    $RUN_CLAUDE && labels+=(claude)
+    $RUN_CURSOR && labels+=(cursor)
+    local IFS=','
+    echo "${labels[*]}"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -114,21 +171,31 @@ while [[ $# -gt 0 ]]; do
             SANDBOX_MODE="$2"
             shift 2
             ;;
+        --with)
+            require_arg "$1" "${2:-}"
+            PROVIDERS_RAW="$2"
+            WITH_SPECIFIED=true
+            shift 2
+            ;;
         --codex-only)
+            LEGACY_PROVIDER_FLAG=true
             RUN_CLAUDE=false
             RUN_CURSOR=false
             shift
             ;;
         --claude-only)
+            LEGACY_PROVIDER_FLAG=true
             RUN_CODEX=false
             RUN_CURSOR=false
             shift
             ;;
         --cursor)
+            LEGACY_PROVIDER_FLAG=true
             RUN_CURSOR=true
             shift
             ;;
         --cursor-only)
+            LEGACY_PROVIDER_FLAG=true
             RUN_CODEX=false
             RUN_CLAUDE=false
             RUN_CURSOR=true
@@ -188,6 +255,19 @@ if [[ -z "$PROMPT" ]]; then
     echo "" >&2
     usage >&2
     exit 1
+fi
+
+if $LEGACY_PROVIDER_FLAG && $WITH_SPECIFIED; then
+    echo "Error: --with は --codex-only / --claude-only / --cursor-only / --cursor と併用できません" >&2
+    exit 1
+fi
+
+if $WITH_SPECIFIED; then
+    if [[ -z "$PROVIDERS_RAW" ]]; then
+        echo "Error: --with にはプロバイダリストが必要です (例: codex,cursor)" >&2
+        exit 1
+    fi
+    apply_providers
 fi
 
 if ! $RUN_CODEX && ! $RUN_CLAUDE && ! $RUN_CURSOR; then
@@ -274,6 +354,7 @@ echo "sandbox: $SANDBOX_MODE"
 if [[ -n "$WORKSPACE" ]]; then
     echo "ワークスペース: $WORKSPACE"
 fi
+echo "プロバイダ: $(providers_label)"
 if $RUN_CURSOR; then
     echo "Cursor: enabled${CURSOR_MODEL:+ (model: $CURSOR_MODEL)}"
 fi

--- a/scripts/so-compare.sh
+++ b/scripts/so-compare.sh
@@ -106,7 +106,7 @@ apply_providers() {
     local parts=()
     local raw p s
 
-    IFS=',' read -ra parts <<< "$PROVIDERS_RAW"
+    IFS=',' read -r -a parts <<< "$PROVIDERS_RAW"
     for raw in "${parts[@]}"; do
         p=$(trim_ws "$raw")
         if [[ -z "$p" ]]; then

--- a/scripts/so-compare.sh
+++ b/scripts/so-compare.sh
@@ -109,13 +109,18 @@ apply_providers() {
     IFS=',' read -ra parts <<< "$PROVIDERS_RAW"
     for raw in "${parts[@]}"; do
         p=$(trim_ws "$raw")
-        [[ -n "$p" ]] || continue
-        for s in "${seen[@]}"; do
-            if [[ "$s" == "$p" ]]; then
-                echo "Error: プロバイダが重複しています: $p" >&2
-                exit 1
-            fi
-        done
+        if [[ -z "$p" ]]; then
+            echo "Error: --with のプロバイダリストに空要素があります" >&2
+            exit 1
+        fi
+        if [[ ${#seen[@]} -gt 0 ]]; then
+            for s in "${seen[@]}"; do
+                if [[ "$s" == "$p" ]]; then
+                    echo "Error: プロバイダが重複しています: $p" >&2
+                    exit 1
+                fi
+            done
+        fi
         seen+=("$p")
         case "$p" in
             codex)  RUN_CODEX=true ;;


### PR DESCRIPTION
## Summary

- `so-compare` に `--with LIST` を追加し、`codex` / `claude` / `cursor` の任意組み合わせ（1〜3社）を明示指定できるようにした
- 従来できなかった `codex+cursor` / `claude+cursor` などの2社比較に対応
- `--with` と `--codex-only` 等のレガシーフラグ併用はエラー
- bash 3.2 + `set -u` 向けに空配列イテレーションをガード

## Test plan

- [x] `shellcheck scripts/so-compare.sh`
- [x] 引数エラー: 未知プロバイダ / 重複 / 空 `--with` / レガシー併用 / `codex,,cursor`
- [x] `/bin/bash -uc` で空配列ガードの bash 3.2 互換確認
- [x] so-compare（Codex + Claude）で実装レビュー実施（`tmp/so-20260616-172341`）

## Notes

- デフォルト挙動（Codex + Claude）は変更なし
- SO 指摘の `codex,` 末尾カンマは bash `read -ra` の仕様上、単一要素として解釈される（`codex,,cursor` はエラー）
