### PR TITLE
refactor(oe): VERDICT 抽出/集約を共有 lib so-verdict.sh 化

### DIFF
--- a/projects/orchestration-engine/bin/oe-refute
+++ b/projects/orchestration-engine/bin/oe-refute
@@ -30,6 +30,9 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "${BIN_DIR}/.." && pwd)"
 # shellcheck source=../lib/session.sh
 source "${PROJECT_DIR}/lib/session.sh"
+# VERDICT 抽出/集約/dissent/exit code は oe-review と共有（#196）。
+# shellcheck source=../lib/so-verdict.sh
+source "${PROJECT_DIR}/lib/so-verdict.sh"
 
 # so-compare 実体。PATH 上の so-compare を既定で使い、テストは PATH 先頭スタブで差し替える。
 OE_REFUTE_SO_COMPARE="${OE_REFUTE_SO_COMPARE:-so-compare}"
@@ -246,91 +249,18 @@ if [[ "$so_rc" -eq 2 ]]; then
   err "warning: so-compare reported all-provider failure (rc=2); lanes will be treated as error"
 fi
 
-# --- per-lane verdict 抽出 ---
-# 各レーンの stdout 末尾の VERDICT: 行を拾う。取れなければ error/unknown。
-# IFS=',' でプロバイダ名（=レーン名）を回す。
-extract_verdict() {
-  local f="$1" line token
-  [[ -s "$f" ]] || { printf 'unknown'; return; }
-  # 末尾から最後の VERDICT: 行を拾う（直後の token が refuted|survived の行のみ対象）
-  line="$(grep -iE '^[[:space:]]*VERDICT:[[:space:]]*(refuted|survived)\b' "$f" | tail -n 1 || true)"
-  if [[ -z "$line" ]]; then printf 'unknown'; return; fi
-  # VERDICT: の直後の token だけを判定する（Fix 1）。行全体への grep だと
-  # "VERDICT: survived (not refuted)" を refuted と誤分類するため、token を切り出す。
-  # 行末の付帯テキストは無視する。
-  token="$(printf '%s' "$line" | sed -E 's/^[[:space:]]*VERDICT:[[:space:]]*([A-Za-z]+).*/\1/I')"
-  if printf '%s' "$token" | grep -qiE '^refuted$'; then printf 'refuted'; else printf 'survived'; fi
-}
-
-extract_reason() {
-  local f="$1" line
-  [[ -s "$f" ]] || { printf ''; return; }
-  line="$(grep -iE '^[[:space:]]*REASON:' "$f" | tail -n 1 || true)"
-  # REASON: ラベルを剥がす
-  printf '%s' "$line" | sed -E 's/^[[:space:]]*REASON:[[:space:]]*//I'
-}
-
-# レーン集約。Bash 3.2 互換: 連想配列を使わず並行配列で扱う。
-lane_names=()
-lane_verdicts=()
-lane_notes=()
-
-refuted_count=0
-survived_count=0
-error_count=0
-
-IFS=',' read -r -a _providers <<< "$PROVIDERS"
-for prov in ${_providers[@]+"${_providers[@]}"}; do
-  stdout_file="${OUTPUT_DIR}/${prov}-stdout.txt"
-  v="$(extract_verdict "$stdout_file")"
-  case "$v" in
-    refuted)  note="$(extract_reason "$stdout_file")"; refuted_count=$((refuted_count + 1)) ;;
-    survived) note="$(extract_reason "$stdout_file")"; survived_count=$((survived_count + 1)) ;;
-    *)        v="error"; note="VERDICT 行を取得できませんでした（レーン出力なし/形式不正）"; error_count=$((error_count + 1)) ;;
-  esac
-  lane_names+=("$prov")
-  lane_verdicts+=("$v")
-  lane_notes+=("$note")
-done
-
-# --- conservative 集約 ---
-# exploration 既定: 1 レーンでも refuted → 全体 refuted。
-# survived は「全レーンが survived」のときのみ。error/unknown が 1 つでもあれば survived 確定不可
-# → conservative に refuted へ倒す（確定が早すぎるコストを避ける thesis 寄り）。
-total_lanes=${#lane_names[@]}
-if [[ "$refuted_count" -gt 0 ]]; then
-  VERDICT="refuted"
-  REASON="${refuted_count}/${total_lanes} レーンが material に反証（conservative 集約: 1 レーン refuted で全体 refuted）"
-elif [[ "$survived_count" -eq "$total_lanes" && "$total_lanes" -gt 0 ]]; then
-  VERDICT="survived"
-  REASON="全 ${total_lanes} レーンが反証を試みたが claim は持ちこたえた"
-else
-  VERDICT="refuted"
-  REASON="verdict 未確定のレーンあり（refuted=${refuted_count} survived=${survived_count} error=${error_count}）。survived を確定できないため conservative に refuted"
-fi
-
-# --- dissent JSON 配列組立 ---
-dissent_json="$(
-  # jq に並行配列を渡して dissent を組む
-  args=()
-  i=0
-  while [[ "$i" -lt "$total_lanes" ]]; do
-    args+=(--arg "lane${i}" "${lane_names[$i]}")
-    args+=(--arg "verdict${i}" "${lane_verdicts[$i]}")
-    args+=(--arg "note${i}" "${lane_notes[$i]}")
-    i=$((i + 1))
-  done
-  # jq プログラムを動的生成（n 個のオブジェクトを配列化）
-  jq_prog="["
-  i=0
-  while [[ "$i" -lt "$total_lanes" ]]; do
-    [[ "$i" -eq 0 ]] || jq_prog="${jq_prog},"
-    jq_prog="${jq_prog}{lane:\$lane${i},verdict:\$verdict${i},note:\$note${i}}"
-    i=$((i + 1))
-  done
-  jq_prog="${jq_prog}]"
-  jq -cn ${args[@]+"${args[@]}"} "$jq_prog"
-)"
+# --- per-lane verdict 抽出 + conservative 集約 + dissent 構築（共有 lib: lib/so-verdict.sh） ---
+# 抽出（#184 Fix 1 含む）/ レーン集約 / conservative 集約 / dissent 組立は oe-review と共有。
+# exploration 既定: 1 レーンでも refuted → 全体 refuted。survived は全レーン survived のとき
+# のみ。error/unknown が 1 つでもあれば survived 確定不可 → conservative に refuted へ倒す
+# （確定が早すぎるコストを避ける thesis 寄り）。verb 固有なのは REASON の文言（phrase 引数）。
+so_verdict_collect_lanes "$OUTPUT_DIR" "$PROVIDERS"
+so_verdict_aggregate "material に反証" "反証を試みたが claim は持ちこたえた"
+# 以降の出力/audit/exit 組立を不変に保つため、lib の global-return を verb ローカル名に束ねる。
+total_lanes="$SO_VERDICT_TOTAL_LANES"
+VERDICT="$SO_VERDICT_VERDICT"
+REASON="$SO_VERDICT_REASON"
+dissent_json="$(so_verdict_dissent_json)"
 
 # --- audit_id（output_dir 名と同じ run ULID を流用・traceability） ---
 AUDIT_ID="$RUN_ID"
