### PR TITLE
feat(wez): pane-board を宣言的に構築する wez layout を追加

### DIFF
--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -205,7 +205,7 @@ Options:
 処理順:
 
 1. ソケットを解決し `WEZTERM_UNIX_SOCKET` を export（`wez_cmd_layout` が1回だけ）。未知サブコマンドは discovery より前に exit 64（`WEZ_EXIT_USAGE`）。
-2. preset を **`ROOT` 解決より前**に読み・検証する。preset 名は `[A-Za-z0-9._-]+` のみ許可（`/`・`..` は exit 64）。不在は exit 1（`WEZ_EXIT_NOT_FOUND`）、schema・引数不正は exit 64（`WEZ_EXIT_USAGE`）。`jq` 未導入は exit 64。
+2. preset を **`ROOT` 解決より前**に読み・検証する。preset 名は `[A-Za-z0-9._-]+` のみ許可（`/`・`..` は exit 64）。不在は exit 1（`WEZ_EXIT_NOT_FOUND`）、schema・引数不正は exit 64（`WEZ_EXIT_USAGE`）。`jq` 未導入は依存失敗として exit 5（`WEZ_EXIT_PANE_OP_FAILED`、`parent-window` と一貫）。
 3. `ROOT`（self ペイン = `WEZTERM_PANE`）を1回解決し実在確認。解決不能・stale なら exit 3（`WEZ_EXIT_PANE_NOT_FOUND`）。
 4. focus 対象（既定 `$ROOT`、`--focus <target>`、preset の `focus`）を**分割前に検証**する。`"root"`・preset の step id・数値 pane id のいずれでもなければ split せず exit 64。
 5. 各 step を順に **explicit `--pane-id $ROOT`** で分割する（`wez pane split` の省略時 active-pane フォールバックを踏ませない）。これにより親が**別ウィンドウを active にした状態でも** self 起点で同一盤面を再現する。
@@ -353,7 +353,7 @@ projects/wezterm-ai-mode/
 
 - **Bash** 3.2+
 - **wezterm** CLI（`brew install --cask wezterm`）
-- **jq**（`discover` / `pane` は推奨。不在時は `grep -c` フォールバックで動作。`layout` は**必須**で、未導入時は exit 64 で明示エラー）
+- **jq**（`discover` / `pane` は推奨。不在時は `grep -c` フォールバックで動作。`layout` は**必須**で、未導入時は依存失敗として exit 5 で明示エラー）
 
 ## 開発方式（検証ケース）
 

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -174,6 +174,97 @@ Options:
 
 指定ペインにフォーカスを移す（`wezterm cli activate-pane` 相当）。`split` はデフォルトで新ペインにフォーカスを奪うため、オーケストレータが作業ウィンドウのフォーカスを維持したい場合は `split` 直後に元ペイン id を `activate` してフォーカスを戻す。成功時は標準出力なし（`--json` 指定時のみ `{"pane_id":N,"status":"activated"}`）。
 
+### `wez layout`
+
+名付き JSON preset に沿ってペインの盤面（親1 + 子N）を機械的に構築する薄い上位層。既存の `wez pane split` プリミティブを preset 順に反復するだけの **wez 基盤専用・盤面構築のみ** のコマンド。**`jq` 必須**（preset 解析と map 出力に使用）。
+
+`wez pane` と同様にソケットを1回だけ解決し、以降の `wezterm cli` 呼び出しは `WEZTERM_UNIX_SOCKET` 経由。エージェント起動コマンドは持たない（盤面のみ。`apply --json` で pane_id map を返すので消費側がそれを使う）。tmux delegate は対象外。
+
+```
+Usage: wez layout [--socket <path>] <subcommand> [options]
+
+Subcommands:
+  apply <name>   Apply a layout preset (splits from the root/self pane)
+  list           List available preset names (lib/layouts/*.json)
+```
+
+> **非冪等（NON-IDEMPOTENT）に関する注記**: `layout apply` は create-only である。所有 marker や置換（`--replace`）は持たないため、**2 回 apply するとペインが倍増する**。「冪等」ではなく **「非冪等・clean baseline に対して再現的」** と理解すること。真の冪等（desired-state 差分）は本 PoC の範囲外。
+
+#### `wez layout apply`
+
+```
+Usage: wez layout apply <name> [options]
+
+Options:
+  --focus <target>   Pane to focus when done (default: root). Either "root", a
+                     step id from the preset, or a numeric pane id (literal).
+                     An invalid target is rejected (exit 64) before any split.
+  --json             Output result as JSON
+```
+
+処理順:
+
+1. ソケットを解決し `WEZTERM_UNIX_SOCKET` を export（`wez_cmd_layout` が1回だけ）。未知サブコマンドは discovery より前に exit 64（`WEZ_EXIT_USAGE`）。
+2. preset を **`ROOT` 解決より前**に読み・検証する。preset 名は `[A-Za-z0-9._-]+` のみ許可（`/`・`..` は exit 64）。不在は exit 1（`WEZ_EXIT_NOT_FOUND`）、schema・引数不正は exit 64（`WEZ_EXIT_USAGE`）。`jq` 未導入は exit 64。
+3. `ROOT`（self ペイン = `WEZTERM_PANE`）を1回解決し実在確認。解決不能・stale なら exit 3（`WEZ_EXIT_PANE_NOT_FOUND`）。
+4. focus 対象（既定 `$ROOT`、`--focus <target>`、preset の `focus`）を**分割前に検証**する。`"root"`・preset の step id・数値 pane id のいずれでもなければ split せず exit 64。
+5. 各 step を順に **explicit `--pane-id $ROOT`** で分割する（`wez pane split` の省略時 active-pane フォールバックを踏ませない）。これにより親が**別ウィンドウを active にした状態でも** self 起点で同一盤面を再現する。
+6. いずれかの split が失敗したら abort し、作成済みペインを**逆順に kill（rollback）** して exit 5（`WEZ_EXIT_PANE_OP_FAILED`）。`--json` 時は `{"status":"partial","root_pane_id":N,"created":[...],"failed_step":K,"rollback_failed":[...]}` を出力（`rollback_failed` は kill に失敗した orphan ペイン）。
+7. 全 step 成功後、focus を復帰する（既定 `$ROOT`、`--focus <target>` で上書き、数値 `--focus` はリテラル pane id）。
+
+**成功時 JSON 出力スキーマ**（`--json`）:
+
+```json
+{
+  "status": "ok",
+  "root_pane_id": 1,
+  "window_id": 0,
+  "panes": [
+    {"id": "worker1", "pane_id": 101, "index": 0},
+    {"id": "worker2", "pane_id": 102, "index": 1}
+  ]
+}
+```
+
+`window_id` は root ペインの所属ウィンドウ（`wezterm cli list` から解決）。
+
+#### `wez layout list`
+
+`lib/layouts/*.json` の preset 名を1行ずつ出力する。
+
+#### preset スキーマ（`lib/layouts/<name>.json`）
+
+```json
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30},
+    {"id": "worker2", "from": "root", "dir": "right", "percent": 50}
+  ],
+  "focus": "root"
+}
+```
+
+**PoC 制約**（逸脱は exit 64）:
+
+- `root` は `"self"` のみ。各 step の `from` は `"root"` のみ。
+- step の `id` は非空文字列。**全桁数値（`^[0-9]+$`）は不可**（数値 `--focus` のリテラル pane id 解釈と衝突するため）。
+- `dir` は次のいずれか。CLI の `--<dir>` フラグへ直接マップされる。
+
+  | `dir` | `wez pane split` フラグ |
+  |-------|------------------------|
+  | `bottom` | `--bottom` |
+  | `right`  | `--right` |
+  | `left`   | `--left` |
+  | `top`    | `--top` |
+
+- `percent` は **1〜99 の整数**（小数は schema 段階で exit 64）。
+- `focus` は `"root"`・step の `id`・数値 pane id のいずれか（既定 `"root"`）。`--focus` が指定されればそちらが優先。不正値は **分割前に** exit 64。
+- グリッド／ネストは将来の再帰ツリー schema v2（本 PoC の範囲外）。
+
+> **スコープ外**: layout は **wez 基盤専用**であり、tmux への delegate は持たない（別 issue）。価値は engine／非対話用の outer WezTerm board の構築に限る。
+
 ### `wez notify`
 
 WezTerm ペインに user-var（OSC 1337 SetUserVar）を送信する。送信方式は TTY 直接書き込み（primary）と command string（fallback）の2段階。
@@ -246,6 +337,8 @@ projects/wezterm-ai-mode/
 │   ├── common.sh        # 共通: カラー、ログ関数、exit code 定数
 │   ├── discover.sh      # wez discover の実装
 │   ├── pane.sh          # wez pane の実装（list/split/send/capture/kill/activate）
+│   ├── layout.sh        # wez layout の実装（apply/list・宣言的盤面構築）
+│   ├── layouts/         # layout preset（<name>.json）
 │   └── notify.sh        # wez notify の実装（TTY direct write + fallback）
 ├── docs/
 │   ├── VERIFICATION_MATRIX.md
@@ -260,7 +353,7 @@ projects/wezterm-ai-mode/
 
 - **Bash** 3.2+
 - **wezterm** CLI（`brew install --cask wezterm`）
-- **jq**（推奨。不在時は `grep -c` フォールバックで動作）
+- **jq**（`discover` / `pane` は推奨。不在時は `grep -c` フォールバックで動作。`layout` は**必須**で、未導入時は exit 64 で明示エラー）
 
 ## 開発方式（検証ケース）
 

--- a/projects/wezterm-ai-mode/bin/wez
+++ b/projects/wezterm-ai-mode/bin/wez
@@ -22,6 +22,8 @@ source "$WEZ_ROOT/lib/common.sh"
 source "$WEZ_ROOT/lib/discover.sh"
 # shellcheck source=../lib/pane.sh
 source "$WEZ_ROOT/lib/pane.sh"
+# shellcheck source=../lib/layout.sh
+source "$WEZ_ROOT/lib/layout.sh"
 # shellcheck source=../lib/notify.sh
 source "$WEZ_ROOT/lib/notify.sh"
 
@@ -34,6 +36,7 @@ Usage: wez <command> [options]
 Commands:
   discover    Auto-detect WezTerm socket and verify connection
   pane        Manage WezTerm panes (list, split, send, capture, kill, activate)
+  layout      Build declarative pane layouts from presets (apply, list)
   notify      Send a notification via user-var (OSC 1337)
   help        Show this help message
   version     Show version
@@ -52,6 +55,9 @@ wez_main() {
       ;;
     pane)
       wez_cmd_pane "$@"
+      ;;
+    layout)
+      wez_cmd_layout "$@"
       ;;
     notify)
       wez_cmd_notify "$@"

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md
@@ -9,6 +9,9 @@ related:
   - type: relates_to
     ref: "https://github.com/stlwolf/ai-development-hub/issues/174"
     reason: "DJ-8 split ターゲティング規約 (self / parent-window / explicit) の判断を追記"
+  - type: relates_to
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/165"
+    reason: "DJ-9 wez layout 宣言的盤面構築規約 (preset schema / 非冪等 / rollback) の判断を追記"
   - type: depends_on
     ref: ADR-001-cli-file-structure.md
     reason: "ファイル構成・命名規約を踏襲"
@@ -88,3 +91,24 @@ PoC-02 では `read -p "Kill pane?"` で確認を取っていたが、AI エー�
 `--target` / `--pane-id` を両方省略した場合は **`self` を試行 → 解決不能なら `--pane-id` を省略し wezterm のネイティブ既定（`WEZTERM_PANE` が設定済みならそれ、未設定なら active pane）に委ねる + `wez_warn`**。一方、ユーザが**明示**した `self` / `parent-window` が解決不能なら**フォールバックせず即エラー終了**（exit 3 = `WEZ_EXIT_PANE_NOT_FOUND`）。これは `discover.sh` の「明示指定の失敗＝即エラー」思想に倣う。
 
 後方互換: 本変更でデフォルトが **「常に native 既定」→「`self` を明示渡し（解決不能時のみ native 既定にフォールバック）」** に変わる。B3 は native が使うのと同じ `WEZTERM_PANE` を `--pane-id` で明示渡しするため、`WEZTERM_PANE` が設定された端末では従来 native が選んでいたペインと同一ペインを分割する。解決不能時は `--pane-id` を省略し native の既定（`WEZTERM_PANE`→active pane）に委ねる。`--pane-id`/`--target` なしの呼び出し（`orchestration-engine` の `spawn.sh` 等）は壊れない。明示 `--pane-id N` の挙動は不変。
