### PR TITLE
fix(oe): oe-refute output_dir を repo 相対化 + runtime gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ tmp/
 .playwright-mcp/
 .thread-exports/
 .oe/
+
+# orchestration-engine runtime output (audit log / session state; .gitkeep stays tracked)
+projects/orchestration-engine/audit/*.jsonl
+projects/orchestration-engine/state/*.state.json

--- a/projects/orchestration-engine/bin/oe-refute
+++ b/projects/orchestration-engine/bin/oe-refute
@@ -211,10 +211,7 @@ trap 'rm -f "$PROMPT_FILE"' EXIT
   printf '%s\n' 'REASON: <1 行の総合判断（改行を含めない）>'
 } > "$PROMPT_FILE"
 
-# --- 出力ディレクトリ ---
-OUTPUT_DIR="$(mktemp -d -t oe-refute.XXXXXX)"
-
-# --- so-compare 実行（同期） ---
+# --- workspace 解決 ---
 # workspace（-w）は呼び出し時 cwd の git root を渡す（Fix 4）。body は repo-root 相対の
 # 参照パス（canonical/... / tmp/... 等）を含み得るため、claim doc の所在 dir では解決できない。
 # git repo でなければ claim_dir → PWD の順でフォールバックする。
@@ -226,6 +223,20 @@ elif [[ -n "$claim_dir" ]]; then
 else
   WORKSPACE="$PWD"
 fi
+
+# --- run ULID（output_dir 名と audit_id で共有・1 run を 1 ULID で辿る traceability） ---
+# 出力 dir 作成より前に 1 回だけ生成し、OUTPUT_DIR 名と AUDIT_ID の両方で使う。
+RUN_ID="$(oe_generate_session_id)"
+
+# --- 出力ディレクトリ ---
+# 契約（explore-turn10）どおり repo 相対 tmp/oe-refute-<ULID>/ に作る（so-compare の tmp/ と同型）。
+# tmp/ は gitignore 済なのでコミットされず、揮発せず安定した evidence anchor になる。
+# system temp（/var/folders/..）に作ると repo 外で揮発し、skill が書く evidence anchor が壊れる。
+# OUTPUT_DIR は削除しない（evidence anchor として返す）。
+OUTPUT_DIR="${WORKSPACE}/tmp/oe-refute-${RUN_ID}"
+mkdir -p "$OUTPUT_DIR"
+
+# --- so-compare 実行（同期） ---
 so_rc=0
 "$OE_REFUTE_SO_COMPARE" --with "$PROVIDERS" -w "$WORKSPACE" -f "$PROMPT_FILE" -o "$OUTPUT_DIR" \
   >"${OUTPUT_DIR}/so-compare-stdout.txt" 2>"${OUTPUT_DIR}/so-compare-stderr.txt" || so_rc=$?
@@ -321,8 +332,8 @@ dissent_json="$(
   jq -cn ${args[@]+"${args[@]}"} "$jq_prog"
 )"
 
-# --- audit_id（ULID 流用） ---
-AUDIT_ID="$(oe_generate_session_id)"
+# --- audit_id（output_dir 名と同じ run ULID を流用・traceability） ---
+AUDIT_ID="$RUN_ID"
 
 # --- 出力 JSON（stdout） ---
 # Stage B のメトリクス superset になれるよう、フィールドは追加余地を残す（今は subset）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-18-episode-oe-refute.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-18-episode-oe-refute.md
@@ -63,6 +63,15 @@ tags: [orchestration, oe-refute, refutation, so-compare, cross-session, episode]
 - **provenance 保全（fix `08ab007`）**: クロスセッション・ラリーの verbatim ログ＋ load-bearing な claim-doc 契約を /tmp（揮発）から `docs/discussions/2026-06-18-rally-log-oe-refute-cross-session.md` へ救出。oe-refute コメントと本 episode の evidence anchor を repo パスへ修正。
 - **Copilot 査読**: 先方リクエストエラーのため今回スキップ（user 承認で締め）。
 
+## follow-up fix: output_dir drift（PR #184 マージ後・peer dogfood 由来）
+
+explore step2 が oe-refute を**自己適用（dogfood）**した際に実運用ドリフト2点が露見し、follow-up で修正（同じ work-item の post-start 継続として本 episode に追記）:
+
+- **output_dir が system temp だった**（`mktemp -d -t` → `/var/folders/..`）→ 契約どおり **repo 相対 `${WORKSPACE}/tmp/oe-refute-<ULID>/`** に修正。skill が evidence anchor に書く output_dir が揮発・repo 外だと壊れる（explore step2 が依存）問題を解消。output_dir 名と `audit_id` を**同一 ULID** に統一（traceability）。
+- engine の runtime 出力（`audit/*.jsonl` / `state/*.state.json`）を **`.gitignore`** に追加（衛生・#185 隣接）。`.gitkeep` は tracked 維持。
+- 検証: ユニット 64/0、shellcheck clean、回帰 PASS。**設計ゲート = peer dogfood**（oe-refute の自己適用 SO が drift を捕捉）のため、本 follow-up は別途 impl SO を省略（mechanical・テスト網羅）。
+- exit 3=refuted ドリフト指摘(#1)は契約どおりで非問題と確認。
+
 ## closure gate
 
 - **次の消費者**: #183 PR の査読（peer ＋ user＋Copilot で全体査読）。**探索クラスタ step2**（so-compare 呼び→`oe-refute --rubric exploration` 差し替え＋ verdict 書き戻し＝skill 側 PR、verb land 後）。

--- a/projects/orchestration-engine/tests/test_oe_refute.sh
+++ b/projects/orchestration-engine/tests/test_oe_refute.sh
@@ -239,8 +239,9 @@ odir="$(printf '%s' "$out" | jq -r '.output_dir')"
 audit_id="$(printf '%s' "$out" | jq -r '.audit_id')"
 ck "output_dir が repo の tmp/oe-refute- 配下" "yes" \
   "$( [[ "$odir" == "${expected_root}/tmp/oe-refute-"* ]] && echo yes || echo no )"
-ck "output_dir が system temp（/var/folders）でない" "yes" \
-  "$( [[ "$odir" != /var/folders/* && "$odir" != /tmp/* ]] && echo yes || echo no )"
+# （旧）system-temp 否定チェックは撤去（Copilot 指摘）: 上の positive 検証
+# 「output_dir == ${expected_root}/tmp/oe-refute-*」が system mktemp 出力を既に除外する。
+# `!= /tmp/*` は repo 自体が /tmp 配下（CI/一時 checkout）のとき false fail するため。
 ck "output_dir が実在（repo 相対）" "yes" "$( [[ -d "$odir" ]] && echo yes || echo no )"
 # traceability: output_dir 名末尾の ULID と audit_id が一致する（同じ run を 1 ULID で辿れる）
 odir_ulid="$(basename "$odir" | sed -E 's/^oe-refute-//')"

--- a/projects/orchestration-engine/tests/test_oe_refute.sh
+++ b/projects/orchestration-engine/tests/test_oe_refute.sh
@@ -20,8 +20,27 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 _TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$_TMP_DIR"' EXIT
 mkdir -p "$_TMP_DIR/pathbin" "$_TMP_DIR/docs" "$_TMP_DIR/audit"
+
+# Fix #2 で oe-refute は output_dir を repo 相対 tmp/oe-refute-<ULID>/ に作る（削除しない＝
+# evidence anchor）。テストはこの実 repo の tmp/ 配下に dir を作るため掃除が要る。
+# mock so-compare が受け取る -o（= oe-refute が作った実 output_dir）を 1 run 分すべて
+# OE_REFUTE_DIRS_LOG に追記し、EXIT でその dir のみを削除する（gitignore 済の throwaway 成果物。
+# 時刻ベースの -newer は秒粒度衝突で取りこぼすため、生成した実パスを正確に列挙して掃除する）。
+export OE_REFUTE_DIRS_LOG="$_TMP_DIR/created-output-dirs.txt"
+: > "$OE_REFUTE_DIRS_LOG"
+cleanup() {
+  if [[ -s "$OE_REFUTE_DIRS_LOG" ]]; then
+    while IFS= read -r d; do
+      # 安全策: tmp/oe-refute-* 配下のみ削除（想定外パスは触らない）
+      case "$d" in
+        */tmp/oe-refute-*) [[ -d "$d" ]] && rm -rf "$d" ;;
+      esac
+    done < "$OE_REFUTE_DIRS_LOG"
+  fi
+  rm -rf "$_TMP_DIR"
+}
+trap cleanup EXIT
 
 # --- mock so-compare（PATH 先頭スタブ） ---
 # 実 so-compare の I/F のうち本テストが使う部分だけ再現する: --with / -w / -f / -o。