@@ -362,8 +292,5 @@ if mkdir -p "$OE_AUDIT_DIR" 2>/dev/null; then
     >> "${OE_AUDIT_DIR}/oe-refute.jsonl" 2>/dev/null || true
 fi
 
-# --- exit code（advisory） ---
-if [[ "$VERDICT" == "refuted" ]]; then
-  exit 3
-fi
-exit 0
+# --- exit code（advisory・共有 lib: survived→0 / refuted→3） ---
+so_verdict_exit

--- a/projects/orchestration-engine/bin/oe-review
+++ b/projects/orchestration-engine/bin/oe-review
@@ -27,9 +27,9 @@
 # 集約は conservative: 1 レーンでも material に refuted → 全体 refuted。verdict を取れない
 # レーンは survived 扱いにせず error とし、dissent に記録した上で survived 確定を阻む。
 #
-# NOTE: VERDICT/REASON 抽出・conservative 集約・dissent 組立は bin/oe-refute から意図的に
-#       複製している（#184 の堅牢化修正を含む）。共有 lib への括り出し＋oe-refute 側の移行は
-#       follow-up（oe-refute を改変する別 PR・1 PR=1 論理変更）。本 PR は oe-refute 非破壊。
+# NOTE: VERDICT/REASON 抽出・conservative 集約・dissent 組立・exit code は oe-refute と共有
+#       （lib/so-verdict.sh・#184 の堅牢化修正を含む）。#196 で複製を解消（旧: #194 のガードで
+#       oe-refute 非破壊のため thin に複製していた）。verb 固有なのは集約 REASON の文言のみ。
 #
 # 出自: docs/episodes の #194 episode / 設計 DJ は tmp/dj-1-vehicle-tree.md（2 ラウンド SO trace）。
 
@@ -39,6 +39,9 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "${BIN_DIR}/.." && pwd)"
 # shellcheck source=../lib/session.sh
 source "${PROJECT_DIR}/lib/session.sh"
+# VERDICT 抽出/集約/dissent/exit code は oe-refute と共有（#196）。
+# shellcheck source=../lib/so-verdict.sh
+source "${PROJECT_DIR}/lib/so-verdict.sh"
 
 # so-compare 実体。PATH 上の so-compare を既定で使い、テストは PATH 先頭スタブで差し替える。
 OE_REVIEW_SO_COMPARE="${OE_REVIEW_SO_COMPARE:-so-compare}"
@@ -210,82 +213,18 @@ if [[ "$so_rc" -eq 2 ]]; then
   err "warning: so-compare reported all-provider failure (rc=2); lanes will be treated as error"
 fi
 
