### PR TITLE
feat(oe): spawn.sh の盤面構築を wez layout 化し機械1サイクルを正規化

### DIFF
--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -59,7 +59,10 @@ oe_main() {
   task_description="${task_description:-${*:-Run orchestration task}}"
   local pane_id
 
-  # 5) spawn 準備 → envelope 生成 → send
+  # 5) 盤面初期化（#175: wez layout で宣言的に board を構築）→ spawn 準備 → envelope 生成 → send
+  #    oe_board_apply は 1 サイクルで 1 回だけ。target は pool[0]、verify の reviewer は pool[1] を消費する
+  #    （盤面初期化と都度 spawn の責務分離）。board 無効/失敗時は従来の都度 split にフォールバックする。
+  oe_board_apply
   oe_spawn_prepare_pane
   pane_id="$OE_SPAWN_PANE_ID"
   oe_envelope_create "$OE_CURRENT_SESSION_ID" "$pane_id" "$task_description" "$PROJECT_DIR" "$OE_CB_TIMEOUT"

--- a/projects/orchestration-engine/docs/discussions/2026-06-20-discussion-175-spawn-layout.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-20-discussion-175-spawn-layout.md
@@ -1,0 +1,132 @@
+---
+id: "01KVHMVQDN34GZAXJF0HJRMYZ1"
+title: "#175 spawn.sh 盤面構築の wez layout 化 — 設計探索と DJ"
+date: 2026-06-20
+type: discussion
+status: stable
+related:
+  - type: implements
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/175"
+    reason: "本 discussion の対象 Issue（spawn.sh の layout 化・機械1サイクル正規化）"
+  - type: depends_on
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md"
+    reason: "DJ-9（wez layout 規約・pane_id map 契約・非冪等）/ DJ-8（split targeting 規約）を消費"
+  - type: depends_on
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-005-bash-shell-standards.md"
+    reason: "bash 3.2/5.2 両対応・local -n 等 4.0+ 機能禁止"
+  - type: source_material
+    ref: "projects/wezterm-ai-mode/docs/episodes/2026-06-20-episode-wez-layout.md"
+    reason: "#191 layout 実装 episode。次の消費者として #175 を明記"
+---
+
+# #175 spawn.sh 盤面構築の wez layout 化 — 設計探索
+
+## Context / なぜ
+
+orchestration-engine の `lib/spawn.sh` は盤面構築をハードコードしている:
+
+```bash
+OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent 30 --wait-ready --timeout "$OE_SPAWN_WAIT_READY_SEC")"
+```
+
+`oe_spawn_prepare_pane` はこの単発 split で都度ペインを作る。#191（merged）で `wez layout apply <name> --json`（宣言的盤面構築・pane_id map 返却・非冪等）が landed したので、engine の機械1サイクル（envelope → spawn → monitor → verify → cleanup）を「規約ベース盤面」で再現的に成立させる（#175）。
+
+## 暗黙の前提（明示化）
+
+- P1: `oe_spawn_prepare_pane` は **2 経路から呼ばれる**: (a) `bin/oe` の target ペイン生成、(b) `lib/verify.sh:oe_verify_spawn` の reviewer ペイン生成。
+- P2: reviewer 数は **動的**（`oe_verify_run_phase` は target ペインのリストを取り各 target に reviewer を1体）。`bin/oe` 1サイクルでは target=1 → reviewer=1。
+- P3: `OE_SPAWN_PANE_ID` の下流消費者: envelope（pane_id を JSON に `--argjson` で**数値**記録）/ `oe_spawn_send` / `oe_monitor_loop`（`OE_MANAGED_PANES` に登録 → cleanup kill）/ `oe_verify_run_phase`（target_pane_id）/ `cleanup`。
+- P4: `wez layout apply` は WEZTERM_PANE から root(self) を解決して全 split。**非冪等**（2 回 apply でペイン倍増）。preset は `wezterm-ai-mode/lib/layouts/<name>.json` のみから読む（ディレクトリは layout.sh 内ハードコード）。**layout の内部 split は `_wez_pane_split` のみで `--wait-ready` を渡さない**（layout.sh:232）。`_wez_wait_pane_ready` は pane.sh の private で `wez pane split --wait-ready` 経由でしか届かず standalone verb は無い。
+- P5: テスト結合: `test_e2e_smoke.sh` は `bin/oe` 全経路を mock wez で回す（mock は `pane split/send/capture/kill/notify` のみ・**`layout` 非対応**）。`test_verify.sh` は `oe_verify_spawn` を**単体**で複数回呼ぶ（mock `pane split` が 888 系を返す前提）。`test_cleanup.sh` は `OE_MANAGED_PANES` のみ設定し `killed_pane_ids==[101,102]` を期待。
+- P6: bash 3.2/5.2 両対応（ADR-005）。`local -n` / `declare -A` / `mapfile` 禁止。空配列展開は `${arr[@]+"${arr[@]}"}`。
+
+## 核心 DJ-1: spawn.sh をどう layout 化するか（盤面初期化 vs 都度 spawn の責務分離）
+
+### ゼロベース選択肢列挙
+
+```
+DJ-1: spawn.sh 盤面構築の layout 化方式
+├── 案A（初期・kickoff 素直読み）: oe_spawn_prepare_pane が毎回 wez layout apply を呼び map から1枚取る
+│     採否: ❌ — layout は非冪等(P4)。2 回呼ぶ(target+reviewer)と盤面倍増。test_verify(layout 非対応 mock)破壊。
+├── 案B: bin/oe で1回だけ layout apply → target=map[0]、reviewer は従来どおり都度 split（pool 非共有）
+│     採否: △→再検討（後述）— 「都度 spawn の責務分離」(issue 文言)に最も忠実。だが parent-children(2子)では
+│             worker2 が未消費アイドルに（cleanup 全登録で orphan は防げるが空ペインが残る・geometry 浪費）。
+├── 案C+（採用）: bin/oe で1回 board apply → pool 化 FIFO 消費。oe_spawn_prepare_pane は pool から pop
+│     （空なら従来 split にフォールバック）。target=pool[0]、reviewer=pool[1]（1サイクルの2役を宣言盤面が宣言）。
+│     + 1回目 SO 指摘を反映: readiness 保証 / partial-apply orphan 回収 / cleanup dedup union / max-panes ガード。
+│     採否: ✅（2 回の oe-refute で反証・指摘を全反映、breadth で案B を再検討の上で選択）→ 採用
+├── 案D: engine 専用 preset(oe-cycle.json) を wezterm-ai-mode/lib/layouts/ に新規追加し board=それ
+│     採否: ❌（既定では）— cross-project ファイル所有。Minimal Scope / 「#191 本体は変更しない」境界に近接。
+│             既定は既存 parent-children に寄せ、preset 追加は将来必要時に別 issue（defer）。OE_BOARD_LAYOUT で差替可。
+└── 未探索: SQLite 的セッション間 board 永続 / desired-state ensure（#191 defer・schema v2）— PoC 範囲外（後戻りコスト高）。
+```
+
+## SO ゲート（確定前ゼロベース反証・engine 運用ゲート = oe-refute が so-compare を wrap）
+
+predecision-exploration + 受け入れ条件「Episode + so-compare」を満たすため `oe-refute --rubric exploration --lanes 2`（codex,cursor）を**2 回**実行。verdict/dissent を確定前に転記（output_dir は揮発するため要点を本文に保全）。
+
+### 1 回目（claim=初期 案C・`refuted`・audit_id `20260620043537W4YCNF4DJ0HS`）
+
+material 指摘 → 全て案C+ に反映:
+- **(1) --wait-ready 回帰**（両レーン・critical）: layout 経路は readiness 待ちなし。→ engine 側 readiness poll `oe_board_wait_ready` を追加（pool pop ペインを送信前に poll）。fallback split は従来どおり `--wait-ready`。
+- **(2) partial-apply orphan**: status≠ok の取りこぼし未検証。→ partial の生存 orphan を cleanup 登録 + board 無効化（fallback）。
+- **(3) cleanup dedup**: 現 cleanup は dedup 無し。→ 3 配列 dedup union。
+- **(4) step順 role 割当 / hidden cursor / reviewer 結合**: → FIFO 消費を契約として明文化、結合は1サイクル限定の既知制約 + fallback で緩和。
+
+### 2 回目（claim=案C+・`refuted`・audit_id `20260620044126WKFA3FJSZ8K2`）
+
+dissent が **実質的な設計欠陥から「微修正＋実装前 grounding」へ収束**。新規の actionable のみ反映:
+- **(5) partial-apply 登録は `rollback_failed` のみ**（codex）: `created` は layout が逆順 rollback kill 済。生存 orphan は `rollback_failed` だけ。→ 登録対象を `rollback_failed` に限定（修正）。
+- **(6) board pre-create が `OE_CB_MAX_PANES` ガードを迂回**（codex）: monitor の max-panes 判定は `OE_MANAGED_PANES` のみ数える。→ `oe_board_apply` で board ペイン数 > `OE_CB_MAX_PANES` なら board を使わず（登録だけして fallback）+ warn。CB 不変条件を保つ。
+- **(7) readiness timeout 契約が未定義**（codex）: → `oe_board_wait_ready` は timeout 時 **warn + 続行（best-effort）**。`wez pane split --wait-ready` が timeout でも pane を返す挙動をミラー。死にペインは monitor CB が捕捉。
+- **(8) 案B+managed の breadth 再検討要求**（cursor）: → 下記「案B 再検討」で対応。
+
+残る dissent（=構造的・実装前 grounding）: 「実装/テスト/oe-refute 未着地」「dedup/readiness の実機検証なし」。これらは **exploration rubric が pre-implementation の claim に対し grounding(軸3) で必ず refute する構造**であり、実装+テストでしか閉じない。reframe-on-stall 判定: 1→2 回目で dissent は material に縮小（=空転ではない）。3 回目は同じ grounding 軸で再 refute する stall になるため**ここで打ち切り**、微修正を反映して実装に進む（grounding は実装+テスト+親 %32 の compliance review + Copilot で閉じる）。
+
+### 案B 再検討（指摘(8)への breadth 応答）
+
+cursor の指摘どおり「全 board ペインを cleanup 登録」を入れれば案B でも orphan は防げる。改めて案B（reviewer=都度 split・decouple）と案C+（reviewer=pool[1]）を比較:
+
+| 観点 | 案B（reviewer 都度 split） | 案C+（reviewer=pool[1]） |
+|---|---|---|
+| issue 文言「都度 spawn の責務分離」 | ◎ 最も忠実 | ○ board が2役を宣言 |
+| 「規約ベース盤面で1サイクル成立」 | △ reviewer は盤面外 | ◎ 盤面が target+reviewer を宣言 |
+| parent-children(2子) 利用 | △ worker2 が空アイドル | ◎ 両ペイン消費・浪費なし |
+| reviewer 結合 | ◎ 無し（動的 N に自然） | △ 1サイクル限定の結合（N>pool は fallback） |
+| 新規ファイル | 1子 preset 追加なら cross-project / 既存流用なら空ペイン | 不要（既存 parent-children を完全消費） |
+
+**採用 = 案C+**。理由: 受け入れ条件の核「`bin/oe` の1サイクルが**規約ベース盤面**で再現的に成立」は、盤面が1サイクルの2役（target/reviewer）を宣言する案C+ に最も忠実。既存 preset を新規ファイル無し・空ペイン無しで完全消費でき Minimal Scope。reviewer 結合は「盤面が1サイクルのペイン集合を宣言する」意図そのもので、N>pool は fallback split が吸収（致命でないと両レーンも明言）。案B は「都度 spawn」文言には忠実だが空ペイン or cross-project preset を招く。**この案B/案C+ の分岐は後戻りコスト中（spawn.sh 1関数 + bin/oe 配線の差）で可逆。PR で %32 に明示し human gate に委ねる**（推測で隠さない）。
+
+## 採用設計（案C+）の具体
+
+- **`oe_board_apply()`（新規・spawn.sh）**: `wez layout apply "$OE_BOARD_LAYOUT" --json` を**1回**。`OE_BOARD_LAYOUT` 空 → board 無し(return)。apply 失敗/非 JSON → warn + board 無し(fallback)。
+  - `status=="ok"`: `panes[].pane_id` を step 順で `OE_BOARD_PANE_IDS` へ、`OE_BOARD_CURSOR=0`。**max-panes ガード**: 件数 > `OE_CB_MAX_PANES` なら全件を `OE_BOARD_MANAGED_PANES` に登録（回収用）し pool を空に（fallback）+ warn。通常は全 board ペインを `OE_BOARD_MANAGED_PANES` に登録（未消費ペインも orphan 化させない）。
+  - `status=="partial"`: `rollback_failed[]`（生存 orphan のみ）を `OE_BOARD_MANAGED_PANES` に登録 + warn。pool 空（fallback）。
+- **`oe_spawn_prepare_pane()`（改修）**: pool に残あり → pop → `OE_SPAWN_PANE_ID` + cursor++ + `oe_board_wait_ready`。残なし → 従来 `wez pane split --bottom --percent "$OE_SPAWN_PERCENT" --wait-ready --timeout "$OE_SPAWN_WAIT_READY_SEC"`。`OE_SPAWN_PANE_ID` の意味は不変。
+- **`oe_board_wait_ready()`（新規・spawn.sh）**: `wez pane capture <id>` が非空+安定（2 連続一致）になるまで 0.5s 間隔で `OE_SPAWN_WAIT_READY_SEC` まで poll。timeout は warn + return 0（best-effort）。`_wez_wait_pane_ready` の最小ミラー。
+- **`bin/oe`**: spawn 前に `oe_board_apply` を1回。target=pool[0]、verify reviewer=pool[1]。
+- **`cleanup.sh`**: `OE_BOARD_MANAGED_PANES` を防御初期化し、3 配列（MANAGED + VERIFY + BOARD）の **dedup union**（先勝ち順保持）を kill + `killed_pane_ids` 化。
+
+## DJ-2: 既定 preset / パラメータ化
+
+- `OE_BOARD_LAYOUT`（既定 `parent-children`・空で board 無効＝kill switch 兼）。layout.sh が読めるのは `wezterm-ai-mode/lib/layouts/` のみ＝この env は同ディレクトリ内 preset 選択に限定（既知制約）。
+- `OE_SPAWN_PERCENT`（既定 30・fallback split の `--percent`）。既存 `OE_SPAWN_WAIT_READY_SEC` 据え置き。
+- **geometry 非互換の honest 記載**: 旧来は target/reviewer とも `--bottom --percent 30`。parent-children は worker1=bottom30% + worker2=right50%。盤面 geometry は変わる（機能後方互換は保つが視覚配置は preset に従う＝「規約ベース盤面」化の意図的帰結）。
+
+## DJ-3: targeting 規約（#190/DJ-8）の適用面
+
+- 盤面構築の self targeting は **layout apply 経路で満たす**（layout.sh が内部で `_wez_resolve_self_pane` を1回固定）。
+- fallback split は `--target` を明示せず **DJ-8 省略時デフォルト**（self 試行→native fallback + warn）に委ねる。明示 `--target self` は解決不能時 hard error(exit3) かつ mock 群が `--target` 非対応 → テスト churn と失敗意味変化を招くため不採用。
+
+## テスト整合（後方互換 critical）
+
+- `test_e2e_smoke.sh`: mock に `wez layout apply --json`（panes=[{id:worker1,pane_id:777,index:0},{id:worker2,pane_id:888,index:1}] を返す）追加。target=777(pool[0])、reviewer=888(pool[1])。**既存アサーション（target=777 / reviewer=888 / kill=[777,888] / notify 等）不変**で通る。board apply 実行のアサーション追加。
+- `test_verify.sh`: **無改修**（`oe_verify_spawn` 単体 → board 未 apply → pool 空 → fallback split → mock 888）。
+- `test_cleanup.sh`: cleanup が `OE_BOARD_MANAGED_PANES` を防御初期化すれば**無改修**（dedup union が `[101,102]` を維持）。
+
+## 残課題 / follow-up routing
+
+- engine 専用 preset（oe-cycle.json）への移行 → 必要時に別 issue（本 PR は既定 parent-children）。
+- multi-target（`oe_verify_run_phase` が複数 target）での pool 不足時の非対称 → fallback split で吸収。将来 multi-agent board は別 issue。
+- desired-state ensure / 真の冪等 board → #191 defer（schema v2）。
+- 対話 `oe-delegate`(tmux) 盤面 → out of scope（#188・別 mux レイヤ）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-175-spawn-layout.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-175-spawn-layout.md
@@ -25,7 +25,9 @@ tags: [orchestration-engine, wez-layout, spawn, board, cockpit, episode]
 
 # #175 spawn.sh 盤面構築の wez layout 化
 
-> `reconstructed`: 本 episode は作業中のリアルタイム追記ではなく closure 時に 1 パスで記述（証拠アンカー = oe-refute audit_id / テスト件数 / git stash 実証は直接取得）。リアルタイム追記ログと同列の証拠価値は持たない。
+> `reconstructed`: 本 episode は作業中のリアルタイム追記ではなく closure 時に 1 パスで記述（証拠アンカー = oe-refute audit_id / テスト件数 / git stash 実証 / Copilot diff `4426f17` は直接取得）。リアルタイム追記ログと同列の証拠価値は持たない。
+>
+> closure 2 段: 初版は PR #192 作成時点。本版は **PR 後の外部ゲート（Copilot レビュー）+ 親 compliance review を畳んだ最終 closure**（実装は `4426f17` で確定・本 closure はコード非変更）。
 
 ## Context / なぜ
 
@@ -35,7 +37,7 @@ orchestration-engine の `lib/spawn.sh` は盤面構築を `wez pane split --bot
 
 - **#177（観測 UI）/ cockpit 本線**: 規約ベース盤面の上で 1 サイクルが回る前提を引き継ぐ。
 - **将来 multi-agent board**: 本 PR の `OE_BOARD_LAYOUT` / pool 機構 + fallback split を土台に拡張（preset 差し替え・engine 専用 preset 化）。
-- **親 %32**: compliance review（ADR-005/bash 互換）+ Copilot を回す消費者。
+- **親 %32（消費済）**: compliance review（ADR-005/bash 互換）+ Copilot を実施済。残る消費者は **マージを判断するユーザー**（PR #192 は MERGEABLE/CLEAN・保留中）。
 
 ## やったこと（要件 → 実装）
 
@@ -46,6 +48,7 @@ orchestration-engine の `lib/spawn.sh` は盤面構築を `wez pane split --bot
 - `cleanup.sh`: 3 配列（MANAGED + VERIFY + BOARD）の dedup union を kill + killed_pane_ids 化。
 - パラメータ化: `OE_BOARD_LAYOUT`（既定 parent-children・空で kill switch）、`OE_SPAWN_PERCENT`（既定 30）。
 - `test_e2e_smoke.sh`: mock に `wez layout apply --json` 追加 + board 適用/fallback 不使用のアサーション。
+- **PR 後の Copilot ラウンド（`4426f17`・親 %32 が実施）**: C1（partial 分岐の到達不能 = orphan 回収 dead code）と C2（`oe_board_wait_ready` の非数値 timeout クラッシュ）を修正し `tests/test_spawn_board.sh`（true-repro・16 アサーション）を追加。詳細は「事実・失敗」。最終コードは `4426f17` で確定。
 
 ## 決定と根拠（→ discussion 2026-06-20-discussion-175-spawn-layout.md が正本）
 
@@ -59,12 +62,17 @@ orchestration-engine の `lib/spawn.sh` は盤面構築を `wez pane split --bot
 - **oe-refute 2 回目: `refuted`（2/2・audit_id 20260620044126WKFA3FJSZ8K2）**。dissent は material 設計欠陥から「微修正＋実装前 grounding」へ収束。新規 actionable: partial 登録は `rollback_failed` のみ（`created` は layout が rollback kill 済）/ `OE_CB_MAX_PANES` ガード追加 / readiness timeout 契約（warn+続行）。→ 反映。残る refute は exploration rubric が pre-implementation claim に対し grounding 軸で必ず立てる**構造的**なもの（実装+テストでしか閉じない）。reframe-on-stall 判定で 3 回目を打ち切り（同軸の再 refute = stall）、微修正を反映して実装へ（grounding は実装+テスト+%32 review で閉じる）。
 - **geometry 非互換**: 旧来は target/reviewer とも bottom30% split。parent-children は worker1=bottom30% + worker2=right50%。機能後方互換は保つが視覚配置は preset に従う（「規約ベース盤面」化の意図的帰結）。
 - **発見した既存債務（back-propagation）**: orchestration-engine のテストは bash 5.x でのみ検証されており、**master/HEAD 時点で真の bash 3.2 では 3 テストが落ちる**（後述・本 PR 起因ではない）。
+- **C1（PR 後 Copilot が捕捉した実バグ・本 PR 由来）**: `oe_board_apply` の partial 分岐が**到達不能（dead code）だった**。#191 layout の realistic な partial は **exit 5（`WEZ_EXIT_PANE_OP_FAILED`）+ stdout `{status:"partial", rollback_failed:[...]}`** で返るが、初版（`d02ebca`）の早期 return 条件が `rc != 0 || -z "$map"` だったため、rc=5 で `status=="partial"` 分岐（`rollback_failed` orphan の cleanup 登録）に到達せず orphan 回収が死んでいた。**oe-refute は「partial-apply orphan を処理せよ」と指摘し分岐を追加させたが、その分岐が rc ガードに遮られ inert になっていることまでは捕捉できなかった**。修正（`4426f17`）: 早期 return を **stdout ベース（`-z "$map"` のみ）** にし、map 非空なら rc に関わらず status で dispatch。
+- **C2（同 Copilot・堅牢化）**: `oe_board_wait_ready` の非数値 `timeout` が `timeout_ms=$(( timeout * 1000 ))` で `set -e` 即クラッシュ。`^[0-9]+$` 検証 + 安全 default フォールバックへ。両 Copilot スレッド返信済。
+- **親 compliance review の mis-verify（ゲートの穴）**: 親 compliance は PASS（shellcheck / 両 bash / ADR-005 / 後方互換 / 設計証跡）だったが、**edge テストに非現実 mock（partial+rc=0）を使ったため C1（realistic partial=rc=5）を見逃した**。外側ゲート（Copilot）が内側ゲート（子 self-review + 親 compliance）の穴を埋めた。
 
 ## わかったこと（W）
 
 - **bash 3.2.57 empty-array 実測**: `${#arr[@]}`（length）と `${arr[@]+"${arr[@]}"}`（guarded）は空配列でも**安全**。**bare `"${arr[@]}"` のみが空配列で unbound クラッシュ**。→ 本 PR の新規コードは全て安全側パターンを使用。
 - layout 経路は `--wait-ready` を持たず、`_wez_wait_pane_ready` は pane.sh private で standalone verb が無い（#191/#190 本体は変更不可）→ engine 側に readiness poll を持つしかない。
 - exploration rubric の oe-refute は pre-implementation の設計 claim に対し grounding 軸で構造的に refute する（実装証跡が無いため）。**SO の価値は verdict の survived/refuted そのものより、surfacing した material 指摘の質**にある（2 回で wait-ready 回帰・dedup・partial・max-panes を捕捉 = ゲートの実価値）。
+- **#191 layout の partial は exit 5 + stdout 併出**（`{status:"partial", rollback_failed:[...]}`）。`wez` 系の「失敗 rc でも stdout に構造化結果を返す」契約を消費側が `rc` 単独で早期 return すると、stdout ベースの分岐が dead code になる（C1 の根因）。**rc と stdout の両方が情報を持つ CLI は stdout 優先で分岐すべき**。
+- **指摘の「実装」と「有効化」は別**: oe-refute が partial 処理を指摘 → 分岐を追加したが、別のガード（rc 早期 return）に遮られ inert だった。**指摘の反映はコードの存在で終わらず、到達可能性（realistic 入力で実行されるか）まで検証して初めて閉じる**（C1 のメタ）。
 
 ## 検証
 
@@ -72,11 +80,13 @@ orchestration-engine の `lib/spawn.sh` は盤面構築を `wez pane split --bot
 - 全 14 テスト（default bash 5.2.37）: **PASS=0 FAIL なし**（e2e_smoke 46/46・verify 104・cleanup 19 等）。
 - **forced bash 3.2.57**（内側 `bin/oe` も 3.2 に固定）: 本 PR が触る経路は PASS（e2e_smoke 46/46 board 経路・verify 104・board 無効化 kill-switch の fallback split smoke は exit0/state=success/killed[777,888]）。
 - 既存 3 失敗（test_cleanup の reviewer-pane 無ガード空配列ループ / test_monitor の `declare -A` / test_oe_delegate の `CLAUDE_ARGS[@]`）は **HEAD でも同様に落ちる pre-existing**（git stash で実証）。本 PR 起因の回帰はゼロ。
+- **C1/C2 修正後（`4426f17`）の検証**: `tests/test_spawn_board.sh` 追加（true-repro: pre-fix FAIL → post-fix PASS）。partial(rc=5) で `rollback_failed`（999）が cleanup 登録される / status==ok で pool 構築 + 全 board ペイン登録 / 空 stdout で fallback（partial 登録しない）/ 非数値 timeout で set -e クラッシュしない、を assert。**bash 5.2.37 と forced 3.2.57 の両方で 16/16 PASS**（本 closure で再実行・確認）。
 
 ## ゲートと SO（heavy: 意図起動の oe-refute 2 本）
 
 - predecision-exploration + 受け入れ条件「Episode + so-compare」を `oe-refute --rubric exploration --lanes 2`（codex,cursor・so-compare を wrap）で充足。2 回実行・verdict/dissent/audit_id を discussion に確定前転記（output_dir は揮発のため要点を本文保全）。
 - SO 出力: `tmp/oe-refute-20260620043537W4YCNF4DJ0HS/` ・ `tmp/oe-refute-20260620044126WKFA3FJSZ8K2/`（gitignore 済 = コミットされない揮発パス。要点は discussion / 本 episode に転記）。
+- **PR 後の外部ゲート（Copilot レビュー・PR #192）**: C1（実バグ・partial 到達不能）+ C2（timeout 堅牢化）を捕捉 → `4426f17` で修正・両スレッド返信済。**ゲート積層の実証**: 設計ゲート（oe-refute）→ 子 self-review → 親 compliance → 外部 Copilot の順で、内側が見逃した穴を外側が反復捕捉した（oe-refute は partial 分岐を追加させたが inert 化を見逃し、compliance は非現実 mock で realistic partial を見逃し、Copilot が realistic 条件で捕捉）。
 
 ## follow-up routing
 
@@ -84,17 +94,26 @@ orchestration-engine の `lib/spawn.sh` は盤面構築を `wez pane split --bot
 - engine 専用 preset（oe-cycle.json）化 → 必要時に別 issue（本 PR は既定 parent-children 流用）。
 - multi-target（`oe_verify_run_phase` 複数 target）での pool 不足の非対称 → fallback split で吸収。将来 multi-agent board は別 issue。
 - 真の冪等 board / desired-state ensure → #191 defer（schema v2）。
+- **compliance-review の realistic-mock 規律**（C1 mis-verify の再発防止）→ %32/人の判断で別 doc/skill 化候補（本 episode では routing のみ）。
+- **完全移譲の closure 所有規約**（子が Copilot ラウンド〜closure まで回す）→ 委譲フロー（`delegate-task`/engine 駆動層）への反映候補（%32/人の判断）。
 
 ## 蒸留シグナル
 
 - **Decision 昇格**: 現時点では無し（layout 規約は ADR-004 DJ-9 に既存。engine 側の board 消費規約は 1 サイクル PoC の段階で、multi-agent board 確立時に昇格候補）。
-- **skill / rule / #62**: 無し。
-- **negative knowledge 候補**: 「bare `"${arr[@]}"` は bash 3.2 で空配列クラッシュ・`${arr[@]+...}` を使う」は ADR-005 に既存。今回の実測は ADR-005 の裏取り。
+- **negative knowledge 候補（#62）**: (a)「bare `"${arr[@]}"` は bash 3.2 で空配列クラッシュ・`${arr[@]+...}` を使う」は ADR-005 に既存（実測で裏取り）。(b)「`wez` 系は失敗 rc でも stdout に構造化結果を返す（partial=exit5+JSON）→ 消費側は rc 単独でなく stdout 内容で分岐」（C1 根因・転用可能な対構造）。
+
+### プロセス蒸留シグナル（完全移譲実験のメタ学び）
+
+- **ゲート積層が機能する（反復実証）**: 外側ゲート（SO / Copilot）が内側ゲート（子 self-review + 親 compliance）の穴を反復捕捉。#165 では SO が `local -n`、#192 では Copilot が C1 を捕捉。**compliance の委譲テストは非現実 mock（partial+rc=0）で realistic 条件バグ（rc=5）を見逃す** → 行き先: compliance-review チェックリストに「依存先の実 exit/stdout 契約に一致する realistic mock を使う」を足す候補（%32/人の判断）。
+- **委譲モデルの構造的学び**: 「子が PR で停止」モデルは **episode が PR 時点で不完全になり Copilot 以降が宙に浮く**。完全移譲では **子が Copilot ラウンド〜closure まで回す**のが正（今回は親が Copilot をやり戻し→本 closure で是正・次回から子が回す）。3 つの第三者視点（SO・親・Copilot）を動的に回し、負の FB は「全保存」でなく「**発見できる仕組み**」を残すのが本筋 → 行き先: 委譲フロー（`delegate-task` / engine 駆動層）の closure 所有規約として検討候補（%32/人の判断）。
+- **fresh session への guidance 伝播は有効**: CLAUDE.md / memory 由来の規律（oe-refute 設計ゲート自己選択・bash 3.2 自己適用・4 層 docs・reframe-on-stall）が新規子セッションで自走した。
+- **運用知**: 自律委譲子は `--permission-mode auto`（`bypassPermissions` は spawn 時に死ぬ）。
+- **skill / rule**: 上記プロセス学びの skill/rule 化は **候補（昇格は %32/人の判断）**。本 episode では昇格せず routing のみ。
 
 ## status
 
-達成（stable）。受け入れ条件: 規約ベース盤面で 1 サイクル成立（e2e_smoke で機械検証）✓ / 既存テスト回帰なし + shellcheck ✓ / engine 運用ゲート（Episode + so-compare = oe-refute 2 本）通過 ✓。PR 作成で停止（マージは %32/ユーザー判断）。
+達成（stable）。受け入れ条件: 規約ベース盤面で 1 サイクル成立（e2e_smoke で機械検証）✓ / 既存テスト回帰なし + shellcheck ✓ / engine 運用ゲート（Episode + so-compare = oe-refute 2 本）通過 ✓。**PR #192 は外部ゲート（Copilot）+ 親 compliance を通し self-complete（MERGEABLE/CLEAN）、C1/C2 は `4426f17` で修正済**。**マージは保留＝ユーザー判断**。本 episode をもって closure 完了（Copilot ラウンド〜closure を畳んだ最終版）。
 
 ## Step 4 外部チェック（heavy tier）
 
-Step4 辞退: closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation）は本 episode で自己充足し、かつ **kickoff 規定により親 %32 が compliance review + Copilot で外部レビューする**（closure を読む外部の目が確保される）。設計自体は意図起動 oe-refute 2 本で別レーン検証済（指摘・refute・ピボット・既存債務発見を省略せず記載、SO 出力パス/audit_id を転記、全 follow-up に行き先付与）。/ 既存チェックで覆った観点: routing / evidence anchor / 省略チェック / back-propagation（%32 review + 本文自己充足）/ 未実施観点と判断: なし。
+Step4 辞退: closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation）の 4 観点が既存チェックで覆われている。**失敗の選択的省略**は本版で C1（自分の実バグ）・C2・親 compliance の mis-verify を省略せず記載し、かつ **C1 は Copilot が独立に捕捉済（外部接地・自己評価のみではない）**。**routing**は全 follow-up（bash 3.2 債務 3 件 / preset / multi-target / compliance realistic-mock / 完全移譲 closure 所有）に行き先付与。**evidence anchor**は oe-refute audit_id・`4426f17`・テスト 16/16（両 bash 再実行）を転記。**back-propagation**は既存 bash 3.2 債務と C1 根因（#191 の exit5+stdout 契約）を反映。設計は oe-refute 2 本 + Copilot で別レーン検証済。本 closure は %32 へ報告し人が読む。/ 既存チェックで覆った観点: 省略チェック（Copilot 外部接地）/ routing / evidence anchor / back-propagation / 未実施観点と判断: なし。

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-175-spawn-layout.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-175-spawn-layout.md
@@ -1,0 +1,100 @@
+---
+id: "01KVHMVQDN1H7284YYGD4NDSY4"
+title: "#175 spawn.sh 盤面構築の wez layout 化（機械1サイクル正規化）実装"
+date: 2026-06-20
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/175"
+    reason: "本 episode の対象 Issue"
+  - type: source_material
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-20-discussion-175-spawn-layout.md"
+    reason: "設計探索・DJ 確定・oe-refute 2 回の反証トレース"
+  - type: depends_on
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md"
+    reason: "DJ-9 layout 規約（pane_id map 契約・非冪等）/ DJ-8 split targeting を消費"
+  - type: depends_on
+    ref: "projects/wezterm-ai-mode/docs/decisions/ADR-005-bash-shell-standards.md"
+    reason: "bash 3.2/5.2 両対応（empty-array 展開・local -n 禁止）"
+  - type: source_material
+    ref: "projects/wezterm-ai-mode/docs/episodes/2026-06-20-episode-wez-layout.md"
+    reason: "#191（消費する layout 本体）の実装 episode"
+tags: [orchestration-engine, wez-layout, spawn, board, cockpit, episode]
+---
+
+# #175 spawn.sh 盤面構築の wez layout 化
+
+> `reconstructed`: 本 episode は作業中のリアルタイム追記ではなく closure 時に 1 パスで記述（証拠アンカー = oe-refute audit_id / テスト件数 / git stash 実証は直接取得）。リアルタイム追記ログと同列の証拠価値は持たない。
+
+## Context / なぜ
+
+orchestration-engine の `lib/spawn.sh` は盤面構築を `wez pane split --bottom --percent 30 --wait-ready` でハードコードし、`oe_spawn_prepare_pane` が都度ペインを作っていた。#191 で `wez layout apply --json`（宣言的盤面・pane_id map 返却・非冪等）が landed したので、engine の機械1サイクル（envelope → spawn → monitor → verify → cleanup）を「規約ベース盤面」で再現的に成立させる（#169 cockpit 本線の機械オーケストレ層整備）。
+
+## 次の消費者
+
+- **#177（観測 UI）/ cockpit 本線**: 規約ベース盤面の上で 1 サイクルが回る前提を引き継ぐ。
+- **将来 multi-agent board**: 本 PR の `OE_BOARD_LAYOUT` / pool 機構 + fallback split を土台に拡張（preset 差し替え・engine 専用 preset 化）。
+- **親 %32**: compliance review（ADR-005/bash 互換）+ Copilot を回す消費者。
+
+## やったこと（要件 → 実装）
+
+- `oe_board_apply()`（spawn.sh 新規）: `wez layout apply "$OE_BOARD_LAYOUT" --json` を **1 回**呼び、pane_id map を pool（`OE_BOARD_PANE_IDS`）化。全 board ペインを `OE_BOARD_MANAGED_PANES` に登録（cleanup 回収）。max-panes ガード / partial-apply orphan 回収 / 失敗時の board 無効化（fallback）。
+- `oe_spawn_prepare_pane()` 改修: pool から FIFO pop（空なら従来 split にフォールバック）。`OE_SPAWN_PANE_ID` の意味は不変。
+- `oe_board_wait_ready()`（新規）: layout 経路に無い `--wait-ready` を engine 側で補う readiness poll（best-effort）。
+- `bin/oe`: spawn 前に `oe_board_apply` を 1 回（盤面初期化と都度 spawn の責務分離）。
+- `cleanup.sh`: 3 配列（MANAGED + VERIFY + BOARD）の dedup union を kill + killed_pane_ids 化。
+- パラメータ化: `OE_BOARD_LAYOUT`（既定 parent-children・空で kill switch）、`OE_SPAWN_PERCENT`（既定 30）。
+- `test_e2e_smoke.sh`: mock に `wez layout apply --json` 追加 + board 適用/fallback 不使用のアサーション。
+
+## 決定と根拠（→ discussion 2026-06-20-discussion-175-spawn-layout.md が正本）
+
+- **採用 = 案C+**（board が 1 サイクルの 2 役 target=pool[0]/reviewer=pool[1] を宣言・FIFO 消費・split fallback）。
+- 棄却: 案A（毎回 layout apply → 非冪等で倍増・test 破壊）/ 案D（engine 専用 preset 新規追加を既定化 → cross-project 所有・Minimal Scope 逸脱、`OE_BOARD_LAYOUT` での将来差替に defer）。
+- **案B（reviewer 常時 split・decouple）との分岐**: SO（cursor レーン）が「全 board 登録すれば案B でも orphan を防げ、reviewer 結合を消せる」と breadth 指摘。再検討の上で **案C+ を採用** — 受け入れ条件の核「1 サイクルが**規約ベース盤面**で成立」に最も忠実（盤面が target+reviewer を宣言）、既存 parent-children を新規ファイル無し・空ペイン無しで完全消費。reviewer 結合は「盤面が 1 サイクルのペイン集合を宣言する」意図そのもので 1 サイクル限定、N>pool は fallback split が吸収。**この分岐は後戻りコスト中・可逆のため自律確定し、PR で %32 に明示**（human gate へ）。
+
+## 事実・失敗（選択的省略なし）
+
+- **oe-refute 1 回目: `refuted`（2/2 レーン・audit_id 20260620043537W4YCNF4DJ0HS）**。material 指摘: (1) `--wait-ready` 回帰（layout 内部 split は readiness 待ち無し・standalone verb も無い）(2) partial-apply orphan 未処理 (3) cleanup dedup 不在 (4) step順 role 割当 / hidden cursor / reviewer 結合。→ 初期案C を **案C+ にピボット**（全反映）。
+- **oe-refute 2 回目: `refuted`（2/2・audit_id 20260620044126WKFA3FJSZ8K2）**。dissent は material 設計欠陥から「微修正＋実装前 grounding」へ収束。新規 actionable: partial 登録は `rollback_failed` のみ（`created` は layout が rollback kill 済）/ `OE_CB_MAX_PANES` ガード追加 / readiness timeout 契約（warn+続行）。→ 反映。残る refute は exploration rubric が pre-implementation claim に対し grounding 軸で必ず立てる**構造的**なもの（実装+テストでしか閉じない）。reframe-on-stall 判定で 3 回目を打ち切り（同軸の再 refute = stall）、微修正を反映して実装へ（grounding は実装+テスト+%32 review で閉じる）。
+- **geometry 非互換**: 旧来は target/reviewer とも bottom30% split。parent-children は worker1=bottom30% + worker2=right50%。機能後方互換は保つが視覚配置は preset に従う（「規約ベース盤面」化の意図的帰結）。
+- **発見した既存債務（back-propagation）**: orchestration-engine のテストは bash 5.x でのみ検証されており、**master/HEAD 時点で真の bash 3.2 では 3 テストが落ちる**（後述・本 PR 起因ではない）。
+
+## わかったこと（W）
+
+- **bash 3.2.57 empty-array 実測**: `${#arr[@]}`（length）と `${arr[@]+"${arr[@]}"}`（guarded）は空配列でも**安全**。**bare `"${arr[@]}"` のみが空配列で unbound クラッシュ**。→ 本 PR の新規コードは全て安全側パターンを使用。
+- layout 経路は `--wait-ready` を持たず、`_wez_wait_pane_ready` は pane.sh private で standalone verb が無い（#191/#190 本体は変更不可）→ engine 側に readiness poll を持つしかない。
+- exploration rubric の oe-refute は pre-implementation の設計 claim に対し grounding 軸で構造的に refute する（実装証跡が無いため）。**SO の価値は verdict の survived/refuted そのものより、surfacing した material 指摘の質**にある（2 回で wait-ready 回帰・dedup・partial・max-panes を捕捉 = ゲートの実価値）。
+
+## 検証
+
+- `shellcheck`: 変更 5 ファイル CLEAN。
+- 全 14 テスト（default bash 5.2.37）: **PASS=0 FAIL なし**（e2e_smoke 46/46・verify 104・cleanup 19 等）。
+- **forced bash 3.2.57**（内側 `bin/oe` も 3.2 に固定）: 本 PR が触る経路は PASS（e2e_smoke 46/46 board 経路・verify 104・board 無効化 kill-switch の fallback split smoke は exit0/state=success/killed[777,888]）。
+- 既存 3 失敗（test_cleanup の reviewer-pane 無ガード空配列ループ / test_monitor の `declare -A` / test_oe_delegate の `CLAUDE_ARGS[@]`）は **HEAD でも同様に落ちる pre-existing**（git stash で実証）。本 PR 起因の回帰はゼロ。
+
+## ゲートと SO（heavy: 意図起動の oe-refute 2 本）
+
+- predecision-exploration + 受け入れ条件「Episode + so-compare」を `oe-refute --rubric exploration --lanes 2`（codex,cursor・so-compare を wrap）で充足。2 回実行・verdict/dissent/audit_id を discussion に確定前転記（output_dir は揮発のため要点を本文保全）。
+- SO 出力: `tmp/oe-refute-20260620043537W4YCNF4DJ0HS/` ・ `tmp/oe-refute-20260620044126WKFA3FJSZ8K2/`（gitignore 済 = コミットされない揮発パス。要点は discussion / 本 episode に転記）。
+
+## follow-up routing
+
+- **既存 bash 3.2 債務**（本 PR 起因でない・Minimal Scope 外）→ **%32 へ報告し別 issue 判断に routing**: (a) cleanup.sh の `for reviewer_pane in "${OE_VERIFY_MANAGED_PANES[@]}"` 無ガード no-op ループ (b) test_monitor.sh の `declare -A`（ADR-005 違反・テスト側）(c) bin/oe-delegate の `CLAUDE_ARGS[@]` 無ガード。いずれも master で真 3.2 時に落ちる。behavioral-rule §4 に従い「別提案」として %32 に上げ、本 PR では触らない。
+- engine 専用 preset（oe-cycle.json）化 → 必要時に別 issue（本 PR は既定 parent-children 流用）。
+- multi-target（`oe_verify_run_phase` 複数 target）での pool 不足の非対称 → fallback split で吸収。将来 multi-agent board は別 issue。
+- 真の冪等 board / desired-state ensure → #191 defer（schema v2）。
+
+## 蒸留シグナル
+
+- **Decision 昇格**: 現時点では無し（layout 規約は ADR-004 DJ-9 に既存。engine 側の board 消費規約は 1 サイクル PoC の段階で、multi-agent board 確立時に昇格候補）。
+- **skill / rule / #62**: 無し。
+- **negative knowledge 候補**: 「bare `"${arr[@]}"` は bash 3.2 で空配列クラッシュ・`${arr[@]+...}` を使う」は ADR-005 に既存。今回の実測は ADR-005 の裏取り。
+
+## status
+
+達成（stable）。受け入れ条件: 規約ベース盤面で 1 サイクル成立（e2e_smoke で機械検証）✓ / 既存テスト回帰なし + shellcheck ✓ / engine 運用ゲート（Episode + so-compare = oe-refute 2 本）通過 ✓。PR 作成で停止（マージは %32/ユーザー判断）。
+
+## Step 4 外部チェック（heavy tier）
+
+Step4 辞退: closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation）は本 episode で自己充足し、かつ **kickoff 規定により親 %32 が compliance review + Copilot で外部レビューする**（closure を読む外部の目が確保される）。設計自体は意図起動 oe-refute 2 本で別レーン検証済（指摘・refute・ピボット・既存債務発見を省略せず記載、SO 出力パス/audit_id を転記、全 follow-up に行き先付与）。/ 既存チェックで覆った観点: routing / evidence anchor / 省略チェック / back-propagation（%32 review + 本文自己充足）/ 未実施観点と判断: なし。

--- a/projects/orchestration-engine/lib/cleanup.sh
+++ b/projects/orchestration-engine/lib/cleanup.sh
@@ -11,8 +11,10 @@ oe_cleanup() {
   # constants.sh を source せず cleanup.sh 単独で source されるケースに備える)
   declare -p OE_MANAGED_PANES >/dev/null 2>&1 || OE_MANAGED_PANES=()
   declare -p OE_VERIFY_MANAGED_PANES >/dev/null 2>&1 || OE_VERIFY_MANAGED_PANES=()
+  # #175: board（wez layout apply）で構築したペインも回収対象（消費済み／未消費を問わず orphan を残さない）
+  declare -p OE_BOARD_MANAGED_PANES >/dev/null 2>&1 || OE_BOARD_MANAGED_PANES=()
 
-  # 通常ペイン + 検証ペイン (OE_VERIFY_MANAGED_PANES) の両方を kill 対象に
+  # 通常ペイン + 検証ペイン + board ペインを kill 対象に集約
   local all_panes=()
   if [[ ${#OE_MANAGED_PANES[@]} -gt 0 ]]; then
     all_panes+=("${OE_MANAGED_PANES[@]}")
@@ -20,13 +22,24 @@ oe_cleanup() {
   if [[ ${#OE_VERIFY_MANAGED_PANES[@]} -gt 0 ]]; then
     all_panes+=("${OE_VERIFY_MANAGED_PANES[@]}")
   fi
+  if [[ ${#OE_BOARD_MANAGED_PANES[@]} -gt 0 ]]; then
+    all_panes+=("${OE_BOARD_MANAGED_PANES[@]}")
+  fi
 
+  # #175: 3 配列は重複し得る（target/reviewer が board pool と重なる）。先勝ち順で dedup し、
+  # kill と killed_pane_ids の両方を一意化する（重複 kill / 重複 audit を防ぎ、既存の
+  # killed_pane_ids 期待 [101,102] / [777,888] を維持する）。
   local killed_json='[]'
   if [[ ${#all_panes[@]} -gt 0 ]]; then
     local pane_id
+    local seen=$'\n'
     local ids_lines=""
     for pane_id in "${all_panes[@]}"; do
       [[ -n "$pane_id" ]] || continue
+      case "$seen" in
+        *$'\n'"${pane_id}"$'\n'*) continue ;;
+      esac
+      seen+="${pane_id}"$'\n'
       ids_lines+="${pane_id}"$'\n'
       wez pane kill "$pane_id" 2>/dev/null || true
     done

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -33,7 +33,18 @@ OE_SLO_DETECT_SEC=5
 OE_POLL_INTERVAL=2
 
 # wez pane split --wait-ready のタイムアウト（秒）。ADR-003 に準拠。
+# pool 経路（oe_board_wait_ready）と fallback split（--wait-ready）の両方で readiness タイムアウトに使う。
 OE_SPAWN_WAIT_READY_SEC="${OE_SPAWN_WAIT_READY_SEC:-10}"
+
+# #175: 機械1サイクルの盤面構築を宣言化する wez layout preset 名（lib/layouts/<name>.json）。
+# 既定は #191 の PoC preset parent-children（worker1=bottom30% / worker2=right50% の2子）。
+# 空文字にすると board を構築せず従来の都度 split のみ（kill switch 兼）。
+# layout.sh は preset を wezterm-ai-mode/lib/layouts/ からのみ読むため、この env は同ディレクトリ内の
+# preset 選択に限定される（既知制約）。
+OE_BOARD_LAYOUT="${OE_BOARD_LAYOUT:-parent-children}"
+
+# #175: board pool が空のときの fallback split（oe_spawn_prepare_pane）の --percent。
+OE_SPAWN_PERCENT="${OE_SPAWN_PERCENT:-30}"
 
 # KVS パス（OE_DATA_DIR でオーバーライド可能、デフォルトはプロジェクトルート相対）
 OE_STATE_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/state"
@@ -44,6 +55,11 @@ OE_AUDIT_DIR="${OE_DATA_DIR:-${PROJECT_DIR}}/audit"
 # Step 4-3 Phase E: 検証ペイン管理用配列 (F2: 通常ペイン OE_MANAGED_PANES / OE_DONE_PANES と分離)
 OE_VERIFY_MANAGED_PANES=()
 OE_VERIFY_DONE_PANES=()
+
+# #175: board（wez layout apply）で構築した全ペインの cleanup 回収用配列。
+# oe_board_apply が登録し、cleanup.sh が OE_MANAGED_PANES / OE_VERIFY_MANAGED_PANES と
+# dedup union して kill する（消費済み／未消費を問わず orphan を残さない）。
+OE_BOARD_MANAGED_PANES=()
 
 # Step 4-3 Phase E: 検証フェーズ完走フラグ (cleanup の wez notify 発火条件、CB 発動時は未設定のまま)
 OE_VERIFY_PHASE_COMPLETED=0

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -34,10 +34,14 @@ oe_board_apply() {
     return 0
   fi
 
+  # #191 の wez layout apply --json は partial 失敗時に exit 5（WEZ_EXIT_PANE_OP_FAILED）でも
+  # stdout に `{status:"partial", ..., rollback_failed:[...]}` を返す（layout.sh）。rc 単独で早期
+  # return すると status=="partial" 分岐（rollback_failed orphan の回収登録）が到達不能になるため、
+  # stdout（map）の中身で分岐する: 空ならハードエラー扱いで fallback、非空なら rc に関わらず status を解析。
   local map rc=0
   map="$(wez layout apply "$OE_BOARD_LAYOUT" --json 2>/dev/null)" || rc=$?
-  if [[ "$rc" -ne 0 || -z "$map" ]]; then
-    echo "oe_board_apply: wez layout apply '${OE_BOARD_LAYOUT}' failed (rc=${rc}); falling back to on-demand split" >&2
+  if [[ -z "$map" ]]; then
+    echo "oe_board_apply: wez layout apply '${OE_BOARD_LAYOUT}' failed (rc=${rc}, no JSON output); falling back to on-demand split" >&2
     return 0
   fi
 
@@ -45,6 +49,8 @@ oe_board_apply() {
   status="$(printf '%s' "$map" | jq -r '.status // "unknown"' 2>/dev/null || echo unknown)"
 
   # partial: layout は created を逆順 rollback kill 済。生存 orphan は rollback_failed のみ。
+  # realistic な partial は rc=5（WEZ_EXIT_PANE_OP_FAILED）で来るが、上で rc 早期 return を
+  # 廃したためこの分岐に到達する（= rollback_failed orphan の回収登録が機能する）。
   if [[ "$status" == "partial" ]]; then
     local rf_str rf
     rf_str="$(printf '%s' "$map" | jq -r '.rollback_failed[]?' 2>/dev/null || true)"
@@ -100,7 +106,14 @@ oe_board_apply() {
 # の最小ミラーを engine 側に持つ。timeout 時は warn + 続行（best-effort・split --wait-ready の挙動に整合）。
 oe_board_wait_ready() {
   local pane_id="$1"
-  local timeout="${2:-$OE_SPAWN_WAIT_READY_SEC}"
+  local timeout="${2:-${OE_SPAWN_WAIT_READY_SEC:-10}}"
+  # timeout は直後に算術展開する。非数値だと set -e 下で即エラー終了するため、非負整数で
+  # なければ安全なデフォルト（OE_SPAWN_WAIT_READY_SEC 既定値、無ければ 10）にフォールバックする。
+  if [[ ! "$timeout" =~ ^[0-9]+$ ]]; then
+    echo "oe_board_wait_ready: non-numeric timeout '${timeout}'; using default ${OE_SPAWN_WAIT_READY_SEC:-10}s" >&2
+    timeout="${OE_SPAWN_WAIT_READY_SEC:-10}"
+    [[ "$timeout" =~ ^[0-9]+$ ]] || timeout=10
+  fi
   local interval_ms=500
   local timeout_ms=$(( timeout * 1000 ))
   local elapsed_ms=0

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -5,11 +5,145 @@
 # グローバル変数: oe_spawn() の戻り値
 OE_SPAWN_PANE_ID=""
 
-# oe_spawn_prepare_pane — 新ペインを作成し OE_SPAWN_PANE_ID に保存
+# #175: 盤面（wez layout apply）由来のペイン pool（step 順）と消費カーソル。
+# oe_board_apply が積み、oe_spawn_prepare_pane が FIFO で pop する。
+# 空（board 無効 / apply 失敗 / 使い切り）のときは従来の都度 split にフォールバックする。
+OE_BOARD_PANE_IDS=()
+OE_BOARD_CURSOR=0
+
+# oe_board_apply — #175: 機械1サイクルの盤面を wez layout で宣言的に構築する（盤面初期化の責務）。
+#
+# `wez layout apply "$OE_BOARD_LAYOUT" --json` を **1 回だけ** 呼び、返る pane_id map から
+# `panes[].pane_id` を step 順で OE_BOARD_PANE_IDS（pool）へ積む。以降の都度 spawn
+# (oe_spawn_prepare_pane) はこの pool から pop する（= 盤面初期化と都度 spawn の責務分離）。
+#
+# 設計（discussions/2026-06-20-discussion-175-spawn-layout.md・oe-refute 2 回反映）:
+#   - 非冪等な layout を二重 apply しないよう bin/oe で 1 回だけ呼ぶ前提。
+#   - 全 board ペインを OE_BOARD_MANAGED_PANES に登録し cleanup で回収する（消費済み／未消費を問わず
+#     orphan を残さない。cleanup は 3 配列を dedup union して kill）。
+#   - max-panes ガード: board ペイン数が OE_CB_MAX_PANES を超えると CB 不変条件を board pre-create が
+#     迂回するため、pool には積まず（fallback split に倒す）回収登録のみ行う。
+#   - 失敗時はすべて「board 無し」に静かに劣化（pool 空 → 従来 split）。後方互換のため engine は止めない。
+#     status=="partial" は生存 orphan（rollback_failed のみ。created は layout が逆順 kill 済）を回収登録。
+oe_board_apply() {
+  OE_BOARD_PANE_IDS=()
+  OE_BOARD_CURSOR=0
+
+  # board 無効（kill switch）: 従来の都度 split のみ。
+  if [[ -z "${OE_BOARD_LAYOUT:-}" ]]; then
+    return 0
+  fi
+
+  local map rc=0
+  map="$(wez layout apply "$OE_BOARD_LAYOUT" --json 2>/dev/null)" || rc=$?
+  if [[ "$rc" -ne 0 || -z "$map" ]]; then
+    echo "oe_board_apply: wez layout apply '${OE_BOARD_LAYOUT}' failed (rc=${rc}); falling back to on-demand split" >&2
+    return 0
+  fi
+
+  local status
+  status="$(printf '%s' "$map" | jq -r '.status // "unknown"' 2>/dev/null || echo unknown)"
+
+  # partial: layout は created を逆順 rollback kill 済。生存 orphan は rollback_failed のみ。
+  if [[ "$status" == "partial" ]]; then
+    local rf_str rf
+    rf_str="$(printf '%s' "$map" | jq -r '.rollback_failed[]?' 2>/dev/null || true)"
+    while IFS= read -r rf; do
+      [[ -n "$rf" ]] || continue
+      OE_BOARD_MANAGED_PANES+=("$rf")
+    done <<< "$rf_str"
+    echo "oe_board_apply: board '${OE_BOARD_LAYOUT}' apply partial; registered rollback_failed orphans for cleanup, falling back to split" >&2
+    return 0
+  fi
+
+  if [[ "$status" != "ok" ]]; then
+    echo "oe_board_apply: board '${OE_BOARD_LAYOUT}' returned status='${status}'; falling back to split" >&2
+    return 0
+  fi
+
+  # status==ok: pane_id を step 順で収集。
+  local ids_str line
+  ids_str="$(printf '%s' "$map" | jq -r '.panes[].pane_id' 2>/dev/null || true)"
+  local pane_ids=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    pane_ids+=("$line")
+  done <<< "$ids_str"
+
+  local count="${#pane_ids[@]}"
+  if [[ "$count" -eq 0 ]]; then
+    echo "oe_board_apply: board '${OE_BOARD_LAYOUT}' returned no panes; falling back to split" >&2
+    return 0
+  fi
+
+  local p
+  # max-panes ガード: board pre-create が monitor の OE_CB_MAX_PANES 判定を迂回しないよう守る。
+  if [[ "$count" -gt "$OE_CB_MAX_PANES" ]]; then
+    for p in ${pane_ids[@]+"${pane_ids[@]}"}; do
+      OE_BOARD_MANAGED_PANES+=("$p")
+    done
+    echo "oe_board_apply: board '${OE_BOARD_LAYOUT}' has ${count} panes > OE_CB_MAX_PANES=${OE_CB_MAX_PANES}; not using board (registered for cleanup, falling back to split)" >&2
+    return 0
+  fi
+
+  # 通常: pool に積み、全 board ペインを cleanup 回収登録。
+  for p in ${pane_ids[@]+"${pane_ids[@]}"}; do
+    OE_BOARD_PANE_IDS+=("$p")
+    OE_BOARD_MANAGED_PANES+=("$p")
+  done
+}
+
+# oe_board_wait_ready — #175: pool から pop した board ペインの readiness を engine 側で保証する。
+#
+# layout apply 経路は内部 split に --wait-ready を渡さず（layout.sh）、standalone な readiness verb も
+# 無いため、`wez pane capture` の出力が非空かつ安定（2 連続一致）になるまで待つ pane.sh:_wez_wait_pane_ready
+# の最小ミラーを engine 側に持つ。timeout 時は warn + 続行（best-effort・split --wait-ready の挙動に整合）。
+oe_board_wait_ready() {
+  local pane_id="$1"
+  local timeout="${2:-$OE_SPAWN_WAIT_READY_SEC}"
+  local interval_ms=500
+  local timeout_ms=$(( timeout * 1000 ))
+  local elapsed_ms=0
+  local prev_tail=""
+
+  while (( elapsed_ms < timeout_ms )); do
+    local curr
+    curr="$(wez pane capture "$pane_id" --lines 5 2>/dev/null)" || true
+    if [[ "$curr" == *[!$' \t\n']* ]]; then
+      local curr_tail
+      curr_tail="$(printf '%s' "$curr" | tail -n 5)"
+      if [[ -n "$prev_tail" && "$curr_tail" == "$prev_tail" ]]; then
+        return 0
+      fi
+      prev_tail="$curr_tail"
+    fi
+    sleep 0.5
+    elapsed_ms=$(( elapsed_ms + interval_ms ))
+  done
+
+  echo "oe_board_wait_ready: pane ${pane_id} not ready within ${timeout}s; proceeding best-effort" >&2
+  return 0
+}
+
+# oe_spawn_prepare_pane — ペインを用意し OE_SPAWN_PANE_ID に保存（都度 spawn の責務）。
+#
+# #175: board pool（oe_board_apply 済）に未消費ペインがあれば FIFO で pop（step 順）。
+# pool が空（board 無効 / 使い切り / 動的 N>pool）のときは従来どおり都度 split にフォールバックする。
+# どちらの経路でも OE_SPAWN_PANE_ID の意味（呼び出し側が消費する単一の pane_id）は変わらない。
 oe_spawn_prepare_pane() {
   OE_SPAWN_PANE_ID=""
-  # --wait-ready: 新ペインが入力受付可能になるまで待機（tmux auto-attach 等のタイミング問題の緩和）
-  OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent 30 --wait-ready --timeout "$OE_SPAWN_WAIT_READY_SEC")"
+
+  if [[ "${OE_BOARD_CURSOR:-0}" -lt "${#OE_BOARD_PANE_IDS[@]}" ]]; then
+    OE_SPAWN_PANE_ID="${OE_BOARD_PANE_IDS[$OE_BOARD_CURSOR]}"
+    OE_BOARD_CURSOR=$(( OE_BOARD_CURSOR + 1 ))
+    # layout 経路は --wait-ready を持たないため、送信前に engine 側で readiness を保証する。
+    oe_board_wait_ready "$OE_SPAWN_PANE_ID"
+    return 0
+  fi
+
+  # pool 空: 従来の都度 split（DJ-8 省略時デフォルトで self 起点・解決不能時は native 既定）。
+  # --wait-ready: 新ペインが入力受付可能になるまで待機（tmux auto-attach 等のタイミング問題の緩和）。
+  OE_SPAWN_PANE_ID="$(wez pane split --bottom --percent "$OE_SPAWN_PERCENT" --wait-ready --timeout "$OE_SPAWN_WAIT_READY_SEC")"
 }
 
 # _oe_spawn_build_cli_command — AI CLI ごとに正しい invocation を組み立てる

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -33,6 +33,14 @@ set -euo pipefail
 
 log_dir="${OE_MOCK_LOG_DIR:?}"
 
+# #175: wez layout apply --json — board（parent-children: worker1=bottom / worker2=right）の
+# pane_id map を返す。target=pool[0]=777、reviewer=pool[1]=888 を engine が FIFO 消費する。
+if [[ "${1:-}" == "layout" && "${2:-}" == "apply" ]]; then
+  printf 'apply\n' >> "${log_dir}/layout.log"
+  printf '%s\n' '{"status":"ok","root_pane_id":1,"window_id":1,"panes":[{"id":"worker1","pane_id":777,"index":0},{"id":"worker2","pane_id":888,"index":1}]}'
+  exit 0
+fi
+
 if [[ "${1:-}" == "pane" && "${2:-}" == "split" ]]; then
   shift 2
   while [[ $# -gt 0 ]]; do
@@ -140,6 +148,14 @@ assert_eq "envelope path used in send" "1" \
   "$(awk -v sid="$session_id" 'index($0,"/tmp/oe-" sid "-envelope.json"){found=1} END{print found+0}' "${OE_MOCK_LOG_DIR}/send.log")"
 assert_eq "spawn send executed" "1" \
   "$(awk -v sid="$session_id" 'index($0,"Read /tmp/oe-" sid "-envelope.json and execute the task"){found=1} END{print found+0}' "${OE_MOCK_LOG_DIR}/send.log")"
+
+# ---- #175: 機械1サイクルが規約ベース盤面（wez layout）で成立する ----
+# board init（layout apply）が 1 回呼ばれ、target(777)/reviewer(888) ともに board pool から
+# FIFO 消費される（= fallback split は使われない）。
+assert_eq "board layout applied (#175)" "apply" \
+  "$( [[ -f "${OE_MOCK_LOG_DIR}/layout.log" ]] && cat "${OE_MOCK_LOG_DIR}/layout.log" || echo MISSING )"
+assert_eq "fallback split not used (board が target+reviewer を供給)" "false" \
+  "$( [[ -f "${OE_MOCK_LOG_DIR}/split_last" ]] && echo true || echo false )"
 
 # ---- Step 4-3 Phase E: 検証フェーズが 1 サイクルに含まれる ----
 echo ""

--- a/projects/orchestration-engine/tests/test_spawn_board.sh
+++ b/projects/orchestration-engine/tests/test_spawn_board.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2317  # wez() mocks are invoked indirectly via the sourced spawn.sh
+set -euo pipefail
+
+# test_spawn_board.sh — spawn.sh の board ロジックのユニットテスト
+#
+# Copilot PR #192 反映:
+#   C1: oe_board_apply の partial 分岐が rc 早期 return で到達不能だったバグの repro。
+#       realistic な partial（exit 5 + {status:"partial", rollback_failed:[...]}）で
+#       rollback_failed orphan が cleanup（OE_BOARD_MANAGED_PANES）に登録されることを確認する。
+#   C2: oe_board_wait_ready が非数値 timeout で set -e クラッシュしないことを確認する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROJECT_DIR
+
+# spawn.sh が参照するグローバル定数を最小限だけ用意（constants.sh の OE_DATA_DIR 依存を避ける）。
+OE_CB_MAX_PANES=5
+OE_SPAWN_WAIT_READY_SEC=10
+OE_SPAWN_PERCENT=30
+OE_BOARD_MANAGED_PANES=()
+
+# shellcheck source=../lib/spawn.sh
+source "${PROJECT_DIR}/lib/spawn.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    (( PASS++ )) || true
+  else
+    echo "  FAIL: $label (expected='$expected', actual='$actual')"
+    (( FAIL++ )) || true
+  fi
+}
+
+# ---- C1: partial (rc=5) で rollback_failed orphan が cleanup 登録される ----
+echo "=== C1: oe_board_apply partial(rc=5) で rollback_failed を cleanup 登録 ==="
+
+# mock 用の split マーカー（oe_spawn_prepare_pane は $(wez pane split ...) を subshell で呼ぶため、
+# 変数フラグは親に伝播しない。観測はファイル経由にする）。
+_SPLIT_MARKER="$(mktemp)"
+trap 'rm -f "$_SPLIT_MARKER"' EXIT
+: > "$_SPLIT_MARKER"
+
+# mock: wez layout apply が realistic な partial 失敗を返す
+#   stdout = {status:"partial", rollback_failed:[999]} / exit 5（WEZ_EXIT_PANE_OP_FAILED）。
+wez() {
+  if [[ "${1:-}" == "layout" && "${2:-}" == "apply" ]]; then
+    printf '%s\n' '{"status":"partial","root_pane_id":1,"created":[],"failed_step":0,"rollback_failed":[999]}'
+    return 5
+  fi
+  if [[ "${1:-}" == "pane" && "${2:-}" == "split" ]]; then
+    echo "split" >> "$_SPLIT_MARKER"
+    echo "1234"
+    return 0
+  fi
+  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+    echo ""
+    return 0
+  fi
+  echo "unexpected wez call: $*" >&2
+  return 1
+}
+
+OE_BOARD_LAYOUT="parent-children"
+OE_BOARD_MANAGED_PANES=()
+OE_BOARD_PANE_IDS=()
+OE_BOARD_CURSOR=0
+
+# set -e 下で apply がクラッシュせず return 0（fallback）すること
+apply_rc=0
+oe_board_apply || apply_rc=$?
+assert_eq "partial apply は return 0（fallback に静かに劣化）" "0" "$apply_rc"
+
+# C1 のコア: rollback_failed の 999 が cleanup 登録される（到達不能だった分岐が機能する）
+assert_eq "OE_BOARD_MANAGED_PANES 件数 = 1" "1" "${#OE_BOARD_MANAGED_PANES[@]}"
+assert_eq "rollback_failed orphan 999 が cleanup 登録" "999" "${OE_BOARD_MANAGED_PANES[0]:-}"
+
+# pool は空のまま（partial なので board は使わない → 後段で fallback split に倒れる）
+assert_eq "pool は空（partial では board pool を構築しない）" "0" "${#OE_BOARD_PANE_IDS[@]}"
+
+# partial 後に prepare_pane を呼ぶと pool 空 → fallback split される
+: > "$_SPLIT_MARKER"
+oe_spawn_prepare_pane
+assert_eq "partial 後の prepare_pane は fallback split を使う" "true" \
+  "$( [[ -s "$_SPLIT_MARKER" ]] && echo true || echo false )"
+assert_eq "fallback split の pane_id が OE_SPAWN_PANE_ID に入る" "1234" "${OE_SPAWN_PANE_ID:-}"
+
+# ---- C1 補強: status==ok は従来どおり pool を構築する（回帰防止） ----
+echo ""
+echo "=== C1 回帰: status==ok は pool 構築 + 全 board ペイン cleanup 登録 ==="
+wez() {
+  if [[ "${1:-}" == "layout" && "${2:-}" == "apply" ]]; then
+    printf '%s\n' '{"status":"ok","root_pane_id":1,"window_id":1,"panes":[{"id":"w1","pane_id":777,"index":0},{"id":"w2","pane_id":888,"index":1}]}'
+    return 0
+  fi
+  echo "unexpected wez call: $*" >&2
+  return 1
+}
+OE_BOARD_LAYOUT="parent-children"
+OE_BOARD_MANAGED_PANES=()
+OE_BOARD_PANE_IDS=()
+OE_BOARD_CURSOR=0
+oe_board_apply
+assert_eq "ok: pool 件数 = 2" "2" "${#OE_BOARD_PANE_IDS[@]}"
+assert_eq "ok: pool[0] = 777" "777" "${OE_BOARD_PANE_IDS[0]:-}"
+assert_eq "ok: pool[1] = 888" "888" "${OE_BOARD_PANE_IDS[1]:-}"
+assert_eq "ok: cleanup 登録件数 = 2" "2" "${#OE_BOARD_MANAGED_PANES[@]}"
+
+# ---- C1 補強: stdout 空（コマンド不在/ハードエラー）は fallback、partial 分岐に入らない ----
+echo ""
+echo "=== C1 回帰: stdout 空（ハードエラー）は fallback（partial 登録しない） ==="
+wez() {
+  if [[ "${1:-}" == "layout" && "${2:-}" == "apply" ]]; then
+    return 127
+  fi
+  echo "unexpected wez call: $*" >&2
+  return 1
+}
+OE_BOARD_LAYOUT="parent-children"
+OE_BOARD_MANAGED_PANES=()
+OE_BOARD_PANE_IDS=()
+OE_BOARD_CURSOR=0
+empty_rc=0
+oe_board_apply || empty_rc=$?
+assert_eq "空 stdout apply は return 0" "0" "$empty_rc"
+assert_eq "空 stdout は cleanup 登録なし" "0" "${#OE_BOARD_MANAGED_PANES[@]}"
+assert_eq "空 stdout は pool 空" "0" "${#OE_BOARD_PANE_IDS[@]}"
+
+# ---- C2: 非数値 timeout で oe_board_wait_ready がクラッシュせず default 適用 ----
+echo ""
+echo "=== C2: oe_board_wait_ready 非数値 timeout で set -e クラッシュしない ==="
+
+# capture が即座に安定（2 連続一致）して return 0 する mock。timeout 経路の算術が走る前に
+# return するが、非数値 timeout の算術展開（timeout_ms=$(( timeout * 1000 ))）は関数冒頭で
+# 実行されるため、非数値検証が無いと set -e でここに到達する前にクラッシュする。
+wez() {
+  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
+    echo "stable line"
+    return 0
+  fi
+  echo "unexpected wez call: $*" >&2
+  return 1
+}
+
+# 非数値 timeout（"abc"）でクラッシュしないこと。set -e 下で関数がクラッシュすれば
+# このサブシェルは非 0 で落ち、wait_rc に拾われる。
+wait_rc=0
+( oe_board_wait_ready "777" "abc" ) >/dev/null 2>&1 || wait_rc=$?
+assert_eq "非数値 timeout でクラッシュしない（return 0）" "0" "$wait_rc"
+
+# 空文字 timeout でも default にフォールバックしてクラッシュしないこと
+wait_rc2=0
+( oe_board_wait_ready "777" "" ) >/dev/null 2>&1 || wait_rc2=$?
+assert_eq "空文字 timeout でもクラッシュしない（return 0）" "0" "$wait_rc2"
+
+# 数値 timeout は従来どおり動作すること（回帰防止）
+wait_rc3=0
+( oe_board_wait_ready "777" "2" ) >/dev/null 2>&1 || wait_rc3=$?
+assert_eq "数値 timeout は従来どおり return 0" "0" "$wait_rc3"
+
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

orchestration-engine の `lib/spawn.sh` がハードコードしていた盤面構築（`wez pane split --bottom --percent 30 --wait-ready`）を、[#191](https://github.com/stlwolf/ai-development-hub/issues/191) で landed した `wez layout apply --json`（宣言的盤面・pane_id map 返却・非冪等）ベースに置換し、engine の機械1サイクル（envelope → spawn → monitor → verify → cleanup）を「規約ベース盤面」で再現的に成立させる。

Refs #175

## 設計判断（採用 = 案C+）

- `bin/oe` で `oe_board_apply` を **1 回**呼び pane_id map を pool 化。`oe_spawn_prepare_pane` が FIFO pop（空なら従来 split にフォールバック）。**target=pool[0] / reviewer=pool[1]** で 1 サイクルの 2 役を宣言盤面が宣言する（盤面初期化と都度 spawn の責務分離）。
- `OE_SPAWN_PANE_ID` の下流契約（envelope/send/monitor/verify/cleanup）は**不変**。
- 確定前に `oe-refute`（exploration rubric・codex/cursor 2 レーン = so-compare wrap）を **2 回**実行。1 回目で `--wait-ready` 回帰 / partial-apply orphan / cleanup dedup / step順 role 割当を捕捉 → 案C+ にピボット。2 回目で partial 登録範囲・max-panes ガード・readiness timeout 契約を精緻化。SO 全文と案B vs 案C+ の breadth 再検討は設計 doc / episode を参照。
  - 設計: [`docs/discussions/2026-06-20-discussion-175-spawn-layout.md`](../blob/feature/%23175_spawn_layout_board/projects/orchestration-engine/docs/discussions/2026-06-20-discussion-175-spawn-layout.md)
  - episode: [`docs/episodes/2026-06-20-episode-175-spawn-layout.md`](../blob/feature/%23175_spawn_layout_board/projects/orchestration-engine/docs/episodes/2026-06-20-episode-175-spawn-layout.md)

## 変更内容

- `lib/spawn.sh`: `oe_board_apply()` / `oe_board_wait_ready()` 追加、`oe_spawn_prepare_pane()` を pool→split フォールバック化。
- `bin/oe`: spawn 前に `oe_board_apply` を 1 回。
- `lib/cleanup.sh`: 3 配列（MANAGED + VERIFY + BOARD）の **dedup union** で kill / killed_pane_ids 化（board ペイン回収・orphan 防止・重複 kill/audit 防止）。
- `lib/constants.sh`: `OE_BOARD_LAYOUT`（既定 `parent-children`・空で board 無効＝kill switch）/ `OE_SPAWN_PERCENT`（既定 30）/ `OE_BOARD_MANAGED_PANES` を追加。
- `tests/test_e2e_smoke.sh`: mock に `wez layout apply --json` 追加 + board 適用/fallback 不使用のアサーション。

### SO 指摘の反映（要点）

- **`--wait-ready` 回帰**: layout の内部 split は readiness 待ちを持たず、`_wez_wait_pane_ready` は pane.sh private で standalone verb も無い（#191/#190 本体は変更不可）→ engine 側に `oe_board_wait_ready`（capture が非空+安定まで poll・timeout は best-effort 続行）。
- **partial-apply**: `status:"partial"` の生存 orphan は `rollback_failed` のみ（`created` は layout が逆順 kill 済）を cleanup 登録 → board 無効化（fallback）。
- **max-panes ガード**: board ペイン数 > `OE_CB_MAX_PANES` なら pool に積まず（回収登録のみ・fallback）、CB 不変条件を保つ。

## 検証

- `shellcheck`: 変更 5 ファイル **clean**。
- 全 14 テスト（bash 5.2.37）: **全 PASS**（e2e_smoke 46/46・verify 104・cleanup 19 ほか）。
- **bash 3.2.57**（内側 `bin/oe` も 3.2 に固定）: 本 PR が触る経路は PASS（e2e_smoke 46/46・verify 104・board 無効化 kill-switch の fallback split smoke = exit0/state=success/killed[777,888]）。空配列展開は `${arr[@]+...}` で安全側。

## 後方互換

- `OE_SPAWN_PANE_ID` 据え置き。board 無効/apply 失敗/partial 時は従来の都度 split にフォールバック。
- **geometry 非互換（honest）**: 旧来は target/reviewer とも bottom30%。`parent-children` は worker1=bottom30% + worker2=right50%。機能後方互換は保つが視覚配置は preset に従う（「規約ベース盤面」化の意図的帰結）。

## レビュー時の確認観点

- 案B（reviewer 都度 split・decouple）vs 案C+（reviewer=pool[1]）の選択（episode「決定と根拠」）。後戻りコスト中・可逆と判断し自律確定 → human gate での判断を仰ぎたい点。
- bash 3.2 互換（ADR-005）と ADR-004 DJ-9（layout 規約）整合。

## ⚠️ 別件として surface（本 PR スコープ外・要判断）

orchestration-engine のテストは bash 5.x でのみ検証されており、**master 時点で真の bash 3.2 では既に 3 テストが落ちる**（本 PR 起因ではない・`git stash` で実証）。Minimal Scope に従い本 PR では触らず、別 issue 判断のため列挙:

- `lib/cleanup.sh`: `for reviewer_pane in "${OE_VERIFY_MANAGED_PANES[@]}"` の無ガード空配列ループ（no-op）。
- `tests/test_monitor.sh`: `declare -A`（bash 4.0+・ADR-005 違反・テスト側）。
- `bin/oe-delegate`: `CLAUDE_ARGS[@]` 無ガード展開。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
