### PR TITLE
docs(oe): 2基盤 identity は pane 層で統一しない設計判断 — read 時相関

### DIFF
--- a/projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md
@@ -1,0 +1,99 @@
+---
+id: "01KVFJ60BGS887DWGBSP7RC942"
+title: "#188 オーケストレーション2基盤の identity は pane 層で統一しない — read 時相関 / 永続マップ不採用"
+date: 2026-06-19
+type: decision
+status: accepted
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/188"
+    reason: "本 ADR の主スコープ（2基盤の identity 統一の設計判断）"
+  - type: source_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/177"
+    reason: "本 ADR の消費者（cockpit 観測UI）。出自であり handoff 先"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md"
+    reason: "本 ADR の探索トレイル（調査・実機観測・設計SO・DJ の経緯）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md"
+    reason: "#177 設計探索。§6 で pane_id ジョイン破綻を捕捉し #188 へピボット"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md"
+    reason: "#114 クリーン出力チャネル。F 投資の陳腐化リスク評価の根拠"
+  - type: source_material
+    ref: "projects/orchestration-engine/schemas/session-state.schema.json"
+    reason: "pane_id を WezTerm integer に固定（F の breaking change 根拠）"
+  - type: source_material
+    ref: "projects/orchestration-engine/lib/spawn.sh"
+    reason: "engine spawn = wez pane split（wez 整数 identity の一次根拠）"
+  - type: source_material
+    ref: "projects/orchestration-engine/lib/delegate-registry.sh"
+    reason: "delegate registry = tmux %N（tmux identity の一次根拠）"
+tags: [orchestration, identity, cockpit, observation, wez, tmux, decision, read-only]
+---
+
+# #188 オーケストレーション2基盤の identity は pane 層で統一しない — read 時相関 / 永続マップ不採用
+
+## コンテキスト
+
+`#177`（cockpit 観測UI）の設計SOで、俯瞰の中核「生存ペイン × session 状態を `pane_id` でジョイン」案が構造破綻した。原因は2つのオーケストレーション基盤が別々の identity 空間を持つこと。これを root-cause として `#188` を切り出し（[discussion #177 §6](../discussions/2026-06-19-discussion-cockpit-observation-ui.md)）、独立した設計判断として確定するのが本 ADR。
+
+問いは「2基盤の identity をそもそも統一すべきか／するならどの方式か」であり、解決策は presume しなかった。探索は (1) read-only 調査（code/schema 直読）、(2) **実機観測**（runtime topology）、(3) **設計SO**（`so-compare --with codex,cursor`・選択肢拡張つき）で行い、経緯は [discussion #188](../discussions/2026-06-19-discussion-188-identity-unification.md) に記録した。
+
+## 確定した事実（決定の前提）
+
+| 項目 | 内容 | 根拠 | status |
+|---|---|---|---|
+| engine `oe` の identity | `wez pane split` の戻り値＝**wez 整数** pane_id。state KVS（完了時のみ）+ audit jsonl を **session_id 主キー**で書く | `lib/spawn.sh:12`、`schemas/session-state.schema.json:14` | verified |
+| delegate（対話子）の identity | `tmux split-window` の **tmux `%N`**。registry のみ（`{pane,label,workspace,parent_pane,role}`）。**state/audit/session_id を持たない** | `bin/oe-delegate:124`、`lib/delegate-registry.sh:56` | verified |
+| session_id の出自 | pane 非依存の ULID 生成 | `lib/session.sh:7` | verified |
+| **runtime topology** | tmux は**単一の WezTerm ペインの内側**で動く。→ engine の wez-split 子は tmux の外の WezTerm pane で **tmux 不可視**、delegate の tmux 子は wez からは親ペインに潰れて **wez 不可視** | 実機観測（`TMUX_PANE=%33` かつ `WEZTERM_PANE=0`、`tmux list-panes -a`=5 / `wez pane list`=1） | verified（実機直接観測） |
+
+→ **2つの pane-ID 空間（wez 整数／tmux `%N`）は別多重化レイヤの別物理エンティティを指し、橋渡すべき対応関係がそもそも存在しない。** これは現行2-spawn-path アーキテクチャ（engine=wez split／delegate=tmux split-window）の不変条件。
+
+## 決定
+
+issue 受入が「観測ツール(#177)が相関できる、**または**『相関しない（別建て観測）』と明示決定され #177 が再設計可能になる」を許容することに基づき、設計SO の収束を踏まえ以下を確定する。
+
+- **DJ-188-1 — pane-ID 層で identity を統一しない。** 対応関係が物理的に存在しない（上記 topology）。pane を主キーに横断同定する案（後述 B/C）は不成立。
+- **DJ-188-2 — engine の session-state/audit スキーマを delegate に拡張しない（案 F 棄却）。** 理由:
+  - **category error**: 対話 delegate 子は success/blocked/timeout の完了 lifecycle を持たない。engine の `state` enum に押し込むと「見た目は統一・意味論は非対称」になる。
+  - **schema breaking change**: `schemas/session-state.schema.json:14` と `schemas/audit-log.schema.json` が `pane_id: integer`（WezTerm）固定。`{mux,id}` 化は state + audit 両方の破壊変更で、「registry に session_id を足すだけ」では済まない。
+  - **ROI 繰延**: 統一の便益は Stage-B 横断メトリクス（保留中）まで発生しない。
+  - **#114 で陳腐化**: pane 属性は engine の tmux 化／file-redirect 化（[#114](../discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md)）で意味が変わる。
+- **DJ-188-3 — identity は基盤ごとに保持し、相関が必要な場合は read 時に行う（永続マッピングを作らない）。** observer が両ソース（engine: wez 生存 + state/audit／delegate: tmux 生存 + registry）を読み取り時に投影する。issue 受入の「相関しないと明示決定」に該当する確定。
+- **DJ-188-4 — 将来 Stage-B で永続的な横断観測が必要になった場合は、session-state 拡張でなく `session_id` 主キーの typed append-only event/activity bus を採る。** 本 issue では実装しない（deferred）。pane 非依存キーのため #114 後も残る。
+- **DJ-188-5 — read-only 制約と書込経路の整合（受入3）。** 「read-only」は**観測者（#177）**を縛る制約であり、producer 側の既存書込（delegate spawn 時の registry `oe_reg_record`、engine 完了時の state/audit `oe_audit_emit`）は対象外。本決定は新規書込経路を一切導入しない。
+
+## 検討した選択肢と評価
+
+| 案 | 概要 | 評価 |
+|---|---|---|
+| **B** engine が tmux `%N` を併記（dual-key） | engine 子に tmux identity を持たせ突合 | ❌ 不成立。engine 子は WezTerm pane で tmux 非所属 → `%N` を持たない（取得対象が存在しない） |
+| **C** wez-primary 俯瞰（`wez pane list` 整数で突合） | wez 側に寄せて整数 ID で一致 | ❌ delegate 子が `wez pane list` に個別 ID として現れない（親ペインに潰れる）。engine 子のみの俯瞰に縮退 |
+| **A** spawn 時 `session_id↔wez↔tmux↔label` マッピング表 | 横断同定表を永続化 | ⚠️ F に縮退。各 session は wez か tmux の**片方の identity しか持たない** → 表は実質 `session_id → {mux, id}` の1対1属性。`label`/`workspace`/`parent_pane` は delegate registry にしかなく、横断キーは label でも張れない |
+| **F** engine session-state/audit を delegate へ拡張 | session 層で統一・delegate も session レコードを書く | ❌ 採用せず（DJ-188-2）。category error + breaking schema + ROI 繰延 + #114 陳腐化 |
+| **D** 統一しない・honest 2表 | engine 側と delegate 側を2つの別ビューで読む | ◯ 機能要件を満たす（受入1を基盤ごとに分解解釈、受入2は engine audit に限定）。本 ADR の DJ-188-3 は D を「read 時投影」に精緻化した形 |
+| **query-side fusion（読取時融合・採用方向）** | 永続マップ無し。read 時に両ソースを読み `kind`/`mux` 列付き1テーブルに投影（join しない・delegate 行は `timeline:none`） | ◎ read-only 維持・単一 cockpit ビュー・非対称を正直に表示。設計SO の codex/cursor 両者が #177 に最も堅いと収束。**#177 の実装選択（DJ-188-3 が許容）** |
+| **typed event/activity bus** | session_id 主キーの append-only event log。識別統一＝イベント型の統一 | △ deferred（DJ-188-4）。Stage-B 永続横断観測の本線候補 |
+| 実行基盤収束（#114 駆動）/ parent-scoped hub | spawn を1 mux に寄せる / 観測起点を親ペインに置く | △ #114 と同一スレッドで評価すべき・別 issue 寄り。本 ADR の identity 判断には不要 |
+
+## 帰結（本決定の影響範囲）
+
+- **identity モデル**: コード変更なし。2-world topology を**アーキテクチャ不変条件**として本 ADR + schema 注記に明文化。
+- **schema**: 構造変更なし。`session-state.schema.json` の `pane_id` description に「WezTerm 整数・delegate(tmux) 子は本 KVS の対象外（DJ-188-2）」を追記し、将来の F 方向の誤改修を予防（受入3 の明文化のコード面ガード）。
+- **#177（消費者）**: identity モデルが「基盤ごと・read 時相関・永続マップ無し」と確定し **unblock**。俯瞰の再設計（query-side fusion 単一ビュー or honest 2 ビュー）は #177 の判断で、本 ADR はロックしない（推奨方向のみ申し送り）。#177 当初 DJ-1/4/5/6 は再開時も有効。
+- **#114 / Stage-B**: 永続横断観測が要るとき event bus（DJ-188-4）を採る方針を申し送り。F に投資しないことで #114 との衝突を回避。
+- **テスト**: なし（schema description 追記のみ・構造/バリデーション不変）。
+
+## 代替案を採用しなかった理由（要点）
+
+- **F（session 層統一）を本 issue で実装しない**: 便益（単一俯瞰の永続基盤）は Stage-B まで顕在化せず、対して category error と schema breaking change のコストが先行する。永続化が必要になった時点で event bus（DJ-188-4）の方が #114 と整合し陳腐化しにくい。
+- **#177 をブロッカーのままにしない**: 破綻したのは #177 DJ-3 の pane_id ジョイン (a) であり、read 時投影／2表並置は topology 問題ではない。identity を「統一しない」と確定すること自体が #177 の unblock になる。
+
+## 関連
+
+- 探索トレイル（調査・実機観測・設計SO・DJ 経緯）: [discussion #188](../discussions/2026-06-19-discussion-188-identity-unification.md)
+- 出自と消費者: [discussion #177 cockpit 観測UI](../discussions/2026-06-19-discussion-cockpit-observation-ui.md)
+- 隣接 concern: [#114 クリーン出力チャネル](../discussions/2026-05-30-discussion-clean-output-channel-for-orchestration.md)
+- Issue: [#188](https://github.com/stlwolf/ai-development-hub/issues/188) / [#177](https://github.com/stlwolf/ai-development-hub/issues/177) / [#114](https://github.com/stlwolf/ai-development-hub/issues/114)

--- a/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md
@@ -123,7 +123,7 @@ Issue タイトル「identity 統一（tmux %N ↔ wez pane_id）」は**2つの
 - **収束2**: **#177 受入は「単一俯瞰／単一 identity」を要求していない**（§3 の暗黙前提 A1 は偽）。受入＝稼働俯瞰 + blocked/timeout 識別／1セッション start→end 追跡／read-only。「1画面ジョイン」は受入文言に無い。破綻したのは #177 DJ-3 の **pane_id ジョイン (a)** であって、2表並置 (b) は topology 問題ではない。[verified — issue 受入文言 + cockpit doc §6]
 - **収束3**: **案F（engine session-state/audit を delegate に拡張）は二重に不可**:
   - (i) **category error** — 対話 delegate 子は success/blocked/timeout の完了 lifecycle を持たない。engine の `state` enum に押し込むと「見た目は統一・意味論は非対称」になる（嘘になる）。
-  - (ii) **schema breaking change の過小評価** — `schemas/session-state.schema.json:14` と `audit-log.schema.json` が `pane_id: integer`（WezTerm）で固定。`{mux,id}` 化は state + audit 両方の破壊変更。「registry に session_id+mux を足すだけ」では済まない。[verified — schema 直読]
+  - (ii) **schema breaking change の過小評価** — `schemas/session-state.schema.json:14` と `schemas/audit-log.schema.json` が `pane_id: integer`（WezTerm）で固定。`{mux,id}` 化は state + audit 両方の破壊変更。「registry に session_id+mux を足すだけ」では済まない。[verified — schema 直読]
 - **収束4**: **#114 が F の動機を弱める**。pane 非依存の `session_id` は #114（`claude -p` + file-redirect 化）後も残るが、`pane_id` 属性は engine の tmux 化／file-redirect 化で陳腐化。
 - **収束5**: read-only = 観測者拘束（仮定 A3 妥当）。spawn/delegate producer の書込は別レイヤで、#177 DJ-3(c) 棄却（観測UIが書く案）とは別。
 

--- a/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md
@@ -3,7 +3,7 @@ id: "01KVFGDQNXQ96TJCEDYB39KJ5B"
 title: "オーケストレーション2基盤の identity 統一（#188）— 設計探索"
 date: 2026-06-19
 type: discussion
-status: draft
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/188"
@@ -23,6 +23,12 @@ related:
   - type: source_material
     ref: "projects/orchestration-engine/lib/session.sh"
     reason: "session_id は pane 非依存生成（ULID 形式）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md"
+    reason: "本探索が帰結した設計判断（ADR・DJ-188-1..5）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/episodes/2026-06-19-episode-188-identity-unification.md"
+    reason: "本探索の closure episode"
 tags: [orchestration, identity, cockpit, observation, wez, tmux, discussion]
 ---
 

--- a/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md
@@ -1,0 +1,150 @@
+---
+id: "01KVFGDQNXQ96TJCEDYB39KJ5B"
+title: "オーケストレーション2基盤の identity 統一（#188）— 設計探索"
+date: 2026-06-19
+type: discussion
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/188"
+    reason: "本探索の対象 Issue（2基盤の identity 分裂を独立タスクとして解決）"
+  - type: source_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/177"
+    reason: "出自。#177 俯瞰の設計SOで pane_id ジョイン破綻が判明 → 本 Issue を切り出し。#188 の消費者"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md"
+    reason: "#177 設計探索ログ。§6 で identity 分裂を root-cause と特定しピボット"
+  - type: source_material
+    ref: "projects/orchestration-engine/lib/spawn.sh"
+    reason: "engine spawn = wez pane split（wez 整数 pane_id）"
+  - type: source_material
+    ref: "projects/orchestration-engine/lib/delegate-registry.sh"
+    reason: "delegate registry = tmux %N キー・per-child レコード"
+  - type: source_material
+    ref: "projects/orchestration-engine/lib/session.sh"
+    reason: "session_id は pane 非依存生成（ULID 形式）"
+tags: [orchestration, identity, cockpit, observation, wez, tmux, discussion]
+---
+
+# オーケストレーション2基盤の identity 統一（#188）— 設計探索
+
+> pre-plan の設計探索ログ。**設計SO 完了・DJ 確定済み（§7-§9）**。設計判断はオーナー委任（#188 子セッション）+ 設計SO（codex gpt-5.5 + cursor）で確定。親 gate は PR 時 intent-check に緩和（オーナー指示 2026-06-19）。
+> 探索: read-only 調査サブエージェント（一次情報＝code/schema 直読）+ **実機観測**（runtime topology を直接確認）+ 設計SO（選択肢拡張つき）。
+
+## 1. Context
+
+`#188` は #177（cockpit 観測UI）の設計SOで「生存ペイン × session 状態を `pane_id` でジョイン」案が構造破綻したのを root-cause として切り出した Issue。問いは「2基盤の identity をそもそも統一すべきか／するならどの方式か」（解決策は未確定・presume しない）。
+
+2基盤:
+- **engine `oe`**（自律パイプライン）: `wez pane split` で子を作る → **wez 整数** pane_id。state KVS（完了時のみ）+ audit jsonl を session_id 主キーで書く。
+- **delegate**（対話 Claude 子）: `tmux split-window` で子を作る → **tmux `%N`**。registry のみ（state/audit を書かない）。
+
+## 2. 調査結果（一次情報 + 実機観測）
+
+### 2.1 コード直読（サブエージェント・file:line）
+
+| 問い | 結論 | 根拠 | status |
+|---|---|---|---|
+| engine spawn identity | `wez pane split` の戻り値＝**非負整数** pane_id。`^[0-9]+$` 検証あり | `lib/spawn.sh:12`、`projects/wezterm-ai-mode/lib/pane.sh:189-193`、`schemas/session-state.schema.json:14-17` | verified |
+| delegate registry 構造 | per-child JSON `{pane, label, workspace, parent_pane, role:"child"}`。キー= `server_pid_pane`。pane は tmux `#{pane_id}`（`%N`） | `lib/delegate-registry.sh:45-65`、`:26-31` | verified |
+| session_id 出自 | **pane 非依存**。`date -u +%Y%m%d%H%M%S`(14) + base32 random(12) の ULID 形式 | `lib/session.sh:4-20` | verified |
+| delegate 子は state/audit を書くか | **書かない**。oe-delegate → oe-send → `tmux send-keys` のみ。audit は engine の `oe_audit_emit` だけ | `bin/oe-delegate:145` → `bin/oe-send:57` → `lib/delegate-send.sh`（send-keys のみ） | verified |
+| delegate 子に session_id はあるか | **無い**。session_id を生成・記録するのは engine 経路のみ。delegate は registry の pane キーだけ | 上記の連鎖（session.sh は engine 経路で呼ばれる） | verified |
+
+### 2.2 実機観測（runtime topology — 本件の決定打）
+
+調査サブエージェントは「wez ペイン内で tmux が動くか（coexist か完全分離か）は file:line で確定できない」と限界を明示した。これを実機プローブで確定した:
+
+```text
+# 自セッション（#188 子）の環境
+TMUX_PANE=%33   WEZTERM_PANE=0   TERM_PROGRAM=tmux
+
+# tmux list-panes -a → 5 ペイン（すべて WezTerm pane 0 の内側）
+%0 win=1 #43 / %3 win=2 #183 / %32 win=3 #177(親) / %33 win=3(自分) / %27 win=7
+
+# wez pane list → wez ペインは pane_id:0 ただ1つ
+```
+
+**確定した topology**（verified — 実機直接観測）:
+- **tmux が WezTerm pane 0 の内側で動いている**（自分が `TMUX_PANE=%33` かつ `WEZTERM_PANE=0`）。現存する全 tmux ペイン（親 `%32` 含む）は wez からは pane 0 に潰れて**個別に見えない**。
+- したがって2基盤は「同じ物理ペインの別ID体系」ではなく、**別多重化レイヤの別物理エンティティ**:
+  - engine の `wez pane split` 子 = tmux の**外**に新 WezTerm ペイン（1,2…）→ **tmux からは不可視**（`%N` を持たない）。
+  - delegate の `tmux split-window` 子 = wez pane 0 の**内**の tmux ペイン → **wez からは不可視**（pane 0 に潰れる）。
+- **マップすべき pane↔pane の対応関係がそもそも存在しない。** `%5` と wez `5` が違うどころか、片方の世界の子はもう片方の世界に実体として現れない。
+
+> 残差: 「engine 子が tmux 不可視」は spawn.sh:12 + topology からの強い推論（live な engine 子の直接観測は未実施。wez-split ペインは tmux を起動しない限り tmux に属さず、engine はそこで agent を直接走らせる）。[verified-by-architecture]
+
+## 3. 設計空間の絞り込み（調査が効かせた絞り）
+
+Issue が挙げた候補に実機証拠を当てると、空間は大きく縮む:
+
+| 候補（Issue 由来） | 実機証拠による判定 |
+|---|---|
+| B: engine が tmux `%N` を併記（dual-key） | **物理的に不成立**。engine 子は WezTerm ペインで tmux に属さず、自分の `%N` を持たない（取得対象が存在しない）。 |
+| C: wez-primary 俯瞰（`wez pane list` 整数一致） | **delegate 子が原理的に載らない**。tmux 子は wez pane 0 に潰れ個別 ID を持たない。engine 子だけの俯瞰になる。 |
+| A: spawn 時 `session_id↔wez↔tmux↔label` マッピング表 | **F に縮退**。各 session は wez か tmux の**片方の identity しか持たない**（両方を持つ session は存在しない）→ 表は実質 `session_id → {mux, pane}` の1対1属性。 |
+
+→ 実質の判断軸は2つに収斂:
+
+- **D（統一しない・honest）**: マッピングを作らない。#177 は engine 側（wez 生存 + state/audit）と delegate 側（tmux 生存 + registry）を**2つの honest な別ビュー**として読む。書込ゼロ・read-only 純度最大。代償: 単一俯瞰にならない。`session/audit-first`（state/audit を持つ engine のみ session 俯瞰、delegate は registry 別建て）はこの系列の非対称変種。
+- **F（session 層で統一）**: pane-ID 層ではなく **session_id を主キー**にして両基盤が session レコードを書く。pane id は `{mux: wez|tmux, id}` の**属性に降格**。#177 は1つの session ストアを読み、native な生存ハンドルで pane 突合。代償: **delegate 経路に session レコード書込を新設**（現状 registry のみ）。ただし registry は既に per-child レコードを持つ → 「registry に session_id + mux タグを足す」程度に収まる可能性があり、コストは見かけより小さいかも（要 plan 精査）。
+
+## 4. ゼロベース再フレーム（調査が生んだ視点転換）
+
+Issue タイトル「identity 統一（tmux %N ↔ wez pane_id）」は**2つの ID 空間の間にマッピングを張る**前提を含む。実機証拠はその前提を否定する — **張るべき対応が無い**（別レイヤの別物）。
+
+- 正しい問いの立て直し: 「2つの pane-ID をどう対応づけるか」ではなく、「identity を**両多重化レイヤの上位＝session 層**に持ち上げるか（F）、それとも2世界を honest に並置するか（D）」。
+- pane-ID 層の解（A/B/C）は**アーキテクチャと戦う**ことになる。B/C は物理的に不成立、A は F に縮退。
+- 付随の整理: 「read-only 制約」は**観測者（#177）を縛るもの**であり、spawn 時の書込は**元からある書込経路**。F の session レコード書込は spawn/delegate 時に起き、観測者の read-only を破らない（Issue Q3「どの経路が書くか」への答え = spawn/delegate 経路）。[speculation — 制約解釈。SO/gate で検証]
+
+## 5. 未解決の問い（設計SO へ）
+
+1. **D vs F の選択**: #177 の価値は「単一俯瞰」を要求するか、honest 2ビューで足りるか。2基盤は観測セマンティクスが異質（engine=自律 state 中心 / delegate=対話 liveness+label 中心）→ 無理な単一スキーマ統一は category error かもしれない（D 寄りの論拠）。一方 F は将来の Stage-B メトリクス/#177 を1基盤に載せられる。
+2. **F なら delegate session レコードの粒度**: delegate 子は engine のような完了イベントを持たない（対話・親/人が駆動）。記録は spawn 時の liveness+label に留まる → 実質「registry の session 化」。session_id を delegate にも振るか。
+3. **#177 への影響**: D なら #177 は2ビュー前提で再設計、F なら単一 session ビュー前提で再設計。
+4. **#114（クリーン出力チャネル）との相互参照**: #114 が `claude -p` file-redirect 化を進めると観測基盤が再形成され identity モデルに影響しうる。F の投資が #114 で陳腐化しないか。
+
+## 6. 次の一手
+
+- 本 doc の §3-§5 を入力に **設計SO（`so-compare --with codex,cursor`・選択肢拡張つき）** を投入し、D/F 以外の見落とし選択肢と各案の欠陥を洗う。→ §7 で実施。
+- 投入可否は親 `%32` の gate を仰ぐ（中間報告済）。→ オーナーが「設計判断を委任・PR 時 intent-check」に緩和。以降 autonomous。
+
+## 7. 設計SO 結果（2026-06-19・codex gpt-5.5 + cursor auto・選択肢拡張つき）
+
+出力 `tmp/so-188-design/`（揮発・gitignore）。両者が**独立に同じ再フレームへ収束**:
+
+- **収束1**: topology + B/C/A 棄却は一次情報と整合（追認でなく検証）。[verified — 両者が code/schema 直読]
+- **収束2**: **#177 受入は「単一俯瞰／単一 identity」を要求していない**（§3 の暗黙前提 A1 は偽）。受入＝稼働俯瞰 + blocked/timeout 識別／1セッション start→end 追跡／read-only。「1画面ジョイン」は受入文言に無い。破綻したのは #177 DJ-3 の **pane_id ジョイン (a)** であって、2表並置 (b) は topology 問題ではない。[verified — issue 受入文言 + cockpit doc §6]
+- **収束3**: **案F（engine session-state/audit を delegate に拡張）は二重に不可**:
+  - (i) **category error** — 対話 delegate 子は success/blocked/timeout の完了 lifecycle を持たない。engine の `state` enum に押し込むと「見た目は統一・意味論は非対称」になる（嘘になる）。
+  - (ii) **schema breaking change の過小評価** — `schemas/session-state.schema.json:14` と `audit-log.schema.json` が `pane_id: integer`（WezTerm）で固定。`{mux,id}` 化は state + audit 両方の破壊変更。「registry に session_id+mux を足すだけ」では済まない。[verified — schema 直読]
+- **収束4**: **#114 が F の動機を弱める**。pane 非依存の `session_id` は #114（`claude -p` + file-redirect 化）後も残るが、`pane_id` 属性は engine の tmux 化／file-redirect 化で陳腐化。
+- **収束5**: read-only = 観測者拘束（仮定 A3 妥当）。spawn/delegate producer の書込は別レイヤで、#177 DJ-3(c) 棄却（観測UIが書く案）とは別。
+
+選択肢拡張で出たゼロベース代替（D/F の小変形でない・両者で概念が重複）:
+
+| 代替 | 差分軸 | 成立条件 / 検証 |
+|---|---|---|
+| **query-side fusion（読取時融合）** | データフロー: 永続マップ無し。#177 が read 時に wez+state/audit と tmux+registry を読み、`kind`/`mux` 列付き1テーブルに**投影**（join しない・delegate 行は `timeline:none`） | 受入が「単一 schema」でなく「単一 view」を許容。`oe-status --dry-run` 試作で列定義が破綻しないか。**両者が #177 に最も堅いと収束** |
+| **#177 スコープ分割（第3の道・#188 不要化）** | 責務分界: #177 = engine-only cockpit、delegate 俯瞰は既存 `oe-list`/`oe-select` に委ねる | #177 受入を「自律 pipeline セッション」に明文化 → ジョイン問題が消える |
+| **typed event/activity bus** | 技術カテゴリ: session-state KVS でなく `~/.claude/state/oe-events.jsonl` に全 spawn 経路が append-only emit。識別統一＝**イベント型の統一**（pane でなく） | 各 spawn 経路に thin emitter。#114 後も残る。Stage-B 着手時の永続横断観測の本線候補 |
+| （実行基盤収束 #114 駆動 / parent-scoped hub） | 実行経路を1 mux に寄せる / 観測起点を親ペインに置く | #114 と同一スレッドで評価すべき・別 issue 寄り |
+
+両者の推奨: **#177 を急ぐなら query-side fusion が最も堅い。永続 write を入れるなら F でなく typed event bus 寄り。session-state を delegate に拡張する案は今のコードと #114 の両方に対して筋が悪い。**
+
+## 8. 設計判断（DJ・#188 の結論）
+
+issue 受入が「観測ツール(#177)が相関できる、**または**『相関しない（別建て観測）』と明示決定され #177 が再設計可能になる」を許容することに基づき、SO の収束を踏まえ確定（オーナー委任の下で本セッションが確定）:
+
+- **DJ-188-1: pane-ID 層で identity を統一しない。** 2 つの pane-ID 空間（wez 整数／tmux `%N`）は別多重化レイヤの別物理エンティティで対応が存在しない＝現行2-spawn-path アーキテクチャ（engine=`wez pane split`／delegate=`tmux split-window`）の**不変条件**。案B/C は物理的に不成立、案A は F に縮退。
+- **DJ-188-2: engine の session-state/audit スキーマを delegate に拡張しない（案F 棄却）。** 理由＝(i) category error（非対称 lifecycle）/ (ii) `pane_id: integer` 固定 schema の破壊変更 / (iii) ROI が Stage-B（保留中）まで繰延 / (iv) #114 で陳腐化。
+- **DJ-188-3: identity は基盤ごとに保持し、相関が必要な場合は read 時に行う（永続マッピングを作らない）。** これが #177 の read-only 制約を満たす（観測者は両ソースを読むだけ・新規永続書込なし）。issue 受入の「相関しないと明示決定」に該当する確定。
+- **DJ-188-4: 将来 Stage-B で永続横断観測が必要になった場合は、session-state 拡張でなく `session_id` 主キーの typed append-only event/activity bus を採る。** 本 issue では実装しない（deferred）。
+- **DJ-188-5（受入3・read-only/write-path 整合）**: 「read-only」は観測者（#177）を縛る制約。既存の producer 側書込（delegate spawn 時の registry、engine 完了時の state/audit）は残る。本決定は新規書込経路を導入しない。
+
+> **昇格**: 本 DJ 群は topology 不変条件 + 「session-state を拡張せず event bus」原則を含み、#177/#114/Stage-B に再利用される横断的アーキ判断 → **Decision/ADR への昇格対象**（closure の episode-retrospective Step3 で最終判断、本件は昇格濃厚）。
+
+## 9. #177 への handoff（#188 スコープ外・方向の申し送りのみ）
+
+- #188 は identity モデルを「基盤ごと・read 時相関・永続マップ無し」と確定し、**#177 を unblock する**。#177 の再設計そのもの（query-side fusion の単一ビュー or honest 2 ビュー）は **#177 の判断**であり、#188 はロックしない。
+- 推奨方向（非拘束）: query-side projection（単一 cockpit ビュー + `kind` 列、delegate 行は liveness+label のみ・`timeline:none`）。#177 当初 DJ-1/4/5/6（UI 形態・oe-refute 対象外・tmux 既定・capture 導線）は再開時も有効。

--- a/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md
@@ -20,12 +20,15 @@ related:
   - type: source_material
     ref: "projects/orchestration-engine/schemas/audit-log.schema.json"
     reason: "per-session audit jsonl のスキーマ（監査ログ閲覧の対象）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md"
+    reason: "#188 の確定（identity は基盤ごと・read 時相関）。本俯瞰の前提・§7 で back-propagation"
 tags: [orchestration, cockpit, oe-status, observation, audit, read-only, discussion]
 ---
 
 # cockpit 観測UI（oe-status）設計探索 — read-only 俯瞰 + 監査ログ閲覧
 
-> pre-plan の設計探索ログ。**当初プランは設計SO で中核欠陥が判明し撤回**（§6）。#177 俯瞰は identity 統一（#188）解決後に再設計する。
+> pre-plan の設計探索ログ。**当初プランは設計SO で中核欠陥が判明し撤回**（§6）。#177 俯瞰は identity 統一（#188）の確定後に再設計する → **#188 確定済み（§7・[decision-188](2026-06-19-decision-188-identity-unification.md)）: identity は基盤ごと・read 時相関・永続マップ無し。俯瞰の方式（query-side fusion or honest 2 ビュー）は #177 の判断**。
 > 探索は調査サブエージェント（一次情報＝code/schema/issue 直読）+ オーナーとの DJ 確定で実施。
 
 ## 1. Context
@@ -107,3 +110,16 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, discuss
 **無効化された DJ**: DJ-3（best-effort ジョイン）と DJ-2 の前提（KVS＝完了源で俯瞰が成立する）。一方 §2 資産マップ（事実）と DJ-1/4/5/6（UI 形態・oe-refute 対象外・tmux 既定・capture 導線）は #177 再開時も有効。
 
 **ピボット決定（オーナー）**: 2 基盤の identity 分裂を root-cause として先に解決する **#188（オーケストレーション2基盤の identity 統一）** を起票。**#177 俯瞰は #188 の解決/設計確定後に再設計**（session/audit-first か別建て観測かは #188 で決める）。当初 plan doc（`docs/plans/2026-06-19-plan-177-oe-status.md`）は撤回・削除済。
+
+## 7. #188 の確定（2026-06-19・#188 → #177 back-propagation）
+
+#188（identity 統一）が確定し、#177 を unblock した。決定の要点（正本は [decision-188](2026-06-19-decision-188-identity-unification.md)）:
+
+- identity は **pane 層で統一しない**。2基盤は別多重化レイヤの別物理エンティティで対応が存在しない（実機観測: tmux は単一 WezTerm pane 内・engine の wez split 子は tmux 不可視・delegate の tmux 子は wez 不可視）。engine の session-state/audit を delegate に拡張する案も棄却（category error + `pane_id:integer` 固定 schema の breaking change + #114 で陳腐化）。
+- identity は基盤ごとに保持し、相関が必要なら **read 時に行う（永続マップ無し）**。これは #177 の read-only 制約を満たす（issue 受入の「相関しないと明示決定」に該当）。
+- 永続横断観測が要るときは session-state 拡張でなく `session_id` 主キーの event bus（deferred・Stage-B）。
+
+**#177 への含意（#188 はロックしない・方向の申し送り）**:
+
+- §6 で無効化された DJ-3（pane_id ジョイン）は復活しない。俯瞰は「生存ペイン ↔ session 状態を pane で join」ではなく、**read 時に両ソース（engine: wez + state/audit／delegate: tmux + registry）を `kind`/`mux` 列付き1テーブルに投影（join しない・delegate 行は `timeline:none`）= query-side fusion**、または honest 2 ビュー。どちらを採るかは #177 再設計時に決める（設計SO の codex/cursor は query-side fusion に収束）。
+- 有効な DJ-1/4/5/6（UI 形態・oe-refute 対象外・tmux 既定・capture 導線）は引き続き使える。

--- a/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md
@@ -28,7 +28,7 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, discuss
 
 # cockpit 観測UI（oe-status）設計探索 — read-only 俯瞰 + 監査ログ閲覧
 
-> pre-plan の設計探索ログ。**当初プランは設計SO で中核欠陥が判明し撤回**（§6）。#177 俯瞰は identity 統一（#188）の確定後に再設計する → **#188 確定済み（§7・[decision-188](2026-06-19-decision-188-identity-unification.md)）: identity は基盤ごと・read 時相関・永続マップ無し。俯瞰の方式（query-side fusion or honest 2 ビュー）は #177 の判断**。
+> pre-plan の設計探索ログ。**当初プランは設計SO で中核欠陥が判明し撤回**（§6）。#177 俯瞰は identity 統一（#188）の確定後に再設計する → **#188 確定済み（§7・[decision-188](../decisions/2026-06-19-decision-188-identity-unification.md)）: identity は基盤ごと・read 時相関・永続マップ無し。俯瞰の方式（query-side fusion or honest 2 ビュー）は #177 の判断**。
 > 探索は調査サブエージェント（一次情報＝code/schema/issue 直読）+ オーナーとの DJ 確定で実施。
 
 ## 1. Context
@@ -113,7 +113,7 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, discuss
 
 ## 7. #188 の確定（2026-06-19・#188 → #177 back-propagation）
 
-#188（identity 統一）が確定し、#177 を unblock した。決定の要点（正本は [decision-188](2026-06-19-decision-188-identity-unification.md)）:
+#188（identity 統一）が確定し、#177 を unblock した。決定の要点（正本は [decision-188](../decisions/2026-06-19-decision-188-identity-unification.md)）:
 
 - identity は **pane 層で統一しない**。2基盤は別多重化レイヤの別物理エンティティで対応が存在しない（実機観測: tmux は単一 WezTerm pane 内・engine の wez split 子は tmux 不可視・delegate の tmux 子は wez 不可視）。engine の session-state/audit を delegate に拡張する案も棄却（category error + `pane_id:integer` 固定 schema の breaking change + #114 で陳腐化）。
 - identity は基盤ごとに保持し、相関が必要なら **read 時に行う（永続マップ無し）**。これは #177 の read-only 制約を満たす（issue 受入の「相関しないと明示決定」に該当）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-19-episode-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-19-episode-188-identity-unification.md
@@ -46,7 +46,7 @@ tags: [orchestration, identity, cockpit, episode, decision, closure]
   - B/C = 物理的に不成立（engine 子は tmux 非所属で `%N` 無し／delegate 子は wez に個別表示されない）。
   - A = F に縮退（各 session は wez か tmux の片方の identity しか持たない）。
   - F = category error（対話子に完了 lifecycle が無く engine の `state` enum に押し込むと嘘）+ `pane_id: integer` 固定 schema の breaking change + ROI が Stage-B 繰延 + #114 で陳腐化。
-- 詳細は ADR `docs/decisions/2026-06-19-decision-188-identity-unification.md`。
+- 詳細は ADR `../decisions/2026-06-19-decision-188-identity-unification.md`。
 
 ## わかったこと（W）
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-19-episode-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-19-episode-188-identity-unification.md
@@ -1,0 +1,92 @@
+---
+id: "01KVFJH8A1FZHJNA2M75WZK6BT"
+title: "#188 オーケストレーション2基盤 identity 統一 — 設計判断 closure"
+date: 2026-06-19
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/188"
+    reason: "本 episode の対象タスク"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md"
+    reason: "本 episode が closure した設計判断の ADR（成果物）"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md"
+    reason: "探索トレイル（調査・実機観測・設計SO）"
+tags: [orchestration, identity, cockpit, episode, decision, closure]
+---
+
+# #188 オーケストレーション2基盤 identity 統一 — 設計判断 closure
+
+## Context（なぜ）
+
+`#177`（cockpit 観測UI）の設計SOで俯瞰の中核「生存ペイン × session 状態を `pane_id` でジョイン」案が構造破綻し、原因の identity 分裂を root-cause として `#188` を切り出した。本作業は #188 の設計判断（2基盤の identity をそもそも統一すべきか／方式）を disciplined フローで確定するもの。子セッション（親=cockpit `%32`）として実施。
+
+## 経緯（時系列・方針転回を含む）
+
+0. **（出自・方針転回）** #177 俯瞰の pane_id ジョインが設計SO で破綻 → identity 分裂を root-cause として #188 を切り出し（#177 当初 plan は撤回・削除）。
+1. 一次情報直読（Explore 委譲）+ 実機 topology 観測 → 「engine=wez 整数 pane / delegate=tmux %N、別多重化レイヤで相互不可視」を確定。
+2. 当初は Issue が挙げた A/B/C/D/F を「D（統一せず）vs F（session 層統一）」の二択に絞り、親 `%32` へ中間報告。
+3. オーナーが gate を「設計判断は委任・PR 時 intent-check」に緩和 → autonomous フローへ。
+4. 設計SO（`so-compare --with codex,cursor`・選択肢拡張つき）投入 → **方針転回**: codex/cursor が独立に「#177 は単一俯瞰を要求していない／F は category error + schema breaking で筋が悪い／pane でなく観測モデルの問題」と収束。D/F の外に query-side fusion・#177 スコープ分割・event bus が出た。
+5. 収束を踏まえ DJ-188-1..5 を確定（ADR 化）。
+
+## 事実・失敗（方針転回の記録）
+
+監査追跡性のため転回を独立に明示（いずれも省略せず上の経緯に対応）:
+- **転回1（出自）**: #177 の pane_id ジョイン設計が破綻 → #188 へ root-cause 切り出し（経緯 step 0）。
+- **転回2（絞り込みの是正）**: 自分は当初 A/B/C/D/F を D vs F に絞ったが、設計SO が「#177 は単一俯瞰を要求していない／F は category error + schema breaking」と是正し、query-side fusion 等を再提示（経緯 step 4）。
+- **誤見積もりの是正**: 案F を「registry に session_id 足すだけ」と過小評価していた点を SO が指摘（`pane_id: integer` 固定 schema の breaking change）。
+
+## 決定と根拠（棄却理由つき）
+
+- **確定**: identity を pane 層で統一しない（DJ-188-1）／ session-state を delegate に拡張する案 F を棄却（DJ-188-2）／ identity は基盤ごとに保持し相関は read 時（DJ-188-3）／ 永続横断観測が要れば event bus（DJ-188-4・deferred）／ read-only は観測者拘束（DJ-188-5）。
+- **棄却の「なぜ」**（diff から復元不可）:
+  - B/C = 物理的に不成立（engine 子は tmux 非所属で `%N` 無し／delegate 子は wez に個別表示されない）。
+  - A = F に縮退（各 session は wez か tmux の片方の identity しか持たない）。
+  - F = category error（対話子に完了 lifecycle が無く engine の `state` enum に押し込むと嘘）+ `pane_id: integer` 固定 schema の breaking change + ROI が Stage-B 繰延 + #114 で陳腐化。
+- 詳細は ADR `docs/decisions/2026-06-19-decision-188-identity-unification.md`。
+
+## わかったこと（W）
+
+- 実機 topology: tmux は**単一 WezTerm ペインの内側**で動く（`TMUX_PANE=%33` かつ `WEZTERM_PANE=0`、`tmux list-panes -a`=5 / `wez pane list`=1）。engine の wez-split 子は tmux 外の WezTerm pane（tmux 不可視）、delegate の tmux 子は wez では親ペインに潰れる（wez 不可視）。
+- `schemas/session-state.schema.json` と `audit-log.schema.json` が `pane_id: integer`（WezTerm）で固定 → F は両 schema の破壊変更を伴う（当初「registry に session_id 足すだけ」と過小評価していた点を SO が是正）。
+
+## 原則（pattern / anti-pattern）
+
+- **Anti-pattern**: 別々の多重化レイヤ（wez / tmux）の pane-ID を、pane 層で対応づけようとする。→ 対応する物理エンティティが存在せず不成立。
+  **Pattern**: identity は多重化レイヤの**上位**（session_id / read 時投影）で扱うか、honest に基盤ごと分離する。
+- **Anti-pattern**: 異質な lifecycle（自律 state vs 対話 liveness）を単一 state enum に押し込む（見た目の統一・意味論の非対称 = category error）。
+  **Pattern**: `kind`/`mux` で型を分け、read 時に投影。完了イベントの無い対話子に `timeline:none` を正直に出す。
+
+## 行動変更
+
+- `session-state.schema.json` の `pane_id` description に identity 境界注記を追加（トリガ＝将来 F 方向の誤改修、機構＝schema description、着地先＝`session-state.schema.json`）。DJ-188-2 のコード面ガード。
+
+## 蒸留シグナル
+
+- **Decision 昇格＝実施済**（ADR `2026-06-19-decision-188-identity-unification.md` を作成）。topology 不変条件 + 「session-state を拡張せず event bus」原則は #177/#114/Stage-B に再利用される横断判断のため。
+
+## closure gate
+
+- **次の消費者**: #177（俯瞰の再設計。identity モデルが「基盤ごと・read 時相関・永続マップ無し」と確定したことが前提）。将来 Stage-B（event bus 方針 DJ-188-4）。
+- **follow-up routing**:
+  - #177 俯瞰の再設計（query-side fusion 単一ビュー or honest 2 ビュー）→ **#177**（ADR §帰結 + discussion §9 に handoff 記載・本 #188 はロックしない）。
+  - query-side fusion の `oe-status --dry-run` 試作（両ソース同時読込で列定義が破綻しないかの検証）→ **#177**（俯瞰再設計の検証ステップ。discussion §7 由来）。
+  - 永続横断観測（event bus）→ **deferred**（DJ-188-4・Stage-B 着手時）。
+  - #114（クリーン出力チャネル）との相互参照 → **#114 設計時**に参照（ADR に記載）。
+- **status**: stable / **達成**（設計判断確定 + ADR + schema ガード + #177 unblock）。
+- **evidence anchor**: 設計SO 出力 `tmp/so-188-design/`（揮発・gitignore）→ 要点は discussion §7 + ADR §検討した選択肢 に転記済み。
+- **SO 証跡**: 設計SO = discussion §7。Step 4 closure SO = §Step4 に記載。
+
+## Step4（heavy tier 外部チェック）
+
+closure 品質の focused check を so-compare（`--with codex,cursor`）で実施。出力 `tmp/so-188-closure/`（揮発・gitignore）。設計の是非でなく closure 品質（失敗の選択的省略 / routing 網羅 / 揮発パス / back-propagation）に限定。
+
+**結果と対応**:
+- 方針転回の選択的省略: **なし**（両者一致）。#177→#188 ピボット・D/F→再フレーム・案F過小評価是正はいずれも記録済みと確認。
+- **back-propagation 漏れ（主要・両者指摘）**: #177 doc（`discussion-cockpit-observation-ui.md`）に #188 確定結果が未反映 → **#177 doc に §7 を追記し handoff を back-propagate、`related` に decision-188 を追加**（本コミットで対応済）。
+- **follow-up routing 欠落（cursor 指摘）**: discussion §7 の `oe-status --dry-run` 試作が未 routing → **下記 follow-up に #177 として追加**（本コミットで対応済）。
+- **discussion-188 status draft vs episode stable（軽微）**: discussion-188 を `stable` に確定、`related` に decision/episode を追加（本コミットで対応済）。
+- 軽微（pivot が経緯 timeline に薄い / 事実・失敗 独立節なし）: 経緯 step 0 に pivot を明記し下記「事実・失敗」節で対応済。

--- a/projects/orchestration-engine/schemas/session-state.schema.json
+++ b/projects/orchestration-engine/schemas/session-state.schema.json
@@ -13,7 +13,7 @@
     },
     "pane_id": {
       "type": "integer",
-      "description": "WezTerm ペイン ID",
+      "description": "WezTerm ペイン ID（wez 整数）。engine oe（wez pane split）専用。delegate 対話子（tmux %N）は別多重化レイヤで本 KVS の対象外 — identity 統一は pane 層で行わない（ADR docs/decisions/2026-06-19-decision-188-identity-unification.md, DJ-188-2）。",
       "minimum": 0
     },
     "state": {

--- a/projects/orchestration-engine/schemas/session-state.schema.json
+++ b/projects/orchestration-engine/schemas/session-state.schema.json
@@ -13,7 +13,7 @@
     },
     "pane_id": {
       "type": "integer",
-      "description": "WezTerm ペイン ID（wez 整数）。engine oe（wez pane split）専用。delegate 対話子（tmux %N）は別多重化レイヤで本 KVS の対象外 — identity 統一は pane 層で行わない（ADR docs/decisions/2026-06-19-decision-188-identity-unification.md, DJ-188-2）。",
+      "description": "WezTerm ペイン ID（wez 整数）。engine oe（wez pane split）専用。delegate 対話子（tmux %N）は別多重化レイヤで本 KVS の対象外 — identity 統一は pane 層で行わない（ADR projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md, DJ-188-1/DJ-188-2）。",
       "minimum": 0
     },
     "state": {


### PR DESCRIPTION
## 概要

#177 cockpit 俯瞰の設計SOで「生存ペイン × session 状態を `pane_id` でジョイン」案が構造破綻 → root-cause の identity 分裂を `#188` として切り出し、設計判断を確定した ADR + 探索トレイル + closure episode。**コード実装でなく設計判断が成果物**（issue 受入は「相関する、**または**相関しないと明示決定」を許容）。

## 確定した判断（DJ-188-1..5）

- **pane 層で identity を統一しない**。2基盤（engine=wez 整数 pane / delegate=tmux `%N`）は別多重化レイヤの別物理エンティティで対応が存在しない（実機観測で確定: tmux は単一 WezTerm pane 内、engine の wez split 子は tmux 不可視、delegate の tmux 子は wez 不可視）。
- engine session-state/audit を delegate に拡張する案 **F を棄却**（category error + `pane_id:integer` 固定 schema の breaking change + ROI が Stage-B 繰延 + #114 で陳腐化）。
- identity は基盤ごとに保持し、相関は **read 時に行う（永続マップ無し）** → 観測者 read-only 維持。`#177` を unblock。
- 永続横断観測が要れば session-state 拡張でなく `session_id` 主キーの **event bus**（deferred・Stage-B）。
- read-only は**観測者拘束**。新規書込経路は導入しない。

## 変更

- `projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md`（新規 ADR・`accepted`）
- `projects/orchestration-engine/docs/discussions/2026-06-19-discussion-188-identity-unification.md`（探索トレイル: 調査・実機観測・設計SO）
- `projects/orchestration-engine/docs/episodes/2026-06-19-episode-188-identity-unification.md`（closure episode・heavy tier）
- `projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md`（#177 doc に §7 で #188 確定結果を back-propagate）
- `projects/orchestration-engine/schemas/session-state.schema.json`（`pane_id` description に identity 境界注記・構造/バリデーション不変）

## 検証

- **設計SO**（`so-compare --with codex,cursor`・選択肢拡張つき）: D/F の外まで探索し再フレームを捕捉（#177 は単一俯瞰を要求していない／F は category error）。
- **closure SO**（`so-compare --with codex,cursor`・closure 品質）: back-propagation 漏れ等を検出 → 本 PR で反映済み。
- JSON 妥当性確認済（schema・`python3 -c json.load`）。

## 影響範囲 / 申し送り

- `#177`: identity モデルが「基盤ごと・read 時相関・永続マップ無し」と確定し unblock。俯瞰の再設計（query-side fusion 単一ビュー or honest 2 ビュー）は **#177 の判断**（本 PR はロックしない・方向のみ申し送り）。
- `#114` / Stage-B: event bus 方針を申し送り（deferred）。
- engine の identity モデルにコード変更なし（schema は description 注記のみ）。テストなし。

Refs #188, #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
