### PR TITLE
feat(oe): add oe-select interactive pane-target selector

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -5,7 +5,7 @@ orchestration-engine の実行可能エントリの簡易リファレンス（AI
 scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統」節）:
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
-- **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-send` / `oe-list` / `oe-report`
+- **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-send` / `oe-list` / `oe-select` / `oe-report`
 
 ---
 
@@ -71,6 +71,22 @@ oe-list
 ```
 
 関連 lib: `delegate-registry.sh`
+
+## oe-select — 宛先をインタラクティブに選んで送信
+
+`oe-list` と同一ソースの候補から fzf（無ければ番号 read）で 1 件選び、pane id を抽出して `oe-send` へ素通しする。既定で自ペインを候補から除外する。
+
+```bash
+oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [--] [ad-hoc...]
+```
+
+- `--print`, `-p` … 選んだ pane id を stdout に出して終了（送信しない）。`message` / `--no-enter` / `--kickoff` とは併用不可。例: `target="$(oe-select -p)" && oe-send "$target" "..."`
+- `--include-self` … 自ペイン（`$TMUX_PANE`）も候補に含める（既定は除外）
+- `--no-enter` / `--kickoff <path>` … `oe-send` へ素通し
+- `ad-hoc...` … 送信メッセージ（無ければ端末から 1 行 read）。`--kickoff` 指定時は省略可
+- 選択キャンセル（ESC / Ctrl-C / 空入力）は exit 130（送信も出力もしない）
+
+関連 lib: `delegate-registry.sh`（送信は `oe-send` 経由）
 
 ## oe-report — 親へ申し送り（legacy）
 

--- a/projects/orchestration-engine/bin/oe-select
+++ b/projects/orchestration-engine/bin/oe-select
@@ -36,7 +36,6 @@ usage: oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [
 候補は oe-list と同一ソース（生存ペイン一覧）。fzf があれば fzf、無ければ番号 read で選ぶ。
 選択をキャンセル（ESC / Ctrl-C / 空入力）した場合は exit 130（送信も出力もしない）。
 EOF
-  exit 1
 }
 
 PRINT_ONLY=0
@@ -51,9 +50,9 @@ while [[ "${1:-}" == -* ]]; do
     --kickoff)
       [[ $# -ge 2 ]] || { echo "oe-select: --kickoff requires a value" >&2; exit 2; }
       KICKOFF="$2"; shift 2 ;;
-    -h|--help) usage ;;
+    -h|--help) usage; exit 0 ;;
     --) shift; break ;;
-    *) echo "oe-select: unknown option: $1" >&2; usage ;;
+    *) echo "oe-select: unknown option: $1" >&2; usage; exit 2 ;;
   esac
 done
 
@@ -98,14 +97,19 @@ fi
 # 選択。fzf があれば fzf、無ければ番号 read。
 SELECTED=""
 if command -v fzf >/dev/null 2>&1; then
-  # fzf が非 0（ESC / Ctrl-C / 未選択）なら cancel 扱い → exit 130。
+  # fzf の exit code を分岐する:
+  #   rc 130（Ctrl-C/SIGINT）/ rc 1（no match=未選択）→ cancel 扱い → exit 130
+  #   rc>=2（fzf 自体のエラー: 不正オプション等）→ exit 2（cancel と区別）
   rc=0
   SELECTED="$(printf '%s\n' "${CANDIDATES[@]}" | fzf \
     --prompt='target> ' \
     --preview 'tmux capture-pane -p -S -200 -t {1} 2>/dev/null || true' \
     --preview-window=right:50%)" || rc=$?
-  if [[ "$rc" -ne 0 ]]; then
+  if [[ "$rc" -eq 130 || "$rc" -eq 1 ]]; then
     exit 130
+  elif [[ "$rc" -ge 2 ]]; then
+    echo "oe-select: fzf failed (rc=${rc})" >&2
+    exit 2
   fi
 else
   # 番号フォールバック: 番号付き候補を stderr に出し、/dev/tty から番号を read。
@@ -128,13 +132,19 @@ else
     echo "oe-select: invalid selection" >&2
     exit 2
   fi
+  # 先頭ゼロ（08/09 等）は 8 進解釈で算術がクラッシュする（value too great for base）。
+  # 10# で明示的に 10 進化してから範囲チェック / インデックスする。
+  idx=$((10#$reply))
   # 範囲外。
-  if [[ "$reply" -lt 1 || "$reply" -gt ${#CANDIDATES[@]} ]]; then
+  if [[ "$idx" -lt 1 || "$idx" -gt ${#CANDIDATES[@]} ]]; then
     echo "oe-select: invalid selection" >&2
     exit 2
   fi
-  SELECTED="${CANDIDATES[$((reply - 1))]}"
+  SELECTED="${CANDIDATES[$((idx - 1))]}"
 fi
+
+# 空選択は cancel 扱い（fzf rc0 + 空 stdout など）。両経路を覆う位置に置く。
+[[ -n "$SELECTED" ]] || exit 130
 
 # 選択行から first-token のみで pane id 抽出（source/label 列はパースしない）。
 PANE="$(printf '%s\n' "$SELECTED" | awk '{print $1}')"
@@ -160,6 +170,10 @@ if [[ -z "$MESSAGE" && -z "$KICKOFF" ]]; then
     # EOF
     exit 130
   fi
+  # 空入力（Enter のみ）は cancel。空のまま oe-send へ渡すと nothing to send で
+  # rc1 になり契約（cancel=130）に反する。--kickoff 指定時は payload があるため
+  # この経路に入らない（上の条件で除外済み）。
+  [[ -n "$MESSAGE" ]] || exit 130
 fi
 
 # 隣接 oe-send を exec で呼ぶ。passthrough: --no-enter / --kickoff <path>。

--- a/projects/orchestration-engine/bin/oe-select
+++ b/projects/orchestration-engine/bin/oe-select
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# oe-select — cockpit ペイン宛先セレクタ（fzf / 番号フォールバック）
+#
+# usage: oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [--] [ad-hoc...]
+#
+# oe-list と同一ソース（delegate-registry.sh の oe_reg_list）から宛先候補を引き、
+# fzf（あれば）か番号 read で 1 件選ばせ、pane id を抽出して oe-send へ渡す。
+# 既定で自ペイン（$TMUX_PANE）を候補から除外する（--include-self で含める）。
+#
+# --print は pane id を stdout に出すだけ（送信しない）。pipe / コマンド置換で使う:
+#   target="$(oe-select --print)" && oe-send "$target" "..."
+# stdout は %N のみ。プロンプト / エラーは全て stderr へ流す。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/delegate-registry.sh
+source "${BIN_DIR}/../lib/delegate-registry.sh"
+
+# 対話入力（番号 read / message read）は端末から直接読む。既定は /dev/tty。
+# OE_SELECT_TTY はテスト用のシーム（自動テストで端末を差し替えるため）。本番では未設定。
+OE_SELECT_TTY="${OE_SELECT_TTY:-/dev/tty}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [--] [ad-hoc...]
+
+  --print, -p         選んだ pane id を stdout に出力して終了（送信しない）。
+                      message / --no-enter / --kickoff とは併用不可
+  --no-enter          oe-send に素通し（投入のみで Enter を発火しない）
+  --include-self      自ペイン（$TMUX_PANE）も候補に含める（既定は除外）
+  --kickoff <path>    oe-send に素通し（"<path> を読んで進めて。" を payload に）
+  ad-hoc...           1 行の追加指示（複数語は空白連結）。oe-send へ素通し
+  -h, --help          このヘルプを表示
+
+候補は oe-list と同一ソース（生存ペイン一覧）。fzf があれば fzf、無ければ番号 read で選ぶ。
+選択をキャンセル（ESC / Ctrl-C / 空入力）した場合は exit 130（送信も出力もしない）。
+EOF
+  exit 1
+}
+
+PRINT_ONLY=0
+SEND_ENTER=1
+INCLUDE_SELF=0
+KICKOFF=""
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -p|--print) PRINT_ONLY=1; shift ;;
+    --no-enter) SEND_ENTER=0; shift ;;
+    --include-self) INCLUDE_SELF=1; shift ;;
+    --kickoff)
+      [[ $# -ge 2 ]] || { echo "oe-select: --kickoff requires a value" >&2; exit 2; }
+      KICKOFF="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    --) shift; break ;;
+    *) echo "oe-select: unknown option: $1" >&2; usage ;;
+  esac
+done
+
+# 残りの位置引数（ad-hoc message）。空白連結。
+ADHOC="$*"
+
+# --print は送信系オプション / message と排他。
+if [[ "$PRINT_ONLY" -eq 1 ]]; then
+  if [[ -n "$ADHOC" || "$SEND_ENTER" -eq 0 || -n "$KICKOFF" ]]; then
+    echo "oe-select: --print cannot be combined with a message, --no-enter, or --kickoff" >&2
+    exit 2
+  fi
+fi
+
+# 候補一覧は oe_reg_list から。pipefail 下で fzf キャンセルと一覧失敗を混同しないよう
+# 先に変数へ取得する。
+LIST="$(oe_reg_list)" || { rc=$?; echo "oe-select: failed to list panes (rc=${rc})" >&2; exit "$rc"; }
+
+# ヘッダ行（1 行目）を除去し、空行を落とす。既定で自ペインを除外する。
+SELF="${TMUX_PANE:-}"
+CANDIDATES=()
+first=1
+while IFS= read -r line; do
+  if [[ "$first" -eq 1 ]]; then
+    first=0
+    continue
+  fi
+  [[ -n "$line" ]] || continue
+  if [[ "$INCLUDE_SELF" -eq 0 && -n "$SELF" ]]; then
+    # first-token（pane id）が自ペインなら除外。
+    paneid="$(printf '%s\n' "$line" | awk '{print $1}')"
+    [[ "$paneid" == "$SELF" ]] && continue
+  fi
+  CANDIDATES+=("$line")
+done <<< "$LIST"
+
+if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
+  echo "oe-select: no candidate panes (try: oe-list, or --include-self)" >&2
+  exit 1
+fi
+
+# 選択。fzf があれば fzf、無ければ番号 read。
+SELECTED=""
+if command -v fzf >/dev/null 2>&1; then
+  # fzf が非 0（ESC / Ctrl-C / 未選択）なら cancel 扱い → exit 130。
+  rc=0
+  SELECTED="$(printf '%s\n' "${CANDIDATES[@]}" | fzf \
+    --prompt='target> ' \
+    --preview 'tmux capture-pane -p -S -200 -t {1} 2>/dev/null || true' \
+    --preview-window=right:50%)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    exit 130
+  fi
+else
+  # 番号フォールバック: 番号付き候補を stderr に出し、/dev/tty から番号を read。
+  echo "oe-select: select a target pane:" >&2
+  idx=1
+  for line in "${CANDIDATES[@]}"; do
+    printf '%3d) %s\n' "$idx" "$line" >&2
+    idx=$((idx + 1))
+  done
+  printf 'number> ' >&2
+  reply=""
+  if ! IFS= read -r reply <"$OE_SELECT_TTY"; then
+    # EOF
+    exit 130
+  fi
+  # 空入力は cancel。
+  [[ -n "$reply" ]] || exit 130
+  # 非数値は invalid。
+  if ! [[ "$reply" =~ ^[0-9]+$ ]]; then
+    echo "oe-select: invalid selection" >&2
+    exit 2
+  fi
+  # 範囲外。
+  if [[ "$reply" -lt 1 || "$reply" -gt ${#CANDIDATES[@]} ]]; then
+    echo "oe-select: invalid selection" >&2
+    exit 2
+  fi
+  SELECTED="${CANDIDATES[$((reply - 1))]}"
+fi
+
+# 選択行から first-token のみで pane id 抽出（source/label 列はパースしない）。
+PANE="$(printf '%s\n' "$SELECTED" | awk '{print $1}')"
+if ! [[ "$PANE" =~ ^%[0-9]+$ ]]; then
+  echo "oe-select: could not extract pane id from selection: ${SELECTED}" >&2
+  exit 1
+fi
+
+# --print: pane id を stdout に出して終了。
+if [[ "$PRINT_ONLY" -eq 1 ]]; then
+  printf '%s\n' "$PANE"
+  exit 0
+fi
+
+# 送信モード: message 確定。
+#  - ad-hoc があればそれを使う
+#  - 無く --kickoff があればメッセージ空でよい（kickoff が payload）
+#  - どちらも無ければ端末（/dev/tty）から 1 行 read
+MESSAGE="$ADHOC"
+if [[ -z "$MESSAGE" && -z "$KICKOFF" ]]; then
+  printf 'message to %s: ' "$PANE" >&2
+  if ! IFS= read -r MESSAGE <"$OE_SELECT_TTY"; then
+    # EOF
+    exit 130
+  fi
+fi
+
+# 隣接 oe-send を exec で呼ぶ。passthrough: --no-enter / --kickoff <path>。
+PASS=()
+[[ "$SEND_ENTER" -eq 0 ]] && PASS+=(--no-enter)
+[[ -n "$KICKOFF" ]] && PASS+=(--kickoff "$KICKOFF")
+
+if [[ -n "$MESSAGE" ]]; then
+  exec "${BIN_DIR}/oe-send" ${PASS[@]+"${PASS[@]}"} -- "$PANE" "$MESSAGE"
+else
+  exec "${BIN_DIR}/oe-send" ${PASS[@]+"${PASS[@]}"} -- "$PANE"
+fi

--- a/projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md
@@ -43,7 +43,7 @@ tags: [orchestration, oe-select, cockpit, fzf, tmux, delegate, episode]
 
 - `bin/oe-select` 新規（既存 oe-* 流儀踏襲: コメントヘッダ / `usage()` / `while [[ "${1:-}" == -* ]]` / `oe-select:` プレフィックス / `BIN_DIR` / 隣接 `${BIN_DIR}/oe-send` を exec）。Bash 3.2 互換（`declare -A` 不使用、空配列は `${PASS[@]+"${PASS[@]}"}` でガード）。
 - `bin/README.md` に oe-select 節を追記。`oe-list`/`oe-send`/`delegate-registry.sh` は非破壊。
-- テスト `tests/test_oe_select.sh`（26/0）: 空白ラベル行 `#142 redesign` からの `%N` 抽出（fzf/番号 両経路）、`--print` の stdout 専用、自ペイン除外/`--include-self`、候補0=1、番号フォールバックの非数値/範囲外/空、fzf cancel=130（送信なし）、`--no-enter`/`--kickoff` の `oe-send` パススルー。テストシーム `OE_SELECT_TTY`（既定 `/dev/tty`、本番未設定）は既存 `OE_*_DIR` 規約と同型。番号フォールバックは system Bash 3.2 でも実行し互換確認。
+- テスト `tests/test_oe_select.sh`（35/0）: 空白ラベル行 `#142 redesign` からの `%N` 抽出（fzf/番号 両経路）、`--print` の stdout 専用、自ペイン除外/`--include-self`、候補0=1、番号フォールバックの非数値/範囲外/空、fzf cancel=130（送信なし）、`--no-enter`/`--kickoff` の `oe-send` パススルー。テストシーム `OE_SELECT_TTY`（既定 `/dev/tty`、本番未設定）は既存 `OE_*_DIR` 規約と同型。番号フォールバックは system Bash 3.2 でも実行し互換確認。
 - ゲート（親が独立検証）: `shellcheck` script+test clean、`bash tests/test_oe_select.sh` 35/0（実装 SO 指摘の修正後）、`test_delegate_registry.sh`/`test_oe_delegate.sh` 回帰 PASS。
 
 ## 実装 SO（欠陥検出・設計 SO と別観点）