-# --- per-lane verdict 抽出（bin/oe-refute から複製・#184 Fix 1/3 を含む） ---
-# 末尾の最後の VERDICT: 行を拾い、VERDICT: 直後の token のみ判定する（行末の付帯テキスト無視）。
-extract_verdict() {
-  local f="$1" line token
-  [[ -s "$f" ]] || { printf 'unknown'; return; }
-  line="$(grep -iE '^[[:space:]]*VERDICT:[[:space:]]*(refuted|survived)\b' "$f" | tail -n 1 || true)"
-  if [[ -z "$line" ]]; then printf 'unknown'; return; fi
-  token="$(printf '%s' "$line" | sed -E 's/^[[:space:]]*VERDICT:[[:space:]]*([A-Za-z]+).*/\1/I')"
-  if printf '%s' "$token" | grep -qiE '^refuted$'; then printf 'refuted'; else printf 'survived'; fi
-}
-
-extract_reason() {
-  local f="$1" line
-  [[ -s "$f" ]] || { printf ''; return; }
-  line="$(grep -iE '^[[:space:]]*REASON:' "$f" | tail -n 1 || true)"
-  printf '%s' "$line" | sed -E 's/^[[:space:]]*REASON:[[:space:]]*//I'
-}
-
-# レーン集約。Bash 3.2 互換: 連想配列を使わず並行配列で扱う。
-lane_names=()
-lane_verdicts=()
-lane_notes=()
-
-refuted_count=0
-survived_count=0
-error_count=0
-
-IFS=',' read -r -a _providers <<< "$PROVIDERS"
-for prov in ${_providers[@]+"${_providers[@]}"}; do
-  stdout_file="${OUTPUT_DIR}/${prov}-stdout.txt"
-  v="$(extract_verdict "$stdout_file")"
-  case "$v" in
-    refuted)  note="$(extract_reason "$stdout_file")"; refuted_count=$((refuted_count + 1)) ;;
-    survived) note="$(extract_reason "$stdout_file")"; survived_count=$((survived_count + 1)) ;;
-    *)        v="error"; note="VERDICT 行を取得できませんでした（レーン出力なし/形式不正）"; error_count=$((error_count + 1)) ;;
-  esac
-  lane_names+=("$prov")
-  lane_verdicts+=("$v")
-  lane_notes+=("$note")
-done
-
-# --- conservative 集約 ---
-# 1 レーンでも refuted → 全体 refuted。survived は全レーン survived のときのみ。
-# error/unknown が 1 つでもあれば survived 確定不可 → conservative に refuted（欠陥見落とし回避）。
-total_lanes=${#lane_names[@]}
-if [[ "$refuted_count" -gt 0 ]]; then
-  VERDICT="refuted"
-  REASON="${refuted_count}/${total_lanes} レーンが material なコード欠陥を検出（conservative 集約: 1 レーン refuted で全体 refuted）"
-elif [[ "$survived_count" -eq "$total_lanes" && "$total_lanes" -gt 0 ]]; then
-  VERDICT="survived"
-  REASON="全 ${total_lanes} レーンがレビューしたが material な欠陥は見つからなかった"
-else
-  VERDICT="refuted"
-  REASON="verdict 未確定のレーンあり（refuted=${refuted_count} survived=${survived_count} error=${error_count}）。survived を確定できないため conservative に refuted"
-fi
-
-# --- dissent JSON 配列組立（並行配列を jq へ） ---
-dissent_json="$(
-  args=()
-  i=0
-  while [[ "$i" -lt "$total_lanes" ]]; do
-    args+=(--arg "lane${i}" "${lane_names[$i]}")
-    args+=(--arg "verdict${i}" "${lane_verdicts[$i]}")
-    args+=(--arg "note${i}" "${lane_notes[$i]}")
-    i=$((i + 1))
-  done
-  jq_prog="["
-  i=0
-  while [[ "$i" -lt "$total_lanes" ]]; do
-    [[ "$i" -eq 0 ]] || jq_prog="${jq_prog},"
-    jq_prog="${jq_prog}{lane:\$lane${i},verdict:\$verdict${i},note:\$note${i}}"
-    i=$((i + 1))
-  done
-  jq_prog="${jq_prog}]"
-  jq -cn ${args[@]+"${args[@]}"} "$jq_prog"
-)"
+# --- per-lane verdict 抽出 + conservative 集約 + dissent 構築（共有 lib: lib/so-verdict.sh） ---
+# 抽出（#184 Fix 1 含む）/ レーン集約 / conservative 集約 / dissent 組立は oe-refute と共有。
+# 1 レーンでも refuted → 全体 refuted。survived は全レーン survived のときのみ。error/unknown が
+# 1 つでもあれば survived 確定不可 → conservative に refuted（欠陥見落とし回避）。verb 固有なのは
+# REASON の文言（phrase 引数）。
+so_verdict_collect_lanes "$OUTPUT_DIR" "$PROVIDERS"
+so_verdict_aggregate "material なコード欠陥を検出" "レビューしたが material な欠陥は見つからなかった"
+# 以降の出力/audit/exit 組立を不変に保つため、lib の global-return を verb ローカル名に束ねる。
+total_lanes="$SO_VERDICT_TOTAL_LANES"
+VERDICT="$SO_VERDICT_VERDICT"
+REASON="$SO_VERDICT_REASON"
+dissent_json="$(so_verdict_dissent_json)"
 
 # --- audit_id（output_dir 名と同じ run ULID を流用・traceability） ---
 AUDIT_ID="$RUN_ID"
@@ -330,8 +269,5 @@ else
   err "warning: cannot create audit dir ${OE_AUDIT_DIR}; audit record skipped"
 fi
 
