### PR TITLE
feat(skills): add code-path-exhaustion skill + hypothesis-gate hook

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -7,7 +7,7 @@
 - **Rules**: English — ルール/原則はモデルの学習分布（CS 概念体系が英語ベース）と一致させるため英語で記述。断定的・厳格・端的な表現を使う
 - **Skills**: Japanese — スキルはドメイン知識・コンテキストを含むため、ユーザーの思考言語（日本語）で記述。description（frontmatter）も日本語
 
-## Skills (24)
+## Skills (25)
 
 | 名前 | 説明 | パス | depends |
 |------|------|------|---------|
@@ -16,6 +16,7 @@
 | branch-finish | ブランチ完了判定フロー（検証→4択→実行→クリーンアップ） | `skills/branch-finish/SKILL.md` | skill: worktrunk-worktrees, skill: pr-conventions, skill: conventional-commits |
 | branch-naming | ブランチ命名規則を適用する | `skills/branch-naming/SKILL.md` | — |
 | c4-architecture | 構造化データからC4アーキテクチャ図（Mermaid）を生成する記述スキル（4レベル視点・graph TD/classDef・AS-IS/TO-BE・サニタイズ指針） | `skills/c4-architecture/SKILL.md` | — |
+| code-path-exhaustion | バグ調査で入力→出力のコードパスに未読がある限り外部要因の仮説に進まない。仮説を tmp/hypothesis-NNN.md に外部化し read-state を可視化（exhaustion-before-conclusion のバグ調査ドメイン層2・#77 の姉妹）。hypothesis-gate フックが N=3 で advisory 誘導 | `skills/code-path-exhaustion/SKILL.md` | skill: persistent-exploration, skill: episode-retrospective |
 | conventional-commits | コミットメッセージをConventional Commits規約に従って生成する | `skills/conventional-commits/SKILL.md` | — |
 | delegate-task | 親子 Claude Code セッション間の委譲操作（delegate / send / list / report）を自然言語から判断して実行する。tmux 環境前提 | `skills/delegate-task/SKILL.md` | — |
 | diff-audit | PR diff全体を原則ベースでレビューする。4つの問いを軸に、チェックリスト外の問題も含めて拾う。既知パターンは各問いのヒントとして残す | `skills/diff-audit/SKILL.md` | — |
@@ -94,6 +95,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 | force push ブロック | `hooks/scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
 | CC 形式チェック | `hooks/scripts/cc-lint.sh` | `git commit -m` の Conventional Commits 形式を検証（3ツール共通） |
 | コミットゲート | `hooks/scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（Claude Code のみ） |
+| 仮説ゲート | `hooks/scripts/hypothesis-gate.sh` | バグ調査で `tmp/hypothesis-*.md` が N=3 に達したら外部要因の結論前にコードパス未読確認を advisory 通知（Claude Code PostToolUse・ブロックしない・#78 code-path-exhaustion） |
 | 通知 | `hooks/scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory、並走時のポーリング解消）。loc にセッション名を表示 |
 | セッション命名 | `hooks/scripts/session-name.sh` | セッション名を自動設定（Claude Code のみ・UserPromptSubmit）。worktree は `#<issue> <slug>`（`scripts/wt/wt-pane-issue.sh`＝worktrunk post-switch と連携）、非 wt は現在 git ブランチ名（issue規約→`#<issue> <slug>` / デフォルト・非git→リポ名）でブランチ変化に追従。並列セッション識別用 |
 

--- a/canonical/commands/investigation/issue-debug.md
+++ b/canonical/commands/investigation/issue-debug.md
@@ -78,6 +78,8 @@ Issue 内容から抽出したキーワード・関数名・エラーメッセ�
 **難航時:**
 調査が難航した場合（再現できない、原因が特定できない）、`persistent-exploration` スキルの行動制約テンプレートをサブエージェントのプロンプトに注入する。
 
+外部要因（インフラ差異・環境等）の結論に傾く前は `code-path-exhaustion` を適用する（入力→出力のコードパスを読み切り、仮説を `tmp/hypothesis-NNN.md` に外部化してから外部要因へ。`hypothesis-gate` フックが N=3 で advisory 誘導）。
+
 ```
 Read ~/.cursor/skills/persistent-exploration/SKILL.md
 ```