+
+## DJ-9: wez layout 宣言的盤面構築の規約（#165）
+
+`wez layout` サブコマンド（`lib/layout.sh` + `bin/wez` dispatch）を追加。既存の `wez pane split` プリミティブを名付き JSON preset に沿って機械的に反復する **薄い上位層**。**wez 基盤専用・盤面構築のみ・非冪等（create-only）** に範囲を固定する。設計探索と設計SO reconcile（6 点）は `docs/discussions/2026-06-20-discussion-wez-layout.md` / `docs/plans/2026-06-20-plan-165-wez-layout.md` を正本とする。
+
+- **定義形式（DJ-a）**: YAML パーサを持ち込まず、`jq` で読む JSON 名付き preset を採用。flat children でなく `steps`（`id` + `from` + `dir` + `percent`）+ 明示 `root` とする。flat `children[].target:self` は grid／連鎖を表現できないため。PoC は `root:"self"` / `from:"root"` のみに制約する（逸脱は exit 64）。`dir` ∈ {bottom,right,left,top}（CLI の `--<dir>` フラグへ直接マップ）、`percent` は 1-99。グリッド／ネストは将来の再帰ツリー schema v2（本 PoC 範囲外）。
+- **責務（DJ-b）**: layout は盤面構築のみで、エージェント起動コマンドを持たない（`#114` クリーン出力との二重化回避）。ただし `apply --json` で **pane_id map** を返す（盤面 only ≠ ID を返さない。消費側 `#175` の `OE_SPAWN_PANE_ID` 要求に応える契約）。
+- **実現方式（DJ-c）**: 既存 `wez pane split` の反復で実現する。Lua の `gui-startup`（`.wezterm.lua`）は別リポ管轄であり CLI 主体の hub と思想が割れるため不採用。
+- **socket / root を一度だけ固定（SO reconcile #5）**: `wez_cmd_layout` が `wez_cmd_pane` と同型でソケットを1回解決し `export WEZTERM_UNIX_SOCKET`、`ROOT=$(_wez_resolve_self_pane)` + `_wez_pane_exists` を1回行う。以降全 split は **explicit `--pane-id $ROOT`** を内部関数 `_wez_pane_split` に渡す（`wez pane split` を N 個の subprocess で呼ばない）。これにより B3 default の active-pane フォールバックを踏まず、親が別ウィンドウを active にしていても self 起点で同一盤面を再現する。
+- **非冪等（SO reconcile #2）**: split は create-only。2 回 apply するとペインが倍増する。「冪等」と呼ばず **「非冪等・clean baseline に再現的」** と help/README に明記する。真の冪等（`--replace` + 所有 marker、desired-state 差分）は PoC 外。
+- **部分失敗の rollback（SO reconcile #4）**: k 番目の split が失敗したら abort し、作成済みペインを **逆順に kill（rollback）** して exit 5（`WEZ_EXIT_PANE_OP_FAILED`）。`--json` 時は `{status:"partial", root_pane_id, created, failed_step}` を出力。エージェント未起動の盤面段階のため逆順 kill は安全。
+- **focus（DJ-d）**: 全 split を explicit ターゲティングするため split 毎 activate は不要。最後に focus を復帰する（既定 `root`、`--focus <target>` で上書き、preset の `focus`（step id 可）も解釈）。
+- **oe / tmux（DJ-e）**: wez 基盤専用とし、tmux への delegate は out of scope（`#188` の2基盤別レイヤ + `#175` の非対話 `claude -p` 限定）。価値は engine／非対話用 outer WezTerm board に限ると honest に明記する。
+
+#### 終了コード（DJ-7 の体系を踏襲）
+
+layout 固有の追加コードは無く、既存定数を再利用する: preset 不在 = 1（`WEZ_EXIT_NOT_FOUND`）、root 不在/stale = 3（`WEZ_EXIT_PANE_NOT_FOUND`）、split 失敗（rollback 済）= 5（`WEZ_EXIT_PANE_OP_FAILED`）、schema/引数不正 = 64（`WEZ_EXIT_USAGE`）。`jq` 未導入は依存失敗として 5 に寄せる（DJ-8 の `parent-window` と一貫）。
+
+#### スコープガード
+
+盤面構築のみ（エージェント起動コマンドを持たない）/ wez 専用（tmux 非対応）/ 非冪等（明記）/ `spawn.sh`（`#175`）は触らない / grid は schema v2。

--- a/projects/wezterm-ai-mode/docs/discussions/2026-06-20-discussion-wez-layout.md
+++ b/projects/wezterm-ai-mode/docs/discussions/2026-06-20-discussion-wez-layout.md
@@ -1,0 +1,79 @@
+---
+id: "01KVG6J2MZ7S762Q7BK55EJBEG"
+title: "wez layout（配置規約付き盤面構築CLI）設計探索 — PoC 親1+子N"
+date: 2026-06-20
+type: discussion
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/165"
+    reason: "本探索の対象 Issue（wez layout 検証・設計 + 最小 PoC）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/174"
+    reason: "前提プリミティブ。wez pane split --target が landed（ターゲット不定性は解消済）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/175"
+    reason: "消費側。spawn.sh を layout 化（本件は #175 を触らず layout プリミティブのみ）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md"
+    reason: "2基盤(wez/tmux)は別 identity レイヤ → layout は wez 専用（DJ-e）"
+tags: [wezterm, wez-layout, board, preset, cockpit, discussion]
+---
+
+# wez layout 設計探索 — PoC 親1+子N
+
+> pre-plan の設計探索ログ。確定プランは `docs/plans/2026-06-20-plan-165-wez-layout.md`。
+> 探索 = 調査サブエージェント（一次情報直読）+ DJ 確定（オーナー承認）+ **設計SO（codex+cursor・選択肢拡張つき）で 6 点 refine**。
+
+## 1. Context
+
+`#165` は cockpit（#169）/ wez layout（Epic #20 Phase4）の検証・設計フェーズ + 最小 PoC「親1+子N の宣言的展開が CLI から再現できるか」。二層構造（wez CLI = 機械的盤面操作 / スキル = 判断・手順）は仮説。
+
+**前提（landed）**: #174 で `wez pane split --target self|parent-window|explicit` + B3 default が入り、「ターゲットウィンドウ不定」課題は解消済（`lib/pane.sh`、ADR-004 DJ-8）。残りの検討項目を詰めるのが本件。
+
+## 2. 現状能力マップ
+
+| 機構 | 状態 |
+|---|---|
+| `wez pane split --target` / `activate` / `send` / `list` / `kill` | 既存（PoC の下回りプリミティブ）[verified] |
+| socket 解決（`discover.sh`）/ exit code 定数（`common.sh`） | 既存 [verified] |
+| **layout / preset 機構** | **存在しない（完全新規）** [verified — grep でコメント言及のみ] |
+
+→ layout は「既存プリミティブを宣言定義に沿って機械オーケストレーションする薄い上位層」。
+
+## 3. 設計判断（DJ）— 確定 + SO reconcile
+
+| DJ | 確定 | 根拠 / SO |
+|---|---|---|
+| DJ-a 定義形式 | **JSON 名付き preset**（jq・YAML パーサ無し）。flat children でなく **`steps`（id + from + dir + percent）** + 明示 root | SO refine #1: flat `children[].target:self` は grid/連鎖を表現不可。PoC は `from=root` のみ |
+| DJ-b 責務 | layout = **盤面構築のみ**（エージェント起動コマンドは持たない）。ただし **pane_id map を返す** | #114 と二重化回避。SO refine #4: 盤面 only ≠ ID 返さない（#175 が `OE_SPAWN_PANE_ID` を要する） |
+| DJ-c 実現方式 | 既存 `wez pane split` の**反復**（Lua gui-startup 不採用 = `.wezterm.lua` 別リポ symlink） | 両 SO 是認 |
+| DJ-d focus | 既定 root へ戻す + `--focus <target>` 上書き | 全 split を explicit `--pane-id $ROOT` にするため split 毎 activate は不要（targeting は決定論的）。最後に root へ復帰 |
+| DJ-e oe/tmux | **wez 基盤専用**（tmux delegate は out of scope） | #188（2基盤別レイヤ）+ #175（非対話 claude -p 限定）。価値 = engine/非対話用 outer board と明記 |
+
+## 4. 設計SO の reconcile（6 点・codex+cursor 収束）
+
+1. **スキーマ**: `{version, root:"self", steps:[{id, from:"root", dir, percent}], focus}`。PoC は `from=root`/`target=self` のみ（`parent-window` mid-layout はフォーカス drift で禁止）。grid は v2（再帰ツリー＝代替 E）。
+2. **非冪等**: split は create-only。2 回 apply で倍増 → 「冪等」と呼ばず **「非冪等・clean baseline に再現的」** と明記。真の冪等は `--replace`+所有 marker（PoC 外）。
+3. **pane_id map 返却**: `apply --json` = `{status, root_pane_id, window_id, panes:[{id, pane_id, index}]}`。#175 接続の契約。
+4. **部分失敗**: k 番目 split 失敗 → abort + 作成済を**逆順 kill（rollback）**（agent 起動無しで安全）+ `--json {status:"partial", created, failed_step}`、exit 5。
+5. **socket / root を一度だけ固定**: `wez_cmd_layout` で socket 解決+`export WEZTERM_UNIX_SOCKET`、`ROOT=$(_wez_resolve_self_pane)`+`_wez_pane_exists` を 1 回、以降全 split は **explicit `--pane-id $ROOT`**（B3 default の active-pane fallback を踏ませない）。N subprocess 呼びの socket 揺れも回避。
+6. **価値の範囲**: wez 専用 → delegate(tmux) cockpit には効かない。「engine/非対話用 outer WezTerm board・delegate は別 issue」と honest に明記。
+
+## 5. 検討した代替案（選択肢拡張・PoC は縮小採用）
+
+| 案 | 評価 |
+|---|---|
+| 初期案（`wez layout apply` + JSON preset + split反復） | **採用**（上記 reconcile 込み） |
+| A Lua/workspace 宣言 | 冪等/原子性は強いが `.wezterm.lua` 別リポ管轄・CLI 主体 hub と思想割れ。PoC 後に再評価余地 |
+| B skill のみ（新 CLI 無し） | `spawn.sh` から機械呼び出しできない（#175 非接続）→ 不可 |
+| C oe spawn template 内蔵 | layout を wez CLI 共通化（Epic #20）でなく oe 内蔵に縮退 → 他ツール再利用不可。#175 の「呼び出し置換」に留めるべき |
+| D ensure（desired-state 差分） | 真の冪等。PoC の最小性を超える（差分算法要）。grid 需要時に再検討 |
+| E 再帰ツリー preset（split ノード） | grid/ネスト可。**schema v2 の本線**。PoC は flat steps で十分 |
+
+## 6. PoC 成功条件
+親が**別ウィンドウを active にした状態でも** self 起点で同一 window に同一盤面を生成（`wez pane list --format json` の window_id/pane_id で機械検証）。#174 の mock shim ハーネス（PATH 差し替え `wezterm` + fixture JSON）流用。
+
+## 7. スコープ境界 / 昇格
+- #175（spawn.sh layout 化＝消費側）は触らない / #111（activate）CLOSED / #114（クリーン出力）はコマンド起動を持たないことで切り分け。
+- **Decision 昇格**: layout 規約は ADR-004 DJ-9 に昇格（closure で確定）。