@@ -43,6 +62,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 mkdir -p "$out_dir"
+# oe-refute が作った実 output_dir（-o）を掃除用ログに追記（EXIT で削除する）
+if [[ -n "${OE_REFUTE_DIRS_LOG:-}" && -n "$out_dir" ]]; then
+  printf '%s\n' "$out_dir" >> "$OE_REFUTE_DIRS_LOG"
+fi
 # プロンプト内容を検証用にコピー（body 不透明渡しテスト）
 if [[ -n "${SO_FAKE_PROMPT_COPY:-}" && -n "$prompt_file" ]]; then
   cp "$prompt_file" "$SO_FAKE_PROMPT_COPY"
@@ -50,6 +73,10 @@ fi
 # 受け取った -w 引数を検証用に書き出す（Fix 4・git root 検証）
 if [[ -n "${SO_FAKE_W_COPY:-}" ]]; then
   printf '%s\n' "$workspace" > "$SO_FAKE_W_COPY"
+fi
+# 受け取った -o 引数を検証用に書き出す（Fix #2・repo 相対 output_dir 検証）
+if [[ -n "${SO_FAKE_O_COPY:-}" ]]; then
+  printf '%s' "$out_dir" > "$SO_FAKE_O_COPY"
 fi
 IFS=',' read -r -a provs <<< "$providers"
 for p in "${provs[@]}"; do