--- a/canonical/commands/investigation/issue-debug.md
+++ b/canonical/commands/investigation/issue-debug.md
@@ -82,6 +82,7 @@ Issue 内容から抽出したキーワード・関数名・エラーメッセ�
 
 ```
 Read ~/.cursor/skills/persistent-exploration/SKILL.md
+Read ~/.cursor/skills/code-path-exhaustion/SKILL.md
 ```
 
 ## Step 4: 原因分析

--- a/canonical/hooks/README.md
+++ b/canonical/hooks/README.md
@@ -16,6 +16,7 @@
 | 破壊コマンドブロック | `scripts/block-destructive.sh` | `rm -rf /`, `chmod -R 777 /`, `DROP TABLE` 等の破壊的コマンドをブロック |
 | force push ブロック | `scripts/block-force-push.sh` | `git push --force` をブロック（`--force-with-lease` は許可） |
 | コミットゲート | `scripts/commit-gate.sh` | タスク完了時に未コミット変更があれば通知（advisory、ブロックしない） |
+| 仮説ゲート | `scripts/hypothesis-gate.sh` | バグ調査で `tmp/hypothesis-*.md` が N=3 に初めて達したら、外部要因の結論前にコードパス未読確認を 1 回 advisory 通知（Claude のみ・ブロックしない・#78 code-path-exhaustion） |
 | CC 形式チェック | `scripts/cc-lint.sh` | `git commit -m` のメッセージが Conventional Commits 形式に準拠しているかチェック |
 | 通知 | `scripts/notify.sh` | エージェントの完了・入力待ちを macOS 通知（advisory）。並走時のポーリング解消が目的 |
 | セッション命名 | `scripts/session-name.sh` ＋ リポジトリルートの `scripts/wt/wt-pane-issue.sh` | セッション名を自動設定し並列セッションを識別（Claude のみ・advisory）。`wt switch` の worktree は `#<issue> <slug>`、非 wt は現在 git ブランチ名（issue規約→`#<issue> <slug>` / デフォルト→リポ名）でブランチ変化に追従 |
@@ -27,6 +28,7 @@
 | 破壊コマンドブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | force push ブロック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | コミットゲート | — | `TaskCompleted` | — |
+| 仮説ゲート | — | `PostToolUse(Write\|Edit\|MultiEdit)` → hypothesis-gate.sh | — |
 | CC 形式チェック | `beforeShellExecution` | `PreToolUse(Bash)` | `PreToolUse(Bash)` |
 | 通知: 完了 | — | `Stop` hook → notify.sh | `notify`(config.toml) → notify.sh |
 | セッション命名 | — | `UserPromptSubmit` → session-name.sh | — |

--- a/canonical/hooks/claude.hooks.json
+++ b/canonical/hooks/claude.hooks.json
@@ -29,6 +29,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/hypothesis-gate.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/canonical/hooks/scripts/hypothesis-gate.sh
+++ b/canonical/hooks/scripts/hypothesis-gate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# hypothesis-gate.sh — PostToolUse(Write|Edit|MultiEdit) フック
+# コードパス調査の仮説外部化ファイル tmp/hypothesis-*.md が閾値 N に初めて達したとき
+# 1回だけ advisory 通知する（marker で一回性を担保。Edit や削除→再作成での再通知を防ぐ）。
+# 外部要因（インフラ差異等）の結論へ進む前に「入力→出力のコードパスに未読区間が無いか」
+# を確認するよう促す（code-path-exhaustion #78）。ブロックはしない（compliance はモデル依存）。
+# N=3 は暫定値（出自 spec は「N 個」としか言っていない）。
+
+THRESHOLD=3
+
+notify() { jq -n --arg msg "$1" '{"user_message":$msg}'; exit 0; }
+silent_exit() { exit 0; }
+
+main() {
+  local input cwd path count marker
+
+  input="$(cat)"
+  cwd="$(jq -r '.cwd // ""' <<< "$input")"
+  path="$(jq -r '.tool_input.file_path // ""' <<< "$input")"
+
+  [[ -z "$cwd" || "$cwd" == "null" ]] && silent_exit
+
+  # 仮説ファイルへの書き込みでなければ無視
+  case "$path" in
+    */tmp/hypothesis-*.md | tmp/hypothesis-*.md) ;;
+    *) silent_exit ;;
+  esac
+
+  # 一回性: 通知済み marker があれば沈黙（再発火 spam を防ぐ）
+  marker="$cwd/tmp/.hypothesis-gate.notified"
+  [[ -f "$marker" ]] && silent_exit
+
+  # tmp/hypothesis-*.md の個数（tmp/ 不在でも 0 になるよう || true でガード）
+  count="$( { find "$cwd/tmp" -maxdepth 1 -name 'hypothesis-*.md' 2>/dev/null || true; } | wc -l | tr -d ' ')"
+
+  if (( count >= THRESHOLD )); then
+    touch "$marker" 2>/dev/null || true
+    notify "[hypothesis-gate] 仮説が ${THRESHOLD} 個以上たまりました（tmp/hypothesis-*.md）。
+
+外部要因（インフラ差異等）の結論へ進む前に確認: 入力→出力のコードパスに未読区間は無いか。
+未読が残るなら、code-path-exhaustion / persistent-exploration の突破口チェックリストでコード側を尽くしてから外部仮説へ。"
+  fi
+
+  silent_exit
+}
+
+main

