### PR TITLE
feat(skills): 探索クラスタ skill に oe-refute を統合（Stage A step2）

### DIFF
--- a/canonical/skills/code-path-exhaustion/SKILL.md
+++ b/canonical/skills/code-path-exhaustion/SKILL.md
@@ -34,6 +34,8 @@ depends:
 2. 仮説を立てるたびに `tmp/hypothesis-NNN.md` にその場で外部化する（下記フォーマット）。空転（同じ抽象度の横移動）を物理的に見えるようにする。
 3. `persistent-exploration` の突破口チェックリスト（API 直接・DB 状態・マイグレーション履歴等）でコード側の代替アプローチを尽くす。
 4. 入出力のコードパスに未読が無くなって初めて外部要因の仮説に進む。
+   - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階）: 外部要因へ進む確定の前に、「コードパスは読了し原因は外部要因である」を `claim` とした claim doc（frontmatter ＋ body に `hypothesis-*.md` 群＋read-state を集約）を `oe-refute --claim <doc> --rubric exploration` で**同期反証**する。生成と物理分離した独立レーンが breadth(軸5＝未読パス/未試行が残らないか)/grounding(軸3＝根拠) レンズで反証し、`{verdict, reason, output_dir}` が `refuted` なら外部要因ジャンプを**保留**する。`output_dir` は揮発するので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。
+   - `oe-refute` / `so-compare` が使えない / timeout する場合は、外部要因ジャンプの確定を止めて人間承認を取る（黙って skip しない）。
 
 ## hypothesis ファイルフォーマット
 
@@ -57,7 +59,7 @@ depends:
 
 ## 記録先
 
-hypothesis ファイル（確定時証跡）→ closure 時に `episode-retrospective` の「事実・失敗 / 決定と根拠」へ蒸留する。**`tmp/` は揮発（gitignore）**なので、読んだコードパス・棄却した仮説の要点は closure を待たず episode/PR 等の永続先へ転記する（tmp 参照だけで終えない＝`episode-retrospective` の evidence anchor と同義。「後で追記」は監査で 100% 不履行）。
+hypothesis ファイル（確定時証跡）→ closure 時に `episode-retrospective` の「事実・失敗 / 決定と根拠」へ蒸留する。**`tmp/` は揮発（gitignore）**なので、読んだコードパス・棄却した仮説の要点は closure を待たず episode/PR 等の永続先へ転記する（tmp 参照だけで終えない＝`episode-retrospective` の evidence anchor と同義。「後で追記」は監査で 100% 不履行）。`oe-refute` を使ったなら verdict/reason＋`output_dir` も同様に確定時証跡へ転記する。
 
 ## 境界（重なり回避）
 
@@ -70,7 +72,7 @@ hypothesis ファイル（確定時証跡）→ closure 時に `episode-retrospe
 
 ## 限界
 
-- compliance はモデル依存。hook は **advisory（ブロックしない）**。決定的な強制ブロック・スクリプト層の収束カウント（hard 化）は #24（フック軸）/ CLI cockpit の infra 強化待ちで defer。
+- compliance はモデル依存。hook は **advisory（ブロックしない）**。hard 版は段階導入に移行: 生成・反証の物理分離は **`oe-refute`（Stage A・engine 統合の同期反証 verb・PR #184）で着地**（独立レーンが生成と物理分離で反証）。決定的な強制ブロック・スクリプト層の収束カウント（hard 化）は engine verify ゲート拡張（Stage B）／ #24（フック軸・Stage C）／ CLI cockpit の infra 強化待ちで defer。
 - hook は現状 **Claude 側のみ**配線（codex / cursor は PostToolUse 未配線）。スキル本体は3者配信される。
 
 ## 参照
@@ -78,6 +80,8 @@ hypothesis ファイル（確定時証跡）→ closure 時に `episode-retrospe
 - `canonical/rules/exhaustion-before-conclusion-rule.md`（傘原則）
 - `canonical/skills/persistent-exploration/SKILL.md`（突破口チェックリスト・後段）
 - `canonical/skills/predecision-exploration/SKILL.md`（#77・姉妹パターン）
+- `projects/orchestration-engine/bin/oe-refute`（Stage A・確定前の同期反証 verb・so-compare wrap）
+- `projects/orchestration-engine/docs/discussions/2026-06-18-discussion-exploration-hard-layer-on-engine.md`（hard 層 × engine substrate の合流）
 - `canonical/hooks/scripts/hypothesis-gate.sh`（advisory hook）
 - `canonical/skills/episode-retrospective/SKILL.md`（蒸留先）
 - `docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md` §2（コードパス網羅原則・仮説ファイル）