--- a/projects/wezterm-ai-mode/docs/episodes/2026-06-20-episode-wez-layout.md
+++ b/projects/wezterm-ai-mode/docs/episodes/2026-06-20-episode-wez-layout.md
@@ -1,0 +1,80 @@
+---
+id: "01KVG8A2SQ9GT6EH2YCR9P8MBF"
+title: "wez layout（宣言的盤面構築 PoC・親1+子N）実装"
+date: 2026-06-20
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/165"
+    reason: "本 episode の対象 Issue"
+  - type: decision
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md"
+    reason: "DJ-9 として layout 規約を昇格（蒸留シグナル）"
+  - type: source_material
+    ref: "projects/wezterm-ai-mode/docs/discussions/2026-06-20-discussion-wez-layout.md"
+    reason: "設計探索・DJ 確定・設計SO reconcile"
+  - type: design_context
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-005-bash-shell-standards.md"
+    reason: "bash 3.2 互換・local -n 禁止（実装SO が捕捉した critical の根拠）"
+tags: [wezterm, wez-layout, board, preset, cockpit, episode]
+---
+
+# wez layout 実装
+
+## Context / なぜ
+
+cockpit（#169）/ wez layout（Epic #20 Phase4）で、AI/CLI からマルチエージェント盤面を宣言的・再現可能に構築する手段が無い。`wez pane split` 等は単発・その場任せ。#174 で targeting 規約が landed した上で、#165 は「宣言 preset → 機械的盤面構築」の最小 PoC（親1+子N）を `wez layout` として実装した。
+
+## 次の消費者
+
+- **#175**: spawn.sh の wez split ハードコードを `wez layout` 化（本 episode が返す `--json` pane_id map = `{root_pane_id, window_id, panes:[{id,pane_id,index}]}` を消費）。
+- スキル層（薄ラッパー）は後続。
+
+## やったこと（要件 → 実装）
+
+- `wez layout apply <name> [--focus] [--json]` / `list` / `--help`（`lib/layout.sh` + `bin/wez` dispatch）。
+- JSON 名付き preset（`lib/layouts/<name>.json`・`{version, root:"self", steps:[{id, from:"root", dir, percent}], focus}`）。PoC preset `parent-children.json`。
+- socket を 1 回解決+export、ROOT=self を 1 回解決、全 step を explicit `--pane-id $ROOT` で分割、失敗時は逆順 kill で rollback、focus 復帰、pane_id map 返却。**wez 専用・盤面構築のみ・非冪等(create-only)**。
+
+## 決定と根拠（Decision 昇格 → ADR-004 DJ-9）
+
+- DJ-a JSON preset（steps+id+root・flat children でない）/ DJ-b 盤面 only（コマンド起動を持たない=#114 切り分け・ただし pane_id map は返す）/ DJ-c split 反復（Lua 不採用）/ DJ-d focus 既定 self+`--focus` / DJ-e wez 専用（#188 の 2 基盤別レイヤ）。
+- 棄却: flat children（grid 不可）/ Lua gui-startup（別リポ symlink）/ skill-only（#175 非接続）/ oe 内蔵（再利用不可）/ ensure（PoC 超過）。grid は再帰ツリー schema v2 へ defer。
+
+## わかったこと（W）— bash 3.2 互換が最大の学び
+
+- **`local -n`（nameref）は bash 4.3+ で macOS 標準 bash 3.2 では動かない**（ADR-005 で禁止・`wez` は `~/bin/` に sync されログインシェル 3.2 から呼ばれる）。初版の `--json` builder が `local -n` を使い、**dev の bash 5 では 38 テスト全 pass だが 3.2 では成功経路が壊れる**潜在 bug だった。→ JSON 組み立てを配列がスコープ内の `_wez_layout_apply` にインライン化して解消。**テストは `/bin/bash`（3.2）でも走らせる**べき（最終は両 bash で 38/0）。
+- preset 名の path traversal（`../`）は CLI で頻出 → 名前を `^[A-Za-z0-9._-]+$` に制限。
+
+## 検証
+
+- mock shim テスト（PATH 差し替え `wezterm`・fixture JSON・kill/split 失敗注入）: **bash 5.2 と macOS bash 3.2 の両方で 38/38 pass**。shellcheck clean。`grep 'local -n'` ゼロ。`bin/wez` 経由 e2e（help/list/dispatch）。
+- 負のコントロール: 各ガード（C2/W2/W5）を外すと対応テストが落ちることを確認（テストがガードを守る）。
+
+## ゲートと SO（heavy: 意図起動の外部レビュー 2 本）
+
+- **設計SO**（`so-compare --with codex,cursor`・選択肢拡張つき）で 6 点 refine（steps schema / 非冪等明記 / pane_id map / rollback / socket・root 固定 / 価値範囲）→ 実装前に反映。
+- **実装SO**（同・欠陥検出）で **critical 3 件**（`local -n` の bash 3.2 破綻 / preset 名 path traversal / `--focus` 不正の silent exit 0）+ warning 6 件を捕捉 → 1 ラウンドで全修正。
+- **学び（プロセス）**: 親の compliance review は SO reconcile 点（ロジック一致）を確認したが、**プラットフォーム/version 互換（ADR-005・bash 3.2）を明示チェックせず `local -n` を見落とした**（行は見たのに）。compliance review に「ADR-005 / bash 3.2 機能の grep」を含めるべき。実装SO がこの穴を埋めた = ゲートの実価値。
+
+## follow-up routing
+
+- grid/ネスト幾何 → 再帰ツリー schema v2（別 issue・本 PoC 範囲外）。
+- spawn.sh の layout 化 → #175（消費側）。
+- 真の冪等（`--replace`+所有 marker）/ ensure(desired-state) → defer（ADR-004 DJ-9 に記載）。
+- delegate(tmux) 盤面 → out of scope（#188・別 mux レイヤ）。
+- 未解決 open issue 化は無し（上記はすべて #175 / 別 issue / defer に routing）。
+
+## 蒸留シグナル
+
+- **Decision**: ADR-004 DJ-9（layout 規約）として昇格済。
+- skill / rule / #62: なし（スキル薄ラッパーは後続だが本 PoC では作らない）。
+
+## status
+
+達成（stable）。PoC 成功条件（別 active window でも self 起点で同一盤面・`wez pane list` JSON 機械検証）+ shellcheck + bash 3.2/5.2 両対応を満たす。
+
+## Step 4 外部チェック（heavy tier）
+
+Step4 辞退: closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation）は本 episode で自己充足 — 設計SO/実装SO の指摘・critical・修正・**親 review の見落とし（local -n）を省略せず記載**、follow-up は全て #175/別 issue/defer に routing、揮発 SO パスの要点は本文転記、bash 3.2 学びは ADR-005 を前方参照。コード品質は実装SO（別レーン）が担保。/ 既存チェックで覆った観点: routing / evidence anchor / 省略チェック / back-propagation / 未実施観点と判断: なし。

--- a/projects/wezterm-ai-mode/docs/plans/2026-06-20-plan-165-wez-layout.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-06-20-plan-165-wez-layout.md
@@ -1,0 +1,86 @@
+---
+id: "01KVG6J2NSTSTJ2R9HQ17ST2F9"
+title: "wez layout 実装計画 — 宣言的盤面構築 PoC（親1+子N）"
+date: 2026-06-20
+type: plan
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/165"
+    reason: "本計画の対象 Issue"
+  - type: source_material
+    ref: "projects/wezterm-ai-mode/docs/discussions/2026-06-20-discussion-wez-layout.md"
+    reason: "設計探索 + DJ 確定 + 設計SO reconcile（6点）"
+tags: [wezterm, wez-layout, board, preset, plan]
+---
+
+# wez layout 実装計画 — 宣言的盤面構築 PoC（親1+子N）
+
+> 駆動層: 調査 → DJ 確定（承認）→ 設計SO（codex+cursor）reconcile 6点 → **本計画**（承認済）→ 実装 → 実装SO → episode → PR。
+> 設計根拠: `docs/discussions/2026-06-20-discussion-wez-layout.md`。
+
+## 1. 成果物
+
+`wez layout` 新サブコマンド（`lib/layout.sh` + `bin/wez` dispatch）。既存プリミティブ（`wez pane split --target` 等）を宣言 preset に沿って機械オーケストレーションする薄い上位層。**wez 基盤専用・盤面構築のみ・非冪等（create-only）**。
+
+## 2. コマンド仕様
+
+```
+wez layout apply <name> [--focus <target>] [--json]
+wez layout list
+wez layout --help
+```
+
+`apply <name>` の処理順（SO reconcile）:
+1. socket 解決 → `export WEZTERM_UNIX_SOCKET`（`wez_cmd_layout` が `wez_cmd_pane` と同型で1回だけ）。内部関数を呼ぶ（`wez pane split` を N subprocess で呼ばない）。
+2. `ROOT=$(_wez_resolve_self_pane)` を1回解決 + `_wez_pane_exists "$ROOT"`。不在→exit 3。
+3. preset 読込: `lib/layouts/<name>.json` を jq で。不在→exit 1、schema 不正/引数不正→exit 64。
+4. steps を順に: `wez pane split --pane-id "$ROOT" --<dir> --percent <p>`（explicit 固定・B3 default を踏まない）。新 pane_id を収集。
+5. split 失敗→ abort、作成済 pane を**逆順 kill（rollback）**、exit 5。`--json` 時 `{status:"partial", root_pane_id, created:[...], failed_step:k}`。
+6. 成功→ focus 復帰（既定 `$ROOT` / `--focus <target>`）。`--json` 時 `{status:"ok", root_pane_id, window_id, panes:[{id, pane_id, index}]}`。
+
+## 3. preset スキーマ（`lib/layouts/<name>.json`）
+
+```json
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30},
+    {"id": "worker2", "from": "root", "dir": "right", "percent": 50}
+  ],
+  "focus": "root"
+}
+```
+
+- PoC 制約: `root` は `self` のみ、各 step の `from` は `root` のみ、`dir` ∈ {bottom,right,left,top}、`percent` は 1-99。`target:parent-window` は preset で禁止（フォーカス drift 回避）。
+- `dir` 値 → CLI `--<dir>` へマップ（バリデーション + README 明記）。
+- 将来の grid/ネストは再帰ツリー schema v2（本 PoC 範囲外）。
+
+## 4. PoC preset
+
+`lib/layouts/parent-children.json`（親1 + 子2 の最小例）1 本。
+
+## 5. テスト（`tests/test_wez_layout.sh`・mock shim）
+
+#174 の `PATH` 差し替え `wezterm` shim + fixture JSON を流用:
+- [ ] apply: preset 通りの split 引数列（`--pane-id $ROOT --bottom --percent 30` 等）が発行される
+- [ ] **再現性**: 異なる active window（fixture で is_active を別 pane に）でも root=self 起点で同一 split 列
+- [ ] `--json`: `{status:"ok", root_pane_id, window_id, panes:[{id,pane_id,index}]}` を返す（`jq -e` 検証）
+- [ ] 部分失敗: k 番目 split 失敗（mock で失敗注入）→ 逆順 kill 発行 + exit 5 + `--json {status:"partial", failed_step}`
+- [ ] 非冪等の確認: 2 回 apply で split が倍発行（仕様として固定）
+- [ ] focus: 末尾に `activate $ROOT`（or `--focus`）
+- [ ] 異常系: preset 不在→1 / schema 不正→64 / root 不在(WEZTERM_PANE 無)→3 / 未知オプション→64
+- [ ] `list` / `--help`
+- [ ] `shellcheck`
+
+## 6. 触るファイル
+- 追加: `lib/layout.sh`、`lib/layouts/parent-children.json`、`tests/test_wez_layout.sh`
+- 変更: `bin/wez`（layout dispatch 追加）、`README.md`（layout 節）、`docs/decisions/ADR-004-pane-design-decisions.md`（**DJ-9** layout 規約昇格）
+- 流用（read）: `lib/pane.sh`（split/activate/kill の内部関数）、`lib/discover.sh`、`lib/common.sh`
+
+## 7. スコープガード
+- 盤面構築のみ（エージェント起動コマンドを持たない）/ wez 専用（tmux 非対応）/ 非冪等（明記）/ `spawn.sh` は触らない（#175）/ grid は v2。
+
+## 8. ゲート
+- 実装SO（option-expansion なし・欠陥検出）/ closure = episode-retrospective（DJ-9 昇格は ADR-004 に実体化済 → 蒸留シグナル=Decision 明示）。

