### PR TITLE
feat(wez): pane split に self/parent-window/explicit ターゲティング規約を追加

### DIFF
--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -104,7 +104,8 @@ Options:
   --bottom         Split vertically, new pane on the bottom
   --left / --top   Other directions
   --percent <N>    Size of the new pane as percentage 1-100 (default: 50)
-  --pane-id <ID>   Specify the source pane to split
+  --pane-id <ID>   Specify the source pane to split (explicit target)
+  --target <T>     Targeting mode: self | parent-window | explicit
   --cwd <PATH>     Set working directory for the new pane
   --json           Output result as JSON
   --wait-ready     Wait until the new pane is ready for input
@@ -112,6 +113,24 @@ Options:
 ```
 
 `--wait-ready` はポーリングで新ペインの出力が安定するまで待機する（tmux auto-attach のタイミング問題を吸収）。
+
+##### ターゲティング規約（`--target`）
+
+分割元ペインの解決方法を選ぶ。優先順位は **明示（`--pane-id` または `--target explicit`） > `self` > `parent-window`**。
+
+- `self` — このコマンドが動作しているペイン（`WEZTERM_PANE` 環境変数から解決）を分割する。MVP では `WEZTERM_PANE` のみ対応（TTY 逆引きは将来）。明示 `--target self` で `WEZTERM_PANE` が数値でも実在しない（stale）場合は exit 3（`WEZ_EXIT_PANE_NOT_FOUND`）。
+- `parent-window` — `self` のペインの `window_id` を `wezterm cli list` から引き、同ウィンドウ内の active pane（`is_active==true`）を分割元にする。`self` が解決できなければ `parent-window` も解決不能。`pane_id` / `window_id` は JSON が数値型でも文字列型でも一致するよう比較する。
+- `explicit` — `--pane-id <ID>` を分割元にする。`--target explicit` 指定時は `--pane-id` が必須（無ければ usage error）。
+
+`self` / `parent-window` を**明示**して解決できない場合（例: `WEZTERM_PANE` 未設定）は、フォールバックせず即エラー終了する（`wez discover` の「明示指定の失敗＝即エラー」思想に倣う）。
+
+既知の限界: 同一 window に active pane が複数報告される場合は JSON 順の先頭を採る（通常 window あたり active 1 の前提）。`--target` を複数指定すると最後が勝つ。
+
+###### 省略時デフォルトと後方互換
+
+`--target` と `--pane-id` を**両方省略**した場合は `self` を試行し、解決できなければ `--pane-id` を省略して `wezterm cli split-pane` のネイティブ既定（`WEZTERM_PANE` が設定済みならそれ、未設定なら active pane）に委ね、`WARNING` を出す。
+
+> **後方互換に関する注記**: `wezterm cli split-pane` のネイティブ既定は「`--pane-id` 省略時に `WEZTERM_PANE` を使い、未設定なら active pane にフォールバック」である。本変更でデフォルトが **「常に native 既定」→「`self` を `--pane-id` で明示渡し（解決不能時のみ native 既定にフォールバック）」** に変わった。B3 は native が使うのと同じ `WEZTERM_PANE` を明示渡しするので、`WEZTERM_PANE` が設定された端末では従来 native が選んでいたペインと同一ペインを分割する。解決不能時は `--pane-id` を省略し native の既定（`WEZTERM_PANE`→active pane）に委ねる。`wez pane split --bottom --percent 30 --wait-ready --timeout N` のような `--pane-id`/`--target` なしの呼び出し（`orchestration-engine` の `spawn.sh` 等）は壊れない。明示 `--pane-id N` の挙動は不変。
 
 #### `wez pane send`
 

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -119,7 +119,7 @@ Options:
 分割元ペインの解決方法を選ぶ。優先順位は **明示（`--pane-id` または `--target explicit`） > `self` > `parent-window`**。
 
 - `self` — このコマンドが動作しているペイン（`WEZTERM_PANE` 環境変数から解決）を分割する。MVP では `WEZTERM_PANE` のみ対応（TTY 逆引きは将来）。明示 `--target self` で `WEZTERM_PANE` が数値でも実在しない（stale）場合は exit 3（`WEZ_EXIT_PANE_NOT_FOUND`）。
-- `parent-window` — `self` のペインの `window_id` を `wezterm cli list` から引き、同ウィンドウ内の active pane（`is_active==true`）を分割元にする。`self` が解決できなければ `parent-window` も解決不能。`pane_id` / `window_id` は JSON が数値型でも文字列型でも一致するよう比較する。
+- `parent-window` — `self` のペインの `window_id` を `wezterm cli list` から引き、同ウィンドウ内の active pane（`is_active==true`）を分割元にする。`self` が解決できなければ `parent-window` も解決不能。`pane_id` / `window_id` は JSON が数値型でも文字列型でも一致するよう比較する。**`jq` 必須**（JSON から `window_id` / `is_active` を解決するため）。`jq` 未導入で明示 `--target parent-window` を指定した場合は `jq` 不在を示す明示エラーで exit 5（`WEZ_EXIT_PANE_OP_FAILED`）となる（`self`（`WEZTERM_PANE` のみ）と省略時デフォルトは `jq` 不要）。
 - `explicit` — `--pane-id <ID>` を分割元にする。`--target explicit` 指定時は `--pane-id` が必須（無ければ usage error）。
 
 `self` / `parent-window` を**明示**して解決できない場合（例: `WEZTERM_PANE` 未設定）は、フォールバックせず即エラー終了する（`wez discover` の「明示指定の失敗＝即エラー」思想に倣う）。

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md
@@ -6,6 +6,9 @@ related:
   - type: implements
     ref: ../plans/2026-04-20-kickoff-wez-pane.md
     reason: "DJ-2, DJ-4, DJ-5, DJ-6, DJ-7, kill 非対話設計の判断を記録"
+  - type: relates_to
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/174"
+    reason: "DJ-8 split ターゲティング規約 (self / parent-window / explicit) の判断を追記"
   - type: depends_on
     ref: ADR-001-cli-file-structure.md
     reason: "ファイル構成・命名規約を踏襲"
@@ -65,3 +68,23 @@ PoC-02 では `read -p "Kill pane?"` で確認を取っていたが、AI エー�
 ## capture の --lines 実装
 
 `--lines N` は `wezterm cli get-text` の全出力に対して `tail -n N` でフィルタリング。`--start-line -N` は「スクロールバック N 行前から画面末尾まで」を返すため、画面行数分余計になる問題を E2E テストで発見し修正。
+
+## DJ-8: split のターゲティング規約（#174）
+
+`wez pane split` に分割元ペインの解決方法を選ぶ `--target self|parent-window|explicit` フラグを追加。優先順位は **明示（`--pane-id` または `--target explicit`） > `self` > `parent-window`**。
+
+- `self`: `WEZTERM_PANE` 環境変数から「コマンドが動作しているペイン」を解決（MVP）。TTY 逆引きは将来スコープ。明示 `--target self` 指定時は解決した pane を `_wez_pane_exists` で実在確認し、`WEZTERM_PANE` が数値でも実在しなければ exit 3（`WEZ_EXIT_PANE_NOT_FOUND`）を返す（send/capture と一貫）。
+- `parent-window`: `self` のペインの `window_id` を `wezterm cli list --format json` から引き、同ウィンドウ内の active pane（`is_active==true`）を分割元にする。`self` が解決不能なら `parent-window` も解決不能。`pane_id` / `window_id` の比較は WezTerm の JSON が数値型でも文字列型でも一致するよう `tostring` ベースで行う。`self` の `window_id` が null/不在なら明示的に失敗させ、`window_id: null` の pane を誤採用しない。
+- `explicit`: 既存の `--pane-id <ID>` を踏襲。`--target explicit` 指定時は `--pane-id` 必須（無ければ usage error）。
+- 解決ヘルパー（`_wez_resolve_self_pane` / `_wez_resolve_parent_window_pane`）は ADR-001 / DJ-2 の `_wez_*` ヘルパー先頭配置に従い `lib/pane.sh` に置く。pane ターゲティングは pane 操作固有のため `lib/discover.sh`（socket 解決専用）ではなく `lib/pane.sh` を選択。
+
+#### 既知の限界
+
+- D1: `parent-window` で同一 window に `is_active==true` の pane が複数存在する場合、JSON 順の先頭を採る（WezTerm は通常 window あたり active 1 という前提）。
+- D2: `--target` を複数指定すると最後が勝つ（例: `--target explicit --target self` では `--pane-id` 必須チェックが後者の `self` で上書きされる）。病的入力につき仕様化はしない。
+
+### 省略時デフォルト（B3）と後方互換
+
+`--target` / `--pane-id` を両方省略した場合は **`self` を試行 → 解決不能なら `--pane-id` を省略し wezterm のネイティブ既定（`WEZTERM_PANE` が設定済みならそれ、未設定なら active pane）に委ねる + `wez_warn`**。一方、ユーザが**明示**した `self` / `parent-window` が解決不能なら**フォールバックせず即エラー終了**（exit 3 = `WEZ_EXIT_PANE_NOT_FOUND`）。これは `discover.sh` の「明示指定の失敗＝即エラー」思想に倣う。
+
+後方互換: 本変更でデフォルトが **「常に native 既定」→「`self` を明示渡し（解決不能時のみ native 既定にフォールバック）」** に変わる。B3 は native が使うのと同じ `WEZTERM_PANE` を `--pane-id` で明示渡しするため、`WEZTERM_PANE` が設定された端末では従来 native が選んでいたペインと同一ペインを分割する。解決不能時は `--pane-id` を省略し native の既定（`WEZTERM_PANE`→active pane）に委ねる。`--pane-id`/`--target` なしの呼び出し（`orchestration-engine` の `spawn.sh` 等）は壊れない。明示 `--pane-id N` の挙動は不変。

--- a/projects/wezterm-ai-mode/docs/episodes/2026-06-19-episode-wez-split-targeting.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-06-19-episode-wez-split-targeting.md
@@ -1,0 +1,82 @@
+---
+id: "01KVFKJT5S584R7VXB88TCE9D7"
+title: "wez pane split ターゲティング規約（--target self/parent-window/explicit）実装"
+date: 2026-06-19
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/174"
+    reason: "本 episode の対象 Issue"
+  - type: decision
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md"
+    reason: "DJ-8 として targeting 規約の決定を昇格（蒸留シグナル）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/165"
+    reason: "本規約を再利用する wez layout（次の消費者）。#174 は #165 から切り出した前提プリミティブ"
+tags: [wezterm, wez-pane, split, targeting, cockpit, episode]
+---
+
+# wez pane split ターゲティング規約 実装
+
+## Context / なぜ
+
+cockpit（#169）/ wez layout（#165）/ engine `spawn.sh` が共通で使う `wez pane split` は、`--pane-id` 省略時に WezTerm のアクティブペイン依存で分割先が不定になる（親が別ウィンドウをアクティブにしていると意図しないウィンドウにペインが生える、#165 で観察）。これを安定させる targeting 規約を `wez` CLI に導入した。#174 は #165 の前提プリミティブとして切り出された。
+
+## 次の消費者
+
+- **#165 wez layout apply**: 本 targeting 規約を盤面構築で使う（直接の依存先）。
+- 後続 issue: `spawn.sh` のハードコード split を本規約へ置換（#174 範囲外）。
+
+## やったこと（要件 → 実装）
+
+- `--target self|parent-window|explicit` を split に追加（`lib/pane.sh`）。優先順位 = explicit(`--pane-id`/`--target explicit`) > self > parent-window。
+- 解決ヘルパー: `_wez_resolve_self_pane`（`WEZTERM_PANE` から・MVP）/ `_wez_resolve_parent_window_pane`（self の `window_id` を `wezterm cli list` から引き同 window の active pane）。
+- 省略時デフォルト（DJ-b=B3）: self 試行 → 解決不能なら native default（`--pane-id` 省略）にフォールバック + warn。明示 self/parent-window の解決失敗は exit 3。
+- 後方互換: 既存 `--pane-id` 不変。`spawn.sh:12` の省略呼び出しは native と同じ `WEZTERM_PANE` を解決するため同一ペインを分割（回帰なし）。
+
+## 決定と根拠（Decision 昇格 → ADR-004 DJ-8）
+
+- DJ-a インタフェース = `--target <mode>`（名前付き規約・拡張性）。activate が pane-id 必須化した「既存一貫性優先」前例と緊張するが、split は規約導入が要件のため名前付き mode を採用。
+- DJ-b デフォルト = B3（self+フォールバック）。「default→規約」と「spawn.sh 非破壊」を両立する唯一の線。明示指定は discover の「明示失敗=即エラー」思想に倣いエラー。
+- DJ-c self = `WEZTERM_PANE`（MVP）。TTY 逆引きは env 非伝搬が問題化したら後続（未着手）。
+- 棄却: 個別フラグ（DJ-a A2）/ デフォルト維持 opt-in（B2・default を変えない）/ self 即エラー（B1・spawn 破壊リスク）。
+
+## わかったこと（W）
+
+- **WezTerm native `split-pane`（`--pane-id` 省略）の既定は「active pane」ではなく `WEZTERM_PANE`（呼び出し元ペイン）。未設定時に active pane**（公式仕様 + `split-pane --help`）。当初 doc が「active pane」と誤記しており実装SO で是正（M1）。
+- `wezterm cli list` の `pane_id` は JSON 数値/文字列のいずれもあり得る → 解決 jq は tostring 比較で版差を吸収（既存 `_wez_pane_exists` と同流儀）。
+
+## 検証
+
+- mock shim テスト（PATH 差し替え `wezterm`・fixture `cli list` JSON）新設: **19 passed / 0 failed**（wezterm-ai-mode 初のテストハーネス）。引数パース・優先順位・B3・明示エラー・後方互換・型差・stale self・非数値 env を機械検証。
+- `shellcheck` clean（`pane.sh` + test）。
+- 実機スモーク（実 wezterm で split→kill）: self/parent-window/default が成功、エラー経路が 64/64/3。
+
+## 実装SO（heavy: 意図起動の外部レビュー）
+
+`so-compare --with codex,cursor`（出力 `tmp/so-20260619-180456/`・揮発）で欠陥検出。後方互換の回帰は無し（codex の「別ペイン分割」は active-pane と `WEZTERM_PANE` の混同で過大主張・cursor が訂正）。1 ラウンドで修正:
+- M1: doc/warn の「active pane」誤記を `WEZTERM_PANE` 基準へ是正（back-propagation）。
+- R1: parent-window jq を tostring 比較 + `$win` null ガード（型差・self 不在で誤採用しない）。
+- R2: 明示 `--target self` の stale pane を `_wez_pane_exists` で検出し exit 3（send/capture と一貫）。
+
+## follow-up routing
+
+- D1（同 window 複数 `is_active` → JSON 順先頭）: ADR-004 DJ-8 に既知限界として記載（destination = ADR。WezTerm は通常 window あたり active 1）。
+- D2（`--target` 二重指定で後勝ち・explicit 必須チェック迂回）: ADR-004 DJ-8 に既知限界として記載（病的入力）。
+- self の TTY 逆引き（C2）: `WEZTERM_PANE` 非伝搬が実問題化したら後続（現状は env 一本で十分）。
+- `spawn.sh` の本規約への置換: 別 issue（#174 範囲外）。
+- 未解決の open issue 化は無し（上記はすべて ADR 記載 or 明示的に「後続/不要」）。
+
+## 蒸留シグナル
+
+- **Decision**: ADR-004 DJ-8（targeting 規約）として昇格済。
+- skill / rule / #62: なし。
+
+## status
+
+達成（stable）。受入条件3点（アクティブウィンドウ切替時も意図通り[実機スモーク]/ `--pane-id` 非破壊 / shellcheck）を満たす。
+
+## Step 4 外部チェック（heavy tier）
+
+Step4 辞退: closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation）は本 episode で自己充足 — 実装SO の指摘・修正・過大主張の訂正を省略せず記載、follow-up は全て ADR 記載 or 後続/不要に routing、揮発 SO パスの要点は本文へ転記、doc 誤記は M1 で back-propagate 済。コード品質は実装SO（別レーン）が既に担保。/ 既存チェックで覆った観点: routing / evidence anchor / 省略チェック / back-propagation / 未実施観点と判断: なし。

--- a/projects/wezterm-ai-mode/lib/pane.sh
+++ b/projects/wezterm-ai-mode/lib/pane.sh
@@ -45,6 +45,66 @@ _wez_strip_trailing_blank() {
 # _wez_strip_ansi: removed (was dormant and BSD sed incompatible).
 # Re-implement in awk when --raw post-processing is needed.
 
+# --- Split targeting resolution (DJ-8) ---
+
+# Resolve the "self" pane id from the WEZTERM_PANE environment variable (MVP).
+# TTY reverse-lookup is out of scope (future).
+# Outputs:
+#   stdout: numeric pane id on success
+# Returns:
+#   0 on success, 1 when WEZTERM_PANE is unset/empty/non-numeric
+_wez_resolve_self_pane() {
+  local self="${WEZTERM_PANE:-}"
+  if [[ -n "$self" ]] && [[ "$self" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$self"
+    return 0
+  fi
+  return 1
+}
+
+# Resolve the active pane within the same window as the "self" pane.
+# Looks up self's window_id from `wezterm cli list --format json`, then returns
+# the pane with is_active==true in that window. self must be resolvable first.
+# Outputs:
+#   stdout: numeric pane id on success
+# Returns:
+#   0 on success, 1 when self is unresolvable or no active pane is found
+_wez_resolve_parent_window_pane() {
+  local self_pane
+  if ! self_pane=$(_wez_resolve_self_pane); then
+    return 1
+  fi
+
+  local json
+  if ! json=$(wezterm cli list --format json 2>/dev/null); then
+    return 1
+  fi
+
+  command -v jq >/dev/null 2>&1 || return 1
+
+  # pane_id / window_id are compared as strings (tostring) to match whether
+  # WezTerm emits them as JSON numbers or strings (same approach as
+  # _wez_pane_exists). $win is required: if self's window_id is null/absent we
+  # fail explicitly rather than matching panes whose window_id is also null.
+  # D1 (known limit): if a window reports multiple is_active==true panes, the
+  # first in JSON order wins (WezTerm normally has one active pane per window).
+  local target
+  target=$(jq -r --arg self "$self_pane" '
+    (map(select((.pane_id | tostring) == $self)) | .[0].window_id) as $win
+    | if ($win == null) then empty
+      else
+        map(select((.window_id | tostring) == ($win | tostring) and .is_active == true))
+        | .[0].pane_id // empty
+      end
+  ' <<< "$json" 2>/dev/null) || return 1
+
+  if [[ -n "$target" ]] && [[ "$target" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$target"
+    return 0
+  fi
+  return 1
+}
+
 # --- Subcommand: list ---
 
 _wez_pane_list() {
@@ -101,6 +161,7 @@ _wez_pane_split() {
   local opt_direction="--right"
   local opt_percent=""
   local opt_pane_id=""
+  local opt_target=""
   local opt_json=false
   local opt_wait_ready=false
   local opt_timeout=10
@@ -129,6 +190,20 @@ _wez_pane_split() {
           return "${WEZ_EXIT_USAGE}"
         fi
         opt_pane_id="$2"; shift
+        ;;
+      --target)
+        if [[ -z "${2:-}" ]]; then
+          wez_error "pane split: --target requires a value (self|parent-window|explicit)"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        case "$2" in
+          self|parent-window|explicit) opt_target="$2" ;;
+          *)
+            wez_error "pane split: --target must be one of: self, parent-window, explicit (got: $2)"
+            return "${WEZ_EXIT_USAGE}"
+            ;;
+        esac
+        shift
         ;;
       --cwd)
         if [[ -z "${2:-}" ]]; then
@@ -163,7 +238,16 @@ Options:
   --left           Split horizontally, new pane on the left
   --top            Split vertically, new pane on the top
   --percent <N>    Size of the new pane as percentage (default: 50)
-  --pane-id <ID>   Specify the source pane to split
+  --pane-id <ID>   Specify the source pane to split (explicit target)
+  --target <T>     Targeting mode: self | parent-window | explicit
+                     self           Split the pane this command runs in
+                                    (resolved from WEZTERM_PANE)
+                     parent-window  Split the active pane in self's window
+                     explicit       Split --pane-id (which becomes required)
+                   Priority: explicit (--pane-id or --target explicit)
+                             > self > parent-window.
+                   Omitting both --target and --pane-id tries self and
+                   falls back to WezTerm's active pane (with a warning).
   --cwd <PATH>     Set working directory for the new pane
   --json           Output result as JSON
   --wait-ready     Wait until the new pane is ready for input
@@ -180,9 +264,50 @@ EOF
     shift
   done
 
+  # --- Resolve the source pane to split (DJ-8 targeting) ---
+  # Priority: explicit (--pane-id or --target explicit) > self > parent-window.
+  # The resolved id (if any) is appended as --pane-id; an empty resolution lets
+  # wezterm use its native default (WEZTERM_PANE if set, else the active pane).
+  local resolved_pane_id="$opt_pane_id"
+
+  if [[ "$opt_target" == "explicit" ]]; then
+    if [[ -z "$opt_pane_id" ]]; then
+      wez_error "pane split: --target explicit requires --pane-id"
+      return "${WEZ_EXIT_USAGE}"
+    fi
+    # explicit + --pane-id: id already in resolved_pane_id.
+  elif [[ -n "$opt_pane_id" ]]; then
+    # Explicit --pane-id (no/compatible --target): highest priority, use as-is.
+    resolved_pane_id="$opt_pane_id"
+  elif [[ "$opt_target" == "self" ]]; then
+    if ! resolved_pane_id=$(_wez_resolve_self_pane); then
+      wez_error "pane split: --target self could not resolve WEZTERM_PANE"
+      return "${WEZ_EXIT_PANE_NOT_FOUND}"
+    fi
+    # Explicit self: WEZTERM_PANE may be numeric but stale (pane gone). Verify
+    # existence for consistency with send/capture, returning NOT_FOUND(3)
+    # instead of letting the split fail later as OP_FAILED(5).
+    if ! _wez_pane_exists "$resolved_pane_id"; then
+      wez_error "pane split: --target self pane ${resolved_pane_id} not found"
+      return "${WEZ_EXIT_PANE_NOT_FOUND}"
+    fi
+  elif [[ "$opt_target" == "parent-window" ]]; then
+    if ! resolved_pane_id=$(_wez_resolve_parent_window_pane); then
+      wez_error "pane split: --target parent-window could not resolve the active pane (WEZTERM_PANE unset or window lookup failed)"
+      return "${WEZ_EXIT_PANE_NOT_FOUND}"
+    fi
+  else
+    # B3 default: no --target, no --pane-id. Try self; on failure omit --pane-id
+    # and let wezterm use its native default (WEZTERM_PANE if set, else active).
+    if ! resolved_pane_id=$(_wez_resolve_self_pane); then
+      wez_warn "pane split: WEZTERM_PANE unresolved; falling back to wezterm native default (WEZTERM_PANE if set, else active pane)"
+      resolved_pane_id=""
+    fi
+  fi
+
   local -a split_args=("$opt_direction")
   [[ -n "$opt_percent" ]] && split_args+=(--percent "$opt_percent")
-  [[ -n "$opt_pane_id" ]] && split_args+=(--pane-id "$opt_pane_id")
+  [[ -n "$resolved_pane_id" ]] && split_args+=(--pane-id "$resolved_pane_id")
   [[ -n "$opt_cwd" ]] && split_args+=(--cwd "$opt_cwd")
 
   local new_pane_id

--- a/projects/wezterm-ai-mode/lib/pane.sh
+++ b/projects/wezterm-ai-mode/lib/pane.sh
@@ -247,7 +247,9 @@ Options:
                    Priority: explicit (--pane-id or --target explicit)
                              > self > parent-window.
                    Omitting both --target and --pane-id tries self and
-                   falls back to WezTerm's active pane (with a warning).
+                   falls back to wezterm's native default with a warning
+                   (WEZTERM_PANE if set, else the active pane).
+                   Note: parent-window requires jq.
   --cwd <PATH>     Set working directory for the new pane
   --json           Output result as JSON
   --wait-ready     Wait until the new pane is ready for input
@@ -292,6 +294,14 @@ EOF
       return "${WEZ_EXIT_PANE_NOT_FOUND}"
     fi
   elif [[ "$opt_target" == "parent-window" ]]; then
+    # parent-window needs jq to query window_id / is_active from the list JSON.
+    # Detect jq absence first so the failure is a clear dependency error
+    # (OP_FAILED) rather than an opaque "pane not found". self (WEZTERM_PANE
+    # only) and the B3 default do not need jq and are unaffected.
+    if ! command -v jq >/dev/null 2>&1; then
+      wez_error "pane split: --target parent-window requires jq (not installed); install jq or use --target self / --pane-id"
+      return "${WEZ_EXIT_PANE_OP_FAILED}"
+    fi
     if ! resolved_pane_id=$(_wez_resolve_parent_window_pane); then
       wez_error "pane split: --target parent-window could not resolve the active pane (WEZTERM_PANE unset or window lookup failed)"
       return "${WEZ_EXIT_PANE_NOT_FOUND}"

--- a/projects/wezterm-ai-mode/tests/test_pane_split_targeting.sh
+++ b/projects/wezterm-ai-mode/tests/test_pane_split_targeting.sh
@@ -214,6 +214,25 @@ WEZ_TEST_FIXTURE="$FIXTURE_DEFAULT"
 # 誤って null window の pane を採用しないことを確認する (既定 fixture を使用)。
 run_case "parent-window: self absent from list fails (no null-window pane)" 7 3 SKIP -- --target parent-window
 
+# F3: 明示 --target parent-window で jq 未導入 → jq 不在の専用エラーで exit 5 (OP_FAILED)。
+# PANE_NOT_FOUND(3) ではなく依存失敗系に寄せる (Copilot #190 指摘)。
+# jq を PATH から外すため、この 1 ケースだけ PATH を mock pathbin のみに絞る
+# (pathbin には wezterm のみ・jq は無い)。終了後に PATH を復元する。
+reset_log
+export WEZTERM_PANE="0"
+_saved_path="$PATH"
+export PATH="$_TMP_DIR/pathbin"
+f3_out=$(_wez_pane_split --target parent-window 2>&1 >/dev/null)
+f3_rc=$?
+export PATH="$_saved_path"
+unset WEZTERM_PANE
+f3_pane="$(split_pane_id_from_log)"
+if [[ "$f3_rc" -eq 5 && -z "$f3_pane" && "$f3_out" == *"jq"* ]]; then
+  ok "F3: parent-window without jq is an explicit OP_FAILED(5) error"
+else
+  fail "F3: expected exit 5 + jq-mentioning error + no split (rc=$f3_rc pane='$f3_pane' out=$f3_out)"
+fi
+
 # ============================================================
 # 4) 明示 self / parent-window で解決不能 → エラー終了 (フォールバックしない)
 # ============================================================

--- a/projects/wezterm-ai-mode/tests/test_pane_split_targeting.sh
+++ b/projects/wezterm-ai-mode/tests/test_pane_split_targeting.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test_pane_split_targeting.sh — wez pane split の --target ターゲティング規約を検証する (#174)
+#
+# 単体テストハーネスは無いため (shellcheck + 手動 E2E 規約)、mock shim 方式を新設する:
+#   - PATH 先頭に mock `wezterm` を置き、`wezterm cli split-pane` の引数を log に記録する。
+#     `wezterm cli list` は固定 fixture JSON を返す (window_id / is_active / pane_id を含む)。
+#   - lib/common.sh + lib/pane.sh を source し、対象関数 `_wez_pane_split` を直接呼ぶ。
+#     socket discovery (wez_cmd_pane) は本テストの対象外のため経由しない。
+#
+# 前例:
+#   - projects/orchestration-engine/tests/e2e_real_agent/bin/wez (PATH 先頭の shim)
+#   - projects/orchestration-engine/tests/test_oe_select.sh:6-11 (export PATH で stub 分離)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/pathbin" "$_TMP_DIR/logs"
+
+SPLIT_LOG="$_TMP_DIR/logs/split-pane-args.log"
+
+# --- Fixtures: `wezterm cli list --format json` の出力 (実機例の構造) ---
+# 既定 fixture (numeric pane_id):
+#   window 0: pane 0 (active=false), pane 1 (active=true) ← parent-window で期待される基準ペイン
+#   window 5: pane 9 (active=true) ← 別ウィンドウ。誤って選ばれないことの確認用
+FIXTURE_DEFAULT="$_TMP_DIR/fixture-default.json"
+cat > "$FIXTURE_DEFAULT" <<'JSON'
+[
+  {"window_id":0,"tab_id":0,"pane_id":0,"is_active":false,"tty_name":"/dev/ttys000"},
+  {"window_id":0,"tab_id":0,"pane_id":1,"is_active":true,"tty_name":"/dev/ttys001"},
+  {"window_id":5,"tab_id":2,"pane_id":9,"is_active":true,"tty_name":"/dev/ttys009"}
+]
+JSON
+
+# 文字列型 fixture (R1): pane_id / window_id を JSON 文字列型にしても解決されること。
+#   self=0 → window "0" の active pane = pane "1"
+FIXTURE_STRING_IDS="$_TMP_DIR/fixture-string-ids.json"
+cat > "$FIXTURE_STRING_IDS" <<'JSON'
+[
+  {"window_id":"0","tab_id":"0","pane_id":"0","is_active":false,"tty_name":"/dev/ttys000"},
+  {"window_id":"0","tab_id":"0","pane_id":"1","is_active":true,"tty_name":"/dev/ttys001"},
+  {"window_id":"5","tab_id":"2","pane_id":"9","is_active":true,"tty_name":"/dev/ttys009"}
+]
+JSON
+
+# self 不在 (R1) は専用 fixture を要しない: 既定 fixture (pane 0/1/9) に対し
+# self=7 を指定すれば self が list に不在となり window_id が引けない (null) →
+# parent-window は失敗すべき。FIXTURE_DEFAULT をそのまま使う。
+
+# どの fixture を `wezterm cli list` が返すかをテストごとに切り替える (既定は FIXTURE_DEFAULT)。
+export WEZ_TEST_FIXTURE="$FIXTURE_DEFAULT"
+
+# --- mock wezterm: split-pane は引数を log に記録し固定 pane id を返す。list は fixture を返す ---
+cat > "$_TMP_DIR/pathbin/wezterm" <<EOF
+#!/usr/bin/env bash
+# \$1 == "cli", \$2 == subcommand
+if [[ "\${1:-}" == "cli" && "\${2:-}" == "split-pane" ]]; then
+  shift 2
+  : > "$SPLIT_LOG"
+  for a in "\$@"; do printf '%s\n' "\$a" >> "$SPLIT_LOG"; done
+  printf '%s\n' "42"   # 新ペイン id (固定)
+  exit 0
+fi
+if [[ "\${1:-}" == "cli" && "\${2:-}" == "list" ]]; then
+  cat "\${WEZ_TEST_FIXTURE:-$FIXTURE_DEFAULT}"
+  exit 0
+fi
+if [[ "\${1:-}" == "cli" && "\${2:-}" == "get-text" ]]; then
+  # --wait-ready 用: 安定した非空出力を返す (stable tail で即 ready 判定)
+  printf 'ready\n'
+  exit 0
+fi
+echo "mock wezterm: unexpected args: \$*" >&2
+exit 1
+EOF
+chmod +x "$_TMP_DIR/pathbin/wezterm"
+
+export PATH="$_TMP_DIR/pathbin:$PATH"
+
+# shellcheck source=../lib/common.sh
+source "$PROJECT_DIR/lib/common.sh"
+# shellcheck source=../lib/pane.sh
+source "$PROJECT_DIR/lib/pane.sh"
+
+# --- Test harness ---
+PASS=0
+FAIL=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  printf 'ok: %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+# split log に記録された --pane-id の値を返す (無ければ空)
+split_pane_id_from_log() {
+  [[ -f "$SPLIT_LOG" ]] || return 0
+  awk '/^--pane-id$/{getline; print; exit}' "$SPLIT_LOG"
+}
+reset_log() { rm -f "$SPLIT_LOG"; }
+
+# 関数を呼んで exit code と (任意で) 期待 pane-id を検証する共通ルーチン。
+# 引数: <name> <wezterm_pane|UNSET> <expected_exit> <expected_pane_id|SKIP> -- <split args...>
+# WEZTERM_PANE はここで設定/解除する (subshell を使わず PASS/FAIL を親に反映させるため)。
+run_case() {
+  local name="$1" wpane="$2" exp_exit="$3" exp_pane="$4"
+  shift 5   # name wpane exp_exit exp_pane "--"
+
+  if [[ "$wpane" == "UNSET" ]]; then
+    unset WEZTERM_PANE
+  else
+    export WEZTERM_PANE="$wpane"
+  fi
+
+  reset_log
+  local out rc
+  out=$(_wez_pane_split "$@" 2>/dev/null); rc=$?
+  unset WEZTERM_PANE
+
+  if [[ "$rc" -ne "$exp_exit" ]]; then
+    fail "$name: exit code expected=$exp_exit got=$rc (stdout=$out)"
+    return
+  fi
+  if [[ "$exp_pane" != "SKIP" ]]; then
+    local got; got="$(split_pane_id_from_log)"
+    if [[ "$got" != "$exp_pane" ]]; then
+      fail "$name: --pane-id expected='$exp_pane' got='$got'"
+      return
+    fi
+  fi
+  ok "$name"
+}
+
+# run_case <name> <WEZTERM_PANE|UNSET> <expected_exit> <expected_pane_id|SKIP> -- <args...>
+
+# ============================================================
+# 1) --target 引数パース
+# ============================================================
+
+# 不正値 → usage error (64)
+run_case "parse: invalid --target value" UNSET 64 SKIP -- --target bogus
+
+# --target に値なし → usage error
+run_case "parse: --target without value" UNSET 64 SKIP -- --target
+
+# --target explicit で --pane-id 欠落 → usage error
+run_case "parse: --target explicit without --pane-id" UNSET 64 SKIP -- --target explicit
+
+# ============================================================
+# 2) self 解決
+# ============================================================
+
+# WEZTERM_PANE セット時に --target self → その id が --pane-id として渡る
+# (R2: 明示 self は実在確認するため、fixture に存在する pane 1 を使う)
+run_case "self: WEZTERM_PANE resolves to --pane-id" 1 0 1 -- --target self
+
+# 省略 (--target/--pane-id なし) + WEZTERM_PANE セット → self を試行し id が渡る (後方互換: 既存挙動同等)
+run_case "default: omitted resolves to self via WEZTERM_PANE" 3 0 3 -- --bottom --percent 30
+
+# 省略 + WEZTERM_PANE 未セット → active-pane フォールバック (--pane-id 渡さない) + warn。exit 0
+run_case "default: omitted + no WEZTERM_PANE falls back to active pane" UNSET 0 "" -- --bottom --percent 30
+
+# 省略時フォールバックで warn が出ることを確認
+reset_log
+unset WEZTERM_PANE
+warn_out=$(_wez_pane_split --bottom --percent 30 2>&1 >/dev/null)
+if [[ "$warn_out" == *"WARNING"* && "$warn_out" == *"native default"* ]]; then
+  ok "default: fallback emits warning"
+else
+  fail "default: fallback warning missing (got: $warn_out)"
+fi
+
+# M1: B3 default + 非数値 WEZTERM_PANE → fallback (--pane-id 省略) + warn。
+# warn 文言が「active pane」を断定せず native 既定 (WEZTERM_PANE→active pane) と
+# 表現することを確認する (WezTerm native は --pane-id 省略時 WEZTERM_PANE を使い、
+# 未設定時のみ active pane にフォールバックする — 公式仕様)。
+reset_log
+export WEZTERM_PANE="not-a-number"
+m1_out=$(_wez_pane_split --bottom --percent 30 2>&1 >/dev/null)
+m1_rc=$?
+unset WEZTERM_PANE
+m1_pane="$(split_pane_id_from_log)"
+if [[ "$m1_rc" -eq 0 && -z "$m1_pane" \
+  && "$m1_out" == *"WARNING"* \
+  && "$m1_out" == *"WEZTERM_PANE if set, else active pane"* ]]; then
+  ok "M1: non-numeric WEZTERM_PANE falls back to native default with accurate warn"
+else
+  fail "M1: expected fallback (rc=0,no --pane-id) + native-default warn (rc=$m1_rc pane='$m1_pane' out=$m1_out)"
+fi
+
+# ============================================================
+# 3) parent-window 解決
+# ============================================================
+
+# self=0 → window 0 の active pane = pane 1 が --pane-id として渡る
+run_case "parent-window: resolves active pane in self's window" 0 0 1 -- --target parent-window
+
+# self=1 (それ自身 active) → 同 window の active pane = 1
+run_case "parent-window: self already active" 1 0 1 -- --target parent-window
+
+# R1: pane_id / window_id が JSON 文字列型でも active pane が解決される (tostring 比較)
+WEZ_TEST_FIXTURE="$FIXTURE_STRING_IDS"
+run_case "parent-window: string-typed ids still resolve active pane" 0 0 1 -- --target parent-window
+WEZ_TEST_FIXTURE="$FIXTURE_DEFAULT"
+
+# R1: self が list に不在 (self=7 は fixture の 0/1/9 に無い → window_id を引けない=null)
+# → parent-window は失敗。明示 --target parent-window なので解決不能はエラー (exit 3)。
+# 誤って null window の pane を採用しないことを確認する (既定 fixture を使用)。
+run_case "parent-window: self absent from list fails (no null-window pane)" 7 3 SKIP -- --target parent-window
+
+# ============================================================
+# 4) 明示 self / parent-window で解決不能 → エラー終了 (フォールバックしない)
+# ============================================================
+
+# 明示 --target self で WEZTERM_PANE 未セット → PANE_NOT_FOUND (3)
+run_case "self: explicit unresolved is an error (no fallback)" UNSET 3 SKIP -- --target self
+
+# R2: 明示 --target self で WEZTERM_PANE は数値だが list に不在 (stale) → PANE_NOT_FOUND (3)。
+# pane 7 は既定 fixture (0/1/9) に存在しない。split 失敗 (OP_FAILED=5) ではなく実在確認で 3。
+run_case "self: explicit numeric but stale pane is NOT_FOUND" 7 3 SKIP -- --target self
+
+# 明示 --target parent-window で WEZTERM_PANE 未セット → PANE_NOT_FOUND (3)
+run_case "parent-window: explicit unresolved is an error" UNSET 3 SKIP -- --target parent-window
+
+# ============================================================
+# 5) explicit / 後方互換 (--pane-id)
+# ============================================================
+
+# 既存 --pane-id N が従来どおり渡る (後方互換)
+run_case "compat: bare --pane-id passes through" UNSET 0 12 -- --pane-id 12
+
+# --target explicit + --pane-id N → その id が渡る
+run_case "explicit: --target explicit + --pane-id" UNSET 0 8 -- --target explicit --pane-id 8
+
+# 明示 --pane-id は self より優先 (priority: explicit > self)
+run_case "priority: --pane-id wins over WEZTERM_PANE/self" 99 0 4 -- --pane-id 4
+
+# orchestration-engine spawn.sh / self_verify_attach.sh の呼び出し型 (--pane-id/--target なし) が壊れないこと
+# WEZTERM_PANE 未セット環境 (CI 的) → フォールバックで exit 0、pane-id 無し
+run_case "compat: engine spawn-style omitted call" UNSET 0 "" -- --bottom --percent 30 --wait-ready --timeout 10
+
+# ============================================================
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 目的

`wez pane split` の分割先不定性を解消する。`--pane-id` 省略時は WezTerm のアクティブペイン依存で、親が別ウィンドウをアクティブにしていると意図しないウィンドウにペインが生える（#165 で観察）。これを安定させる targeting 規約を導入する。`#165`（wez layout）の前提プリミティブ。