@@ -200,6 +227,33 @@ odir="$(printf '%s' "$out" | jq -r '.output_dir')"
 ck "output_dir 非空" "yes" "$( [[ -n "$odir" ]] && echo yes || echo no )"
 ck "output_dir が実在" "yes" "$( [[ -d "$odir" ]] && echo yes || echo no )"
 ck "audit_id 26 文字" "26" "$(printf '%s' "$out" | jq -r '.audit_id' | awk '{print length}')"
+
+# ----------------------------------------------------------------------------
+# [6b] Fix #2: output_dir が repo 相対 tmp/oe-refute-<ULID>/（system temp でない）
+# ----------------------------------------------------------------------------
+echo "[6b] Fix #2: output_dir が repo 相対 tmp/oe-refute-<ULID>/（/var/folders でない）"
+# 呼び出し時 cwd の git root（=このリポジトリルート）配下 tmp/oe-refute-<ULID>/ に作られる。
+expected_root="$(cd "$PROJECT_DIR" && { git rev-parse --show-toplevel 2>/dev/null || true; })"
+out="$( cd "$PROJECT_DIR" && "$REFUTE" --claim "$DOC" 2>/dev/null )"
+odir="$(printf '%s' "$out" | jq -r '.output_dir')"
+audit_id="$(printf '%s' "$out" | jq -r '.audit_id')"
+ck "output_dir が repo の tmp/oe-refute- 配下" "yes" \
+  "$( [[ "$odir" == "${expected_root}/tmp/oe-refute-"* ]] && echo yes || echo no )"
+ck "output_dir が system temp（/var/folders）でない" "yes" \
+  "$( [[ "$odir" != /var/folders/* && "$odir" != /tmp/* ]] && echo yes || echo no )"
+ck "output_dir が実在（repo 相対）" "yes" "$( [[ -d "$odir" ]] && echo yes || echo no )"
+# traceability: output_dir 名末尾の ULID と audit_id が一致する（同じ run を 1 ULID で辿れる）
+odir_ulid="$(basename "$odir" | sed -E 's/^oe-refute-//')"
+ck "output_dir 名の ULID = audit_id（traceability）" "$audit_id" "$odir_ulid"
+# mock so-compare が -o で受けた dir = oe-refute が作った repo 相対 output_dir
+export SO_FAKE_O_COPY="$_TMP_DIR/captured-o.txt"
+out="$( cd "$PROJECT_DIR" && "$REFUTE" --claim "$DOC" 2>/dev/null )"
+odir="$(printf '%s' "$out" | jq -r '.output_dir')"
+captured_o="$(cat "$SO_FAKE_O_COPY" 2>/dev/null)"
+ck "so-compare -o = oe-refute の output_dir" "$odir" "$captured_o"
+ck "so-compare -o が repo の tmp/oe-refute- 配下" "yes" \
+  "$( [[ "$captured_o" == "${expected_root}/tmp/oe-refute-"* ]] && echo yes || echo no )"
+unset SO_FAKE_O_COPY
 
 # ----------------------------------------------------------------------------
 # [7] --rubric 上書き: frontmatter exploration を consensus で上書き