-# --- exit code（advisory） ---
-if [[ "$VERDICT" == "refuted" ]]; then
-  exit 3
-fi
-exit 0
+# --- exit code（advisory・共有 lib: survived→0 / refuted→3） ---
+so_verdict_exit

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-196-so-verdict-lib.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-196-so-verdict-lib.md
@@ -1,0 +1,58 @@
+---
+id: "01KVJ5ZJ04Q4D7HSADFQ2SNBHR"
+title: "oe-refute / oe-review の VERDICT 抽出/集約を共有 lib 化（#196・実装SO=oe-review 初の実運用）"
+date: 2026-06-20
+type: episode
+status: in-development
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/196"
+    reason: "本サイクルの Issue（共有 lib 化・純リファクタ）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/194"
+    reason: "oe-review 追加時に重複させた経緯（oe-refute 非変更ガード）"
+  - type: prior_work
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/195"
+    reason: "oe-review が oe-refute の VERDICT ロジックを thin 複製した PR"
+tags: [orchestration, oe-refute, oe-review, refactor, so-verdict, lib, episode]
+---
+
+# oe-refute / oe-review の VERDICT 抽出/集約を共有 lib 化（#196）
+
+> PR #195（#194）で oe-review が oe-refute の VERDICT 抽出/集約/dissent/exit code を thin に複製（#194 の「oe-refute 非変更」ガードのため）。重複＝drift risk（#184 の VERDICT 部分一致 fix のような修正が2箇所必要・片方取りこぼし）。本サイクルは共有 lib `lib/so-verdict.sh` 化で解消する**純リファクタ（両 verb 挙動不変・回帰ゼロ）**。**実装SO に新 verb `oe-review` を自分の diff へ適用する初の実運用ケース**でもある。
+
+## Context / なぜ
+
+- 重複実体は4つ: extract_verdict/extract_reason（#184 Fix 1 の token 切り出し含む）/ per-lane 集約ループ（並行配列＋count）/ conservative 集約 / dissent JSON 組立。
+- 観測した verb 差（保持必須）: conservative 集約の **REASON 文言のみ** が verb で異なる（refuted 句・survived 句）。error 句・verdict 判定・exit code・dissent 構造・抽出は完全同一。
+
+## 設計（DJ-1）と設計SO のスキップ判断
+
+確定前証跡を `tmp/dj-1-so-verdict-lib.md` に外部化（predecision-exploration 手順4・確定前 artifact）。
+
+- 採用 = **案A: global-return lib**（関数が文書化グローバル `SO_VERDICT_*` を populate）。根拠 = `lib/envelope.sh` が既に global-return（「戻り値: OE_ENVELOPE_PATH に設定」）を採用済の既存パターン（behavioral-rule §6）。bash 3.2 で関数から配列を返す現実解（nameref 禁止）。
+- 棄却 = 案B stdout-serialization（dissent 二重エンコード・既存慣習逸脱）/ 案C leaf 関数のみ抽出（issue 受け入れ条件「集約が単一 lib に一元化」を満たさず過少デリバリ）。
+- REASON 差は **phrase 引数** で受け、文言を完全一致で保持。
+- **設計SO（別途 oe-refute）はスキップ（記録された skip・黙った skip ではない）**: 制約された純リファクタの責務分界で incumbent パターンが強く後戻りコスト低い。かつ下流の**必須 実装SO（oe-review）が lib 分解のコード品質・到達可能性・bash 堅牢性を敵対的にレビューする**＝この判断への敵対的チェックを兼ねる。predecision-exploration「いつ使わないか（低リスク・過剰適用回避）」に該当。
+
+## 実装と検証
+
+- 新規 `lib/so-verdict.sh`（source 専用・`# shellcheck disable=SC2034` は envelope.sh と同じ global-return 規約）に6関数を切り出し:
+  `so_verdict_extract_verdict` / `so_verdict_extract_reason` / `so_verdict_collect_lanes`（並行配列＋count を populate）/ `so_verdict_aggregate <refuted_phrase> <survived_phrase>`（conservative 集約・error 句は固定）/ `so_verdict_dissent_json`（stdout）/ `so_verdict_exit`（refuted→3 / else→0）。
+- `bin/oe-refute` / `bin/oe-review` は lib を source し、複製していた抽出2関数＋レーンループ＋集約＋dissent 組立＋exit を lib 呼び出しに置換。出力/audit jq 組立を不変に保つため lib の global-return を verb ローカル名（`VERDICT`/`REASON`/`total_lanes`/`dissent_json`）に束ねた＝verb 固有の出力アセンブリ（oe-review の reviewed_sha 等）は無改変。
+- verb 差は集約 REASON の文言のみ。phrase 引数で完全一致保持:
+  - oe-refute: refuted=「material に反証」/ survived=「反証を試みたが claim は持ちこたえた」
+  - oe-review: refuted=「material なコード欠陥を検出」/ survived=「レビューしたが material な欠陥は見つからなかった」
+- oe-review の冒頭 NOTE（旧: 複製は意図的で lib 化は follow-up）を「#196 で共有・解消」へ更新。
+- **検証（回帰ゼロ）**:
+  - shellcheck: `lib/so-verdict.sh` `bin/oe-refute` `bin/oe-review` 全 CLEAN。
+  - 既存ユニット: `test_oe_refute` 63/0・`test_oe_review` 64/0。**bash 5.2.37 と system bash 3.2.57 の両方**で green（lib 抽出前の baseline と同数＝回帰ゼロ）。
+  - **負のコントロール（lib 抽出前後で同一挙動）**: master(旧) verb と worktree(新) verb の出力 JSON を、`output_dir`/`audit_id`（run 毎の ULID）のみ正規化して byte 比較。refuted/survived/error/mixed・rubric exploration|consensus・lanes 3 を網羅して **fail=0**＝ユニットが検証しない `reason` 文言まで含め完全一致を確認。
+
+## 実装SO（oe-review・初の実運用）
+
+（oe-review --lanes 2 の verdict / dissent / 所感をここに転記）
+
+## closure
+
+（episode-retrospective で締める）

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-196-so-verdict-lib.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-196-so-verdict-lib.md
@@ -76,6 +76,7 @@ tier=heavy（意図的に oe-review=so-compare wrap を品質ゲートとして�
 - **次の消費者**: (1) #196 PR レビュアー（親 %3 が oe-refute/oe-review 契約の文脈でレビュー）。(2) 今後 VERDICT 抽出/集約ロジックを触る者（単一 source = lib/so-verdict.sh）。(3) cockpit/探索クラスタ — oe-review の**実運用初ケースの記録**として。
 - **follow-up routing**:
   - oe-review の changed_files_count に episode doc（非コード）が混じる件 → **verb への follow-up 候補（本 PR では実装しない・routing のみ）**。再発・摩擦が顕在化したら Issue 化、しなければ追わない。