## 変更内容

- `wez pane split` に `--target self|parent-window|explicit` を追加（`projects/wezterm-ai-mode/lib/pane.sh`）
  - 優先順位: `explicit`（`--pane-id` または `--target explicit`） > `self` > `parent-window`
  - 解決ヘルパー: `_wez_resolve_self_pane`（`WEZTERM_PANE` から・MVP）/ `_wez_resolve_parent_window_pane`（self の `window_id` を `wezterm cli list` から引き同 window の active pane）
- 省略時デフォルト（DJ-b = B3）: `self` を試行 → 解決不能なら WezTerm native default（`--pane-id` 省略 = `WEZTERM_PANE` if set, else active pane）にフォールバック + warn。明示 `--target self`/`parent-window` の解決失敗は exit 3
- `ADR-004` に `DJ-8`（本規約の決定）を追記、`README` に targeting 節 + 後方互換注記
- mock shim テストハーネス新設（wezterm-ai-mode 初）+ episode 記録

## 後方互換（回帰なし）

- 既存 `wez pane split --pane-id N` は挙動不変
- `spawn.sh:12` / E2E の省略呼び出し（`--bottom --percent N --wait-ready --timeout N`）は、B3 が native と同じ `WEZTERM_PANE` を解決するため**同一ペインを分割**。未設定時は `--pane-id` を省略し native の既定に委ねる（同等）