--- a/canonical/skills/predecision-exploration/SKILL.md
+++ b/canonical/skills/predecision-exploration/SKILL.md
@@ -34,7 +34,7 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 
 1. 初期選択肢セットと暗黙の前提を明示的に列挙する。
 2. 最低1回、ゼロベース SO を**実際に回す**（インラインで「なぞる」だけにしない）。`so-compare` の「選択肢拡張（設計を確定する SO のとき）」テンプレを使い、初期案と異なるカテゴリ / 責務分界 / データフロー / 実行経路 / 運用前提の代替案を出させる。タイミングは「A/B 仮決定後・最終確定前」を含む（最終確定後ではない）。
-   - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir`（`oe-refute` が作る repo 相対 `tmp/oe-refute-<ULID>/`）は gitignore 対象で永続しないので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
+   - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir`（`oe-refute` が返す反証レーンの生出力先・永続しない）なので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
    - `so-compare` / `oe-refute` が使えない / timeout する場合は、確定を止めて人間承認を取る（黙って skip しない）。
 3. 出た代替案は「良さそう」で止めず、検証可能な条件で即検証する（検証不能な環境では検証条件を残して保留）。
 4. **確定前に証跡をその場で残す**: 探索木＋反証の出力パス（`so-compare` なら `tmp/so-*/`、`oe-refute` なら `verdict`/`reason`＋`output_dir`）＋採否を、確定と同一セッションで**確定前 artifact** に書く。置き場は手近なもの: `tmp/dj-N-tree.md` / ADR 草稿の「棄却案」節 / kickoff の DJ 節 / PR 本文 / peer-review ログ（`tmp/peer-review-*/review-log.md`）。**episode closure まで先送りしない**（「後で追記」は監査で 100% 不履行＝L4）。

--- a/canonical/skills/predecision-exploration/SKILL.md
+++ b/canonical/skills/predecision-exploration/SKILL.md
@@ -34,7 +34,7 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 
 1. 初期選択肢セットと暗黙の前提を明示的に列挙する。
 2. 最低1回、ゼロベース SO を**実際に回す**（インラインで「なぞる」だけにしない）。`so-compare` の「選択肢拡張（設計を確定する SO のとき）」テンプレを使い、初期案と異なるカテゴリ / 責務分界 / データフロー / 実行経路 / 運用前提の代替案を出させる。タイミングは「A/B 仮決定後・最終確定前」を含む（最終確定後ではない）。
-   - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir` は揮発（mktemp 系一時領域）なので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
+   - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir`（`oe-refute` が作る repo 相対 `tmp/oe-refute-<ULID>/`）は gitignore 対象で永続しないので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
    - `so-compare` / `oe-refute` が使えない / timeout する場合は、確定を止めて人間承認を取る（黙って skip しない）。
 3. 出た代替案は「良さそう」で止めず、検証可能な条件で即検証する（検証不能な環境では検証条件を残して保留）。
 4. **確定前に証跡をその場で残す**: 探索木＋反証の出力パス（`so-compare` なら `tmp/so-*/`、`oe-refute` なら `verdict`/`reason`＋`output_dir`）＋採否を、確定と同一セッションで**確定前 artifact** に書く。置き場は手近なもの: `tmp/dj-N-tree.md` / ADR 草稿の「棄却案」節 / kickoff の DJ 節 / PR 本文 / peer-review ログ（`tmp/peer-review-*/review-log.md`）。**episode closure まで先送りしない**（「後で追記」は監査で 100% 不履行＝L4）。

--- a/canonical/skills/predecision-exploration/SKILL.md
+++ b/canonical/skills/predecision-exploration/SKILL.md
@@ -34,14 +34,15 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 
 1. 初期選択肢セットと暗黙の前提を明示的に列挙する。
 2. 最低1回、ゼロベース SO を**実際に回す**（インラインで「なぞる」だけにしない）。`so-compare` の「選択肢拡張（設計を確定する SO のとき）」テンプレを使い、初期案と異なるカテゴリ / 責務分界 / データフロー / 実行経路 / 運用前提の代替案を出させる。タイミングは「A/B 仮決定後・最終確定前」を含む（最終確定後ではない）。