@@ -70,7 +70,7 @@ tags: [orchestration, oe-select, cockpit, fzf, tmux, delegate, episode]
   - F（ステートフル宛先 `oe-target set` + `oe-send` target 省略）→ **defer**。同一子への連続追送が頻発したら別 enhancement として issue 化検討。
   - E（tmux popup）/ G（tmux bind）→ **追わない**（現行 shell 起動で足りる。狭ペイン UX が課題化したら再考）。
   - 実装 SO defer: 複数行 label/pane_title の候補行偽造 → **issue 化候補**（`oe_reg_list` 出力衛生 + `oe-delegate --label` 改行拒否。oe-list にも共通の cross-cutting）。`$TMUX_PANE` 未設定の self 除外無効 / fzf+非TTY → **明記のみ**（設計限界・対話専用ツール）。
-- **status**: stable（達成）。コード + README + ユニット 26/0 + 親レビュー + 設計 SO ゲート完了。
+- **status**: stable（達成）。コード + README + ユニット 35/0 + 親レビュー + 設計 SO + 実装 SO ゲート完了。
 - **SO ゲートの形**: 設計 SO（codex+cursor、A' 確定・選択肢拡張つき）と実装 SO（codex+cursor、実コード欠陥検出・option-expansion なし）の**両方を実施**。観点が違うので設計 SO だけで実装 SO を省略しない。実装 SO 指摘の契約違反4点を修正、cross-cutting/設計限界3点は defer（上記「実装 SO」表）。
 - **evidence anchor**: 設計 SO 出力 `tmp/so-20260617-222442/`、実装 SO 出力 `tmp/so-20260617-225419/`（いずれも codex/cursor stdout・gitignore 対象）。
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md
@@ -19,7 +19,7 @@ tags: [orchestration, oe-select, cockpit, fzf, tmux, delegate, episode]
 
 # oe-select — cockpit ペイン宛先セレクタ（fzf/番号フォールバック）追加（#176 駆動層記録）
 