### PR DESCRIPTION
## 目的

`oe-refute`（#183 / PR #184 マージ済）を explore step2 が**自己適用（dogfood）**した際に露見した実運用ドリフト2点の follow-up fix。

## 背景

explore クラスタが step2（skill 統合・PR #186）で oe-refute を自分の PR に self-apply したところ、2点のドリフトを検出:

- **output_dir が契約と乖離**: 契約（claim-doc 契約）は repo 相対 `tmp/oe-refute-<ulid>/` だが、実装は `mktemp -d -t`＝**system temp（`/var/folders/..`）**だった。skill は output_dir を**確定時 artifact の evidence anchor** に書くため、揮発・repo 外だと anchor が壊れる（step2 が依存＝load-bearing）。
- engine の runtime 出力（`audit/*.jsonl` / `state/*.state.json`）が **gitignore 未対象**で untracked 汚染。

## 変更内容

- `bin/oe-refute`:
  - output_dir を `mktemp -d -t`（system temp）→ **`${WORKSPACE}/tmp/oe-refute-<ULID>/`**（repo 相対・`mkdir -p`・`tmp/` は gitignore 済＝安定 anchor・so-compare の `tmp/` と同型）
  - ULID を1回生成し **output_dir 名と `audit_id` で共用**（run の traceability）
  - 挙動はこの2点のみ変更（rubric/verdict/集約は不変）
- `.gitignore`: `projects/orchestration-engine/audit/*.jsonl` と `state/*.state.json` を追加（`.gitkeep` は tracked 維持）
- `tests/test_oe_refute.sh`: output_dir が repo `tmp/oe-refute-*` 配下（`/var/folders` でない）・ULID = audit_id を assert するケース追加
- `docs/episodes/2026-06-18-episode-oe-refute.md`: follow-up fix を追記

## 検証

- `shellcheck` clean、`bash tests/test_oe_refute.sh` → **64/0**、回帰 `test_delegate_registry` 16/0
- gitignore は tracked を巻き込まない（`git ls-files` 確認・`.gitkeep` 維持）

## ゲート

- **設計ゲート = peer dogfood**（oe-refute 自己適用 SO が drift を捕捉）。mechanical・テスト網羅のため別途 impl SO は省略。締めは user+Copilot 査読
- exit 3=refuted（peer 指摘 #1）は契約どおりで非問題と確認

Refs #183