-   - `so-compare` が使えない / timeout する場合は、確定を止めて人間承認を取る（黙って skip しない）。
+   - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir` は揮発（mktemp 系一時領域）なので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
+   - `so-compare` / `oe-refute` が使えない / timeout する場合は、確定を止めて人間承認を取る（黙って skip しない）。
 3. 出た代替案は「良さそう」で止めず、検証可能な条件で即検証する（検証不能な環境では検証条件を残して保留）。
-4. **確定前に証跡をその場で残す**: 探索木＋SO 出力パス（`tmp/so-*/`）＋採否を、確定と同一セッションで**確定前 artifact** に書く。置き場は手近なもの: `tmp/dj-N-tree.md` / ADR 草稿の「棄却案」節 / kickoff の DJ 節 / PR 本文 / peer-review ログ（`tmp/peer-review-*/review-log.md`）。**episode closure まで先送りしない**（「後で追記」は監査で 100% 不履行＝L4）。
+4. **確定前に証跡をその場で残す**: 探索木＋反証の出力パス（`so-compare` なら `tmp/so-*/`、`oe-refute` なら `verdict`/`reason`＋`output_dir`）＋採否を、確定と同一セッションで**確定前 artifact** に書く。置き場は手近なもの: `tmp/dj-N-tree.md` / ADR 草稿の「棄却案」節 / kickoff の DJ 節 / PR 本文 / peer-review ログ（`tmp/peer-review-*/review-log.md`）。**episode closure まで先送りしない**（「後で追記」は監査で 100% 不履行＝L4）。
 5. 暫定停止条件を満たしたら確定に進む（下記）。
 
 ## 探索木フォーマット（選択肢の外部化）
 
-`persistent-exploration` の探索木を設計選択肢に流用。検討案・差分軸・採否・未探索ブランチ・SO 出力パスを残す。
+`persistent-exploration` の探索木を設計選択肢に流用。検討案・差分軸・採否・未探索ブランチ・反証の出力パス（`oe-refute` の `verdict`/`output_dir` を含む）を残す。
 
 ```text
 <設計判断 DJ-N: ...>
@@ -76,7 +77,7 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 ## 限界
 
 - 遵守はモデル依存。**確定的トリガ（hook, #24）は未実装**（spot-check 後）。発火は description マッチ＋kickoff 予防＋（plan-mode 経路の）DJ-GATE。
-- **hard 版は defer**（orchestration 多周プリミティブ待ち）: §3.1 出力差分 reject／§3.2 生成・反証の物理分離／§3.3 一次検証の機械義務化（hook exit code）／§3.4 スクリプト層カウント収束。本スキルはこれらを持たない soft 層2。
+- **hard 版は段階導入に移行**（旧: 全 defer）: §3.2 生成・反証の物理分離は **`oe-refute`（Stage A・engine 統合の同期反証 verb・PR #184）で着地**（生成と物理分離した独立レーンが反証）。oe-refute は exit code（survived 0 / refuted 3）を持つが Stage A では advisory（JSON verdict が正本）＝§3.3 一次検証の機械義務化そのものは Stage B/C 待ち。§3.1 出力差分 reject／§3.4 スクリプト層カウント収束は engine verify ゲート拡張（Stage B）、決定的トリガは Stage C（#24）待ちで defer。本スキルの soft forcing はこの上で動く。
 - episode への蒸留の追記信頼性は #159（未着手）依存。ただし**確定時証跡（手順4）は本スキルが今担保する**ので、#159 未着手でも確定前 forcing は成立する。
 
 ## 参照
@@ -86,6 +87,8 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 - `canonical/skills/episode-retrospective/SKILL.md`（closure 時の蒸留先＝決定と根拠）
 - `canonical/skills/persistent-exploration/SKILL.md`（探索木・逆向きの弁別）
 - `canonical/commands/verification/peer-ai-review.md`（合意ループ）
+- `projects/orchestration-engine/bin/oe-refute`（Stage A・確定前の同期反証 verb・so-compare wrap）
+- `projects/orchestration-engine/docs/discussions/2026-06-18-discussion-exploration-hard-layer-on-engine.md`（hard 層 × engine substrate の合流）
 - `docs/specs/2026-04-23-discussion-exploration-process-design.md` / `docs/specs/2026-04-22-discussion-hypothesis-driven-exploration.md`
 - `projects/wezterm-ai-mode/docs/episodes/2026-04-22-episode-wez-notify.md`（option C）