+  - **Copilot 指摘（back-propagation）**: `so_verdict_extract_verdict` の `grep -iE '…(refuted|survived)\b'` の `\b` は GNU 拡張で厳密 POSIX ERE ではない → 真に POSIX-only な grep 環境では非互換の懸念。**本 PR では非対応**（この行は #184 Fix 1 の既存実装を verbatim に lib 移設したもので、変更は純リファクタの挙動不変を破る）。実機検証では macOS `/usr/bin/grep`=「BSD grep (GNU compatible) 2.6.0-FreeBSD」で `\b` は意図通り（survived/refuted は MATCH・survivedXYZ は非マッチ）＝当環境では再現せず。→ **follow-up（routing のみ）**: POSIX-only grep を対象化する場合の移植性ハードニング。**共有 lib 化により修正は1か所で済む**（本リファクタの便益）。顕在化しなければ追わない。
   - 設計SO（別途 oe-refute）スキップ → 記録済み・follow-up なし（実装SO=oe-review が分解の敵対的チェックを兼ねた）。
   - その他の残課題なし。
 - **status 確定**: in-development → **stable**。達成度: **達成**（受け入れ条件3つ全充足・回帰ゼロ）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-196-so-verdict-lib.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-196-so-verdict-lib.md
@@ -3,7 +3,7 @@ id: "01KVJ5ZJ04Q4D7HSADFQ2SNBHR"
 title: "oe-refute / oe-review の VERDICT 抽出/集約を共有 lib 化（#196・実装SO=oe-review 初の実運用）"
 date: 2026-06-20
 type: episode
-status: in-development
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/196"
@@ -51,8 +51,49 @@ tags: [orchestration, oe-refute, oe-review, refactor, so-verdict, lib, episode]
 
 ## 実装SO（oe-review・初の実運用）
 
-（oe-review --lanes 2 の verdict / dissent / 所感をここに転記）
+`oe-review --lanes 2 --base master --context tmp/oe-review-context-196.md` を自分の diff（`478a75f`）に実行。output_dir は非永続のため verdict/dissent の内容を転記する。
 
-## closure
+- **verdict: survived**（exit 0）。reason=「全 2 レーンがレビューしたが material な欠陥は見つからなかった」。lens=impl / diff_base=master / reviewed_sha=478a75f / diff_hash=022f93e / changed_files_count=4 / audit_id=20260620094339FYHNGGY46DF1。
+- dissent:
+  - `[codex] survived`: 共有 lib 化による correctness / 到達可能性 / Bash 堅牢性 / セキュリティ上の material な欠陥なし。
+  - `[cursor] survived`: master との突合・REASON 文言・set -e/IFS/jq/exit/global-return の各経路を反証的に検証し、純リファクタとして挙動不変を確認。
+- audit: `audit/oe-review.jsonl` に event_type=oe_review・lens=impl・diff バインド付きで記録（設計SO の oe-refute.jsonl とは別 stream＝構造的に識別可能）。
 