-> `oe-list` の宛先候補を fzf（無ければ番号 read）で対話選択し、選んだペインの `%N` を抽出して `oe-send` へ繋ぐ最小 cockpit UI を追加した1サイクル。設計段階で codex+cursor の SO を通し、案 A を「自ペイン既定除外・明示 exit semantics・first-token 抽出・option パススルー」で補強した A' を実装。shellcheck clean / ユニット 26/0 / 既存テスト回帰 PASS。
+> `oe-list` の宛先候補を fzf（無ければ番号 read）で対話選択し、選んだペインの `%N` を抽出して `oe-send` へ繋ぐ最小 cockpit UI を追加した1サイクル。設計段階で codex+cursor の SO を通し、案 A を「自ペイン既定除外・明示 exit semantics・first-token 抽出・option パススルー」で補強した A' を実装。さらに**設計 SO とは別観点の実装 SO（実コード欠陥検出）**を実施し契約違反4点を修正。shellcheck clean / ユニット 35/0 / 既存テスト回帰 PASS。
 
 ## Context / なぜ
 
@@ -44,7 +44,23 @@ tags: [orchestration, oe-select, cockpit, fzf, tmux, delegate, episode]
 - `bin/oe-select` 新規（既存 oe-* 流儀踏襲: コメントヘッダ / `usage()` / `while [[ "${1:-}" == -* ]]` / `oe-select:` プレフィックス / `BIN_DIR` / 隣接 `${BIN_DIR}/oe-send` を exec）。Bash 3.2 互換（`declare -A` 不使用、空配列は `${PASS[@]+"${PASS[@]}"}` でガード）。
 - `bin/README.md` に oe-select 節を追記。`oe-list`/`oe-send`/`delegate-registry.sh` は非破壊。
 - テスト `tests/test_oe_select.sh`（26/0）: 空白ラベル行 `#142 redesign` からの `%N` 抽出（fzf/番号 両経路）、`--print` の stdout 専用、自ペイン除外/`--include-self`、候補0=1、番号フォールバックの非数値/範囲外/空、fzf cancel=130（送信なし）、`--no-enter`/`--kickoff` の `oe-send` パススルー。テストシーム `OE_SELECT_TTY`（既定 `/dev/tty`、本番未設定）は既存 `OE_*_DIR` 規約と同型。番号フォールバックは system Bash 3.2 でも実行し互換確認。
-- ゲート（親が独立検証）: `shellcheck` script+test clean、`bash tests/test_oe_select.sh` 26/0、`test_delegate_registry.sh`/`test_oe_delegate.sh` 回帰 PASS。
+- ゲート（親が独立検証）: `shellcheck` script+test clean、`bash tests/test_oe_select.sh` 35/0（実装 SO 指摘の修正後）、`test_delegate_registry.sh`/`test_oe_delegate.sh` 回帰 PASS。
+
+## 実装 SO（欠陥検出・設計 SO と別観点）
+
+設計 SO（アプローチ妥当性）とは別観点として、実装後に **実コードの欠陥検出 SO**（`so-compare --with codex,cursor`、option-expansion なし）を実施。設計 SO + テスト GREEN では出ない契約違反・堅牢性欠陥を複数検出した（実装 SO は設計 SO の代替にならない＝両方回す。[[feedback_engine_driving_layer_flow]]）。
+
+| 指摘 | 重大度 | 対応 |
+|------|--------|------|
+| message 空入力が cancel(130) でなく oe-send 経由 rc1 | 両者 medium | 修正（空入力→exit 130） |
+| unknown option が rc2 でなく rc1 | 両者 low | 修正（usage 非 exit 化、unknown→2 / --help→0） |
+| 番号 `08`/`09` が 8 進解釈で算術クラッシュ | codex low | 修正（`10#` で 10 進化） |
+| fzf 非 cancel エラー / rc0+空も一律 130 | 両者 low | 修正（130/1=cancel、rc>=2=2、空選択=130） |
+| 複数行 label/pane_title で候補行偽造→別ペイン送信 | codex medium | **defer**（`oe_reg_list` 出力衛生 + `oe-delegate --label` 改行拒否。oe-select 範囲外・oe-list にも影響） |
+| `$TMUX_PANE` 未設定時 self 除外が無効 | cursor medium | **defer/明記**（tmux 内では設定済・`oe_reg_list` 自体 tmux 必須・強制 fail は正当用途を壊す。自入力で復帰可） |
+| fzf あり + 非 TTY で番号フォールバック不可 | cursor medium | **defer/明記**（対話専用ツール。非対話は `oe-send %N` 直叩き） |
+
+修正後: ユニット 35/0、shellcheck clean、回帰 PASS（親が独立検証）。
 
 ## closure gate
 