-- 関連 issue: #159（start-side episode gate）/ #24（フック軸）
+- 関連 issue: #159（start-side episode gate）/ #24（フック軸）/ #183（oe-refute Stage A）


### PR DESCRIPTION
## 目的

探索原則クラスタ（#75-78）の hard 層 **Stage A** として着地した engine 同期反証 verb `oe-refute`（PR #184）を、**消費側の skill に統合**する（クロスセッション・ラリーで決めた step2）。設計判断・バグ調査の「確定前反証」を、手動 `so-compare` から engine 統合・addressable・再現的な `oe-refute` 経路へ格上げする道筋を skill 本体に明記する。

出自: `projects/orchestration-engine/docs/discussions/2026-06-18-discussion-exploration-hard-layer-on-engine.md`（Stage A）。

## 変更内容

- `canonical/skills/predecision-exploration/SKILL.md`（#77・設計ドメイン層2）
  - 手順2 に **engine 統合経路（推奨）** `oe-refute --claim <doc> --rubric exploration` を追加（`so-compare` を wrap・breadth(軸5)/grounding(軸3) レンズ・`verdict=refuted` で確定保留）
  - 手順4・探索木フォーマットに oe-refute の `verdict`/`output_dir` 書き戻しを追加
  - claim doc 形式を明記（frontmatter `claim` 必須・`rubric` 任意＝省略時既定 exploration）＝rally 契約の「rubric 必須→既定」改訂を反映
  - 限界を **「hard 版は段階導入に移行」** へ更新（§3.2 物理分離は oe-refute で着地 / §3.3 exit code は土台だが advisory / §3.1・§3.4 は Stage B / 決定的トリガは Stage C #24 defer）
  - 参照に `oe-refute`・discussion doc・#183 を追加
- `canonical/skills/code-path-exhaustion/SKILL.md`（#78・バグ調査ドメイン層2）
  - #77 と並行: 手順4 に「コードパス読了・原因は外部要因」claim の oe-refute 反証、記録先に verdict 書き戻し、限界 §3.2 更新、参照追加

新規ファイルなし・skill 本文のみ（sync で Claude/Cursor/Codex の3者配信）。

## ゲート

- **Second Opinion = `oe-refute` 自己適用（dogfood）**: 今回 wiring した verb を本変更の確定前反証に使用（`oe-refute --claim <doc> --rubric exploration`、lanes=codex,cursor、実装者 Claude を抜いて多様性担保）。**verdict=refuted（2/2 レーン）**＝skill の規律どおり確定を保留し、material な指摘を反映:
  - #78 の失敗時分岐の非対称（codex/cursor）→ #77 同型の「`oe-refute`/`so-compare` 不可・timeout なら確定を止め人間承認」を **#78 に追加**
  - 「推奨」の過大評価（効果未測定・#177 pending）（cursor）→ 「推奨」を外し **「engine 統合経路（効果は #177 で測定予定・現状 so-compare と同列）」へ格下げ**（#77/#78）
  - `output_dir` の永続性不足（codex）→ output_dir は揮発（mktemp 系）と明記し **verdict/reason の内容を確定時証跡へ転記（パスに頼らない）** を追記（#77/#78）
  - §3.3 を exit code に対応付ける過大解釈（codex/cursor）→ 「exit code はあるが §3.3 の機械義務化は Stage B/C 待ち」へ**表現を弱めた**（#77 限界）
  - 残（範囲外・noted）: breadth の代替 wiring（hook/command 配置・claim doc の spec-card 化）は探索木の 未探索 として deferred ／「契約文書未同期」は discussion doc が rubric 必須を主張しておらず低重大度（skill が consumer 正本）
- **dogfood の副産物（`oe-refute` 実装ドリフト・cockpit へ別途共有）**: ① exit code は契約どおり refuted→3 を**確認**（正常）② `output_dir` が repo `tmp/oe-refute-<ulid>/`（契約/turn11）でなく system mktemp 一時領域だった＝evidence-anchor 観点で要確認
- **最終査読 = ユーザー + Copilot**（全体成果物として大丈夫か）

## 後続（範囲外）

- 効果測定: #177 観測 UI で soft/hard 層の before/after（Stage B とセット）
- Stage B（verify ゲート reject 条件＋探索メトリクス emit）/ Stage C（#24 決定論トリガ）= #177 測定後に判断（保留）

Refs #183