-（episode-retrospective で締める）
+### oe-review を実 impl-SO に使った所感（初の実運用）
+
+- end-to-end で機能: base=master 自動突合 → diff バインド（reviewed_sha/diff_hash/changed_files_count）→ 2 レーン → conservative 集約 → JSON + audit emit まで一気通貫。
+- **impl-SO レンズが「正しい関心」に当たった**: 純リファクタで本当に効くのは「旧実装との突合」で、cursor レーンが明示的に master cross-check を行った。設計SO（breadth/grounding）では出ない観点で、設計SO ≠ 実装SO の分離（episode-flow-discipline）が実地で機能した。
+- lens=impl が別 audit stream（oe-review.jsonl）に落ちる＝#192 の false-pass（設計SO を回して実装SO 代替とみなす）を構造的に防ぐことを実運用で確認。
+- **out-of-scope finding（verb への follow-up 候補・本 PR では実装しない）**: changed_files_count=4 に episode doc（非コード）が含まれた。コミット後に diff バインドする運用だと doc も対象に入る。レビュー品質には無害だが、将来 doc 除外 or コミット前 diff レビューの選択肢は verb 側の検討余地（routing のみ）。
+
+## closure（episode-retrospective・tier=heavy）
+
+tier=heavy（意図的に oe-review=so-compare wrap を品質ゲートとして起動・DJ-1 で選択肢比較棄却あり）。
+
+### closure gate
+
+- **Context / なぜ**: 冒頭ブロック引用に自己完結（#195 で複製した VERDICT ロジックの drift risk を共有 lib で解消する純リファクタ）。
+- **次の消費者**: (1) #196 PR レビュアー（親 %3 が oe-refute/oe-review 契約の文脈でレビュー）。(2) 今後 VERDICT 抽出/集約ロジックを触る者（単一 source = lib/so-verdict.sh）。(3) cockpit/探索クラスタ — oe-review の**実運用初ケースの記録**として。
+- **follow-up routing**:
+  - oe-review の changed_files_count に episode doc（非コード）が混じる件 → **verb への follow-up 候補（本 PR では実装しない・routing のみ）**。再発・摩擦が顕在化したら Issue 化、しなければ追わない。
+  - 設計SO（別途 oe-refute）スキップ → 記録済み・follow-up なし（実装SO=oe-review が分解の敵対的チェックを兼ねた）。
+  - その他の残課題なし。
+- **status 確定**: in-development → **stable**。達成度: **達成**（受け入れ条件3つ全充足・回帰ゼロ）。
+- **evidence anchor（揮発パス転記）**: oe-review output_dir / DJ-1 artifact / 負のコントロール script は tmp・scratchpad（揮発）。verdict/dissent・採否理由・neg-control 手法と結果（fail=0）・shellcheck/test 結果は本文へ転記済。audit は `audit/oe-review.jsonl`（永続）に残存。
+- **SO 証跡リンク**: 実装SO セクションに verdict/reason/audit_id/output_dir を転記。
+
+### 内容（出力型 × 消費チャネル）
+
+- **決定と根拠**: DJ-1 で案A（global-return lib）採用、案B（stdout-serialization）/案C（leaf 関数のみ抽出）を理由付きで棄却（上記「設計」節）。
+- **わかったこと（W）**: oe-review は実 diff に対し end-to-end で機能。impl-SO レンズが純リファクタで効く「旧実装との突合」観点に当たった（cursor が master cross-check 実施）。
+- **原則（Pattern）**: 設計SO ≠ 実装SO の分離（別レンズ・別 audit stream）が実地で機能＝#192 false-pass の構造的予防を実運用確認。global-return lib は envelope.sh の既存パターン転用で bash 3.2 制約下の現実解。
+- **蒸留シグナル**: 昇格候補 **なし**（lib は実装詳細・Decision/skill/rule 昇格不要）。oe-review 実運用初ケースの知見は本 episode に保全し cockpit 側が参照すれば足りる。
+- **残課題**: 上記 routing の oe-review doc 混じり 1 件のみ（行き先付与済）。
+
+### Step4（外部チェック）辞退
+
+```
+Step4 辞退: 本 episode は実行ログに失敗・撤回・指摘が無い純リファクタ（test 初回 green・neg-control fail=0・oe-review survived）で、Step4 が主に守る「失敗の選択的省略」が構造的に該当しない。
+既存チェックで覆った観点: routing（残課題1件に行き先付与済）/ evidence anchor（揮発パスの要点を本文転記済）/ back-propagation（欠陥を見つけた他文書なし）
+未実施観点と判断: 「失敗の選択的省略」チェック=該当する失敗が存在しないため不要（低リスク・非該当）
+```

