### PR TITLE
fix(oe-send): guard receiver copy-mode and surface silent non-delivery

### DIFF
--- a/projects/orchestration-engine/bin/oe-send
+++ b/projects/orchestration-engine/bin/oe-send
@@ -71,5 +71,17 @@ if [[ -n "$ADHOC" ]]; then
 fi
 [[ -n "$payload" ]] || { echo "oe-send: nothing to send (provide --kickoff and/or ad-hoc text)" >&2; usage; }
 
-oe_send_line "$PANE" "$payload" "$SEND_ENTER"
+rc=0
+oe_send_line "$PANE" "$payload" "$SEND_ENTER" || rc=$?
+if [[ "$rc" -eq 4 ]]; then
+  # 確定的に未着（finalize の stage-miss signal・OE_SEND_SIGNAL_MISS=1 時のみ）。
+  # 手動フォールバックを案内して非0で抜ける（呼び出し側がリトライ判断できるように）。
+  cat >&2 <<EOF
+oe-send: ${PANE} に未着の可能性があります（stage miss）。手動フォールバック:
+  tmux send-keys -l -t ${PANE} -- '<message>'
+  tmux send-keys -t ${PANE} Enter
+EOF
+  exit "$rc"
+fi
+[[ "$rc" -eq 0 ]] || exit "$rc"
 echo "oe-send: sent to ${PANE}" >&2

--- a/projects/orchestration-engine/bin/oe-send
+++ b/projects/orchestration-engine/bin/oe-send
@@ -74,7 +74,7 @@ fi
 rc=0
 oe_send_line "$PANE" "$payload" "$SEND_ENTER" || rc=$?
 if [[ "$rc" -eq 4 ]]; then
-  # 確定的に未着（finalize の stage-miss signal・OE_SEND_SIGNAL_MISS=1 時のみ）。
+  # 未着の可能性が高い（finalize の stage-miss signal・OE_SEND_SIGNAL_MISS=1 時のみ）。
   # 手動フォールバックを案内して非0で抜ける（呼び出し側がリトライ判断できるように）。
   cat >&2 <<EOF
 oe-send: ${PANE} に未着の可能性があります（stage miss）。手動フォールバック:

--- a/projects/orchestration-engine/docs/episodes/2026-06-09-episode-oe-send-finalize-ingestion.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-09-episode-oe-send-finalize-ingestion.md
@@ -83,3 +83,4 @@ tags: [orchestration, oe-send, delegate-send, tmux, ingestion, enter-absorption,
 - ②/③ の deterministic 再現環境（「整形崩れセッション」の人工再現）は未達＝根本の機構特定は保留。
 - `oe-capture` の pane-id 2系統・出力チャネル統一 → #114。
 - #144 後も残る間欠的な無言失敗（未着でも rc=0 / not in a mode）→ #154 で継続調査。本サイクルは観測ベース finalize 回復までで closure（後続は別サイクル）。
+  - back-prop（2026-06-16・#154 closure 時）: #154 で **copy-mode 吸収を主トリガ**として決定論的に再現・除去し、`not in a mode` 源（`send-keys -X` を mode 外に撃った場合）も特定。ここで断定保留した負荷下 Enter 原子性レース（②）は #154 でも未着手（別物）。詳細は `2026-06-16-episode-oe-send-copymode-guard.md`。

--- a/projects/orchestration-engine/docs/episodes/2026-06-16-episode-oe-send-copymode-guard.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-16-episode-oe-send-copymode-guard.md
@@ -1,0 +1,107 @@
+---
+id: "01KV7YW1GMX2Z5MF99T9TRDS3C"
+title: "oe-send copy-mode ガード — 間欠不達の主トリガ確定・除去と silent-failure signal（#154 駆動層記録）"
+date: 2026-06-16
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/154"
+    reason: "本サイクルの傘 Issue（#144 後も残る間欠的な無言失敗の根治）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/episodes/2026-06-09-episode-oe-send-finalize-ingestion.md"
+    reason: "前史（#144 finalize 回復）。その follow-up が本件を #154 として明示的に分岐していた"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/144"
+    reason: "送信信頼化の傘 Issue（transport 据え置き・finalize は rc 透過の決定の出自）"
+tags: [orchestration, oe-send, delegate-send, tmux, copy-mode, not-in-a-mode, silent-failure, episode]
+---
+
+# oe-send copy-mode ガード — 間欠不達の主トリガ確定・除去と silent-failure signal（#154 駆動層記録）
+
+> #144 で再現不能ゆえ「論証で選ぶ・断定不可」に留めた間欠不達を、**オーナー指摘（受け手の copy-mode 吸収）を起点に使い捨てペインで決定論的に再現・確定**できた1サイクル（観測された全間欠性の単一根本原因ではなく、**主トリガ**の確定・除去）。`not in a mode` の発生源も isolation で特定。コード4点（copy-mode ガード / opt-in signal / フォールバック案内 / transport 失敗の明示伝播）を実装・ユニット 36/0・実地検証 + so-compare ゲートまで。
+
+## Context / なぜ
+
+#144（観測ベース finalize）クローズ後も、親子委譲 dogfood で `oe-send` が **exit 0 を返すのにメッセージが受け手に届かない**間欠不達が残存。加えて実行中に `not in a mode` が複数回（初回×26・再試行×2）出力された（#144 の症状リストに無い新規症状）。#144 episode の follow-up が「未着でも rc=0 / not in a mode → #154 で継続」と明示しており、本件はその分岐。
+
+オーナー指摘（issue #154 コメント）: 受け手ペインが **trackpad スクロールで意図せず tmux copy-mode に入る**と、`send-keys -l` / `Enter` がコピーモードのキーテーブルで吸収されプロンプトに届かない。「人が触っていない clean な時だけ届く」＝間欠性と整合。#144 が再現不能で断定を諦めた相手を、この仮説は**意図的に再現できる**問題へ変換した。
+
+## 駆動層の流れと、各検証が何を確定したか
+
+### root cause の2点更新（issue 本文 + オーナーコメント）
+1. **finalize が rc を変えない（silent）**: `_oe_send_finalize` は best-effort で常に 0 を返す設計（誤再送→二重 submit 防止）。`oe_send_line` は未着でも 0 を返し、呼び出し側に伝わらない構造的な穴。← コードで確認（verified）。
+2. **送信前に受け手の copy-mode を解除しない**: copy-mode 吸収が間欠不達の主トリガ。← 仮説（オーナー指摘）を本サイクルで実機検証。
+
+### 実地検証（使い捨てペインのみ・ライブ %0/%3/%11 非接触）
+
+揮発スクリプト（実行後に削除）の結果を以下へ転記（evidence anchor）。
+
+**機構検証**（cat 受け手を copy-mode 化して着弾差を観測）:
+- (0) copy-mode でない warmup → 着弾 YES, in_mode=0（受け手正常）
+- (1) copy-mode 中に素の `send-keys -l "ABSORBED_MSG"` + Enter → recv 未着 ＝ **吸収＝バグ再現**
+- (2) copy-mode 中にパッチ済 `oe_send_line` → in_mode が **1→0** にクリーンに解除され **DELIVERED_MSG 着弾** ＝ **ガードで回復**
+
+**`not in a mode` 発生源の切り分け**（controlled isolation・各コマンドを単独計測）:
+
+| コマンド | mode 外 | copy-mode 中 |
+|---|---|---|
+| `send-keys -l` | not-in-a-mode=0 | 0（in_mode=1 維持＝吸収） |
+| `send-keys Enter` | 0 | 0（in_mode 1→0＝Enter で copy 確定&exit） |
+| `send-keys -X cancel` | **=1（発生源）** | 0（正常解除） |
+
+- **`not in a mode` は `send-keys -X` を mode 外ペインに撃ったときだけ出る**（verified）。素の `-l`/`Enter` は in/out どちらでも出さない。
+- リポ全体 grep（`send-keys -X` / `-X cancel` / `copy-mode`）→ **本パッチが追加する copy-mode ガードを除く送信パスでは** engine 含め **0件**（verified）。元 dogfood の連発は**リポ外の `-X` 発行元**由来で、送信パスからは出ていなかった。
+
+## 確定した設計と、その射程
+
+- **A. copy-mode ガード**: transport（`send-keys -l`）の前に `#{pane_in_mode}` を確認し、`1` のときだけ `send-keys -X cancel`。baseline capture より前に抜けるので baseline が settled を反映。`in_mode==1` 限定＋`2>/dev/null || true` で、check→cancel 間に mode が抜ける **TOCTOU race でも `not in a mode` を出さず失敗もしない**。
+- **B. silent-failure signal（opt-in）**: finalize の `stage_miss_suspect`（一度も staged 観測せず・入力欄空＝確定的な未着候補）で `return 3`（sentinel）。`oe_send_line` は `OE_SEND_SIGNAL_MISS=1` のときだけ rc=4 へ昇格。**既定 off** は、fast submit を未着と誤判定したときの二重 submit を避けるため（#144 の「finalize は rc を変えない」設計を既定で温存）。
+- **C. フォールバック案内**: `oe-send` が rc=4 を受けたら手動 `send-keys -l + Enter` を stderr 案内して非0終了。
+- **D. transport 失敗の明示伝播（so-compare ゲートで追加）**: `oe-send` が `oe_send_line ... || rc=$?` で受けると関数内 `set -e` が無効化される（bash 仕様・クリーン repro で実証）。これにより transport の `send-keys` 失敗が握り潰され "sent" まで進む**新たな silent failure 経路**が生じていた（#154 と同じ穴を作る回帰）。`oe_send_line` 内で `send-keys -l`/`Enter` の失敗を明示チェックし rc=2 を返すよう修正（errexit に依存しない）。回帰ガード [23] を追加。
+
+射程: A は不達の主トリガ（copy-mode 吸収）を**除去**する一次施策。B/C は未着を呼び出し側に**伝える**安全網で、#144 が残した silent failure の穴を opt-in で塞ぐ。D は本 PR が自ら作った silent 経路を塞ぐ。A は決定論的に検証できた一方、`not in a mode` の野良発行元は本 PR の対象外（engine は発行しない）。copy-mode は **主トリガ**であって、#144 が断定保留した負荷下の Enter 原子性レース（②）は別物で本 PR では潰していない（finalize の best-effort 回復のまま）。
+
+## closure gate
+
+- **次の消費者**: #154 PR レビュアー（ガードと opt-in の妥当性確認）。将来 oe-send transport を触る駆動層作業（copy-mode 吸収が既知の一次トリガとして参照可能）。
+- **follow-up routing**:
+  - `not in a mode` の**野良発行元（リポ外の何が `-X` を撃つか）**の特定 → **追わない**（engine は発行せず、ガードは race でも出さない。実害なし。再発・実機 dogfood で必要になれば issue 化）。
+  - Fix B（opt-in signal）の**実機 Claude TUI 上での真の stage-miss 検証** → **deferred（どの呼び出し側も opt-in しないうちは実害休眠）**。fast-submit を stage-miss と誤判定する確率は実 TUI で未測定（shell ペインの stage-miss は `❯` 不在の人工物）。ユニット [22] は **lib が rc=4 を返すこと**の検証であって、判定精度や bin 側の案内出力は対象外。「不要」ではなく「未測定ゆえ defer」（SO 指摘で訂正）。
+- **status**: stable（達成）。コード4点（A〜D）+ ユニット [20]-[23]（36/0）+ 実地検証 + so-compare ゲートまで完了。
+- **evidence anchor**: 揮発スクリプト（`/tmp/oe154_*.sh`）は実行後削除済。上記「実地検証」節に数値結果を転記済。so-compare 出力は `tmp/so-154-copymode/`（gitignore 対象）。
+
+## 振り返り（出力型 × 消費チャネル）
+
+### 事実・わかったこと（W）
+- copy-mode 吸収は **tmux 層の現象**で、受け手が Claude TUI でなくても（plain shell でも）再現する＝ガードは TUI 非依存に効く。
+- `send-keys -X` を mode 外に撃つと `not in a mode`。`-l`/`Enter` は出さない。Enter は emacs copy-mode で copy+cancel ＝ mode を抜ける。
+
+### 決定と根拠
+- signal を **opt-in（既定 off）** にした: 確定未着判定は強いが fast-submit 誤判定の二重 submit リスクが残る。呼び出し側が文脈で判断できる方が安全（#144 の rc 透過設計を既定で壊さない）。default-on は棄却。
+- copy-mode 解除は **条件付き**（無条件 `-X cancel` は `not in a mode` を生むため）。さらに stderr 抑制で race も無害化。
+
+### 原則（Pattern / Anti-pattern）
+- **Pattern**: 「再現不能」を相手にするとき、より説明力のある仮説（copy-mode 吸収）が出たら、それを**決定論的に再現できる最小ハーネス**（自作 cat 受け手 + `copy-mode` 強制）へ落として確定する。#144 の「論証で選ぶ」から一歩進めた。
+- **Anti-pattern**: 状態を変えるコマンド（`-X cancel`）を前提確認なしに撃つ → `not in a mode` のようなノイズを生む。**前提（in_mode）を確認してから撃つ + 失敗を無害化**。
+- **Pattern**: 混合出力（stdout echo と stderr エラーの interleave）で発生源を見誤りそうなときは、各コマンドを**単独計測（isolation）**して帰属を確定する。
+
+### 蒸留シグナル
+- 昇格候補: **なし**（コード修正 + 既存 episode 形式で十分。skill/rule/Decision 化の必要は見えない）。
+
+### 残課題
+- `not in a mode` の野良発行元は未特定（追わない判断・上記 routing）。証明できていないことは証明できていないと明記。
+
+## Step 4: 外部チェック（so-compare）
+
+`so-compare`（Codex gpt-5.5 / Claude opus・SO_TIMEOUT=480）でコード5観点 + episode closure 4観点を反証ベースで検証。出力: `tmp/so-154-copymode/`（codex-stdout.txt / claude-stdout.txt・gitignore 対象）。
+
+主な指摘と対応:
+- **（blocking・両者一致）transport 失敗の silent 化**: `oe-send` の `|| rc=$?` で関数内 `set -e` が無効化され、`send-keys` 失敗が握り潰される回帰。クリーン repro で実証 → 上記 D で修正（明示伝播 + 回帰ガード [23]）。
+- **rc=4 の契約が強すぎ**（"confirmed" non-delivery）: fast-submit 誤判定があり得るため "suspected (stage miss)" に表現緩和。
+- **表題 "root cause 確定" が強い**: 確定したのは主トリガであって全間欠性の単一根本原因ではない → 表題・headline・射程を「主トリガ確定・除去」に修正。
+- **Fix B 検証の "不要" → "deferred"**: opt-in が誰にも使われない間は実害休眠だが判定精度は実 TUI 未測定 → follow-up を deferred に訂正。
+- **episode の grep "0件" 表現 / Step4 プレースホルダ**: grep 表現を「ガード追加分を除く送信パス」に明確化、本節で Step4 を充足。
+- copy-mode ガード / opt-in signal / フォールバック / 後方互換は両者とも**決定的バグを反証できず妥当**と確認。
+
+合意判定: 問題認識・修正方針は一致。blocking 指摘（transport silent 化）は修正済。残差は表現・closure の精緻化で解消 → 3者（自分 + Codex + Claude）合意とみなす。

--- a/projects/orchestration-engine/docs/episodes/2026-06-16-episode-oe-send-copymode-guard.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-16-episode-oe-send-copymode-guard.md
@@ -56,7 +56,7 @@ tags: [orchestration, oe-send, delegate-send, tmux, copy-mode, not-in-a-mode, si
 ## 確定した設計と、その射程
 
 - **A. copy-mode ガード**: transport（`send-keys -l`）の前に `#{pane_in_mode}` を確認し、`1` のときだけ `send-keys -X cancel`。baseline capture より前に抜けるので baseline が settled を反映。`in_mode==1` 限定＋`2>/dev/null || true` で、check→cancel 間に mode が抜ける **TOCTOU race でも `not in a mode` を出さず失敗もしない**。
-- **B. silent-failure signal（opt-in）**: finalize の `stage_miss_suspect`（一度も staged 観測せず・入力欄空＝確定的な未着候補）で `return 3`（sentinel）。`oe_send_line` は `OE_SEND_SIGNAL_MISS=1` のときだけ rc=4 へ昇格。**既定 off** は、fast submit を未着と誤判定したときの二重 submit を避けるため（#144 の「finalize は rc を変えない」設計を既定で温存）。
+- **B. silent-failure signal（opt-in）**: finalize の `stage_miss_suspect`（一度も staged 観測せず・入力欄空＝未着候補 / suspected miss）で `return 3`（sentinel）。`oe_send_line` は `OE_SEND_SIGNAL_MISS=1` のときだけ rc=4 へ昇格。**既定 off** は、fast submit を未着と誤判定したときの二重 submit を避けるため（#144 の「finalize は rc を変えない」設計を既定で温存）。
 - **C. フォールバック案内**: `oe-send` が rc=4 を受けたら手動 `send-keys -l + Enter` を stderr 案内して非0終了。
 - **D. transport 失敗の明示伝播（so-compare ゲートで追加）**: `oe-send` が `oe_send_line ... || rc=$?` で受けると関数内 `set -e` が無効化される（bash 仕様・クリーン repro で実証）。これにより transport の `send-keys` 失敗が握り潰され "sent" まで進む**新たな silent failure 経路**が生じていた（#154 と同じ穴を作る回帰）。`oe_send_line` 内で `send-keys -l`/`Enter` の失敗を明示チェックし rc=2 を返すよう修正（errexit に依存しない）。回帰ガード [23] を追加。
 

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -44,7 +44,7 @@ _oe_send_has_content() {
 #   - settle 窓 = 中心安全パラメータ。遅延配送の Enter は窓内に着弾→submitted 判定で撃たない。
 #   - 受け手状態に依存する best-effort。二重 submit を「確実に」防ぐとは主張しない（窓 < 遅延の
 #     病的負荷下では残存）。原則 0 を返し transport の rc を変えない（誤再送→二重 submit 防止）。
-#     例外: 確定的な未着候補（stage miss）のときだけ rc=3 を返す。呼び出し側が opt-in
+#     例外: 未着候補（suspected miss / stage miss）のときだけ rc=3 を返す。呼び出し側が opt-in
 #     （OE_SEND_SIGNAL_MISS=1）のときだけ非0へ昇格する（既定は rc 不変・#154）。
 _oe_send_finalize() {
   local pane="$1" payload="$2" base_proc="$3" base_staged="$4"
@@ -98,8 +98,8 @@ _oe_send_finalize() {
     tmux send-keys -t "$pane" Enter
     return 0
   fi
-  # stage_miss_suspect: 一度も staged 観測せず、入力欄が空のとき → 確定的な未着候補。warn を出し
-  # rc=3（confirmed-miss sentinel）を返す。呼び出し側が OE_SEND_SIGNAL_MISS=1 のときだけ非0へ昇格
+  # stage_miss_suspect: 一度も staged 観測せず、入力欄が空のとき → 未着候補（suspected miss）。warn を出し
+  # rc=3（suspected-miss sentinel）を返す。呼び出し側が OE_SEND_SIGNAL_MISS=1 のときだけ非0へ昇格
   # する（既定は rc 不変・#154）。fast submit を未着と誤判定し得るため opt-in（二重 submit 回避）。
   # 入力欄に内容が残る（折返し/省略で payload と完全一致しない）ケースは unknown 扱いで warn しない（Copilot 指摘）。
   if [[ "$saw_staged" == "0" && "$staged" == "0" ]] && ! _oe_send_has_content "$input"; then
@@ -118,7 +118,7 @@ _oe_send_finalize() {
 #   成功時は tmux send-keys -l でリテラル注入し、既定では続けて Enter を発火する。
 #   自動送信時は送信後に観測ベース finalize（Enter 吸収の after-the-fact 回復）を走らせる
 #   （`OE_SEND_FINALIZE=0` で無効化可。finalize は既定では rc を変えない best-effort）。
-#   `OE_SEND_SIGNAL_MISS=1` のときのみ、finalize が確定的な未着候補（stage miss）を観測したら
+#   `OE_SEND_SIGNAL_MISS=1` のときのみ、finalize が未着候補（suspected miss / stage miss）を観測したら
 #   rc=4 を返す（呼び出し側のフォールバック/リトライ用。既定 off は二重 submit 回避のため・#154）。
 oe_send_line() {
   local pane="${1:-}"
@@ -160,7 +160,7 @@ oe_send_line() {
   # baseline capture より前に抜けることで baseline が settled な画面を反映する。
   # in_mode=0 で無条件に -X cancel を撃つと `not in a mode` が出るため、必ず条件付き（#154）。
   local in_mode
-  in_mode="$(tmux display -p -t "$pane" '#{pane_in_mode}' 2>/dev/null)" || in_mode=""
+  in_mode="$(tmux display-message -p -t "$pane" '#{pane_in_mode}' 2>/dev/null)" || in_mode=""
   if [[ "$in_mode" == "1" ]]; then
     tmux send-keys -t "$pane" -X cancel 2>/dev/null || true
   fi
@@ -200,7 +200,7 @@ oe_send_line() {
       return 2
     fi
     # 観測ベース finalize（best-effort）。Enter 吸収の after-the-fact 回復。
-    # finalize は確定的な未着候補（stage miss）で rc=3 を返す。OE_SEND_SIGNAL_MISS=1 のときだけ
+    # finalize は未着候補（suspected miss / stage miss）で rc=3 を返す。OE_SEND_SIGNAL_MISS=1 のときだけ
     # それを rc=4（suspected non-delivery / stage miss）へ昇格し、呼び出し側のフォールバック/
     # リトライを可能にする（既定は従来どおり rc を変えない・#154）。「confirmed」ではなく「suspected」
     # なのは fast-submit を未着と誤判定し得るため（SO 指摘）。

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -156,8 +156,8 @@ oe_send_line() {
 
   # 受け手ペインが copy-mode（trackpad スクロール等で意図せず混入）だと、send-keys -l /
   # Enter がコピーモードのキーテーブルで吸収されプロンプトに届かない（#154 の間欠不達の主因）。
-  # 送信前に #{pane_in_mode} を確認し、copy-mode のときだけ解除する。baseline capture より前に
-  # 抜けることで baseline が settled な画面を反映する。
+  # 送信前に #{pane_in_mode} を確認し、何らかの mode（主因は copy-mode）のときだけ解除する。
+  # baseline capture より前に抜けることで baseline が settled な画面を反映する。
   # in_mode=0 で無条件に -X cancel を撃つと `not in a mode` が出るため、必ず条件付き（#154）。
   local in_mode
   in_mode="$(tmux display -p -t "$pane" '#{pane_in_mode}' 2>/dev/null)" || in_mode=""
@@ -184,22 +184,31 @@ oe_send_line() {
 
   # -- で text のオプション誤解釈を防ぐ。-l はリテラル送信。Enter は別途発火（任意）。
   # transport は据え置き（#144: 機構未確定ゆえ送信経路は賭けない）。
-  tmux send-keys -l -t "$pane" -- "$text"
+  # 呼び出し側が `oe_send_line ... || rc=$?` で受けると関数内 set -e が無効化されるため、
+  # transport 失敗（送信中の pane 死など）は errexit に頼らず明示伝播する（silent 化防止・#154 SO 指摘）。
+  if ! tmux send-keys -l -t "$pane" -- "$text"; then
+    echo "oe_send_line: tmux send-keys (literal) failed on ${pane}" >&2
+    return 2
+  fi
   if [[ "$send_enter" != "0" ]]; then
     # リテラル送信の直後に Enter を撃つと、Claude Code TUI の paste 検知で Enter が
     # 「paste 内の改行」として吸収され submit されないことがある（dogfood で間欠確認）。
     # 小休止で paste 検知窓を閉じてから Enter を撃つ。OE_SEND_ENTER_DELAY で上書き可。
     sleep "${OE_SEND_ENTER_DELAY:-0.3}"
-    tmux send-keys -t "$pane" Enter
+    if ! tmux send-keys -t "$pane" Enter; then
+      echo "oe_send_line: tmux send-keys Enter failed on ${pane}" >&2
+      return 2
+    fi
     # 観測ベース finalize（best-effort）。Enter 吸収の after-the-fact 回復。
     # finalize は確定的な未着候補（stage miss）で rc=3 を返す。OE_SEND_SIGNAL_MISS=1 のときだけ
-    # それを rc=4（confirmed non-delivery）へ昇格し、呼び出し側のフォールバック/リトライを可能に
-    # する（既定は従来どおり rc を変えない・#154）。
+    # それを rc=4（suspected non-delivery / stage miss）へ昇格し、呼び出し側のフォールバック/
+    # リトライを可能にする（既定は従来どおり rc を変えない・#154）。「confirmed」ではなく「suspected」
+    # なのは fast-submit を未着と誤判定し得るため（SO 指摘）。
     if [[ "$fin_on" == "1" ]]; then
       local fin_rc=0
       _oe_send_finalize "$pane" "$text" "$base_proc" "$base_staged" || fin_rc=$?
       if [[ "$fin_rc" == "3" && "${OE_SEND_SIGNAL_MISS:-0}" == "1" ]]; then
-        echo "oe_send_line: signaling confirmed non-delivery to ${pane} (rc=4; OE_SEND_SIGNAL_MISS=1)" >&2
+        echo "oe_send_line: signaling suspected non-delivery (stage miss) on ${pane} (rc=4; OE_SEND_SIGNAL_MISS=1)" >&2
         return 4
       fi
     fi

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -43,7 +43,9 @@ _oe_send_has_content() {
 #   settle 窓終端まで観測し、なお staged なら Enter を1回だけ再送して回復する。
 #   - settle 窓 = 中心安全パラメータ。遅延配送の Enter は窓内に着弾→submitted 判定で撃たない。
 #   - 受け手状態に依存する best-effort。二重 submit を「確実に」防ぐとは主張しない（窓 < 遅延の
-#     病的負荷下では残存）。常に 0 を返し transport の rc を変えない（誤再送→二重 submit 防止）。
+#     病的負荷下では残存）。原則 0 を返し transport の rc を変えない（誤再送→二重 submit 防止）。
+#     例外: 確定的な未着候補（stage miss）のときだけ rc=3 を返す。呼び出し側が opt-in
+#     （OE_SEND_SIGNAL_MISS=1）のときだけ非0へ昇格する（既定は rc 不変・#154）。
 _oe_send_finalize() {
   local pane="$1" payload="$2" base_proc="$3" base_staged="$4"
   local interval="${OE_SEND_FINALIZE_INTERVAL:-0.3}"
@@ -96,11 +98,13 @@ _oe_send_finalize() {
     tmux send-keys -t "$pane" Enter
     return 0
   fi
-  # stage_miss_suspect: 一度も staged 観測せず、入力欄が空のとき → warn のみ（観測補助・rc は変えない）。
+  # stage_miss_suspect: 一度も staged 観測せず、入力欄が空のとき → 確定的な未着候補。warn を出し
+  # rc=3（confirmed-miss sentinel）を返す。呼び出し側が OE_SEND_SIGNAL_MISS=1 のときだけ非0へ昇格
+  # する（既定は rc 不変・#154）。fast submit を未着と誤判定し得るため opt-in（二重 submit 回避）。
   # 入力欄に内容が残る（折返し/省略で payload と完全一致しない）ケースは unknown 扱いで warn しない（Copilot 指摘）。
   if [[ "$saw_staged" == "0" && "$staged" == "0" ]] && ! _oe_send_has_content "$input"; then
     echo "oe_send_line: finalize: payload not observed staged or submitted on ${pane} (possible stage miss / fast submit)" >&2
-    return 0
+    return 3
   fi
   # それ以外（base_proc=1・非安定・折返し等）= unknown → 撃たない
   return 0
@@ -110,9 +114,12 @@ _oe_send_finalize() {
 #   <text> に改行（LF / CR）が含まれていれば送信せず非 0 で失敗する（途中送信の根本封じ）。
 #   対象ペインが存在しなければ非 0 で失敗する（死んだペインへの無言送信を防ぐ）。
 #   send_enter（既定 "1"）が "0" のときは Enter を発火せずテキスト投入のみ（ステージ）。
+#   送信前に受け手が copy-mode なら解除する（copy-mode 吸収による不達の防止・#154）。
 #   成功時は tmux send-keys -l でリテラル注入し、既定では続けて Enter を発火する。
 #   自動送信時は送信後に観測ベース finalize（Enter 吸収の after-the-fact 回復）を走らせる
-#   （`OE_SEND_FINALIZE=0` で無効化可。finalize は rc を変えない best-effort）。
+#   （`OE_SEND_FINALIZE=0` で無効化可。finalize は既定では rc を変えない best-effort）。
+#   `OE_SEND_SIGNAL_MISS=1` のときのみ、finalize が確定的な未着候補（stage miss）を観測したら
+#   rc=4 を返す（呼び出し側のフォールバック/リトライ用。既定 off は二重 submit 回避のため・#154）。
 oe_send_line() {
   local pane="${1:-}"
   local text="${2:-}"
@@ -147,6 +154,17 @@ oe_send_line() {
     return 1
   fi
 
+  # 受け手ペインが copy-mode（trackpad スクロール等で意図せず混入）だと、send-keys -l /
+  # Enter がコピーモードのキーテーブルで吸収されプロンプトに届かない（#154 の間欠不達の主因）。
+  # 送信前に #{pane_in_mode} を確認し、copy-mode のときだけ解除する。baseline capture より前に
+  # 抜けることで baseline が settled な画面を反映する。
+  # in_mode=0 で無条件に -X cancel を撃つと `not in a mode` が出るため、必ず条件付き（#154）。
+  local in_mode
+  in_mode="$(tmux display -p -t "$pane" '#{pane_in_mode}' 2>/dev/null)" || in_mode=""
+  if [[ "$in_mode" == "1" ]]; then
+    tmux send-keys -t "$pane" -X cancel 2>/dev/null || true
+  fi
+
   # finalize 用の送信前 baseline（自動送信 かつ finalize 有効時のみ）。
   # base_proc: 送信前から処理中か（子がビジー）／ base_staged: 入力欄に既存内容があるか。
   local fin_on=0 base_proc=0 base_staged=0
@@ -173,9 +191,17 @@ oe_send_line() {
     # 小休止で paste 検知窓を閉じてから Enter を撃つ。OE_SEND_ENTER_DELAY で上書き可。
     sleep "${OE_SEND_ENTER_DELAY:-0.3}"
     tmux send-keys -t "$pane" Enter
-    # 観測ベース finalize（best-effort・rc を変えない）。Enter 吸収の after-the-fact 回復。
+    # 観測ベース finalize（best-effort）。Enter 吸収の after-the-fact 回復。
+    # finalize は確定的な未着候補（stage miss）で rc=3 を返す。OE_SEND_SIGNAL_MISS=1 のときだけ
+    # それを rc=4（confirmed non-delivery）へ昇格し、呼び出し側のフォールバック/リトライを可能に
+    # する（既定は従来どおり rc を変えない・#154）。
     if [[ "$fin_on" == "1" ]]; then
-      _oe_send_finalize "$pane" "$text" "$base_proc" "$base_staged" || true
+      local fin_rc=0
+      _oe_send_finalize "$pane" "$text" "$base_proc" "$base_staged" || fin_rc=$?
+      if [[ "$fin_rc" == "3" && "${OE_SEND_SIGNAL_MISS:-0}" == "1" ]]; then
+        echo "oe_send_line: signaling confirmed non-delivery to ${pane} (rc=4; OE_SEND_SIGNAL_MISS=1)" >&2
+        return 4
+      fi
     fi
   fi
 }

--- a/projects/orchestration-engine/tests/test_delegate_send.sh
+++ b/projects/orchestration-engine/tests/test_delegate_send.sh
@@ -44,6 +44,7 @@ tmux() {
       printf '%s\n' "${MOCK_CAP_SEQ[$use]}"
       echo $((idx+1)) > "$CAP_IDXFILE" ;;
     "send-keys"*) MOCK_SENDKEYS_LOG+="tmux $*"$'\n' ;;
+    "display"*) printf '%s\n' "${MOCK_PANE_IN_MODE:-0}" ;;  # display / display-message: #{pane_in_mode}
     *) return 0 ;;
   esac
 }
@@ -110,7 +111,8 @@ export OE_SEND_FINALIZE_STABLE=2
 # 各シナリオ: MOCK_CAP_SEQ[0]=送信前 baseline、以降=finalize の poll/最終 capture。
 enter_count() { printf '%s' "$MOCK_SENDKEYS_LOG" | grep -c 'send-keys -t %5 Enter'; }
 cap_calls()   { cat "$CAP_CALLSFILE"; }
-reset_fin() { MOCK_SENDKEYS_LOG=""; echo 0 > "$CAP_IDXFILE"; echo 0 > "$CAP_CALLSFILE"; MOCK_CAP_FAIL=""; }
+cancel_fired() { printf '%s' "$MOCK_SENDKEYS_LOG" | grep -q -- '-X cancel' && echo yes || echo no; }
+reset_fin() { MOCK_SENDKEYS_LOG=""; echo 0 > "$CAP_IDXFILE"; echo 0 > "$CAP_CALLSFILE"; MOCK_CAP_FAIL=""; MOCK_PANE_IN_MODE=0; }
 
 echo "[7] finalize: staged_idle（窓終端までstaged・baseline idle）→ Enter を1回再送"
 reset_fin
@@ -201,6 +203,29 @@ OE_SEND_FINALIZE_TIMEOUT=1 OE_SEND_FINALIZE_INTERVAL=0.3 OE_SEND_FINALIZE_STABLE
   oe_send_line "%5" "PAY19" >/dev/null 2>&1
 ck "ceil で capture 回数 = baseline+4+final = 6（floor なら5）" "6" "$(cap_calls)"
 ck "staged_idle で再送（計2回）" "2" "$(enter_count)"
+
+# === Issue #154: copy-mode ガード + silent-failure signal（opt-in） ===
+
+echo "[20] copy-mode ガード: pane_in_mode=1 → 送信前に -X cancel で解除し transport は継続（#154）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY20')" )
+MOCK_PANE_IN_MODE=1
+oe_send_line "%5" "PAY20" >/dev/null 2>&1
+ck "copy-mode 時は -X cancel を撃つ" "yes" "$(cancel_fired)"
+ck "copy-mode 解除後も literal を送信する" "yes" "$(printf '%s' "$MOCK_SENDKEYS_LOG" | grep -q 'PAY20' && echo yes || echo no)"
+
+echo "[21] copy-mode 非該当: pane_in_mode=0 → -X cancel を撃たない（not in a mode 回避・#154）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'PAY21')" )
+oe_send_line "%5" "PAY21" >/dev/null 2>&1
+ck "非 copy-mode 時は -X cancel を撃たない" "no" "$(cancel_fired)"
+
+echo "[22] silent-failure signal: OE_SEND_SIGNAL_MISS=1 + stage_miss → rc=4（既定 off は[12]・#154）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_empty)" )
+rc=0; OE_SEND_SIGNAL_MISS=1 oe_send_line "%5" "PAY22" >/dev/null 2>"$ERRFILE" || rc=$?
+ck "opt-in 時の確定未着は rc=4" "4" "$rc"
+ck "rc=4 でも追加 submit しない（transport の Enter 1回のみ）" "1" "$(enter_count)"
 
 echo "=== RESULT: pass=${pass} fail=${fail} ==="
 [[ "$fail" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_delegate_send.sh
+++ b/projects/orchestration-engine/tests/test_delegate_send.sh
@@ -43,7 +43,7 @@ tmux() {
       local use="$idx"; [[ "$use" -ge "$n" ]] && use=$((n-1))
       printf '%s\n' "${MOCK_CAP_SEQ[$use]}"
       echo $((idx+1)) > "$CAP_IDXFILE" ;;
-    "send-keys"*) MOCK_SENDKEYS_LOG+="tmux $*"$'\n' ;;
+    "send-keys"*) MOCK_SENDKEYS_LOG+="tmux $*"$'\n'; [[ "${MOCK_SENDKEYS_FAIL:-}" == "1" ]] && return 1 || return 0 ;;
     "display"*) printf '%s\n' "${MOCK_PANE_IN_MODE:-0}" ;;  # display / display-message: #{pane_in_mode}
     *) return 0 ;;
   esac
@@ -112,7 +112,7 @@ export OE_SEND_FINALIZE_STABLE=2
 enter_count() { printf '%s' "$MOCK_SENDKEYS_LOG" | grep -c 'send-keys -t %5 Enter'; }
 cap_calls()   { cat "$CAP_CALLSFILE"; }
 cancel_fired() { printf '%s' "$MOCK_SENDKEYS_LOG" | grep -q -- '-X cancel' && echo yes || echo no; }
-reset_fin() { MOCK_SENDKEYS_LOG=""; echo 0 > "$CAP_IDXFILE"; echo 0 > "$CAP_CALLSFILE"; MOCK_CAP_FAIL=""; MOCK_PANE_IN_MODE=0; }
+reset_fin() { MOCK_SENDKEYS_LOG=""; echo 0 > "$CAP_IDXFILE"; echo 0 > "$CAP_CALLSFILE"; MOCK_CAP_FAIL=""; MOCK_PANE_IN_MODE=0; MOCK_SENDKEYS_FAIL=""; }
 
 echo "[7] finalize: staged_idle（窓終端までstaged・baseline idle）→ Enter を1回再送"
 reset_fin
@@ -224,8 +224,14 @@ echo "[22] silent-failure signal: OE_SEND_SIGNAL_MISS=1 + stage_miss → rc=4（
 reset_fin
 MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_empty)" )
 rc=0; OE_SEND_SIGNAL_MISS=1 oe_send_line "%5" "PAY22" >/dev/null 2>"$ERRFILE" || rc=$?
-ck "opt-in 時の確定未着は rc=4" "4" "$rc"
+ck "opt-in 時の未着候補は rc=4" "4" "$rc"
 ck "rc=4 でも追加 submit しない（transport の Enter 1回のみ）" "1" "$(enter_count)"
+
+echo "[23] transport 失敗の明示伝播: send-keys 失敗 → rc=2（|| rc=\$? 文脈でも握り潰さない・#154 SO 指摘）"
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" )
+rc=0; MOCK_SENDKEYS_FAIL=1 oe_send_line "%5" "PAY23" >/dev/null 2>&1 || rc=$?
+ck "send-keys 失敗は rc=2 で伝播（errexit に頼らない）" "2" "$rc"
 
 echo "=== RESULT: pass=${pass} fail=${fail} ==="
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## 概要

`oe-send` が #144 後も exit 0 を返すのにメッセージが受け手に届かない**間欠的な無言失敗**（[#154](https://github.com/stlwolf/ai-development-hub/issues/154)）の修正。オーナー指摘の copy-mode 吸収仮説を起点に、使い捨てペインで**決定論的に再現・除去**し、`not in a mode` の発生源も isolation で特定した。

## root cause（実地検証で確定）

- **主トリガ**: 受け手ペインが trackpad スクロール等で tmux copy-mode に入ると、`send-keys -l` / `Enter` がコピーモードのキーテーブルに吸収され不達。`not in a mode` は `send-keys -X` を mode 外ペインに撃ったときだけ出る（リポ内に `-X` 発行コードは無く、元 dogfood の連発はリポ外の発行元由来）。
- これは観測された全間欠性の単一根本原因ではなく**主トリガ**。#144 が断定保留した負荷下の Enter 原子性レースは別物で本 PR では未着手（finalize の best-effort 回復のまま）。

## 変更内容

- **A. copy-mode ガード** (`lib/delegate-send.sh`): transport 前に `#{pane_in_mode}` を確認し、mode のとき（主因は copy-mode）だけ `send-keys -X cancel`。条件付き + `2>/dev/null || true` で TOCTOU race でも `not in a mode` を出さず失敗もしない。
- **B. silent-failure signal（opt-in）**: finalize の確定的な未着候補（stage miss）で `rc=3` sentinel、`OE_SEND_SIGNAL_MISS=1` のときだけ `oe_send_line` を rc=4 へ昇格。**既定 off** は fast-submit 誤判定による二重 submit 回避（#144 の rc 透過設計を既定で温存）。
- **C. フォールバック案内** (`bin/oe-send`): rc=4 で手動 `send-keys -l + Enter` を stderr 案内して非0終了。
- **D. transport 失敗の明示伝播**（so-compare ゲートで発見）: `oe_send_line ... || rc=$?` で受けると関数内 `set -e` が無効化され、transport の `send-keys` 失敗が握り潰される回帰を実証 → `oe_send_line` 内で明示チェックし rc=2 を返すよう修正（errexit 非依存）。

## 検証

- ユニット `test_delegate_send.sh`: **36/0**（新規 [20]-[23]: copy-mode ガード / opt-in signal / transport 失敗伝播）。`shellcheck` クリーン。
- 実地検証（使い捨てペイン）: copy-mode 中の素送信は未着（吸収を再現）、パッチ済 `oe_send_line` は in_mode 1→0 解除して着弾。`not in a mode` の発生源は各コマンド単独計測で `send-keys -X`（mode 外）に特定。
- so-compare ゲート（Codex / Claude）: blocking 指摘（transport silent 化）を修正、rc=4 の表現緩和・表題の honesty 修正まで反映。駆動層記録は [episode](projects/orchestration-engine/docs/episodes/2026-06-16-episode-oe-send-copymode-guard.md)。

## 後方互換

- 既定（`OE_SEND_SIGNAL_MISS` 未設定）で rc 挙動は従来どおり。copy-mode ガードは通常 pane（in_mode=0）で完全 no-op。`oe-delegate` は `oe_send_line` を直接呼ばず波及なし。

## 残課題 / リスク

- `not in a mode` の野良発行元（リポ外の `-X` 発行元）は未特定 → **追わない**（engine は発行せず、ガードは race でも出さない。実害なし）。
- opt-in signal の fast-submit 誤判定率は実 Claude TUI で未測定 → 呼び出し側が opt-in するまで **deferred**。

## 関連

- Refs #154
- 前史: #144（送信信頼化・観測ベース finalize）