--- a/canonical/rules/exhaustion-before-conclusion-rule.md
+++ b/canonical/rules/exhaustion-before-conclusion-rule.md
@@ -28,12 +28,12 @@ The same failure structure recurs across domains. The two cases below are illust
 The reachable space splits in two, so the planned mechanisms split into two tracks while the principle stays single:
 
 - Design-decision domain (unexplored options): a soft forcing layer — the `predecision-exploration` skill, which requires ≥1 zero-base alternative exploration with a confirm-time trace before confirming — has landed (#77). Its deterministic hard gate (script-layer convergence) is still deferred.
-- Bug-investigation domain (unread code paths): a hard mechanism to externalize hypotheses and make spinning visible — design tracked in #78 (planned, not yet implemented).
+- Bug-investigation domain (unread code paths): a soft layer — the `code-path-exhaustion` skill (externalize hypotheses to `tmp/hypothesis-NNN.md` + an advisory `hypothesis-gate` hook) — has landed (#78). Its deterministic hard gate (blocking + script-layer convergence) is still deferred.
 - An always-on soft floor (reframe / zero-base on detecting spin) — landed as `reframe-on-stall-rule.md` (#161).
 
 ## Minimal discipline (until the hard mechanisms land)
 
-The deterministic hard mechanisms (#77 / #78) do not exist yet (#77's soft forcing layer `predecision-exploration` has landed; the hard gates are deferred). At high-stakes conclusions — committing a design, asserting a root cause, or jumping to an external hypothesis — apply this floor directly:
+The deterministic hard mechanisms (#77 / #78) do not exist yet (#77's `predecision-exploration` and #78's `code-path-exhaustion` soft layers have landed; the hard gates are deferred). At high-stakes conclusions — committing a design, asserting a root cause, or jumping to an external hypothesis — apply this floor directly:
 
 - Do not self-declare "explored enough" without a stated reason. The model is biased to announce sufficiency; the design discussion is explicit that convergence must not be left to the model's own judgment.
 - Decide the stopping condition before exploring, not when you feel done.

--- a/canonical/skills/code-path-exhaustion/SKILL.md
+++ b/canonical/skills/code-path-exhaustion/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: code-path-exhaustion
+description: エラー/バグ調査で、入力→出力のコードパスに未読区間がある限り外部要因（インフラ差異等）の仮説に進まない。外部要因に飛ぼうとするとき、原因が再現しないと判断しそうなときに使用する。仮説を tmp/hypothesis-NNN.md に外部化し、コードパスの read-state を可視化する。
+depends:
+  - skill: persistent-exploration
+  - skill: episode-retrospective
+---
+
+# Code Path Exhaustion — コードパス網羅原則
+
+`exhaustion-before-conclusion-rule`（傘原則）の**バグ調査ドメインの層2**（soft forcing ＋ 仮説の外部化）。#77 `predecision-exploration`（設計ドメイン）の姉妹。
+
+> **コードパス網羅原則**: エラー調査において、入力から出力までのコードパスに未読区間がある限り、外部要因の仮説に進むな。
+
+> **不変条件**: 外部要因の仮説に進む前に、各仮説を `tmp/hypothesis-NNN.md` にその場で外部化し（試したアプローチ・結果・未読/未試行ブランチ・コードパスの read-state）、closure まで先送りしない。
+
+## いつ使うか
+
+- エラー/バグ調査で、外部要因（インフラ差異・環境・他システム等）の仮説に飛ぼうとするとき
+- 「再現できない」「コードは悪くない」と判断しそうなとき
+- 仮説が複数たまってきたとき（hypothesis-gate フックが N=3 で誘導する）
+
+## いつ使わないか
+
+- 入出力のコードパスが小さく即読了できる些末な調査（過剰適用しない）
+
+## 原則の出自
+
+別プロジェクトの Sentry 調査で、入力→出力のコードパスに未読区間が残ったまま外部仮説（インフラ差異）に飛び、2ステップで解けるところを6ステップ要した。この「未読のまま外部へ飛ぶ」を既定手順で止める。
+
+## 手順
+
+1. 入力→出力のコードパスを辿り、**未読区間を可視化**する（どこを読んだ / 読んでいないか）。
+2. 仮説を立てるたびに `tmp/hypothesis-NNN.md` にその場で外部化する（下記フォーマット）。空転（同じ抽象度の横移動）を物理的に見えるようにする。
+3. `persistent-exploration` の突破口チェックリスト（API 直接・DB 状態・マイグレーション履歴等）でコード側の代替アプローチを尽くす。
+4. 入出力のコードパスに未読が無くなって初めて外部要因の仮説に進む。
+
+## hypothesis ファイルフォーマット
+
+```text
+# hypothesis-NNN: <仮説の一文>
+- 種別: コード内 / 外部要因
+- 試したアプローチ: ...
+- 結果: ❌ / ⚠️ / ✅
+- 読んだコードパス: <file:line 範囲>
+- 未読 / 未試行: <残り>
+```
+
+## 暫定停止条件（確定的収束ではない）
+
+- 入出力コードパス読了、または `persistent-exploration` の代替を尽くしたら外部要因へ進んでよい。
+- disposition（モデル依存）。スクリプト層での強制ブロック・収束カウントの hard 化は defer（限界参照）。
+
+## 半機械ゲート（advisory hook）
+
+`canonical/hooks/scripts/hypothesis-gate.sh`（Claude PostToolUse(Write|Edit|MultiEdit)）が `tmp/hypothesis-*.md` を数え、**N=3 に初めて達したとき marker で1回だけ advisory 通知**する（Edit や削除→再作成では再発火しない）。「外部要因に進む前にコードパス未読を確認」を促すが**ブロックはしない**（compliance はモデル依存）。N=3 は暫定値（出自 spec は「N 個」とだけ）。**この hook は仮説ファイル外部化経路のリマインダであり、ファイルを作らず chat 上で外部仮説に飛ぶ経路は捕捉しない**（その経路は skill 本体／description マッチ任せ）。
+
+## 記録先
+
+hypothesis ファイル（確定時証跡）→ closure 時に `episode-retrospective` の「事実・失敗 / 決定と根拠」へ蒸留する。**`tmp/` は揮発（gitignore）**なので、読んだコードパス・棄却した仮説の要点は closure を待たず episode/PR 等の永続先へ転記する（tmp 参照だけで終えない＝`episode-retrospective` の evidence anchor と同義。「後で追記」は監査で 100% 不履行）。
+
+## 境界（重なり回避）
+
+- `persistent-exploration`: 諦めず代替アプローチを尽くす突破口チェックリスト（手段集合）。本スキルとの差は**時系列の前後ではなく役割**: 本スキル＝「外部要因に飛ぶ gate＋コードパス read-state の証跡フォーマット」、persistent＝「突破口チェックリスト」。手順3 で persistent を**内包**し、実運用では両者を交互に行き来する（線形の前後ではない）。
+- `reframe-on-stall-rule`: 空転時のゼロベース作り直し（探索中の反射）。仮説が同じ抽象度で横滑りしているなら本スキルの外部化と同時に効きうる — 仮説を外部化してなお空転なら reframe で枠ごと組み直す。
+- `sentry-investigation`: Sentry API のパターン集（道具）。本スキルはコードパス網羅の起動条件。
+- `issue-debug`: 調査フロー全体。本スキルはその Step（コード探索→原因分析）での「外部要因ゲート」。
+- `exhaustion-before-conclusion-rule`: 傘原則。本スキルはバグ調査ドメインの層2。
+- `predecision-exploration`（#77）: 設計確定の層2（別ドメイン・別トリガ）。確定時証跡＋外部化のパターンは共通。
+
+## 限界
+
+- compliance はモデル依存。hook は **advisory（ブロックしない）**。決定的な強制ブロック・スクリプト層の収束カウント（hard 化）は #24（フック軸）/ CLI cockpit の infra 強化待ちで defer。
+- hook は現状 **Claude 側のみ**配線（codex / cursor は PostToolUse 未配線）。スキル本体は3者配信される。
+
+## 参照
+
+- `canonical/rules/exhaustion-before-conclusion-rule.md`（傘原則）
+- `canonical/skills/persistent-exploration/SKILL.md`（突破口チェックリスト・後段）
+- `canonical/skills/predecision-exploration/SKILL.md`（#77・姉妹パターン）
+- `canonical/hooks/scripts/hypothesis-gate.sh`（advisory hook）
+- `canonical/skills/episode-retrospective/SKILL.md`（蒸留先）
+- `docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md` §2（コードパス網羅原則・仮説ファイル）


### PR DESCRIPTION
## 目的

#78「コードパス網羅原則の仮説外部化メカニズム」を、`exhaustion-before-conclusion-rule` の**バグ調査ドメイン層2**として実装する。#77 `predecision-exploration`（設計ドメイン）の姉妹。**クラスタ初の実フックを landed**。

## 変更内容

- 新規 `canonical/skills/code-path-exhaustion/SKILL.md`（日本語）
  - 原則: 入力→出力のコードパスに未読がある限り外部要因（インフラ差異等）に進むな
  - **不変条件**: 外部要因に進む前に各仮説を `tmp/hypothesis-NNN.md` にその場で外部化（#77 同型の確定時証跡）。tmp 揮発に対し evidence anchor 義務（要点を episode/PR 等の永続先へ転記）
  - 境界: persistent-exploration とは「ゲート＋証跡フォーマット」で弁別（前段/後段でなく nested・交互）／reframe-on-stall 共発火／sentry-investigation／issue-debug／#77
- 新規フック `canonical/hooks/scripts/hypothesis-gate.sh`（Claude `PostToolUse(Write|Edit|MultiEdit)`）
  - `tmp/hypothesis-*.md` が N=3 に**初めて達したとき marker で1回だけ** advisory 通知（Edit/削除再作成で再発火しない）。**ブロックしない**（compliance はモデル依存）。N=3 は暫定値
  - 仮説ファイル外部化経路のリマインダ。chat 上で外部仮説に飛ぶ経路は捕捉しない（skill 本体任せ）と明記
  - shellcheck PASS・スモークテスト（3個で通知／再 Edit で沈黙）通過
- 配線: `claude.hooks.json` に PostToolUse 追加（codex/cursor は未対応＝Claude のみ。skill 本体は3者配信）
- cross-doc: `exhaustion-before-conclusion-rule` #78 を soft landed へ／`hooks/README.md`（一覧＋カバレッジ表）／`CATALOG`（Skills 25・Hooks 行）／`issue-debug` に配線

## レビュー

- so-compare（Codex gpt-5.5 / Cursor composer-2.5、実装者 Claude を抜いて多様性担保、`--with codex,cursor`、2者合意）: **hook の一回性バグ（==N で再発火）**・matcher 狭さ（MultiEdit 漏れ）・境界の線形化・cross-doc/README 未更新・tmp 揮発 → 全反映。

## defer（限界に明記）

- 決定的な強制ブロック・スクリプト層の収束カウント（hard 化）＝ #24（フック軸）/ CLI cockpit の infra 強化待ち
- hook は file 外部化経路のみ・Claude のみ配線

Refs #78
Refs #19