## 設計判断（→ ADR-004 DJ-8）

- DJ-a インタフェース = `--target <mode>`（名前付き規約・拡張性）
- DJ-b デフォルト = B3（self+フォールバック）。「default→規約」と「spawn.sh 非破壊」を両立する唯一の線
- DJ-c self = `WEZTERM_PANE`（MVP）。TTY 逆引きは env 非伝搬が問題化したら後続

## 検証

- mock テスト（`tests/test_pane_split_targeting.sh`）: **19 passed / 0 failed**（引数パース・優先順位・B3・明示エラー・後方互換・型差・stale self・非数値 env）
- `shellcheck` clean（`lib/pane.sh` + test）
- 実機スモーク（実 wezterm で split→kill）: self/parent-window/default 成功、エラー経路 64/64/3

## 実装SO（codex + cursor）反映

- 後方互換の回帰は無し（codex の「別ペイン分割」は active-pane と `WEZTERM_PANE` の混同で過大主張・cursor が訂正）
- M1: doc/warn の「active pane」誤記を `WEZTERM_PANE` 基準へ是正
- R1: parent-window jq を tostring 比較 + `$win` null ガード（JSON 型差・self 不在で誤採用しない）
- R2: 明示 `--target self` の stale pane を `_wez_pane_exists` で検出し exit 3（send/capture と一貫）

## 既知限界（ADR-004 DJ-8 記載）

- D1: 同一 window に `is_active==true` が複数ある場合、JSON 順の先頭を採る（WezTerm は通常 window あたり active 1）
- D2: `--target` を複数指定すると最後が勝つ（病的入力）

## 範囲外

- 盤面 preset（#165）/ split 後フォーカス戻し（#165・#111）/ `spawn.sh` のハードコード置換（後続）/ self の TTY 逆引き（将来）

Refs #174