@@ -53,9 +69,10 @@ tags: [orchestration, oe-select, cockpit, fzf, tmux, delegate, episode]
   - D（lib の構造化 enum: JSON/TSV）→ **defer**。表パースは first-token 限定で現状堅牢。列追加やラベルで send したい要求が出たら #177（観測 UI）と合わせて検討。
   - F（ステートフル宛先 `oe-target set` + `oe-send` target 省略）→ **defer**。同一子への連続追送が頻発したら別 enhancement として issue 化検討。
   - E（tmux popup）/ G（tmux bind）→ **追わない**（現行 shell 起動で足りる。狭ペイン UX が課題化したら再考）。
+  - 実装 SO defer: 複数行 label/pane_title の候補行偽造 → **issue 化候補**（`oe_reg_list` 出力衛生 + `oe-delegate --label` 改行拒否。oe-list にも共通の cross-cutting）。`$TMUX_PANE` 未設定の self 除外無効 / fzf+非TTY → **明記のみ**（設計限界・対話専用ツール）。
 - **status**: stable（達成）。コード + README + ユニット 26/0 + 親レビュー + 設計 SO ゲート完了。
-- **SO ゲートの形**: 本件は SO を**設計段階**で実施（ユーザー指示）。合意した A' を忠実実装→テスト検証したため、設計 SO + 親レビュー + テストでゲート充足とし、実装後 SO の再投入はしていない。
-- **evidence anchor**: 設計 SO 出力は `tmp/so-20260617-222442/`（codex/cursor stdout・gitignore 対象）。
+- **SO ゲートの形**: 設計 SO（codex+cursor、A' 確定・選択肢拡張つき）と実装 SO（codex+cursor、実コード欠陥検出・option-expansion なし）の**両方を実施**。観点が違うので設計 SO だけで実装 SO を省略しない。実装 SO 指摘の契約違反4点を修正、cross-cutting/設計限界3点は defer（上記「実装 SO」表）。
+- **evidence anchor**: 設計 SO 出力 `tmp/so-20260617-222442/`、実装 SO 出力 `tmp/so-20260617-225419/`（いずれも codex/cursor stdout・gitignore 対象）。
 
 ## 振り返り（出力型 × 消費チャネル）
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md
@@ -1,0 +1,79 @@
+---
+id: "01KVAX293595K4VVKRABX80H5E"
+title: "oe-select — cockpit ペイン宛先セレクタ（fzf/番号フォールバック）追加（#176 駆動層記録）"
+date: 2026-06-17
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/176"
+    reason: "本サイクルの Issue（cockpit 最小 UI＝oe-list + fzf 対話セレクタ）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/169"
+    reason: "傘 Issue（CLI cockpit リッチ UI 群。oe-list/state/audit を data source に WezTerm+tmux を本線化）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/episodes/2026-06-08-episode-oe-delegate-redesign.md"
+    reason: "疎結合 CLI 設計（delegate は spawn+kick に純化、隣接 bin を ${BIN_DIR}/oe-send で呼ぶ）— 本件が踏襲した責務分界"
+tags: [orchestration, oe-select, cockpit, fzf, tmux, delegate, episode]
+---
+
+# oe-select — cockpit ペイン宛先セレクタ（fzf/番号フォールバック）追加（#176 駆動層記録）
+
+> `oe-list` の宛先候補を fzf（無ければ番号 read）で対話選択し、選んだペインの `%N` を抽出して `oe-send` へ繋ぐ最小 cockpit UI を追加した1サイクル。設計段階で codex+cursor の SO を通し、案 A を「自ペイン既定除外・明示 exit semantics・first-token 抽出・option パススルー」で補強した A' を実装。shellcheck clean / ユニット 26/0 / 既存テスト回帰 PASS。
+
+## Context / なぜ
+
+#169 で「オーケストレーションの主戦場を WezTerm + tmux（CLI cockpit）に寄せ、Cursor は補助」と方針確定（README 明文化済・PR #180）。その並列トラックの「最小の1点」が #176＝`oe-list` 出力を対話選択して `oe-send` に繋ぐ導線。data source（`oe_reg_list` の `PANE/SOURCE/LABEL`）と送信口（`oe-send`、target に `%N` 素通し可）は既存で、間の対話導線だけが欠けていた。
+
+## 確定した設計（A'）と設計 SO の流れ
+
+初期に形態 3 案を提示しユーザーが A（新規 `bin/oe-select`、end-to-end + 合成）を選択。確定前に設計 SO（`so-compare --with codex,cursor`、選択肢拡張セクション込み）を実施。
+
+- **2者合意**: 案 A が妥当（B=`oe-list --select` は「引数なし一覧」契約を破る／C=純セレクタは `--print` として A に内包）。`%N` 素通しも妥当（行で実体特定済→ラベル再解決は冗長・空白ラベルのパース事故も回避。`%N` は `oe_reg_resolve` の escape hatch として既存契約）。
+- **両者が指摘した改善必須点（ゲートの価値）**→ A' に反映:
+  - 自ペイン誤送信: `oe_reg_list` は `$TMUX_PANE` 含む全生存ペインを出す → **既定除外 + `--include-self`**。
+  - `set -euo pipefail` × fzf cancel: 一覧を先に変数取得し、fzf 非0 を **cancel=130** に明示。
+  - option パススルー: `--no-enter` だけでなく **`--kickoff`** も `oe-send` へ。
+  - `command -v fzf`（path 固定不可）、preview は `-S -200 … 2>/dev/null || true` で fail-soft、抽出は **first-token のみ**。
+- **ゼロベース代替案（選択肢拡張）**: D=lib に JSON/TSV 中間層（表パース廃止・長期堅牢）、E=tmux display-popup、F=ステートフル宛先（連続追送向け）、G=tmux bind（新 bin なし）。いずれも A と直交し #176 のブロッカーではない → follow-up に記録。
+
+確定 CLI 契約: `oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [--] [ad-hoc...]`。cancel(ESC/Ctrl-C/空)=130、候補0=1、不正opt=2。
+
+## 実装と検証
+
+- `bin/oe-select` 新規（既存 oe-* 流儀踏襲: コメントヘッダ / `usage()` / `while [[ "${1:-}" == -* ]]` / `oe-select:` プレフィックス / `BIN_DIR` / 隣接 `${BIN_DIR}/oe-send` を exec）。Bash 3.2 互換（`declare -A` 不使用、空配列は `${PASS[@]+"${PASS[@]}"}` でガード）。
+- `bin/README.md` に oe-select 節を追記。`oe-list`/`oe-send`/`delegate-registry.sh` は非破壊。
+- テスト `tests/test_oe_select.sh`（26/0）: 空白ラベル行 `#142 redesign` からの `%N` 抽出（fzf/番号 両経路）、`--print` の stdout 専用、自ペイン除外/`--include-self`、候補0=1、番号フォールバックの非数値/範囲外/空、fzf cancel=130（送信なし）、`--no-enter`/`--kickoff` の `oe-send` パススルー。テストシーム `OE_SELECT_TTY`（既定 `/dev/tty`、本番未設定）は既存 `OE_*_DIR` 規約と同型。番号フォールバックは system Bash 3.2 でも実行し互換確認。
+- ゲート（親が独立検証）: `shellcheck` script+test clean、`bash tests/test_oe_select.sh` 26/0、`test_delegate_registry.sh`/`test_oe_delegate.sh` 回帰 PASS。
+
+## closure gate
+
+- **次の消費者**: #176 PR レビュアー（A' 妥当性・exit semantics 確認）。cockpit を使う人間（`oe-select` で選択→送信）。将来 `oe-select` を触る駆動層作業。
+- **follow-up routing**:
+  - D（lib の構造化 enum: JSON/TSV）→ **defer**。表パースは first-token 限定で現状堅牢。列追加やラベルで send したい要求が出たら #177（観測 UI）と合わせて検討。
+  - F（ステートフル宛先 `oe-target set` + `oe-send` target 省略）→ **defer**。同一子への連続追送が頻発したら別 enhancement として issue 化検討。
+  - E（tmux popup）/ G（tmux bind）→ **追わない**（現行 shell 起動で足りる。狭ペイン UX が課題化したら再考）。
+- **status**: stable（達成）。コード + README + ユニット 26/0 + 親レビュー + 設計 SO ゲート完了。
+- **SO ゲートの形**: 本件は SO を**設計段階**で実施（ユーザー指示）。合意した A' を忠実実装→テスト検証したため、設計 SO + 親レビュー + テストでゲート充足とし、実装後 SO の再投入はしていない。
+- **evidence anchor**: 設計 SO 出力は `tmp/so-20260617-222442/`（codex/cursor stdout・gitignore 対象）。
+
+## 振り返り（出力型 × 消費チャネル）
+
+### 事実・わかったこと（W）
+- `oe_reg_list` は全生存ペイン（自ペイン含む）を出す。即送信 UI では自ペイン選択＝自分のシェルへ注入の事故経路になる → セレクタ側で既定除外が要る（list 側は非破壊のまま）。
+- 人間が「行」を選ぶ UI では `%N` 素通しが最適。ラベル再解決は曖昧一致・空白ラベル・親スコープ差を再導入するだけ。
+
+### 決定と根拠
+- 形態 A（独立 bin）: 単機能分離（oe-delegate redesign と同型）。`oe-list` の「引数なし一覧」契約を壊さない。C（純セレクタ）は `--print` として内包。
+- cancel=130: 慣習的な SIGINT 相当。`--print` 合成時に空ターゲット送信を防ぐ。
+
+### 原則（Pattern / Anti-pattern）
+- **Pattern**: 既存の data source（一覧）と sink（送信）が揃っているなら、間の導線は薄い合成 bin に純化し、両端は非破壊で残す。
+- **Anti-pattern**: 人間表示用の固定幅テキストを多列パースする → ラベル空白で壊れる。**first-token だけ**に限定する。
+- **Pattern**: 設計確定 SO に選択肢拡張を付け、初期 3 案の外（JSON 層・tmux popup 等）を引き出してから確定する。
+
+### 蒸留シグナル
+- 昇格候補: **なし**（コード追加 + 既存 episode 形式で十分。skill/rule/Decision 化は不要）。
+
+### 残課題
+- D（構造化 enum）/ F（ステートフル宛先）は defer（上記 routing）。現行は first-token パースで堅牢、実需が出たら再評価。