--- a/projects/wezterm-ai-mode/docs/plans/2026-06-20-plan-165-wez-layout.md
+++ b/projects/wezterm-ai-mode/docs/plans/2026-06-20-plan-165-wez-layout.md
@@ -31,10 +31,10 @@ wez layout list
 wez layout --help
 ```
 
-`apply <name>` の処理順（SO reconcile）:
+`apply <name>` の処理順（W1 修正後・実装/README に一致）:
 1. socket 解決 → `export WEZTERM_UNIX_SOCKET`（`wez_cmd_layout` が `wez_cmd_pane` と同型で1回だけ）。内部関数を呼ぶ（`wez pane split` を N subprocess で呼ばない）。
-2. `ROOT=$(_wez_resolve_self_pane)` を1回解決 + `_wez_pane_exists "$ROOT"`。不在→exit 3。
-3. preset 読込: `lib/layouts/<name>.json` を jq で。不在→exit 1、schema 不正/引数不正→exit 64。
+2. preset 読込・検証を **`ROOT` 解決より前**に行う（W1）: preset 名は `[A-Za-z0-9._-]+` のみ許可（`/`・`..`→exit 64）。`lib/layouts/<name>.json` 不在→exit 1、parse 不能/schema 不正/引数不正→exit 64、`jq` 未導入→exit 5（依存失敗）。preset を先に検証することで missing/invalid preset が root-not-found (3) に隠れない。
+3. `ROOT=$(_wez_resolve_self_pane)` を1回解決 + `_wez_pane_exists "$ROOT"`。不在/stale→exit 3。
 4. steps を順に: `wez pane split --pane-id "$ROOT" --<dir> --percent <p>`（explicit 固定・B3 default を踏まない）。新 pane_id を収集。
 5. split 失敗→ abort、作成済 pane を**逆順 kill（rollback）**、exit 5。`--json` 時 `{status:"partial", root_pane_id, created:[...], failed_step:k}`。
 6. 成功→ focus 復帰（既定 `$ROOT` / `--focus <target>`）。`--json` 時 `{status:"ok", root_pane_id, window_id, panes:[{id, pane_id, index}]}`。

--- a/projects/wezterm-ai-mode/lib/layout.sh
+++ b/projects/wezterm-ai-mode/lib/layout.sh
@@ -76,8 +76,9 @@ Exit codes:
   0    Success
   1    Preset not found
   3    Root pane (self) not found (WEZTERM_PANE unset/stale)
-  5    A split failed; created panes were rolled back (killed in reverse)
-  64   Usage error (bad argument, invalid preset name/schema, jq not installed)
+  5    Dependency failure (jq not installed) or a split failed
+       (created panes were rolled back, killed in reverse)
+  64   Usage error (bad argument, invalid preset name/schema)
 EOF
 }
 
@@ -122,9 +123,11 @@ _wez_layout_apply() {
   fi
 
   # jq is mandatory for layout (preset parsing + map output). (W6)
+  # Missing jq is a dependency failure (exit 5), consistent with ADR-004 DJ-9 /
+  # DJ-8 parent-window — NOT a usage error (64). (V3)
   if ! command -v jq >/dev/null 2>&1; then
     wez_error "layout apply: jq is required but not installed; install jq (e.g. brew install jq)"
-    return "${WEZ_EXIT_USAGE}"
+    return "${WEZ_EXIT_PANE_OP_FAILED}"
   fi
 
   # Reject preset names that could escape the layouts directory (C2). Only a
@@ -152,12 +155,13 @@ _wez_layout_apply() {
   fi
 
   # --- Validate schema (PoC constraints) ---
-  # version present, root == "self", steps is a non-empty array, each step has a
-  # non-empty string id that is NOT all-digits (W3: a numeric id collides with
-  # the numeric-pane-id meaning of --focus), from == "root", dir in
-  # {bottom,right,left,top}, percent an integer 1-99 (W2).
+  # version == 1 (fail-fast on unsupported versions: V1), root == "self", steps
+  # is a non-empty array, each step has a non-empty string id that is NOT
+  # all-digits (W3: a numeric id collides with the numeric-pane-id meaning of
+  # --focus), from == "root", dir in {bottom,right,left,top}, percent an integer
+  # 1-99 (W2).
   if ! jq -e '
-    (.version != null)
+    (.version == 1)
     and (.root == "self")
     and ((.steps | type) == "array")
     and ((.steps | length) > 0)
@@ -171,7 +175,7 @@ _wez_layout_apply() {
           and (.percent >= 1) and (.percent <= 99)
         ))
   ' "$preset_file" >/dev/null 2>&1; then
-    wez_error "layout apply: preset ${opt_name} has an invalid schema (expected {version, root:\"self\", steps:[{id (non-empty, not all-digits), from:\"root\", dir in bottom|right|left|top, percent integer 1-99}]}); PoC supports root/from=self/root only"
+    wez_error "layout apply: preset ${opt_name} has an invalid schema (expected {version:1, root:\"self\", steps:[{id (non-empty, not all-digits), from:\"root\", dir in bottom|right|left|top, percent integer 1-99}]}); PoC supports version 1, root/from=self/root only"
     return "${WEZ_EXIT_USAGE}"
   fi
 
@@ -363,7 +367,7 @@ Exit codes:
   1    Socket / preset not found
   2    Connection failed
   3    Root pane (self) not found
-  5    Split failed (created panes rolled back)
+  5    Dependency failure (jq not installed) or split failed (created panes rolled back)
   64   Usage error
   127  wezterm not installed
 EOF

--- a/projects/wezterm-ai-mode/lib/layout.sh
+++ b/projects/wezterm-ai-mode/lib/layout.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# layout.sh - Declarative board construction for wez CLI (PoC: parent + N children)
+#
+# Sourced by bin/wez. Not intended for standalone execution.
+# Layout: helper functions at top, dispatcher (wez_cmd_layout) at bottom.
+# Naming: wez_* for public, _wez_* for private.
+#
+# Thin orchestration layer over the existing pane primitives (_wez_pane_split /
+# _wez_pane_kill / _wez_pane_activate). wez-only, board-construction only,
+# NON-IDEMPOTENT (create-only). Reads named JSON presets from lib/layouts/.
+
+# Directory holding layout preset JSON files (lib/layouts/<name>.json).
+# Resolved relative to this script so it works regardless of the caller's cwd.
+_wez_layout_presets_dir() {
+  local src_dir
+  src_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s\n' "${src_dir}/layouts"
+}
+
+# --- Subcommand: list ---
+
+_wez_layout_list() {
+  # list takes no positional arguments; only --help / unknown-option handling.
+  if [[ $# -gt 0 ]]; then
+    case "$1" in
+      --help|-h)
+        cat <<'EOF'
+Usage: wez layout list
+
+List the names of available layout presets (lib/layouts/*.json).
+EOF
+        return 0
+        ;;
+      *)
+        wez_error "layout list: unknown option: $1"
+        return "${WEZ_EXIT_USAGE}"
+        ;;
+    esac
+  fi
+
+  local dir
+  dir="$(_wez_layout_presets_dir)"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+
+  local f name
+  for f in "$dir"/*.json; do
+    [[ -e "$f" ]] || continue
+    name="$(basename "$f" .json)"
+    printf '%s\n' "$name"
+  done
+}
+
+# --- Subcommand: apply ---
+
+_wez_layout_apply_help() {
+  cat <<'EOF'
+Usage: wez layout apply <name> [options]
+
+Apply a declarative layout preset to build a board (parent + N children).
+Splits are performed in preset order from the root (self) pane.
+Requires jq.
+
+NON-IDEMPOTENT: layout apply is create-only. Running it twice doubles the panes
+(no ownership tracking / no replace). Apply once against a clean baseline.
+
+Options:
+  --focus <target>   Pane to focus when done (default: root). Either "root",
+                     a step id from the preset, or a numeric pane id. An
+                     invalid target is rejected (exit 64) before any split.
+  --json             Output result as JSON
+  -h, --help         Show this help
+
+Exit codes:
+  0    Success
+  1    Preset not found
+  3    Root pane (self) not found (WEZTERM_PANE unset/stale)
+  5    A split failed; created panes were rolled back (killed in reverse)
+  64   Usage error (bad argument, invalid preset name/schema, jq not installed)
+EOF
+}
+
+_wez_layout_apply() {
+  local opt_name=""
+  local opt_focus=""
+  local opt_json=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --focus)
+        if [[ -z "${2:-}" ]]; then
+          wez_error "layout apply: --focus requires a value"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        opt_focus="$2"; shift
+        ;;
+      --json)  opt_json=true ;;
+      --help|-h)
+        _wez_layout_apply_help
+        return 0
+        ;;
+      -*)
+        wez_error "layout apply: unknown option: $1"
+        return "${WEZ_EXIT_USAGE}"
+        ;;
+      *)
+        if [[ -z "$opt_name" ]]; then
+          opt_name="$1"
+        else
+          wez_error "layout apply: too many arguments"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -z "$opt_name" ]]; then
+    wez_error "layout apply: preset name is required"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  # jq is mandatory for layout (preset parsing + map output). (W6)
+  if ! command -v jq >/dev/null 2>&1; then
+    wez_error "layout apply: jq is required but not installed; install jq (e.g. brew install jq)"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  # Reject preset names that could escape the layouts directory (C2). Only a
+  # single path segment of [A-Za-z0-9._-] is allowed; '/', '..' and empty are
+  # rejected so "${presets_dir}/${opt_name}.json" cannot read arbitrary files.
+  if [[ ! "$opt_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    wez_error "layout apply: invalid preset name '${opt_name}' (allowed: letters, digits, '.', '_', '-'; no '/' or '..')"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  # --- Load + validate preset BEFORE resolving root (W1) ---
+  # Preset problems are usage errors (1/64) independent of the live pane state;
+  # resolving root first would mask a missing preset as a root-not-found (3).
+  local preset_file
+  preset_file="$(_wez_layout_presets_dir)/${opt_name}.json"
+  if [[ ! -f "$preset_file" ]]; then
+    wez_error "layout apply: preset not found: ${opt_name} (${preset_file})"
+    return "${WEZ_EXIT_NOT_FOUND}"
+  fi
+
+  local preset
+  if ! preset=$(jq -e '.' "$preset_file" 2>/dev/null); then
+    wez_error "layout apply: preset ${opt_name} is not valid JSON"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  # --- Validate schema (PoC constraints) ---
+  # version present, root == "self", steps is a non-empty array, each step has a
+  # non-empty string id that is NOT all-digits (W3: a numeric id collides with
+  # the numeric-pane-id meaning of --focus), from == "root", dir in
+  # {bottom,right,left,top}, percent an integer 1-99 (W2).
+  if ! jq -e '
+    (.version != null)
+    and (.root == "self")
+    and ((.steps | type) == "array")
+    and ((.steps | length) > 0)
+    and (all(.steps[];
+          ((.id | type) == "string") and ((.id | length) > 0)
+          and ((.id | test("^[0-9]+$")) | not)
+          and (.from == "root")
+          and (.dir as $d | ["bottom","right","left","top"] | index($d) != null)
+          and ((.percent | type) == "number")
+          and ((.percent | floor) == .percent)
+          and (.percent >= 1) and (.percent <= 99)
+        ))
+  ' "$preset_file" >/dev/null 2>&1; then
+    wez_error "layout apply: preset ${opt_name} has an invalid schema (expected {version, root:\"self\", steps:[{id (non-empty, not all-digits), from:\"root\", dir in bottom|right|left|top, percent integer 1-99}]}); PoC supports root/from=self/root only"
+    return "${WEZ_EXIT_USAGE}"
+  fi
+
+  # focus from the preset (optional). Default to root. --focus overrides.
+  local preset_focus
+  preset_focus="$(jq -r '.focus // "root"' <<< "$preset" 2>/dev/null)"
+
+  # --- Resolve root (self) once (SO reconcile #5) ---
+  local root
+  if ! root=$(_wez_resolve_self_pane); then
+    wez_error "layout apply: could not resolve root pane from WEZTERM_PANE"
+    return "${WEZ_EXIT_PANE_NOT_FOUND}"
+  fi
+  if ! _wez_pane_exists "$root"; then
+    wez_error "layout apply: root pane ${root} not found"
+    return "${WEZ_EXIT_PANE_NOT_FOUND}"
+  fi
+
+  local step_count
+  step_count="$(jq '.steps | length' <<< "$preset")"
+
+  # --- Resolve effective focus spec (DJ-d): default root, --focus overrides preset focus ---
+  local focus_spec="$preset_focus"
+  [[ -n "$opt_focus" ]] && focus_spec="$opt_focus"
+
+  # --- Validate the focus target BEFORE splitting (C3) ---
+  # A valid focus spec is: "root", a numeric literal pane id (W3), or a step id
+  # declared in the preset. An invalid spec must fail loudly (64) and split
+  # NOTHING, rather than warn + silently fall back to root and exit 0.
+  # Step ids are guaranteed non-numeric by the schema (W3), so a numeric spec is
+  # unambiguously a literal pane id and is checked first.
+  if [[ "$focus_spec" != "root" ]] && [[ ! "$focus_spec" =~ ^[0-9]+$ ]]; then
+    if ! jq -e --arg f "$focus_spec" 'any(.steps[]; .id == $f)' <<< "$preset" >/dev/null 2>&1; then
+      wez_error "layout apply: --focus target '${focus_spec}' is neither 'root', a numeric pane id, nor a step id in preset ${opt_name}"
+      return "${WEZ_EXIT_USAGE}"
+    fi
+  fi
+
+  # --- Execute steps in order: explicit --pane-id "$root" (no B3 fallback) ---
+  # Collect created pane ids and their step ids/indices for the JSON map.
+  local -a created=()
+  local -a created_step_ids=()
+  local -a created_indices=()
+
+  local i=0
+  while (( i < step_count )); do
+    local dir percent
+    dir="$(jq -r ".steps[$i].dir" <<< "$preset")"
+    percent="$(jq -r ".steps[$i].percent" <<< "$preset")"
+    local step_id
+    step_id="$(jq -r ".steps[$i].id" <<< "$preset")"
+
+    local new_pane
+    if ! new_pane=$(_wez_pane_split --pane-id "$root" "--${dir}" --percent "$percent"); then
+      # --- Partial failure: rollback created panes in reverse order ---
+      wez_error "layout apply: split failed at step ${i} (id=${step_id}); rolling back ${#created[@]} created pane(s)"
+      # Track panes whose rollback kill failed, so consumers can flag orphans (W4).
+      local -a rollback_failed=()
+      local j=$(( ${#created[@]} - 1 ))
+      while (( j >= 0 )); do
+        if ! _wez_pane_kill --pane-id "${created[$j]}" >/dev/null 2>&1; then
+          wez_warn "layout apply: rollback failed to kill pane ${created[$j]}"
+          rollback_failed+=("${created[$j]}")
+        fi
+        j=$(( j - 1 ))
+      done
+      if [[ "$opt_json" == true ]]; then
+        # --- Inline partial-failure JSON (C1: no nameref; arrays in scope) ---
+        #   {status:"partial", root_pane_id, created:[...], failed_step:K,
+        #    rollback_failed:[...]}
+        local created_json="[]"
+        local p
+        for p in ${created[@]+"${created[@]}"}; do
+          created_json="$(jq --argjson v "$p" '. + [$v]' <<< "$created_json")"
+        done
+        local rollback_json="[]"
+        for p in ${rollback_failed[@]+"${rollback_failed[@]}"}; do
+          rollback_json="$(jq --argjson v "$p" '. + [$v]' <<< "$rollback_json")"
+        done
+        jq -n \
+          --argjson root_pane_id "$root" \
+          --argjson created "$created_json" \
+          --argjson failed_step "$i" \
+          --argjson rollback_failed "$rollback_json" \
+          '{"status": "partial", "root_pane_id": $root_pane_id, "created": $created, "failed_step": $failed_step, "rollback_failed": $rollback_failed}'
+      fi
+      return "${WEZ_EXIT_PANE_OP_FAILED}"
+    fi
+
+    created+=("$new_pane")
+    created_step_ids+=("$step_id")
+    created_indices+=("$i")
+    i=$(( i + 1 ))
+  done
+
+  # --- Restore / set focus: spec already validated above (C3) ---
+  local focus_target="$root"
+  if [[ "$focus_spec" != "root" ]]; then
+    if [[ "$focus_spec" =~ ^[0-9]+$ ]]; then
+      # Numeric spec is a literal pane id (W3).
+      focus_target="$focus_spec"
+    else
+      # Non-numeric spec is a step id; resolve to its created pane id. The spec
+      # was validated against the preset and all steps succeeded, so this match
+      # always exists.
+      local k=0
+      while (( k < ${#created_step_ids[@]} )); do
+        if [[ "${created_step_ids[$k]}" == "$focus_spec" ]]; then
+          focus_target="${created[$k]}"
+          break
+        fi
+        k=$(( k + 1 ))
+      done
+    fi
+  fi
+
+  _wez_pane_activate --pane-id "$focus_target" >/dev/null 2>&1 || \
+    wez_warn "layout apply: failed to focus pane ${focus_target}"
+
+  # --- Success output (C1: inline JSON, arrays in scope; no nameref) ---
+  if [[ "$opt_json" == true ]]; then
+    # {status:"ok", root_pane_id, window_id, panes:[{id, pane_id, index}]}
+    # window_id is the root pane's window from `wezterm cli list`.
+    local window_id
+    window_id="$(_wez_layout_root_window "$root")"
+
+    local panes_json="[]"
+    local idx=0
+    while (( idx < ${#created[@]} )); do
+      panes_json="$(jq \
+        --arg id "${created_step_ids[$idx]}" \
+        --argjson pane_id "${created[$idx]}" \
+        --argjson index "${created_indices[$idx]}" \
+        '. + [{"id": $id, "pane_id": $pane_id, "index": $index}]' \
+        <<< "$panes_json")"
+      idx=$(( idx + 1 ))
+    done
+
+    local window_arg="null"
+    [[ "$window_id" =~ ^[0-9]+$ ]] && window_arg="$window_id"
+
+    jq -n \
+      --argjson root_pane_id "$root" \
+      --argjson window_id "$window_arg" \
+      --argjson panes "$panes_json" \
+      '{"status": "ok", "root_pane_id": $root_pane_id, "window_id": $window_id, "panes": $panes}'
+  fi
+  return "${WEZ_EXIT_SUCCESS}"
+}
+
+# JSON map emission was inlined into _wez_layout_apply (C1): the success and
+# partial-failure builders needed the created/step-id/index arrays. bash 3.2 has
+# no nameref (banned by ADR-005), so the JSON is built where the arrays are in
+# scope instead of passing them to a helper.
+
+# Resolve the window_id of the root pane from `wezterm cli list --format json`.
+# Outputs numeric window_id on stdout, or nothing if unresolved.
+_wez_layout_root_window() {
+  local root="$1"
+  local json
+  json=$(wezterm cli list --format json 2>/dev/null) || return 0
+  jq -r --arg root "$root" '
+    (map(select((.pane_id | tostring) == $root)) | .[0].window_id) // empty
+  ' <<< "$json" 2>/dev/null || true
+}
+
+# --- Dispatcher ---
+
+_wez_layout_help() {
+  cat <<'EOF'
+Usage: wez layout [--socket <path>] <subcommand> [options]
+
+Build declarative pane layouts (boards) from named JSON presets.
+Thin orchestration over `wez pane split`. wez-only, board-construction only,
+NON-IDEMPOTENT (create-only: re-running doubles panes).
+A tmux delegate is out of scope. Requires jq.
+
+Subcommands:
+  apply <name>   Apply a layout preset (splits from the root/self pane)
+  list           List available preset names (lib/layouts/*.json)
+
+Options (before subcommand):
+  --socket <path>  Use specific socket path (skip auto-detection)
+
+Run 'wez layout <subcommand> --help' for more information.
+
+Exit codes:
+  0    Success
+  1    Socket / preset not found
+  2    Connection failed
+  3    Root pane (self) not found
+  5    Split failed (created panes rolled back)
+  64   Usage error
+  127  wezterm not installed
+EOF
+}
+
+# Two-stage parsing (mirrors wez_cmd_pane):
+# Stage 1: Extract --socket and subcommand (--socket must precede subcommand)
+# Stage 2: Forward remaining args to the subcommand handler.
+# Socket is resolved ONCE here and exported (SO reconcile #5).
+wez_cmd_layout() {
+  local opt_socket=""
+  local subcmd=""
+  local -a subcmd_args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --socket)
+        if [[ -z "${2:-}" ]]; then
+          wez_error "layout: --socket requires a path argument"
+          return "${WEZ_EXIT_USAGE}"
+        fi
+        opt_socket="$2"
+        shift
+        ;;
+      --help|-h|help)
+        _wez_layout_help
+        return 0
+        ;;
+      -*)
+        wez_error "layout: unknown option: $1 (options must precede subcommand)"
+        return "${WEZ_EXIT_USAGE}"
+        ;;
+      *)
+        subcmd="$1"
+        shift
+        if [[ $# -gt 0 ]]; then
+          subcmd_args=("$@")
+        fi
+        break
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -z "$subcmd" ]]; then
+    _wez_layout_help
+    return 0
+  fi
+
+  # Whitelist subcommands BEFORE socket discovery (W5): an unknown subcommand is
+  # a usage error (64) regardless of socket availability, so reject it here
+  # rather than letting socket discovery turn it into a socket exit code.
+  case "$subcmd" in
+    apply|list) ;;
+    *)
+      wez_error "layout: unknown subcommand: ${subcmd}"
+      printf '%s\n' "Run 'wez layout --help' for usage information." >&2
+      return "${WEZ_EXIT_USAGE}"
+      ;;
+  esac
+
+  # 'list' does not require a live socket connection; serve it before discovery.
+  if [[ "$subcmd" == "list" ]]; then
+    _wez_layout_list "${subcmd_args[@]+"${subcmd_args[@]}"}"
+    return $?
+  fi
+
+  # Socket discovery and export (once, mirrors wez_cmd_pane).
+  local socket exit_code=0
+  socket=$(wez_discover_socket "$opt_socket") || exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    case $exit_code in
+      "${WEZ_EXIT_NO_WEZTERM}")
+        wez_error "layout: wezterm is not installed"
+        ;;
+      "${WEZ_EXIT_NOT_FOUND}")
+        if [[ -n "$opt_socket" ]]; then
+          wez_error "layout: specified socket not found: ${opt_socket}"
+        else
+          wez_error "layout: no WezTerm socket found"
+        fi
+        ;;
+      "${WEZ_EXIT_CONN_FAIL}")
+        wez_error "layout: socket connection failed"
+        ;;
+    esac
+    return "$exit_code"
+  fi
+
+  if ! wez_verify_connection "$socket" >/dev/null; then
+    wez_error "layout: socket connection failed"
+    return "${WEZ_EXIT_CONN_FAIL}"
+  fi
+
+  export WEZTERM_UNIX_SOCKET="$socket"
+
+  # Only 'apply' reaches here: 'list' returns early and unknown subcommands were
+  # rejected by the pre-discovery whitelist above (W5).
+  _wez_layout_apply "${subcmd_args[@]+"${subcmd_args[@]}"}"
+}

--- a/projects/wezterm-ai-mode/lib/layouts/parent-children.json
+++ b/projects/wezterm-ai-mode/lib/layouts/parent-children.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30},
+    {"id": "worker2", "from": "root", "dir": "right", "percent": 50}
+  ],
+  "focus": "root"
+}

--- a/projects/wezterm-ai-mode/tests/test_wez_layout.sh
+++ b/projects/wezterm-ai-mode/tests/test_wez_layout.sh
@@ -1,0 +1,716 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test_wez_layout.sh — wez layout apply/list の規約を検証する (#165)
+#
+# 単体テストハーネスは無いため、test_pane_split_targeting.sh と同型の mock shim 方式:
+#   - PATH 先頭に mock `wezterm` を置く。
+#       cli split-pane   → 引数を SPLIT_LOG に追記し、新 pane id を返す（インクリメント）。
+#                          WEZ_TEST_FAIL_SPLIT_AT が「N 回目の split」を指すとき exit 1（失敗注入）。
+#       cli kill-pane     → 引数を KILL_LOG に追記。
+#       cli activate-pane → 引数を ACTIVATE_LOG に追記。
+#       cli list          → 固定 fixture JSON（root の存在確認・window_id 解決用）。
+#   - lib/common.sh + lib/pane.sh + lib/layout.sh を source し、対象関数を直接呼ぶ。
+#     socket discovery (wez_cmd_layout) は対象外のため経由せず _wez_layout_apply / _wez_layout_list を呼ぶ。
+#
+# 前例: tests/test_pane_split_targeting.sh（PATH 差し替え wezterm + fixture JSON）。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'SKIP: jq not installed; layout tests require jq\n' >&2
+  exit 0
+fi
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/pathbin" "$_TMP_DIR/logs"
+
+SPLIT_LOG="$_TMP_DIR/logs/split-pane-args.log"
+KILL_LOG="$_TMP_DIR/logs/kill-pane-args.log"
+ACTIVATE_LOG="$_TMP_DIR/logs/activate-pane-args.log"
+SPLIT_COUNT="$_TMP_DIR/logs/split-count"
+
+# --- Fixtures: `wezterm cli list --format json` ---
+# 既定: root=1（window 0, active）が存在する。別 window 5 の active pane 9 もある。
+FIXTURE_DEFAULT="$_TMP_DIR/fixture-default.json"
+cat > "$FIXTURE_DEFAULT" <<'JSON'
+[
+  {"window_id":0,"tab_id":0,"pane_id":0,"is_active":false,"tty_name":"/dev/ttys000"},
+  {"window_id":0,"tab_id":0,"pane_id":1,"is_active":true,"tty_name":"/dev/ttys001"},
+  {"window_id":5,"tab_id":2,"pane_id":9,"is_active":true,"tty_name":"/dev/ttys009"}
+]
+JSON
+
+# 再現性 fixture: active pane が「別 window 5」側 (pane 9) でも root=self(=1) 起点で同一 split 列になること。
+# root pane 1 は window 0・非 active だが list には存在する。
+FIXTURE_ACTIVE_ELSEWHERE="$_TMP_DIR/fixture-active-elsewhere.json"
+cat > "$FIXTURE_ACTIVE_ELSEWHERE" <<'JSON'
+[
+  {"window_id":0,"tab_id":0,"pane_id":1,"is_active":false,"tty_name":"/dev/ttys001"},
+  {"window_id":5,"tab_id":2,"pane_id":9,"is_active":true,"tty_name":"/dev/ttys009"}
+]
+JSON
+
+# window_id 解決失敗 fixture: root=1 は存在するが window_id が null。
+# _wez_pane_exists は通るが _wez_layout_root_window は空を返す → JSON は window_id:null。
+FIXTURE_NULL_WINDOW="$_TMP_DIR/fixture-null-window.json"
+cat > "$FIXTURE_NULL_WINDOW" <<'JSON'
+[
+  {"window_id":null,"tab_id":0,"pane_id":1,"is_active":true,"tty_name":"/dev/ttys001"}
+]
+JSON
+
+export WEZ_TEST_FIXTURE="$FIXTURE_DEFAULT"
+
+# --- mock wezterm ---
+cat > "$_TMP_DIR/pathbin/wezterm" <<EOF
+#!/usr/bin/env bash
+sub="\${2:-}"
+if [[ "\${1:-}" == "cli" && "\$sub" == "split-pane" ]]; then
+  shift 2
+  # split 呼び出し回数をインクリメント
+  n=0
+  [[ -f "$SPLIT_COUNT" ]] && n=\$(cat "$SPLIT_COUNT")
+  n=\$(( n + 1 ))
+  printf '%s' "\$n" > "$SPLIT_COUNT"
+  # 引数ログ（追記。区切りに ---SPLIT--- を入れる）
+  printf -- '---SPLIT---\n' >> "$SPLIT_LOG"
+  for a in "\$@"; do printf '%s\n' "\$a" >> "$SPLIT_LOG"; done
+  # 失敗注入
+  if [[ -n "\${WEZ_TEST_FAIL_SPLIT_AT:-}" && "\$n" -eq "\${WEZ_TEST_FAIL_SPLIT_AT}" ]]; then
+    echo "mock wezterm: injected split failure at call \$n" >&2
+    exit 1
+  fi
+  # 新 pane id: 100 + 呼び出し回数（root と衝突しない）
+  printf '%s\n' "\$(( 100 + n ))"
+  exit 0
+fi
+if [[ "\${1:-}" == "cli" && "\$sub" == "kill-pane" ]]; then
+  shift 2
+  printf -- '---KILL---\n' >> "$KILL_LOG"
+  for a in "\$@"; do printf '%s\n' "\$a" >> "$KILL_LOG"; done
+  # 失敗注入: WEZ_TEST_FAIL_KILL に列挙された pane-id の kill を失敗させる（空白区切り）。
+  if [[ -n "\${WEZ_TEST_FAIL_KILL:-}" ]]; then
+    prev=""
+    for a in "\$@"; do
+      if [[ "\$prev" == "--pane-id" ]]; then
+        for fk in \${WEZ_TEST_FAIL_KILL}; do
+          if [[ "\$a" == "\$fk" ]]; then
+            echo "mock wezterm: injected kill failure for pane \$a" >&2
+            exit 1
+          fi
+        done
+      fi
+      prev="\$a"
+    done
+  fi
+  exit 0
+fi
+if [[ "\${1:-}" == "cli" && "\$sub" == "activate-pane" ]]; then
+  shift 2
+  printf -- '---ACTIVATE---\n' >> "$ACTIVATE_LOG"
+  for a in "\$@"; do printf '%s\n' "\$a" >> "$ACTIVATE_LOG"; done
+  exit 0
+fi
+if [[ "\${1:-}" == "cli" && "\$sub" == "list" ]]; then
+  cat "\${WEZ_TEST_FIXTURE:-$FIXTURE_DEFAULT}"
+  exit 0
+fi
+echo "mock wezterm: unexpected args: \$*" >&2
+exit 1
+EOF
+chmod +x "$_TMP_DIR/pathbin/wezterm"
+
+export PATH="$_TMP_DIR/pathbin:$PATH"
+
+# shellcheck source=../lib/common.sh
+source "$PROJECT_DIR/lib/common.sh"
+# shellcheck source=../lib/discover.sh
+source "$PROJECT_DIR/lib/discover.sh"
+# shellcheck source=../lib/pane.sh
+source "$PROJECT_DIR/lib/pane.sh"
+# shellcheck source=../lib/layout.sh
+source "$PROJECT_DIR/lib/layout.sh"
+
+# layout はプリインストールの preset を lib/layouts/ から読む。テストでは独自 preset を
+# 使いたいので、_wez_layout_presets_dir を一時ディレクトリに差し替える。
+_LAYOUT_PRESET_DIR="$_TMP_DIR/layouts"
+mkdir -p "$_LAYOUT_PRESET_DIR"
+_wez_layout_presets_dir() { printf '%s\n' "$_LAYOUT_PRESET_DIR"; }
+
+# 正常 preset: 親1 + 子2（bottom 30, right 50）, focus root
+cat > "$_LAYOUT_PRESET_DIR/parent-children.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30},
+    {"id": "worker2", "from": "root", "dir": "right", "percent": 50}
+  ],
+  "focus": "root"
+}
+JSON
+
+# focus を step id に向ける preset
+cat > "$_LAYOUT_PRESET_DIR/focus-worker.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30}
+  ],
+  "focus": "worker1"
+}
+JSON
+
+# schema 不正: dir が不正値
+cat > "$_LAYOUT_PRESET_DIR/bad-dir.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "diagonal", "percent": 30}
+  ],
+  "focus": "root"
+}
+JSON
+
+# schema 不正: percent 範囲外
+cat > "$_LAYOUT_PRESET_DIR/bad-percent.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 0}
+  ],
+  "focus": "root"
+}
+JSON
+
+# schema 不正: from が root 以外（PoC 制約違反）
+cat > "$_LAYOUT_PRESET_DIR/bad-from.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "worker0", "dir": "bottom", "percent": 30}
+  ],
+  "focus": "root"
+}
+JSON
+
+# schema 不正: percent が小数（W2: 整数制約）
+cat > "$_LAYOUT_PRESET_DIR/decimal-percent.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30.5}
+  ],
+  "focus": "root"
+}
+JSON
+
+# schema 不正: step id が全桁数値（W3: focus の numeric=リテラル pane-id と衝突）
+cat > "$_LAYOUT_PRESET_DIR/numeric-id.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "101", "from": "root", "dir": "bottom", "percent": 30}
+  ],
+  "focus": "root"
+}
+JSON
+
+# focus 不正: preset の focus が未知の step id（C3: split 前に 64 で弾く）
+cat > "$_LAYOUT_PRESET_DIR/bad-focus.json" <<'JSON'
+{
+  "version": 1,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30}
+  ],
+  "focus": "nonexistent"
+}
+JSON
+
+# --- 実 Unix domain socket（wez_cmd_layout の discovery 経路テスト用） ---
+# discover.sh の `[[ -S "$socket" ]]` を満たす本物の socket ファイルを作る。
+# 接続検証 (wez_verify_connection) は mock `wezterm cli list` が応答するため通る。
+TEST_SOCKET="$_TMP_DIR/gui-sock-test"
+python3 - "$TEST_SOCKET" <<'PY'
+import socket, sys
+p = sys.argv[1]
+s = socket.socket(socket.AF_UNIX)
+s.bind(p)
+s.close()
+PY
+
+# --- Test harness ---
+PASS=0
+FAIL=0
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { printf 'ok: %s\n' "$1"; PASS=$((PASS + 1)); }
+
+# expect_rc <expected> <actual> <name>
+expect_rc() {
+  if [[ "$2" -eq "$1" ]]; then
+    ok "$3"
+  else
+    fail "$3 (expected exit $1, got $2)"
+  fi
+}
+
+reset_logs() {
+  rm -f "$SPLIT_LOG" "$KILL_LOG" "$ACTIVATE_LOG" "$SPLIT_COUNT"
+}
+
+# SPLIT_LOG を「(dir,percent,pane-id) のシーケンス」として正規化して表示する。
+# 各 split ブロックから --pane-id / 方向 / --percent を抽出し "dir:percent:paneid" を1行に。
+split_sequence() {
+  [[ -f "$SPLIT_LOG" ]] || return 0
+  awk '
+    /^---SPLIT---$/ { if (have) emit(); have=1; dir=""; pct=""; pid=""; next }
+    /^--(bottom|right|left|top)$/ { sub(/^--/,"",$0); dir=$0; next }
+    /^--percent$/ { getline; pct=$0; next }
+    /^--pane-id$/ { getline; pid=$0; next }
+    END { if (have) emit() }
+    function emit() { printf "%s:%s:%s\n", dir, pct, pid }
+  ' "$SPLIT_LOG"
+}
+
+# KILL_LOG の --pane-id 値を出現順に返す
+kill_sequence() {
+  [[ -f "$KILL_LOG" ]] || return 0
+  awk '/^--pane-id$/{getline; print}' "$KILL_LOG"
+}
+
+# ACTIVATE_LOG の最後の --pane-id 値を返す
+last_activate_pane() {
+  [[ -f "$ACTIVATE_LOG" ]] || return 0
+  awk '/^--pane-id$/{v=$0; getline; v=$0} END{print v}' "$ACTIVATE_LOG"
+}
+
+# ============================================================
+# 1) apply: preset 通りの split 引数列
+# ============================================================
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+expected=$'bottom:30:1\nright:50:1'
+if [[ "$rc" -eq 0 && "$seq" == "$expected" ]]; then
+  ok "apply: emits preset split sequence with explicit --pane-id ROOT"
+else
+  fail "apply: split sequence mismatch (rc=$rc)
+expected:
+$expected
+got:
+$seq"
+fi
+
+# ============================================================
+# 2) 再現性: active pane が別 window でも root=self 起点で同一 split 列
+# ============================================================
+reset_logs
+export WEZ_TEST_FIXTURE="$FIXTURE_ACTIVE_ELSEWHERE"
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+export WEZ_TEST_FIXTURE="$FIXTURE_DEFAULT"
+seq="$(split_sequence)"
+if [[ "$rc" -eq 0 && "$seq" == "$expected" ]]; then
+  ok "reproducibility: same split sequence even when active pane is in another window"
+else
+  fail "reproducibility: expected same sequence (rc=$rc got=$seq)"
+fi
+
+# ============================================================
+# 3) --json: {status:ok, root_pane_id, window_id, panes:[{id,pane_id,index}]}
+# ============================================================
+reset_logs
+export WEZTERM_PANE="1"
+json=$(_wez_layout_apply parent-children --json 2>/dev/null); rc=$?
+unset WEZTERM_PANE
+if [[ "$rc" -eq 0 ]] && \
+   jq -e '.status == "ok"' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.root_pane_id == 1' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.window_id == 0' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '(.panes | length) == 2' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.panes[0] == {"id":"worker1","pane_id":101,"index":0}' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.panes[1] == {"id":"worker2","pane_id":102,"index":1}' <<< "$json" >/dev/null 2>&1; then
+  ok "json: ok-status map with root_pane_id/window_id/panes"
+else
+  fail "json: unexpected map (rc=$rc json=$json)"
+fi
+
+# ============================================================
+# 4) 部分失敗: 2番目 split 失敗 → 逆順 kill + exit 5 + partial JSON
+# ============================================================
+reset_logs
+export WEZTERM_PANE="1"
+export WEZ_TEST_FAIL_SPLIT_AT=2
+json=$(_wez_layout_apply parent-children --json 2>/dev/null); rc=$?
+unset WEZ_TEST_FAIL_SPLIT_AT
+unset WEZTERM_PANE
+killed="$(kill_sequence)"
+# 1番目 split 成功 (pane 101) → 2番目失敗 → rollback で 101 を kill。
+if [[ "$rc" -eq 5 && "$killed" == "101" ]] && \
+   jq -e '.status == "partial"' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.failed_step == 1' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.root_pane_id == 1' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.created == [101]' <<< "$json" >/dev/null 2>&1; then
+  ok "partial: 2nd split fails → reverse kill + exit 5 + partial JSON"
+else
+  fail "partial: expected exit5/kill 101/partial JSON (rc=$rc killed='$killed' json=$json)"
+fi
+
+# 4b) 失敗注入で harness（apply）が落ちる（非ゼロ終了）ことを確認
+reset_logs
+export WEZTERM_PANE="1"
+export WEZ_TEST_FAIL_SPLIT_AT=1
+_wez_layout_apply parent-children >/dev/null 2>&1; rc=$?
+unset WEZ_TEST_FAIL_SPLIT_AT
+unset WEZTERM_PANE
+killed="$(kill_sequence)"
+# 1番目で失敗 → created 0 件 → kill 無し → exit 5
+if [[ "$rc" -eq 5 && -z "$killed" ]]; then
+  ok "partial: 1st split fails → no created panes, no kill, exit 5"
+else
+  fail "partial(first): expected exit5/no-kill (rc=$rc killed='$killed')"
+fi
+
+# ============================================================
+# 5) 非冪等: 2 回 apply で split が倍発行される
+# ============================================================
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children >/dev/null 2>&1
+_wez_layout_apply parent-children >/dev/null 2>&1
+unset WEZTERM_PANE
+n_splits="$(split_sequence | wc -l | tr -d '[:space:]')"
+if [[ "$n_splits" -eq 4 ]]; then
+  ok "non-idempotent: two applies issue 4 splits (2x)"
+else
+  fail "non-idempotent: expected 4 splits got $n_splits"
+fi
+
+# ============================================================
+# 6) focus 復帰: 既定 root / --focus 上書き / preset focus=step
+# ============================================================
+# 6a) 既定 root へ activate
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children >/dev/null 2>&1
+unset WEZTERM_PANE
+if [[ "$(last_activate_pane)" == "1" ]]; then
+  ok "focus: default restores focus to root"
+else
+  fail "focus: expected activate root(1) got '$(last_activate_pane)'"
+fi
+
+# 6b) --focus <step-id> が created pane に解決される
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children --focus worker2 >/dev/null 2>&1
+unset WEZTERM_PANE
+# worker2 は 2番目 split = pane 102
+if [[ "$(last_activate_pane)" == "102" ]]; then
+  ok "focus: --focus <step-id> resolves to created pane"
+else
+  fail "focus: expected activate worker2(102) got '$(last_activate_pane)'"
+fi
+
+# 6c) preset focus=step-id（--focus 無し）が created pane に解決される
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply focus-worker >/dev/null 2>&1
+unset WEZTERM_PANE
+# focus-worker preset: focus=worker1（1番目 split = pane 101）
+if [[ "$(last_activate_pane)" == "101" ]]; then
+  ok "focus: preset focus=step resolves to created pane"
+else
+  fail "focus: expected activate worker1(101) got '$(last_activate_pane)'"
+fi
+
+# 6d) --focus <numeric pane id> がそのまま使われる
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children --focus 999 >/dev/null 2>&1
+unset WEZTERM_PANE
+if [[ "$(last_activate_pane)" == "999" ]]; then
+  ok "focus: --focus <numeric> used as literal pane id"
+else
+  fail "focus: expected activate 999 got '$(last_activate_pane)'"
+fi
+
+# ============================================================
+# 7) 異常系: preset 不在 / schema 不正 / root 不在 / 未知オプション
+# ============================================================
+# 7a) preset 不在 → exit 1
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply does-not-exist >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 1 "$rc" "error: missing preset → exit 1"
+
+# 7b) schema 不正（bad dir）→ exit 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply bad-dir >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "error: invalid dir schema → exit 64"
+
+# 7c) schema 不正（bad percent）→ exit 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply bad-percent >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "error: percent out of range → exit 64"
+
+# 7d) schema 不正（from != root）→ exit 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply bad-from >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "error: from!=root → exit 64"
+
+# 7e) root 不在（WEZTERM_PANE 未設定）→ exit 3
+reset_logs
+unset WEZTERM_PANE
+_wez_layout_apply parent-children >/dev/null 2>&1; rc=$?
+expect_rc 3 "$rc" "error: no WEZTERM_PANE → exit 3"
+
+# 7f) root 数値だが stale（list に不在）→ exit 3
+reset_logs
+export WEZTERM_PANE="777"
+_wez_layout_apply parent-children >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 3 "$rc" "error: stale WEZTERM_PANE → exit 3"
+
+# 7g) 未知オプション → exit 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children --bogus >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "error: unknown option → exit 64"
+
+# 7h) 引数過多 → exit 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children extra >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "error: too many args → exit 64"
+
+# 7i) preset 名なし → exit 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "error: missing preset name → exit 64"
+
+# ============================================================
+# 8) list
+# ============================================================
+list_out="$(_wez_layout_list 2>/dev/null)"; rc=$?
+if [[ "$rc" -eq 0 ]] && grep -qx "parent-children" <<< "$list_out" && grep -qx "focus-worker" <<< "$list_out"; then
+  ok "list: lists preset names"
+else
+  fail "list: expected preset names (rc=$rc out=$list_out)"
+fi
+
+# list 未知オプション → 64
+_wez_layout_list --bogus >/dev/null 2>&1; rc=$?
+expect_rc 64 "$rc" "list: unknown option → exit 64"
+
+# ============================================================
+# 9) --help
+# ============================================================
+help_out="$(_wez_layout_apply --help 2>/dev/null)"; rc=$?
+if [[ "$rc" -eq 0 ]] && grep -q "Usage: wez layout apply" <<< "$help_out" && grep -qi "NON-IDEMPOTENT" <<< "$help_out"; then
+  ok "help: apply --help shows usage + non-idempotent note"
+else
+  fail "help: apply --help missing usage/non-idempotent (rc=$rc)"
+fi
+
+dispatch_help="$(_wez_layout_help 2>/dev/null)"; rc=$?
+if [[ "$rc" -eq 0 ]] && grep -q "Usage: wez layout" <<< "$dispatch_help"; then
+  ok "help: dispatcher help shows usage"
+else
+  fail "help: dispatcher help missing usage (rc=$rc)"
+fi
+
+# ============================================================
+# 10) schema/引数/focus エッジ（_wez_layout_apply 直叩き）
+# ============================================================
+# 10a) path traversal: preset 名に '../' → split せず 64（C2）
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply "../bad-dir" >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 64 && -z "$seq" ]]; then
+  ok "security: path traversal preset name (../) → exit 64, no split (C2)"
+else
+  fail "security: expected 64/no-split for ../ (rc=$rc seq='$seq')"
+fi
+
+# 10b) path traversal: preset 名に '/' → 64
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply "sub/preset" >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "security: preset name with '/' → exit 64 (C2)"
+
+# 10c) decimal percent → schema 段階で 64（W2、rollback 5 ではない）
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply decimal-percent >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 64 && -z "$seq" ]]; then
+  ok "schema: decimal percent → exit 64 at schema stage, no split (W2)"
+else
+  fail "schema: expected 64/no-split for decimal percent (rc=$rc seq='$seq')"
+fi
+
+# 10d) numeric step id → schema 段階で 64（W3）
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply numeric-id >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+expect_rc 64 "$rc" "schema: numeric step id → exit 64 (W3)"
+
+# 10e) 不正 --focus（未知 step id）→ split せず 64（C3）
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children --focus bogus >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 64 && -z "$seq" ]]; then
+  ok "focus: invalid --focus step id → exit 64 before any split (C3)"
+else
+  fail "focus: expected 64/no-split for invalid --focus (rc=$rc seq='$seq')"
+fi
+
+# 10f) preset の focus が不正 step id → split せず 64（C3）
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply bad-focus >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 64 && -z "$seq" ]]; then
+  ok "focus: invalid preset focus → exit 64 before any split (C3)"
+else
+  fail "focus: expected 64/no-split for invalid preset focus (rc=$rc seq='$seq')"
+fi
+
+# 10g) numeric --focus は step id 照合より先にリテラル pane id として使われる（W3）
+#   注: schema が numeric step id を禁止するので衝突は起き得ないが、
+#   numeric spec がリテラルとして解決されることを明示的に確認する。
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply parent-children --focus 555 >/dev/null 2>&1
+unset WEZTERM_PANE
+if [[ "$(last_activate_pane)" == "555" ]]; then
+  ok "focus: numeric --focus resolved as literal pane id (W3)"
+else
+  fail "focus: expected activate 555 got '$(last_activate_pane)'"
+fi
+
+# 10h) rollback の kill 失敗が partial JSON の rollback_failed に反映される（W4）
+reset_logs
+export WEZTERM_PANE="1"
+export WEZ_TEST_FAIL_SPLIT_AT=2   # 2番目 split 失敗 → pane 101 を rollback
+export WEZ_TEST_FAIL_KILL="101"   # その kill を失敗させる
+json=$(_wez_layout_apply parent-children --json 2>/dev/null); rc=$?
+unset WEZ_TEST_FAIL_SPLIT_AT WEZ_TEST_FAIL_KILL WEZTERM_PANE
+if [[ "$rc" -eq 5 ]] && \
+   jq -e '.status == "partial"' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.created == [101]' <<< "$json" >/dev/null 2>&1 && \
+   jq -e '.rollback_failed == [101]' <<< "$json" >/dev/null 2>&1; then
+  ok "rollback: failed kill reflected in partial JSON rollback_failed (W4)"
+else
+  fail "rollback: expected exit5/rollback_failed=[101] (rc=$rc json=$json)"
+fi
+
+# 10i) rollback の kill 成功時は rollback_failed が空配列（W4 回帰）
+reset_logs
+export WEZTERM_PANE="1"
+export WEZ_TEST_FAIL_SPLIT_AT=2
+json=$(_wez_layout_apply parent-children --json 2>/dev/null); rc=$?
+unset WEZ_TEST_FAIL_SPLIT_AT WEZTERM_PANE
+if [[ "$rc" -eq 5 ]] && jq -e '.rollback_failed == []' <<< "$json" >/dev/null 2>&1; then
+  ok "rollback: successful kill → rollback_failed is empty (W4)"
+else
+  fail "rollback: expected empty rollback_failed (rc=$rc json=$json)"
+fi
+
+# 10j) window_id 解決失敗 → JSON は window_id:null
+reset_logs
+export WEZ_TEST_FIXTURE="$FIXTURE_NULL_WINDOW"
+export WEZTERM_PANE="1"
+json=$(_wez_layout_apply parent-children --json 2>/dev/null); rc=$?
+unset WEZTERM_PANE
+export WEZ_TEST_FIXTURE="$FIXTURE_DEFAULT"
+if [[ "$rc" -eq 0 ]] && jq -e '.window_id == null' <<< "$json" >/dev/null 2>&1; then
+  ok "json: unresolved window_id → window_id:null"
+else
+  fail "json: expected window_id:null (rc=$rc json=$json)"
+fi
+
+# ============================================================
+# 11) wez_cmd_layout 経由（socket 1回解決+export / list discovery前 / unknown / --socket 位置）
+# ============================================================
+# 11a) apply 経由: socket 解決 → WEZTERM_UNIX_SOCKET export → split 列
+reset_logs
+unset WEZTERM_UNIX_SOCKET
+export WEZTERM_PANE="1"
+wez_cmd_layout --socket "$TEST_SOCKET" apply parent-children >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 0 && "$seq" == "$expected" && "${WEZTERM_UNIX_SOCKET:-}" == "$TEST_SOCKET" ]]; then
+  ok "cmd: apply via wez_cmd_layout resolves+exports socket and splits"
+else
+  fail "cmd: expected ok/exported-socket/split (rc=$rc sock='${WEZTERM_UNIX_SOCKET:-}' seq='$seq')"
+fi
+unset WEZTERM_UNIX_SOCKET
+
+# 11b) list は discovery 前に処理される（bogus socket でも成功）
+reset_logs
+export WEZTERM_UNIX_SOCKET="/nonexistent/socket"
+list_out="$(wez_cmd_layout list 2>/dev/null)"; rc=$?
+unset WEZTERM_UNIX_SOCKET
+if [[ "$rc" -eq 0 ]] && grep -qx "parent-children" <<< "$list_out"; then
+  ok "cmd: list served before socket discovery (W5)"
+else
+  fail "cmd: expected list before discovery (rc=$rc out='$list_out')"
+fi
+
+# 11c) unknown subcommand → discovery 前に 64（socket 不在でも socket 系 exit にしない、W5）
+reset_logs
+export WEZTERM_UNIX_SOCKET="/nonexistent/socket"  # discovery が走れば 1 になる値
+wez_cmd_layout bogus-subcommand >/dev/null 2>&1; rc=$?
+unset WEZTERM_UNIX_SOCKET
+expect_rc 64 "$rc" "cmd: unknown subcommand → exit 64 before discovery (W5)"
+
+# 11d) --socket は subcommand より前でなければならない（後置は subcommand 扱い）
+reset_logs
+export WEZTERM_PANE="1"
+wez_cmd_layout apply parent-children --socket "$TEST_SOCKET" >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+# apply の --socket は _wez_layout_apply にとって未知オプション → 64
+expect_rc 64 "$rc" "cmd: --socket after subcommand is rejected (must precede)"
+
+# 11e) unknown option（subcommand 前）→ 64
+reset_logs
+wez_cmd_layout --bogus-flag apply parent-children >/dev/null 2>&1; rc=$?
+expect_rc 64 "$rc" "cmd: unknown option before subcommand → exit 64"
+
+# ============================================================
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/projects/wezterm-ai-mode/tests/test_wez_layout.sh
+++ b/projects/wezterm-ai-mode/tests/test_wez_layout.sh
@@ -225,6 +225,18 @@ cat > "$_LAYOUT_PRESET_DIR/numeric-id.json" <<'JSON'
 }
 JSON
 
+# schema 不正: version が非対応（V1: version==1 で fail-fast）
+cat > "$_LAYOUT_PRESET_DIR/bad-version.json" <<'JSON'
+{
+  "version": 2,
+  "root": "self",
+  "steps": [
+    {"id": "worker1", "from": "root", "dir": "bottom", "percent": 30}
+  ],
+  "focus": "root"
+}
+JSON
+
 # focus 不正: preset の focus が未知の step id（C3: split 前に 64 で弾く）
 cat > "$_LAYOUT_PRESET_DIR/bad-focus.json" <<'JSON'
 {
@@ -240,14 +252,22 @@ JSON
 # --- 実 Unix domain socket（wez_cmd_layout の discovery 経路テスト用） ---
 # discover.sh の `[[ -S "$socket" ]]` を満たす本物の socket ファイルを作る。
 # 接続検証 (wez_verify_connection) は mock `wezterm cli list` が応答するため通る。
+# socket 生成には python3 が要るが、project 要件は Bash/jq/wezterm のみ。python3 が
+# 無い環境では socket 依存ケース (11a/11d) を clean に skip する（冒頭 jq skip と同型）。
 TEST_SOCKET="$_TMP_DIR/gui-sock-test"
-python3 - "$TEST_SOCKET" <<'PY'
+HAVE_PYTHON3=false
+if command -v python3 >/dev/null 2>&1; then
+  HAVE_PYTHON3=true
+  python3 - "$TEST_SOCKET" <<'PY'
 import socket, sys
 p = sys.argv[1]
 s = socket.socket(socket.AF_UNIX)
 s.bind(p)
 s.close()
 PY
+else
+  printf 'SKIP: python3 not installed; skipping wez_cmd_layout socket-discovery cases (11a/11d)\n' >&2
+fi
 
 # --- Test harness ---
 PASS=0
@@ -585,6 +605,33 @@ _wez_layout_apply numeric-id >/dev/null 2>&1; rc=$?
 unset WEZTERM_PANE
 expect_rc 64 "$rc" "schema: numeric step id → exit 64 (W3)"
 
+# 10d2) 非対応 version → schema 段階で 64、split 無し（V1: version==1 で fail-fast）
+reset_logs
+export WEZTERM_PANE="1"
+_wez_layout_apply bad-version >/dev/null 2>&1; rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 64 && -z "$seq" ]]; then
+  ok "schema: unsupported version (!=1) → exit 64 at schema stage, no split (V1)"
+else
+  fail "schema: expected 64/no-split for version!=1 (rc=$rc seq='$seq')"
+fi
+
+# 10d3) jq 未導入 → 依存失敗 exit 5、split 無し（V3: ADR-004 DJ-9 と一貫）
+#   jq 不在を再現するため、PATH を pathbin のみ（mock wezterm はあるが jq は無い）に
+#   差し替えた subshell で 1 回だけ呼ぶ。jq チェックは preset 読込より前なので即 5 を
+#   返す。subshell で隔離するので親シェルの PATH は汚さない。
+reset_logs
+export WEZTERM_PANE="1"
+( export PATH="$_TMP_DIR/pathbin"; _wez_layout_apply parent-children >/dev/null 2>&1 ); rc=$?
+unset WEZTERM_PANE
+seq="$(split_sequence)"
+if [[ "$rc" -eq 5 && -z "$seq" ]]; then
+  ok "deps: jq not installed → exit 5 (dependency failure), no split (V3)"
+else
+  fail "deps: expected 5/no-split for missing jq (rc=$rc seq='$seq')"
+fi
+
 # 10e) 不正 --focus（未知 step id）→ split せず 64（C3）
 reset_logs
 export WEZTERM_PANE="1"
@@ -667,18 +714,23 @@ fi
 # 11) wez_cmd_layout 経由（socket 1回解決+export / list discovery前 / unknown / --socket 位置）
 # ============================================================
 # 11a) apply 経由: socket 解決 → WEZTERM_UNIX_SOCKET export → split 列
-reset_logs
-unset WEZTERM_UNIX_SOCKET
-export WEZTERM_PANE="1"
-wez_cmd_layout --socket "$TEST_SOCKET" apply parent-children >/dev/null 2>&1; rc=$?
-unset WEZTERM_PANE
-seq="$(split_sequence)"
-if [[ "$rc" -eq 0 && "$seq" == "$expected" && "${WEZTERM_UNIX_SOCKET:-}" == "$TEST_SOCKET" ]]; then
-  ok "cmd: apply via wez_cmd_layout resolves+exports socket and splits"
+# 実 socket 生成に python3 が要るため、python3 不在時は skip（V4）。
+if [[ "$HAVE_PYTHON3" == true ]]; then
+  reset_logs
+  unset WEZTERM_UNIX_SOCKET
+  export WEZTERM_PANE="1"
+  wez_cmd_layout --socket "$TEST_SOCKET" apply parent-children >/dev/null 2>&1; rc=$?
+  unset WEZTERM_PANE
+  seq="$(split_sequence)"
+  if [[ "$rc" -eq 0 && "$seq" == "$expected" && "${WEZTERM_UNIX_SOCKET:-}" == "$TEST_SOCKET" ]]; then
+    ok "cmd: apply via wez_cmd_layout resolves+exports socket and splits"
+  else
+    fail "cmd: expected ok/exported-socket/split (rc=$rc sock='${WEZTERM_UNIX_SOCKET:-}' seq='$seq')"
+  fi
+  unset WEZTERM_UNIX_SOCKET
 else
-  fail "cmd: expected ok/exported-socket/split (rc=$rc sock='${WEZTERM_UNIX_SOCKET:-}' seq='$seq')"
+  printf 'skip: cmd apply socket-discovery (python3 absent)\n'
 fi
-unset WEZTERM_UNIX_SOCKET
 
 # 11b) list は discovery 前に処理される（bogus socket でも成功）
 reset_logs
@@ -699,12 +751,17 @@ unset WEZTERM_UNIX_SOCKET
 expect_rc 64 "$rc" "cmd: unknown subcommand → exit 64 before discovery (W5)"
 
 # 11d) --socket は subcommand より前でなければならない（後置は subcommand 扱い）
-reset_logs
-export WEZTERM_PANE="1"
-wez_cmd_layout apply parent-children --socket "$TEST_SOCKET" >/dev/null 2>&1; rc=$?
-unset WEZTERM_PANE
-# apply の --socket は _wez_layout_apply にとって未知オプション → 64
-expect_rc 64 "$rc" "cmd: --socket after subcommand is rejected (must precede)"
+# TEST_SOCKET を参照するため python3 不在時は skip（V4）。
+if [[ "$HAVE_PYTHON3" == true ]]; then
+  reset_logs
+  export WEZTERM_PANE="1"
+  wez_cmd_layout apply parent-children --socket "$TEST_SOCKET" >/dev/null 2>&1; rc=$?
+  unset WEZTERM_PANE
+  # apply の --socket は _wez_layout_apply にとって未知オプション → 64
+  expect_rc 64 "$rc" "cmd: --socket after subcommand is rejected (must precede)"
+else
+  printf 'skip: cmd --socket-position (python3 absent)\n'
+fi
 
 # 11e) unknown option（subcommand 前）→ 64
 reset_logs


### PR DESCRIPTION
## 目的

cockpit（#169）/ wez layout（Epic #20 Phase4）で、AI/CLI からマルチエージェント盤面を**宣言的・再現可能**に構築する手段が無い。`wez pane split` 等は単発・その場任せ。#174（targeting 規約）landed の上で、本 PR は最小 PoC「親1+子N」を `wez layout` として実装する。

## 変更内容

- `wez layout apply <name> [--focus <target>] [--json]` / `list` / `--help`（`lib/layout.sh` + `bin/wez` dispatch）
- JSON 名付き preset（`lib/layouts/<name>.json`）: `{version, root:"self", steps:[{id, from:"root", dir, percent}], focus}`。PoC preset `parent-children.json`
- 処理: socket を**1回**解決+export → ROOT=self を**1回**解決+存在確認 → 各 step を **explicit `--pane-id $ROOT`** で分割（B3 fallback を踏まない）→ 失敗時は作成済 pane を**逆順 kill（rollback）** → focus 復帰 → pane_id map 返却
- `apply --json`: 成功 `{status:"ok", root_pane_id, window_id, panes:[{id, pane_id, index}]}` / 部分失敗 `{status:"partial", root_pane_id, created, failed_step, rollback_failed}`（**#175 接続契約**）
- `ADR-004` に **DJ-9**（layout 規約）昇格、README に layout 節（schema・`dir` マップ・jq 必須・非冪等・wez 専用）

## 設計判断（DJ-a..e）

- DJ-a JSON preset（steps+id+root） / DJ-b 盤面構築のみ（コマンド起動は持たない=#114 切り分け・ただし pane_id map は返す） / DJ-c split 反復（Lua 不採用） / DJ-d focus 既定 self+`--focus` / DJ-e **wez 基盤専用**（#188 の 2 基盤別レイヤ）

## 性質（明示）

- **非冪等（create-only）**: 2 回 apply で倍増。真の冪等（`--replace`+所有 marker）は PoC 外
- **wez 専用**: delegate(tmux) 盤面は out of scope（#188・別 mux レイヤ）。価値 = engine/非対話用 outer board

## 検証（設計SO + 実装SO・heavy）

- 設計SO（`so-compare --with codex,cursor`・選択肢拡張）→ 6 点 refine（steps schema / 非冪等 / pane_id map / rollback / socket・root 固定 / 価値範囲）を実装前に反映
- 実装SO → **critical 3 件**（`local -n` の bash 3.2 破綻[ADR-005 違反] / preset 名 path traversal / `--focus` 不正の silent exit 0）+ warning 6 件を捕捉 → 1 ラウンド全修正
- mock shim テスト（`tests/test_wez_layout.sh`）: **bash 5.2 と macOS bash 3.2 の両方で 38/38 pass**。shellcheck clean。`local -n` 残存ゼロ
- 負のコントロール: 各ガードを外すと対応テストが落ちることを確認

## スコープ境界

- `spawn.sh` の layout 化（消費側）は **#175** / grid・ネストは再帰ツリー schema v2（別 issue） / #111（activate）CLOSED / #114 とはコマンド起動を持たないことで切り分け

## デプロイ注記

`~/bin/wez` は repo `bin/wez` への symlink（sync-bin.sh）で、`bin/wez` は WEZ_ROOT を in-repo 解決して `lib/*.sh` を source する。よってマージ後 `lib/layout.sh` は既存 symlink 経由で即 live（sync スクリプト変更不要）。

Refs #165