--- a/projects/orchestration-engine/lib/so-verdict.sh
+++ b/projects/orchestration-engine/lib/so-verdict.sh
@@ -1,0 +1,126 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # SO_VERDICT_* は source 元 verb が読む global-return 値（envelope.sh と同方式）
+# so-verdict.sh — SO レーン verdict の抽出/集約/dissent 構築/exit code（source 専用）
+#
+# oe-refute（設計SO）と oe-review（実装SO）が共有する VERDICT ロジックを一元化する。
+# 両 verb は so-compare のレーン別 stdout（<provider>-stdout.txt）から VERDICT/REASON を
+# 抽出し、conservative に集約（1 レーンでも refuted → 全体 refuted。verdict を取れない
+# レーンは survived 扱いにせず error とし survived 確定を阻む保守側）して dissent JSON を
+# 組み、verdict で exit する。この4処理を共有し、verb 固有なのは集約 REASON の文言のみ
+# （so_verdict_aggregate の phrase 引数で渡す）。
+#
+# 由来: #196。PR #195（#194）で oe-review が oe-refute から複製したロジック（#184 Fix 1 の
+# VERDICT token 切り出し堅牢化を含む）を共有化し drift risk を解消する純リファクタ。
+#
+# bash 3.2/5.2 両対応: 連想配列・nameref（local -n）を使わず、文書化したグローバル変数で
+# 戻り値を返す（lib/envelope.sh と同じ global-return 規約）。呼び出し側は set -euo pipefail
+# 前提（各抽出は grep 不一致を `|| true` で吸収する）。
+
+# so_verdict_extract_verdict <lane_stdout_file>
+#   stdout: refuted | survived | unknown
+#   末尾の最後の VERDICT: 行を拾い、VERDICT: 直後の token のみ判定する
+#   （#184 Fix 1: 行末の付帯テキスト "VERDICT: survived (not refuted)" を refuted と誤分類しない）。
+so_verdict_extract_verdict() {
+  local f="$1" line token
+  [[ -s "$f" ]] || { printf 'unknown'; return; }
+  line="$(grep -iE '^[[:space:]]*VERDICT:[[:space:]]*(refuted|survived)\b' "$f" | tail -n 1 || true)"
+  if [[ -z "$line" ]]; then printf 'unknown'; return; fi
+  token="$(printf '%s' "$line" | sed -E 's/^[[:space:]]*VERDICT:[[:space:]]*([A-Za-z]+).*/\1/I')"
+  if printf '%s' "$token" | grep -qiE '^refuted$'; then printf 'refuted'; else printf 'survived'; fi
+}
+
+# so_verdict_extract_reason <lane_stdout_file>
+#   stdout: REASON: 行のラベルを剥がした本文（無ければ空）。末尾の最後の REASON: 行を採る。
+so_verdict_extract_reason() {
+  local f="$1" line
+  [[ -s "$f" ]] || { printf ''; return; }
+  line="$(grep -iE '^[[:space:]]*REASON:' "$f" | tail -n 1 || true)"
+  printf '%s' "$line" | sed -E 's/^[[:space:]]*REASON:[[:space:]]*//I'
+}
+
+# so_verdict_collect_lanes <output_dir> <providers_csv>
+#   <output_dir>/<provider>-stdout.txt をレーンとして回し、以下のグローバルを populate する
+#   （本関数が呼び出しごとに初期化する）。Bash 3.2 互換: 連想配列を使わず並行配列で扱う。
+#     SO_VERDICT_LANE_NAMES[]    レーン名（= provider 名）
+#     SO_VERDICT_LANE_VERDICTS[] refuted | survived | error
+#     SO_VERDICT_LANE_NOTES[]    各レーンの REASON（error は固定文言）
+#     SO_VERDICT_REFUTED_COUNT / SO_VERDICT_SURVIVED_COUNT / SO_VERDICT_ERROR_COUNT
+#     SO_VERDICT_TOTAL_LANES
+#   verdict を取れないレーンは error 扱いとし、survived にしない（保守側に倒す）。
+so_verdict_collect_lanes() {
+  local output_dir="$1" providers_csv="$2"
+  local _providers prov stdout_file v note
+  SO_VERDICT_LANE_NAMES=()
+  SO_VERDICT_LANE_VERDICTS=()
+  SO_VERDICT_LANE_NOTES=()
+  SO_VERDICT_REFUTED_COUNT=0
+  SO_VERDICT_SURVIVED_COUNT=0
+  SO_VERDICT_ERROR_COUNT=0
+  IFS=',' read -r -a _providers <<< "$providers_csv"
+  for prov in ${_providers[@]+"${_providers[@]}"}; do
+    stdout_file="${output_dir}/${prov}-stdout.txt"
+    v="$(so_verdict_extract_verdict "$stdout_file")"
+    case "$v" in
+      refuted)  note="$(so_verdict_extract_reason "$stdout_file")"; SO_VERDICT_REFUTED_COUNT=$((SO_VERDICT_REFUTED_COUNT + 1)) ;;
+      survived) note="$(so_verdict_extract_reason "$stdout_file")"; SO_VERDICT_SURVIVED_COUNT=$((SO_VERDICT_SURVIVED_COUNT + 1)) ;;
+      *)        v="error"; note="VERDICT 行を取得できませんでした（レーン出力なし/形式不正）"; SO_VERDICT_ERROR_COUNT=$((SO_VERDICT_ERROR_COUNT + 1)) ;;
+    esac
+    SO_VERDICT_LANE_NAMES+=("$prov")
+    SO_VERDICT_LANE_VERDICTS+=("$v")
+    SO_VERDICT_LANE_NOTES+=("$note")
+  done
+  SO_VERDICT_TOTAL_LANES=${#SO_VERDICT_LANE_NAMES[@]}
+}
+
+# so_verdict_aggregate <refuted_phrase> <survived_phrase>
+#   so_verdict_collect_lanes 後の count グローバルから conservative 集約し、以下を設定する:
+#     SO_VERDICT_VERDICT  refuted | survived
+#     SO_VERDICT_REASON   集約理由（1 行）
+#   exploration 既定: 1 レーンでも refuted → 全体 refuted。survived は全レーン survived のとき
+#   のみ。error/unknown が 1 つでもあれば survived 確定不可 → conservative に refuted へ倒す。
+#   verb 固有の文言だけ phrase 引数で渡す（refuted/survived 句。error 句は両 verb 共通で固定）。
+so_verdict_aggregate() {
+  local refuted_phrase="$1" survived_phrase="$2"
+  if [[ "$SO_VERDICT_REFUTED_COUNT" -gt 0 ]]; then
+    SO_VERDICT_VERDICT="refuted"
+    SO_VERDICT_REASON="${SO_VERDICT_REFUTED_COUNT}/${SO_VERDICT_TOTAL_LANES} レーンが ${refuted_phrase}（conservative 集約: 1 レーン refuted で全体 refuted）"
+  elif [[ "$SO_VERDICT_SURVIVED_COUNT" -eq "$SO_VERDICT_TOTAL_LANES" && "$SO_VERDICT_TOTAL_LANES" -gt 0 ]]; then
+    SO_VERDICT_VERDICT="survived"
+    SO_VERDICT_REASON="全 ${SO_VERDICT_TOTAL_LANES} レーンが${survived_phrase}"
+  else
+    SO_VERDICT_VERDICT="refuted"
+    SO_VERDICT_REASON="verdict 未確定のレーンあり（refuted=${SO_VERDICT_REFUTED_COUNT} survived=${SO_VERDICT_SURVIVED_COUNT} error=${SO_VERDICT_ERROR_COUNT}）。survived を確定できないため conservative に refuted"
+  fi
+}
+
+# so_verdict_dissent_json
+#   so_verdict_collect_lanes 後の並行配列から dissent JSON 配列を stdout に出力する。
+#   [{lane,verdict,note}, ...]。Bash 3.2 互換に並行配列を jq の --arg へ渡す。
+so_verdict_dissent_json() {
+  local args=() i=0 jq_prog
+  while [[ "$i" -lt "$SO_VERDICT_TOTAL_LANES" ]]; do
+    args+=(--arg "lane${i}" "${SO_VERDICT_LANE_NAMES[$i]}")
+    args+=(--arg "verdict${i}" "${SO_VERDICT_LANE_VERDICTS[$i]}")
+    args+=(--arg "note${i}" "${SO_VERDICT_LANE_NOTES[$i]}")
+    i=$((i + 1))
+  done
+  jq_prog="["
+  i=0
+  while [[ "$i" -lt "$SO_VERDICT_TOTAL_LANES" ]]; do
+    [[ "$i" -eq 0 ]] || jq_prog="${jq_prog},"
+    jq_prog="${jq_prog}{lane:\$lane${i},verdict:\$verdict${i},note:\$note${i}}"
+    i=$((i + 1))
+  done
+  jq_prog="${jq_prog}]"
+  jq -cn ${args[@]+"${args[@]}"} "$jq_prog"
+}
+
+# so_verdict_exit
+#   SO_VERDICT_VERDICT を見て exit する（advisory: refuted→3 / else→0。stdout JSON が正本）。
+#   source 元スクリプトの最終行で呼ぶ（同一プロセスなので exit が伝播する）。
+so_verdict_exit() {
+  if [[ "$SO_VERDICT_VERDICT" == "refuted" ]]; then
+    exit 3
+  fi
+  exit 0
+}