--- a/projects/orchestration-engine/tests/test_oe_select.sh
+++ b/projects/orchestration-engine/tests/test_oe_select.sh
@@ -7,7 +7,7 @@ set -uo pipefail
 #   - tmux: PATH 先頭の mock。list-panes は $MOCK_LIVE_PANES を返す
 #   - jq:   PATH 先頭の mock（delegate-registry.sh が要求するため）。
 #           pane-issue / spawn-registry を使わず pane-title 経路に倒すため空を返す
-#   - fzf:  ある/無いをテストごとに切替（FZF_PRESENT）。あるときは固定行を返す
+#   - fzf:  make_fzf / rm_fzf で mock バイナリを作成・削除して有無をテストごとに切替。存在時は固定行を返す
 #   - oe-send: BIN_DIR 隣の stub（exec で呼ばれる）。引数を log に記録する
 #
 # oe-select は BIN_DIR="$(dirname "$0")" 隣の oe-send を exec する。実体ではなく
@@ -76,7 +76,7 @@ exit 0
 EOF
 chmod +x "$_TMP_DIR/pathbin/jq"
 
-# mock fzf: FZF_PRESENT=1 のときのみ存在。$FZF_PICK_PANE に一致する行を返す。
+# mock fzf: make_fzf で作成（rm_fzf で削除）。存在時に呼ばれ、$FZF_PICK_PANE に一致する行を返す。
 make_fzf() {
   cat > "$_TMP_DIR/pathbin/fzf" <<'EOF'
 #!/usr/bin/env bash

--- a/projects/orchestration-engine/tests/test_oe_select.sh
+++ b/projects/orchestration-engine/tests/test_oe_select.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test_oe_select.sh — oe-select の宛先選択 / pane id 抽出 / oe-send 素通しを検証する
+#
+# 実 tmux / fzf / oe-send は起動せず、すべて mock する:
+#   - tmux: PATH 先頭の mock。list-panes は $MOCK_LIVE_PANES を返す
+#   - jq:   PATH 先頭の mock（delegate-registry.sh が要求するため）。
+#           pane-issue / spawn-registry を使わず pane-title 経路に倒すため空を返す
+#   - fzf:  ある/無いをテストごとに切替（FZF_PRESENT）。あるときは固定行を返す
+#   - oe-send: BIN_DIR 隣の stub（exec で呼ばれる）。引数を log に記録する
+#
+# oe-select は BIN_DIR="$(dirname "$0")" 隣の oe-send を exec する。実体ではなく
+# テスト用 bin/ に oe-select をコピーし、隣に stub oe-send を置くことで素通しを観測する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/lib" "$_TMP_DIR/pathbin" "$_TMP_DIR/logs"
+
+# oe-select をテスト用 bin/ にコピー。lib/ は実体を symlink（delegate-registry.sh を共有）。
+cp "$PROJECT_DIR/bin/oe-select" "$_TMP_DIR/bin/oe-select"
+chmod +x "$_TMP_DIR/bin/oe-select"
+ln -s "$PROJECT_DIR/lib/delegate-registry.sh" "$_TMP_DIR/lib/delegate-registry.sh"
+
+# stub oe-send: 受けた全引数を 1 行ずつ log に記録する（送信はしない）。
+cat > "$_TMP_DIR/bin/oe-send" <<'EOF'
+#!/usr/bin/env bash
+log="${OE_SELECT_TEST_LOG_DIR:?}/oe-send-args.log"
+: > "$log"
+for a in "$@"; do
+  printf '%s\n' "$a" >> "$log"
+done
+exit 0
+EOF
+chmod +x "$_TMP_DIR/bin/oe-send"
+
+# mock tmux: list-panes は $MOCK_LIVE_PANES（空白区切り）を返す。
+cat > "$_TMP_DIR/pathbin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "list-panes -a"|"list-panes"*)
+    # shellcheck disable=SC2086
+    printf '%s\n' ${MOCK_LIVE_PANES:-} ;;
+  "display-message"*) printf 'mock-pane-title\n' ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$_TMP_DIR/pathbin/tmux"
+
+# mock jq: delegate-registry.sh は pane-issue/spawn JSON を jq で引く。
+# fixture を本物の jq 同様に解釈するのは過剰なので、ここでは「pane-issue ファイルから
+# .name を引く呼び出し」だけ最小実装する。引数末尾のファイルから JSON 風 "name" を取り出す。
+# それ以外（spawn ラベル等）は空を返し pane-title 経路へ倒す。
+cat > "$_TMP_DIR/pathbin/jq" <<'EOF'
+#!/usr/bin/env bash
+# 末尾引数をファイル候補とみなす。filter に .name が含まれ、ファイルがあれば name を返す。
+filter=""
+file=""
+prev=""
+for a in "$@"; do
+  case "$a" in
+    .name*|*'.name'*) filter="name" ;;
+  esac
+  prev="$file"; file="$a"
+done
+if [[ "$filter" == "name" && -f "$file" ]]; then
+  # 雑な抽出: "name":"<...>" の値を取り出す（fixture は単純な 1 行 JSON 前提）。
+  sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file"
+  exit 0
+fi
+printf ''
+exit 0
+EOF
+chmod +x "$_TMP_DIR/pathbin/jq"
+
+# mock fzf: FZF_PRESENT=1 のときのみ存在。$FZF_PICK_PANE に一致する行を返す。
+make_fzf() {
+  cat > "$_TMP_DIR/pathbin/fzf" <<'EOF'
+#!/usr/bin/env bash
+# stdin から候補を受け、$FZF_PICK_PANE（first-token 一致）の行を返す。
+# FZF_CANCEL=1 なら非 0 で抜ける（ESC 相当）。
+if [[ -n "${FZF_CANCEL:-}" ]]; then exit 130; fi
+pick="${FZF_PICK_PANE:-}"
+while IFS= read -r line; do
+  tok="$(printf '%s\n' "$line" | awk '{print $1}')"
+  if [[ "$tok" == "$pick" ]]; then printf '%s\n' "$line"; exit 0; fi
+done
+exit 1
+EOF
+  chmod +x "$_TMP_DIR/pathbin/fzf"
+}
+rm_fzf() { rm -f "$_TMP_DIR/pathbin/fzf"; }
+
+# 隔離 state（delegate-registry.sh が参照。空ディレクトリにして pane-title 経路へ）。
+export OE_DELEGATE_STATE_DIR; OE_DELEGATE_STATE_DIR="$_TMP_DIR/state"
+export OE_PANE_ISSUE_DIR;     OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
+mkdir -p "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+
+# 厳選 PATH: mock の tmux/jq（pathbin）+ システム実体（awk/sed/cat/env/bash）。
+# 実 fzf（/opt/homebrew/bin）は意図的に除外する。これにより `command -v fzf` は
+# pathbin に mock fzf がある時だけ成功し、make_fzf / rm_fzf で fzf の有無を切替できる。
+export PATH="${_TMP_DIR}/pathbin:/usr/bin:/bin"
+export TMUX="/tmp/mock-tmux,12345,0"
+export OE_SELECT_TEST_LOG_DIR="$_TMP_DIR/logs"
+
+# 番号 read / message read のための tty シーム。テストごとに入力をファイルへ書いて差し替える。
+# /dev/tty は非対話環境で開けないため、OE_SELECT_TTY でファイルを指す。
+TTY_FILE="$_TMP_DIR/tty-input"
+export OE_SELECT_TTY="$TTY_FILE"
+feed_tty() { printf '%s\n' "$1" > "$TTY_FILE"; }   # 1 行入力
+feed_tty_empty() { : > "$TTY_FILE"; }              # 空入力（即 EOF）
+
+SEL="$_TMP_DIR/bin/oe-select"
+
+PASS=0
+FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (want='$expected' got='$actual')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+send_log() { cat "$_TMP_DIR/logs/oe-send-args.log" 2>/dev/null; }
+reset_send_log() { rm -f "$_TMP_DIR/logs/oe-send-args.log"; }
+
+# ----------------------------------------------------------------------------
+# [1] fzf 経路: 空白ラベル行から first-token %5 を抽出し、--print で stdout に %5 のみ
+# ----------------------------------------------------------------------------
+echo "[1] fzf --print: 空白ラベル行 '#142 redesign' から first-token %5 抽出 / stdout は %N のみ"
+make_fzf
+export MOCK_LIVE_PANES="%1 %5 %7"
+export TMUX_PANE="%1"
+# %5 に空白を含む pane-issue ラベル "#142 redesign" を fixture として直挿しする。
+# server pid = 12345（$TMUX の 2 番目）、key = "12345_%5" の非英数を _ に → 12345__5。
+printf '{"name":"#142 redesign"}\n' > "${OE_PANE_ISSUE_DIR}/12345__5"
+# 一覧行は "%5     pane-issue     #142 redesign"。fzf がこの行を返す → first-token %5。
+export FZF_PICK_PANE="%5"
+out="$("$SEL" --print 2>/dev/null)"; rc=$?
+ck "rc=0" "0" "$rc"
+ck "空白ラベル行から first-token %5 を抽出し stdout は %5 のみ" "%5" "$out"
+rm -f "${OE_PANE_ISSUE_DIR}/12345__5"
+
+# ----------------------------------------------------------------------------
+# [2] 自ペイン既定除外 / --include-self で含む
+# ----------------------------------------------------------------------------
+echo "[2] 自ペイン既定除外 / --include-self"
+make_fzf
+export MOCK_LIVE_PANES="%1 %5"
+export TMUX_PANE="%1"
+# 既定では %1（self）は候補から除外 → fzf が %1 を選ぼうとしても候補に無い → 非 0 → cancel(130)
+export FZF_PICK_PANE="%1"
+rc=0; "$SEL" --print >/dev/null 2>&1 || rc=$?
+ck "self(%1) は既定で候補外 → 選べず cancel(130)" "130" "$rc"
+# --include-self では %1 が候補に入る → 選べる
+rc=0; out="$("$SEL" --include-self --print 2>/dev/null)" || rc=$?
+ck "--include-self rc=0" "0" "$rc"
+ck "--include-self で self(%1) を選べる" "%1" "$out"
+
+# ----------------------------------------------------------------------------
+# [3] 候補 0 件 → exit 1
+# ----------------------------------------------------------------------------
+echo "[3] 候補 0 件 → exit 1"
+make_fzf
+export MOCK_LIVE_PANES="%1"   # self のみ → 既定除外で 0 件
+export TMUX_PANE="%1"
+rc=0; "$SEL" --print >/dev/null 2>&1 || rc=$?
+ck "candidates empty → exit 1" "1" "$rc"
+
+# ----------------------------------------------------------------------------
+# [4] fzf 無しの番号フォールバック: 空白ラベル行から %5 抽出、oe-send へ正しい引数
+#     空白ラベル fixture（"#142 redesign"）を pane-issue state に直挿しして検証する。
+# ----------------------------------------------------------------------------
+echo "[4] fzf 無し 番号フォールバック: 番号 1 → %5、oe-send へ正しい引数で素通し"
+rm_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"   # self は候補外（候補は %5 %7）
+reset_send_log
+feed_tty "1"            # 番号 1 → 1 行目（%5）を選択
+"$SEL" "go ahead" >/dev/null 2>&1
+log="$(send_log)"
+ck "oe-send 引数に -- 含む" "yes" "$(printf '%s\n' "$log" | grep -qxF -- '--' && echo yes || echo no)"
+ck "oe-send に %5 が渡る"   "yes" "$(printf '%s\n' "$log" | grep -qxF -- '%5' && echo yes || echo no)"
+ck "oe-send に message が渡る" "yes" "$(printf '%s\n' "$log" | grep -qxF -- 'go ahead' && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [4b] 空白ラベル行の first-token 抽出（純粋な抽出ロジック）を独立に確認する。
+#      oe-select の抽出は `awk '{print $1}'` なので "%5 pane-issue #142 redesign" から %5。
+# ----------------------------------------------------------------------------
+echo "[4b] 番号フォールバックでも空白ラベル行 '#142 redesign' から %5 を抽出（end-to-end）"
+rm_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+printf '{"name":"#142 redesign"}\n' > "${OE_PANE_ISSUE_DIR}/12345__5"
+feed_tty "1"   # 1 行目（%5、ラベル "#142 redesign"）を選択
+out="$("$SEL" --print 2>/dev/null)"; rc=$?
+ck "rc=0" "0" "$rc"
+ck "空白ラベル行から %5 を抽出（first-token）" "%5" "$out"
+rm -f "${OE_PANE_ISSUE_DIR}/12345__5"
+
+# ----------------------------------------------------------------------------
+# [5] 番号フォールバック: 非数値 → exit 2 / 範囲外 → exit 2 / 空 → 130
+# ----------------------------------------------------------------------------
+echo "[5] 番号フォールバック: 非数値/範囲外/空 の扱い"
+rm_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+feed_tty "abc"; rc=0; "$SEL" "m" >/dev/null 2>&1 || rc=$?
+ck "非数値 → exit 2" "2" "$rc"
+feed_tty "99"; rc=0; "$SEL" "m" >/dev/null 2>&1 || rc=$?
+ck "範囲外 → exit 2" "2" "$rc"
+feed_tty_empty; rc=0; "$SEL" "m" >/dev/null 2>&1 || rc=$?
+ck "空入力 → cancel 130" "130" "$rc"
+
+# ----------------------------------------------------------------------------
+# [6] fzf 無し --print: 番号選択 → stdout に %N のみ（プロンプトは stderr）
+# ----------------------------------------------------------------------------
+echo "[6] fzf 無し --print: stdout は %N のみ"
+rm_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+feed_tty "2"
+out="$("$SEL" --print 2>/dev/null)"; rc=$?
+ck "rc=0" "0" "$rc"
+ck "番号 2 → %7 を stdout に" "%7" "$out"
+
+# ----------------------------------------------------------------------------
+# [7] --print と message 併用 → exit 2
+# ----------------------------------------------------------------------------
+echo "[7] --print と message / --no-enter / --kickoff 併用 → exit 2"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+export FZF_PICK_PANE="%5"
+rc=0; "$SEL" --print "a message" >/dev/null 2>&1 || rc=$?
+ck "--print + message → exit 2" "2" "$rc"
+rc=0; "$SEL" --print --no-enter >/dev/null 2>&1 || rc=$?
+ck "--print + --no-enter → exit 2" "2" "$rc"
+rc=0; "$SEL" --print --kickoff /tmp/k.md >/dev/null 2>&1 || rc=$?
+ck "--print + --kickoff → exit 2" "2" "$rc"
+
+# ----------------------------------------------------------------------------
+# [8] fzf キャンセル（ESC 相当）→ exit 130、送信も出力もしない
+# ----------------------------------------------------------------------------
+echo "[8] fzf キャンセル → exit 130（送信なし）"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+reset_send_log
+export FZF_CANCEL=1
+rc=0; out="$("$SEL" "m" 2>/dev/null)" || rc=$?
+unset FZF_CANCEL
+ck "fzf cancel → exit 130" "130" "$rc"
+ck "送信されない（oe-send log なし）" "no" "$( [[ -e "$_TMP_DIR/logs/oe-send-args.log" ]] && echo yes || echo no )"
+
+# ----------------------------------------------------------------------------
+# [9] passthrough: --no-enter / --kickoff が oe-send に渡る（送信モード）
+# ----------------------------------------------------------------------------
+echo "[9] passthrough: --no-enter / --kickoff が oe-send に渡る"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+export FZF_PICK_PANE="%5"
+reset_send_log
+"$SEL" --no-enter --kickoff /tmp/k.md "task text" >/dev/null 2>&1
+log="$(send_log)"
+ck "oe-send に --no-enter" "yes" "$(printf '%s\n' "$log" | grep -qxF -- '--no-enter' && echo yes || echo no)"
+ck "oe-send に --kickoff"  "yes" "$(printf '%s\n' "$log" | grep -qxF -- '--kickoff' && echo yes || echo no)"
+ck "oe-send に kickoff path" "yes" "$(printf '%s\n' "$log" | grep -qxF -- '/tmp/k.md' && echo yes || echo no)"
+ck "oe-send に %5"         "yes" "$(printf '%s\n' "$log" | grep -qxF -- '%5' && echo yes || echo no)"
+ck "oe-send に task text"  "yes" "$(printf '%s\n' "$log" | grep -qxF -- 'task text' && echo yes || echo no)"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_select.sh
+++ b/projects/orchestration-engine/tests/test_oe_select.sh
@@ -81,8 +81,12 @@ make_fzf() {
   cat > "$_TMP_DIR/pathbin/fzf" <<'EOF'
 #!/usr/bin/env bash
 # stdin から候補を受け、$FZF_PICK_PANE（first-token 一致）の行を返す。
-# FZF_CANCEL=1 なら非 0 で抜ける（ESC 相当）。
+# FZF_CANCEL=1 なら rc 130 で抜ける（ESC/Ctrl-C 相当）。
+# FZF_FAIL=<n> なら rc <n> で抜ける（fzf 自体のエラー: 不正オプション等を模す）。
+# FZF_EMPTY=1 なら rc 0 + 空 stdout（選択ゼロ）を返す。
 if [[ -n "${FZF_CANCEL:-}" ]]; then exit 130; fi
+if [[ -n "${FZF_FAIL:-}" ]]; then exit "$FZF_FAIL"; fi
+if [[ -n "${FZF_EMPTY:-}" ]]; then exit 0; fi
 pick="${FZF_PICK_PANE:-}"
 while IFS= read -r line; do
   tok="$(printf '%s\n' "$line" | awk '{print $1}')"
@@ -274,6 +278,81 @@ ck "oe-send に --kickoff"  "yes" "$(printf '%s\n' "$log" | grep -qxF -- '--kick
 ck "oe-send に kickoff path" "yes" "$(printf '%s\n' "$log" | grep -qxF -- '/tmp/k.md' && echo yes || echo no)"
 ck "oe-send に %5"         "yes" "$(printf '%s\n' "$log" | grep -qxF -- '%5' && echo yes || echo no)"
 ck "oe-send に task text"  "yes" "$(printf '%s\n' "$log" | grep -qxF -- 'task text' && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [10] message 空入力（ad-hoc/kickoff なし）→ exit 130、oe-send は呼ばれない
+#      選択後の message read で空行（Enter のみ）を返した場合の cancel 契約。
+#      選択は fzf 経路で行う（番号 read で tty を消費しないため、message read だけが
+#      tty を読む。OE_SELECT_TTY は redirect で都度開き直すので 2 段 read は同一行を
+#      返してしまう — fzf 経路ならその衝突を避けられる）。
+#      tty には「空行 1 行」を入れる → read は成功し MESSAGE="" → 新ガードで 130。
+# ----------------------------------------------------------------------------
+echo "[10] message 空入力 → exit 130（oe-send 呼ばれない）"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+export FZF_PICK_PANE="%5"
+reset_send_log
+printf '\n' > "$TTY_FILE"   # 空行（Enter のみ）→ read 成功 + MESSAGE 空
+rc=0; "$SEL" >/dev/null 2>&1 || rc=$?
+ck "message 空入力 → exit 130" "130" "$rc"
+ck "oe-send 呼ばれない（log なし）" "no" "$( [[ -e "$_TMP_DIR/logs/oe-send-args.log" ]] && echo yes || echo no )"
+
+# ----------------------------------------------------------------------------
+# [11] unknown option（--bogus）→ exit 2
+# ----------------------------------------------------------------------------
+echo "[11] unknown option → exit 2"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+rc=0; "$SEL" --bogus >/dev/null 2>&1 || rc=$?
+ck "--bogus → exit 2" "2" "$rc"
+
+# ----------------------------------------------------------------------------
+# [12] --help → exit 0
+# ----------------------------------------------------------------------------
+echo "[12] --help → exit 0"
+rc=0; "$SEL" --help >/dev/null 2>&1 || rc=$?
+ck "--help → exit 0" "0" "$rc"
+
+# ----------------------------------------------------------------------------
+# [13] 番号フォールバックで範囲外の先頭ゼロ（候補数 < 8 のとき "08"）→ exit 2
+#      "08" を 8 進解釈してクラッシュ（rc1）させず、10 進化して範囲外 → exit 2。
+# ----------------------------------------------------------------------------
+echo "[13] 先頭ゼロの範囲外 '08'（候補2件）→ exit 2（クラッシュ/rc1 でなく）"
+rm_fzf
+export MOCK_LIVE_PANES="%5 %7"   # 候補 2 件（08=8 は範囲外）
+export TMUX_PANE="%9"
+feed_tty "08"; rc=0; "$SEL" "m" >/dev/null 2>&1 || rc=$?
+ck "先頭ゼロ範囲外 '08' → exit 2" "2" "$rc"
+
+# ----------------------------------------------------------------------------
+# [14] fzf エラー（mock fzf が rc 2 を返す）→ exit 2（cancel 130 と区別）
+# ----------------------------------------------------------------------------
+echo "[14] fzf エラー（rc 2）→ exit 2（cancel 130 と区別）"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+reset_send_log
+export FZF_FAIL=2   # mock fzf が rc 2 で抜ける
+rc=0; "$SEL" "m" >/dev/null 2>&1 || rc=$?
+unset FZF_FAIL
+ck "fzf rc 2 → exit 2" "2" "$rc"
+ck "送信されない（oe-send log なし）" "no" "$( [[ -e "$_TMP_DIR/logs/oe-send-args.log" ]] && echo yes || echo no )"
+
+# ----------------------------------------------------------------------------
+# [15] fzf rc0 + 空 stdout（選択ゼロ）→ exit 130（cancel 扱い）、送信なし
+# ----------------------------------------------------------------------------
+echo "[15] fzf rc0 + 空 stdout → exit 130（cancel）"
+make_fzf
+export MOCK_LIVE_PANES="%5 %7"
+export TMUX_PANE="%9"
+reset_send_log
+export FZF_EMPTY=1   # mock fzf が rc 0 で空を返す
+rc=0; "$SEL" "m" >/dev/null 2>&1 || rc=$?
+unset FZF_EMPTY
+ck "fzf rc0+空 → exit 130" "130" "$rc"
+ck "送信されない（oe-send log なし）" "no" "$( [[ -e "$_TMP_DIR/logs/oe-send-args.log" ]] && echo yes || echo no )"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 目的

cockpit の最小 UI（#176）。`oe-list` の宛先候補を fzf（無ければ番号 read）で対話選択し、選んだペインの `%N` を抽出して `oe-send` へ繋ぐ。data source（`oe_reg_list`）と送信口（`oe-send`）は既存で、間の対話導線だけを薄く合成する。#169 cockpit 並列トラックの「最小の1点」。

## 変更内容

- `bin/oe-select`（新規・実行可能）
  - CLI 契約: `oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [--] [ad-hoc...]`
  - `oe-select "msg"`: 選択→即送信 / 省略時: 選択後に `/dev/tty` から1行 read / `--print`: `%N` のみ stdout（合成用）
  - 自ペイン（`$TMUX_PANE`）既定除外（`--include-self` で含める）
  - cancel(ESC/Ctrl-C/空)=rc130、候補0=rc1、不正opt=rc2
  - first-token `%N` 抽出（source/label 列は非パース）、preview は `tmux capture-pane -p -S -200 … 2>/dev/null || true`、`command -v fzf` 検出
  - `--no-enter`/`--kickoff` は隣接 `${BIN_DIR}/oe-send` へパススルー。Bash 3.2 互換（`declare -A` 不使用・空配列ガード）
- `bin/README.md`: oe-select 節を追記
- `tests/test_oe_select.sh`（新規、35/0）
- `docs/episodes/2026-06-17-episode-oe-select.md`: 駆動層記録

`oe-list` / `oe-send` / `delegate-registry.sh` は**非破壊**。

## 設計 SO（ゲート）

確定前に `so-compare --with codex,cursor`（選択肢拡張込み）を実施。2者合意で案 A を採用し、両者指摘の改善点を A' に反映（自ペイン誤送信の既定除外・`set -euo pipefail` × fzf cancel の明示処理・`--kickoff` パススルー・`command -v fzf`・preview fail-soft）。`%N` 素通しも妥当判定。ゼロベース代替案（JSON 中間層 D / ステートフル宛先 F 等）は #176 範囲外として episode に follow-up 記録。

## 検証

- `shellcheck bin/oe-select` / `tests/test_oe_select.sh` → clean
- `bash tests/test_oe_select.sh` → 35/0
- 回帰: `test_delegate_registry.sh` / `test_oe_delegate.sh` → PASS

Refs #176