### PR DESCRIPTION
## 目的

PR #195（#194）で `oe-review`（実装SO verb）が `oe-refute`（設計SO verb）の **VERDICT 抽出/集約(conservative)/dissent JSON 構築/exit code を thin に複製**した（#194 の「`oe-refute` 非変更」ガードのため）。複製＝**drift risk**（#184 の VERDICT 部分一致 fix のような修正が今後2箇所に必要・片方取りこぼし）。本 PR は共有 lib 化で解消する**純リファクタ（両 verb 挙動不変・回帰ゼロ）**。

## 変更内容

- **新規 `lib/so-verdict.sh`**（source 専用・`envelope.sh` と同じ global-return 規約・bash 3.2/5.2 両対応＝連想配列/`local -n` 不使用の並行配列）。6 関数:
  - `so_verdict_extract_verdict` / `so_verdict_extract_reason`（#184 Fix 1 の VERDICT token 切り出し堅牢化を含む）
  - `so_verdict_collect_lanes`（レーンを回し並行配列＋count を populate）
  - `so_verdict_aggregate <refuted_phrase> <survived_phrase>`（conservative 集約。1 レーンでも refuted→全体 refuted、verdict 不明レーンは survived 確定を阻む保守側）
  - `so_verdict_dissent_json`（dissent JSON を stdout）／ `so_verdict_exit`（advisory: refuted→3 / else→0）
- `bin/oe-refute` / `bin/oe-review` が lib を source し、複製ロジックを呼び出しに置換。出力/audit jq 組立を不変に保つため lib の global-return を verb ローカル名に束ねた（verb 固有の出力アセンブリは無改変）。
- **verb 固有なのは集約 REASON の文言のみ**＝`so_verdict_aggregate` の phrase 引数で完全一致保持。
- 差分: 2 verb から計 -137 行、共有 lib +126 行（単一 source 化）。

## 設計判断（DJ-1）

`lib` の切り出し方は **案A: global-return lib** を採用（確定前証跡は `tmp/dj-1-so-verdict-lib.md`・episode に蒸留）。

- 根拠: `lib/envelope.sh` が既に global-return（戻り値をグローバルに設定）を採用済の**既存パターン**。bash 3.2 で関数から配列を返す現実解。
- 棄却: 案B stdout-serialization（dissent 二重エンコード・既存慣習逸脱）／案C leaf 関数のみ抽出（受け入れ条件「集約が単一 lib に一元化」を満たさず過少デリバリ）。
- 設計SO（別途 `oe-refute`）はスキップ（記録された判断）: 制約された純リファクタの責務分界で incumbent パターンが強く、下流の**必須 実装SO（`oe-review`）が lib 分解の敵対的チェックを兼ねる**ため。

## 検証（回帰ゼロ）

- **shellcheck**: `lib/so-verdict.sh` `bin/oe-refute` `bin/oe-review` 全 CLEAN
- **既存ユニット**: `test_oe_refute` 63/0・`test_oe_review` 64/0 を **bash 5.2.37 と system bash 3.2.57 の両方**で green（lib 抽出前の baseline と同数＝回帰ゼロ）
- **負のコントロール（lib 抽出前後で同一挙動）**: master(旧) verb と worktree(新) verb の出力 JSON を `output_dir`/`audit_id`（run 毎 ULID）のみ正規化して byte 比較。refuted/survived/error/mixed・rubric exploration|consensus・lanes 3 を網羅して **fail=0**＝ユニットが検証しない `reason` 文言まで完全一致を確認
- **実装SO = `oe-review --lanes 2`（codex,cursor）を本 PR の diff（`478a75f`）に実行**（この verb の実運用初ケース）: **verdict=survived**。両レーンが material 欠陥なしと判定（cursor は master cross-check・`set -e`/IFS/jq/exit/global-return 経路を反証検証）。audit は `audit/oe-review.jsonl`（lens=impl・diff バインド・設計SO と別 stream）。

## 受け入れ条件

- [x] VERDICT 抽出/集約が単一 lib に一元化され、両 verb が消費
- [x] `oe-refute` / `oe-review` とも挙動不変・回帰ゼロ（既存テスト green 維持・負のコントロール fail=0）
- [x] 駆動層フロー（discussion/DJ → 設計SO判断 → 実装 → 実装SO → Episode → PR）

## マージ判断

マージはユーザー判断。純リファクタ・挙動不変のため低リスク。

Refs #194 #195 #196
