### PR TITLE
feat(oe): add oe-status cockpit 観測UI (read-only 俯瞰 + 監査ログ閲覧)

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -39,7 +39,8 @@ projects/orchestration-engine/
 │   ├── oe-delegate            # 子 Claude セッションを起動しタスクをキック（親子委譲: spawn + kick）
 │   ├── oe-send                # 既存ペインへ 1 行を汎用送信（%N/ラベル・--kickoff・--no-enter・送信信頼化 finalize）
 │   ├── oe-list                # 委譲の宛先候補を一覧（spawn registry + pane-issue）
-│   └── oe-report              # 親へ申し送り/レビュー依頼（legacy・戻しは oe-send に一本化）
+│   ├── oe-report              # 親へ申し送り/レビュー依頼（legacy・戻しは oe-send に一本化）
+│   └── oe-status              # cockpit 観測UI: read-only 俯瞰（ENGINE=audit-terminal state / DELEGATE=liveness）+ 監査ログ閲覧（#177）
 ├── lib/                       # Bash 関数ライブラリ（source 専用）
 │   ├── constants.sh           # OE_POLL_INTERVAL, OE_CB_*, OE_DATA_DIR, OE_TARGET_AI_*, OE_VERIFY_AI_* 等
 │   ├── envelope.sh            # JSON エンベロープ生成

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -6,6 +6,7 @@ scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
 - **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-send` / `oe-list` / `oe-select` / `oe-report`
+- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰）
 
 ---
 
@@ -137,6 +138,29 @@ oe-report [--review] <message>
 ```
 
 関連 lib: `delegate-send.sh`
+
+---
+
+## oe-status — cockpit 観測UI（read-only 俯瞰 + 監査ログ閲覧）(#177)
+
+2 つの identity 空間（#188: engine=wez 整数 / delegate=tmux `%N`）を **join せず read 時に投影**する単一コマンド・typed sections の観測ツール。`oe-status` 1 回で 2 区画を出す:
+
+- `=== ENGINE (wez · state/audit) ===`: engine session を **audit-terminal reducer** 由来の STATE 付きで一覧。STATE は `audit/{sid}.jsonl` の終端シグナルを **severity-max** で reduce する（末尾行ではない。`cleanup`/`verification_*` は除外）。**CB timeout は audit のみ・KVS 未書込のため audit から導く**（KVS だけだと取りこぼす）。state file があれば outputs/blockers を補足。
+- `=== DELEGATE (tmux · liveness) ===`: `oe_reg_list` の生存ペインを **liveness のみ**で一覧（state/audit を持たない＝timeline:none）。tmux 不在時は degrade（engine 区画は出す）。
+
+```bash
+oe-status                       # 俯瞰（typed sections・既定・プレーン）
+oe-status <session_id>          # 1 セッションの監査ログを時系列表示（start→end）
+oe-status -i | --interactive    # fzf で行を選び preview（ENGINE=timeline / DELEGATE=meta）
+oe-status -h | --help
+```
+
+- STATE 導出（precedence・severity-max worst 勝ち）: `circuit_breaker_triggered` reason=`timeout`/`verification_timeout`→`timeout`（verification_timeout は session 終端に寄与せず注記のみ） / reason=`max_turns`/`max_panes`→`blocked`（DI-4。`limit_type` フォールバックあり） / `session_end.state` / `interrupt`→`interrupted` / 終端無し+`session_start`→`running?` / それ以外→`?`。multi-pane でも blocked/timeout が success に隠れない。
+- **read-only / 非検出**: 触れるのは (1) state/audit ファイル (2) tmux/wez ペイン存在（mux query）のみ。**ペイン出力は読まない**（polling 常駐・capture マーカー走査＝検出をしない）。preview は ENGINE=audit timeline 表示 / DELEGATE=registry メタのみ。
+- DJ-4: `oe-refute.jsonl` / `oe-review.jsonl`（別スキーマ）は ULID 不一致で session 行に出ない（v1 対象外）。
+- データ源は `OE_DATA_DIR`（または `OE_AUDIT_DIR` / `OE_STATE_DIR`）で上書き可。
+
+設計の正本: [`../docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md`](../docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md) §8 / [`../docs/decisions/2026-06-19-decision-188-identity-unification.md`](../docs/decisions/2026-06-19-decision-188-identity-unification.md)。関連 lib: `delegate-registry.sh`（`oe_reg_list`）。
 
 ---
 

--- a/projects/orchestration-engine/bin/oe-status
+++ b/projects/orchestration-engine/bin/oe-status
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# oe-status — cockpit 観測UI（read-only 俯瞰 + 監査ログ閲覧）(#177)
+#
+# usage:
+#   oe-status                       俯瞰（typed sections・既定・プレーン）
+#   oe-status <session_id>          1 セッションの監査ログを時系列表示（start→end）
+#   oe-status -i | --interactive    fzf で行を選び preview（ENGINE=timeline / DELEGATE=meta）
+#   oe-status -h | --help
+#
+# 設計の正本: docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md §8
+#            （DJ-2再/DJ-3再 = 単一コマンド typed sections・audit-terminal reducer）
+#            docs/decisions/2026-06-19-decision-188-identity-unification.md
+#            （identity は基盤ごと・read 時相関・永続マップ無し）
+#
+# 2 つの identity 空間（#188）を join せず read 時に投影する:
+#   - ENGINE 区画（wez · state/audit）: engine session を audit-terminal reducer で導いた
+#     STATE 付きで一覧。STATE は audit jsonl の終端シグナルを severity-max で reduce する
+#     （末尾行ではない。cleanup / verification_* は STATE 導出から除外）。
+#     CB timeout は audit のみ・KVS 未書込のため、KVS でなく audit から導くのが正（caveat1）。
+#   - DELEGATE 区画（tmux · liveness）: oe_reg_list の生存ペインを liveness のみで一覧
+#     （state/audit を持たない＝timeline:none）。
+#
+# read-only / 非検出: 触れるのは (1) state/audit ファイル (2) tmux/wez ペイン存在（mux query）
+#   のみ。ペイン出力は一切読まない（polling 常駐・capture マーカー走査＝検出はしない）。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${BIN_DIR}/.." && pwd)"
+# shellcheck source=../lib/delegate-registry.sh
+source "${BIN_DIR}/../lib/delegate-registry.sh"
+
+# データ源（OE_DATA_DIR で上書き可。既定はプロジェクトルート相対。oe-refute/constants.sh と同規約）。
+OE_AUDIT_DIR="${OE_AUDIT_DIR:-${OE_DATA_DIR:-${PROJECT_DIR}}/audit}"
+OE_STATE_DIR="${OE_STATE_DIR:-${OE_DATA_DIR:-${PROJECT_DIR}}/state}"
+
+# session_id（ULID）パターン。audit/oe-refute.jsonl・oe-review.jsonl（別スキーマ・DJ-4）は
+# このパターンに合致しないため自動的に除外される。
+OE_STATUS_ULID_RE='^[0-9A-HJKMNP-TV-Z]{26}$'
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  oe-status                     俯瞰（ENGINE / DELEGATE の typed sections・既定）
+  oe-status <session_id>        1 セッションの監査ログを時系列表示（start→end）
+  oe-status -i | --interactive  fzf で行を選び preview（ENGINE=timeline / DELEGATE=meta）
+  oe-status -h | --help         このヘルプ
+
+read-only: state/audit ファイルと tmux/wez のペイン存在のみを読む（検出・送信はしない）。
+EOF
+}
+
+err() { echo "oe-status: $*" >&2; }
+
+# --- audit-terminal reducer（engine session の STATE 導出） ---
+# 引数: <audit jsonl path>
+# 出力: 1 行 JSON {state, panes, last_ts, last_event, vto}
+#   state    : severity-max で導いた session-level STATE（running?/? を含む）
+#   panes    : session_end の数（multi-pane 把握用）
+#   last_ts  : 最終イベントの ts
+#   last_event: 最終イベントの event_type
+#   vto      : verification_timeout の発生数（注記用・STATE には寄与しない）
+_oe_status_reduce() {
+  local file="$1"
+  jq -s '
+    def sev:
+      {"protocol_error":0,"timeout":1,"blocked":2,"retryable_failure":3,
+       "partial":4,"interrupted":5,"success":6}[.] // 99;
+    ( [ .[]
+        | if .event_type=="session_end" and (.state != null) then .state
+          elif .event_type=="circuit_breaker_triggered" then
+            ( ((.payload.reason // .payload.limit_type) // "") as $r
+              | if $r=="timeout" then "timeout"
+                elif ($r=="max_turns" or $r=="max_panes") then "blocked"
+                else empty end )
+          elif .event_type=="interrupt" then "interrupted"
+          else empty end ] ) as $terms
+    | { state: ( if ($terms|length) > 0 then ($terms | min_by(sev))
+                 elif ([ .[] | select(.event_type=="session_start") ] | length) > 0 then "running?"
+                 else "?" end ),
+        panes:      ( [ .[] | select(.event_type=="session_end") ] | length ),
+        last_ts:    ( (.[-1] // {}).ts // "" ),
+        last_event: ( (.[-1] // {}).event_type // "" ),
+        vto:        ( [ .[] | select(.event_type=="circuit_breaker_triggered"
+                        and ((.payload.reason // .payload.limit_type) == "verification_timeout")) ] | length )
+      }
+  ' "$file"
+}
+
+# engine session id 一覧（audit ULID ファイル ∪ state ファイル）を改行区切りで（新しい順）
+_oe_status_engine_ids() {
+  local f base
+  {
+    if [[ -d "$OE_AUDIT_DIR" ]]; then
+      for f in "$OE_AUDIT_DIR"/*.jsonl; do
+        [[ -e "$f" ]] || continue
+        base="$(basename "$f" .jsonl)"
+        [[ "$base" =~ $OE_STATUS_ULID_RE ]] && printf '%s\n' "$base"
+      done
+    fi
+    if [[ -d "$OE_STATE_DIR" ]]; then
+      for f in "$OE_STATE_DIR"/*.state.json; do
+        [[ -e "$f" ]] || continue
+        base="$(basename "$f" .state.json)"
+        [[ "$base" =~ $OE_STATUS_ULID_RE ]] && printf '%s\n' "$base"
+      done
+    fi
+  } | sort -u -r
+}
+
+# ENGINE 区画を出力（plain=表 / fzf=候補行）
+#   $1: mode = plain | fzf
+_oe_status_engine_section() {
+  local mode="$1"
+  local ids sid audit_file state_file reduced state panes last_event note kvs_state
+  ids="$(_oe_status_engine_ids)"
+
+  if [[ "$mode" == "plain" ]]; then
+    printf '=== ENGINE (wez · state/audit) ===\n'
+    if [[ -z "$ids" ]]; then
+      printf '  (no engine sessions in %s)\n' "$OE_AUDIT_DIR"
+      return 0
+    fi
+    printf '%-26s  %-11s  %-5s  %-20s  %s\n' "SESSION" "STATE" "PANES" "LAST_EVENT" "NOTE"
+  fi
+
+  [[ -n "$ids" ]] || return 0
+  while IFS= read -r sid; do
+    [[ -n "$sid" ]] || continue
+    audit_file="${OE_AUDIT_DIR}/${sid}.jsonl"
+    state_file="${OE_STATE_DIR}/${sid}.state.json"
+    note=""
+    if [[ -f "$audit_file" ]]; then
+      reduced="$(_oe_status_reduce "$audit_file" 2>/dev/null)" || reduced='{}'
+      [[ -n "$reduced" ]] || reduced='{}'
+      state="$(printf '%s' "$reduced"  | jq -r '.state // "?"' 2>/dev/null)"
+      panes="$(printf '%s' "$reduced"  | jq -r '.panes // 0' 2>/dev/null)"
+      last_event="$(printf '%s' "$reduced" | jq -r '.last_event // "-"' 2>/dev/null)"
+      [[ "$(printf '%s' "$reduced" | jq -r '.vto // 0' 2>/dev/null)" != "0" ]] && note="verify-timeout"
+    else
+      # audit 不在で state file のみ → KVS の state を表示（kvs-only 注記）
+      kvs_state="$(jq -r '.state // "?"' "$state_file" 2>/dev/null)"
+      state="${kvs_state:-?}"; panes="-"; last_event="-"; note="kvs-only"
+    fi
+    [[ "${state:-}" == "" ]] && state="?"
+    # outputs/blockers の補足（state file があれば）
+    if [[ -f "$state_file" ]]; then
+      local nout nblk
+      nout="$(jq -r '(.outputs // []) | length' "$state_file" 2>/dev/null || echo 0)"
+      nblk="$(jq -r '(.blockers // []) | length' "$state_file" 2>/dev/null || echo 0)"
+      [[ "${nblk:-0}" -gt 0 ]] 2>/dev/null && note="${note:+${note} }blockers=${nblk}"
+      [[ "${nout:-0}" -gt 0 ]] 2>/dev/null && note="${note:+${note} }outputs=${nout}"
+    fi
+
+    if [[ "$mode" == "plain" ]]; then
+      printf '%-26s  %-11s  %-5s  %-20s  %s\n' "$sid" "${state}" "${panes}" "${last_event}" "${note}"
+    else
+      # fzf 候補行（first-token=session_id）
+      printf '%-26s  ENGINE    %-11s  %s\n' "$sid" "${state}" "${note}"
+    fi
+  done <<< "$ids"
+}
+
+# DELEGATE 区画を出力（plain=表 / fzf=候補行）。tmux 不在は degrade（engine だけは出す）。
+#   $1: mode = plain | fzf
+_oe_status_delegate_section() {
+  local mode="$1"
+  local list rc first pane source label
+  [[ "$mode" == "plain" ]] && printf '\n=== DELEGATE (tmux · liveness) ===\n'
+
+  # set -e 下で oe_reg_list の失敗（tmux 不在=rc2）が assignment を介して abort しないよう
+  # || rc=$? で受ける（degrade して engine 区画だけは出す）。
+  rc=0
+  list="$(oe_reg_list 2>/dev/null)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    [[ "$mode" == "plain" ]] && printf '  (tmux unavailable — delegate liveness not shown)\n'
+    return 0
+  fi
+
+  if [[ "$mode" == "plain" ]]; then
+    # oe_reg_list の表（PANE/SOURCE/LABEL）をそのまま liveness ビューとして出す。
+    printf '%s\n' "$list"
+    return 0
+  fi
+
+  # fzf モード: ヘッダ行を落として候補行（first-token=%N）に整形。
+  first=1
+  while IFS= read -r line; do
+    if [[ "$first" -eq 1 ]]; then first=0; continue; fi
+    [[ -n "$line" ]] || continue
+    pane="$(printf '%s\n' "$line"   | awk '{print $1}')"
+    source="$(printf '%s\n' "$line" | awk '{print $2}')"
+    label="$(printf '%s\n' "$line"  | awk '{$1="";$2="";sub(/^  */,"");print}')"
+    printf '%-26s  DELEGATE  %-11s  %s\n' "$pane" "live(${source})" "$label"
+  done <<< "$list"
+}
+
+# 1 セッションの監査ログを時系列表示（受入2: start→end）
+_oe_status_timeline() {
+  local sid="$1"
+  local audit_file="${OE_AUDIT_DIR}/${sid}.jsonl"
+  local state_file="${OE_STATE_DIR}/${sid}.state.json"
+
+  if [[ ! -f "$audit_file" && ! -f "$state_file" ]]; then
+    err "no audit/state for session: ${sid} (in ${OE_AUDIT_DIR})"
+    return 1
+  fi
+
+  printf '=== session %s ===\n' "$sid"
+  if [[ -f "$audit_file" ]]; then
+    local reduced
+    reduced="$(_oe_status_reduce "$audit_file" 2>/dev/null)" || reduced=""
+    printf 'derived state: %s\n\n' "$(printf '%s' "$reduced" | jq -r '.state // "?"' 2>/dev/null)"
+    printf 'TIMELINE (%s):\n' "$audit_file"
+    # 時系列 1 行ずつ。state は [..]、payload は非空のとき末尾に JSON で添える。
+    jq -r '
+      "  " + .ts
+      + "  " + .event_type
+      + (if .state then "  [" + .state + "]" else "" end)
+      + (if (.payload // {} | length) > 0 then "  " + (.payload | tojson) else "" end)
+    ' "$audit_file" 2>/dev/null || {
+      err "failed to read audit jsonl: ${audit_file}"; return 1; }
+  else
+    printf '(no audit jsonl — KVS only)\n'
+  fi
+
+  if [[ -f "$state_file" ]]; then
+    printf '\nKVS (%s):\n' "$state_file"
+    jq -r '
+      "  state: " + (.state // "?")
+      + "  last_updated: " + (.last_updated // "-")
+      + (if (.outputs // [] | length) > 0 then "\n  outputs: " + (.outputs | join(", ")) else "" end)
+      + (if (.blockers // [] | length) > 0 then "\n  blockers: " + (.blockers | join("; ")) else "" end)
+      + (if .verification_summary then "\n  verification: " + (.verification_summary | tojson) else "" end)
+    ' "$state_file" 2>/dev/null || true
+  fi
+}
+
+# fzf preview ディスパッチ（内部用）。token=ULID→timeline / token=%N→delegate meta。
+_oe_status_preview() {
+  local token="$1"
+  if [[ "$token" =~ $OE_STATUS_ULID_RE ]]; then
+    _oe_status_timeline "$token"
+  elif [[ "$token" =~ ^%[0-9]+$ ]]; then
+    # DELEGATE: liveness のみ・timeline 無し。registry メタのみ表示（ペイン出力は読まない）。
+    printf '=== delegate pane %s (tmux · liveness only) ===\n' "$token"
+    oe_reg_list 2>/dev/null | awk -v p="$token" 'NR==1 || $1==p' || true
+    printf '\n(no audit timeline for delegate panes — timeline:none / #188)\n'
+  else
+    printf '(no preview for: %s)\n' "$token"
+  fi
+}
+
+# 俯瞰（plain・typed sections）
+_oe_status_overview() {
+  _oe_status_engine_section plain
+  _oe_status_delegate_section plain
+}
+
+# --interactive: fzf で 1 行選ぶ → 選択行の preview を stdout に出す（read-only 観測）。
+_oe_status_interactive() {
+  command -v jq >/dev/null 2>&1 || { err "jq is required"; return 2; }
+  if ! command -v fzf >/dev/null 2>&1; then
+    err "fzf not found — falling back to plain overview"
+    _oe_status_overview
+    return 0
+  fi
+  local candidates header selected rc token
+  header="$(printf '%-26s  %-8s  %-11s  %s' "ID" "KIND" "STATE" "NOTE/LABEL")"
+  candidates="$( { _oe_status_engine_section fzf; _oe_status_delegate_section fzf; } )"
+  if [[ -z "$candidates" ]]; then
+    err "no rows to show"
+    return 1
+  fi
+  rc=0
+  selected="$(printf '%s\n' "$candidates" | fzf \
+    --header="$header" \
+    --prompt='oe-status> ' \
+    --preview "${BIN_DIR}/oe-status --preview {1}" \
+    --preview-window=right:60%)" || rc=$?
+  if [[ "$rc" -eq 130 || "$rc" -eq 1 ]]; then
+    return 130
+  elif [[ "$rc" -ge 2 ]]; then
+    err "fzf failed (rc=${rc})"; return 2
+  fi
+  [[ -n "$selected" ]] || return 130
+  token="$(printf '%s\n' "$selected" | awk '{print $1}')"
+  _oe_status_preview "$token"
+}
+
+# --- arg 解析 / dispatch ---
+command -v jq >/dev/null 2>&1 || { err "jq is required"; exit 2; }
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  -i|--interactive)
+    [[ $# -eq 1 ]] || { err "unexpected argument after ${1}"; usage; exit 2; }
+    _oe_status_interactive; exit $? ;;
+  --preview)
+    [[ $# -eq 2 ]] || { err "--preview requires exactly one token"; exit 2; }
+    _oe_status_preview "$2"; exit 0 ;;
+  "" )
+    _oe_status_overview; exit 0 ;;
+  -*)
+    err "unknown option: $1"; usage; exit 2 ;;
+  *)
+    [[ $# -eq 1 ]] || { err "unexpected argument after ${1}"; usage; exit 2; }
+    if [[ "$1" =~ $OE_STATUS_ULID_RE ]]; then
+      _oe_status_timeline "$1"; exit $?
+    else
+      err "not a session_id (ULID): $1"; usage; exit 2
+    fi
+    ;;
+esac

--- a/projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md
@@ -83,6 +83,7 @@ issue 受入が「観測ツール(#177)が相関できる、**または**『相�
 - **identity モデル**: コード変更なし。2-world topology を**アーキテクチャ不変条件**として本 ADR + schema 注記に明文化。
 - **schema**: 構造変更なし。`session-state.schema.json` の `pane_id` description に「WezTerm 整数・delegate(tmux) 子は本 KVS の対象外（DJ-188-2）」を追記し、将来の F 方向の誤改修を予防（受入3 の明文化のコード面ガード）。
 - **#177（消費者）**: identity モデルが「基盤ごと・read 時相関・永続マップ無し」と確定し **unblock**。俯瞰の再設計（query-side fusion 単一ビュー or honest 2 ビュー）は #177 の判断で、本 ADR はロックしない（推奨方向のみ申し送り）。#177 当初 DJ-1/4/5/6 は再開時も有効。
+  - **back-prop（2026-06-20・#177 実装時）**: #177 は本 ADR 上の推奨表現「`kind`/`mux` 列付き**1テーブル**に投影」を、設計SO（2 ラウンド）を経て **単一コマンド・typed sections**（ENGINE / DELEGATE を別区画・列融合しない）へ精緻化した（flat 1テーブルは engine/delegate の STATE/TIMELINE 列の意味を混同するため）。read 時投影・join しない・delegate は liveness のみ（timeline:none）という本 ADR の骨子は不変。詳細は [discussion #177 §8](../discussions/2026-06-19-discussion-cockpit-observation-ui.md)。
 - **#114 / Stage-B**: 永続横断観測が要るとき event bus（DJ-188-4）を採る方針を申し送り。F に投資しないことで #114 との衝突を回避。
 - **テスト**: なし（schema description 追記のみ・構造/バリデーション不変）。
 

--- a/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md
@@ -123,3 +123,55 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, discuss
 
 - §6 で無効化された DJ-3（pane_id ジョイン）は復活しない。俯瞰は「生存ペイン ↔ session 状態を pane で join」ではなく、**read 時に両ソース（engine: wez + state/audit／delegate: tmux + registry）を `kind`/`mux` 列付き1テーブルに投影（join しない・delegate 行は `timeline:none`）= query-side fusion**、または honest 2 ビュー。どちらを採るかは #177 再設計時に決める（設計SO の codex/cursor は query-side fusion に収束）。
 - 有効な DJ-1/4/5/6（UI 形態・oe-refute 対象外・tmux 既定・capture 導線）は引き続き使える。
+
+## 8. DJ-2/DJ-3 再設計の確定（2026-06-20・#177 実装着手・predecision-exploration 証跡）
+
+§7 で #188 が unblock した俯瞰方式（query-side fusion 単一ビュー or honest 2 ビュー）を #177 実装着手にあたり確定する。確定前に **predecision-exploration**（ゼロベース代替＋確定前証跡）を engine 統合経路 `oe-refute --rubric exploration --lanes 2`（codex+cursor）で **2 ラウンド**回した。両ラウンドとも verdict=`refuted` だったが、**反証は「カテゴリ」ではなく「過剰主張」と「grounding 詳細」に収束**したため、それらを設計へ織り込んだ上で確定する（exploration rubric は「迷ったら refuted 寄り」＝設計の残不確実性では survived を返しにくい。verdict は advisory・REASON 内容が正本：predecision-exploration / so-verdict 規約）。
+
+### 8.1 設計SO の証跡（揮発 output_dir の verdict/reason を転記）
+
+- **R1**（claim=flat 1テーブル fusion + 素朴 audit-tail。`audit_id=202606201236549TGTSWFP090S`）→ **refuted**。
+  - codex: 「audit-tail reducer・CB/multi-pane 合成・tmux liveness の非検出扱い・**単一画面 typed sections 案**が未確定」。
+  - cursor: 「audit-tail 単独完全性・CB/taxonomy 写像・interrupt/attach 終端・『最も適合』比較優位が未検証/コード矛盾、**structured honest-2** 等の未探索代替が残る」。
+  - → **新カテゴリ「単一コマンド・typed sections（structured honest-2）」が出た**。flat fusion は engine/delegate の異質な STATE/TIMELINE 列を混同する欠陥が判明。
+- **R2**（claim=typed sections + audit-terminal reducer。R1 反映済。`audit_id=20260620124213Q2FXT4JXYFJA`）→ **refuted（収束）**。
+  - 両レーンとも「**typed sections 自体は有望**」と合意（カテゴリ収束）。残る指摘は (a) `verification_timeout` の誤分類、(b) multi-pane 要約が blocked を隠す、(c) interrupt が部分 session_end 後に誤分類、(d) max_turns/max_panes 表示と受入1「blocked」文言のずれ、(e) CB payload schema(`limit_type`)↔実装(`reason`)不一致、(f) 「honest 2 より優れる」優位主張が ADR 上未立証、(g) read-only/非検出境界の preview 不統一。
+  - **新カテゴリは出ず**（残りは grounding 詳細 ＋ owner 既決の scope-split 再掲）。→ predecision-exploration の暫定停止条件（新カテゴリが出なければ確定可）を満たす。これ以上の exploration-refute 反復は lateral repetition（reframe-on-stall の stall）と判断し、grounding を設計へ織り込んで確定する。
+- 生出力: `tmp/oe-refute-202606201236549TGTSWFP090S/` ・ `tmp/oe-refute-20260620124213Q2FXT4JXYFJA/`（揮発）。claim doc: `tmp/dj-2-3-claim.md` / `tmp/dj-2-3-claim-v2.md`。
+
+### 8.2 確定（DJ-2/DJ-3 再設計）
+
+- **DJ-2再 / DJ-3再 確定 = 単一コマンド・typed sections（query-side fusion を正直に描画した形）**。1 回の `oe-status` で read 時に両ソースを投影し、**列融合せず区画ごとに適切な列**を持つ:
+  - `=== ENGINE (wez · state/audit) ===`: 行=engine session。STATE は **audit-terminal reducer** 由来（§8.3）。state file があれば outputs/blockers を補足。
+  - `=== DELEGATE (tmux · liveness) ===`: 行=`oe_reg_list` の生存ペイン。**liveness のみ・TIMELINE 列を持たない**（timeline:none を区画レベルで正直に表現）。
+- **優位主張は取り下げる**（R2(f) 反映）。本確定は「honest 2 ビューより優れる」証明に依らない。**owner/cockpit が query-side fusion 方向を既決（kickoff 方針・%32 agree）**であり、typed sections はそれを #188 制約下で正直に描画した**十分**な形（受入1〜3 を満たす）という根拠で確定する。honest 2 ビューは #188 ADR で「◯ 機能充足」とされ等価に近い＝本確定は UX 上の単一画面化であって受入の優劣判断ではない。
+- **scope-split（engine-only + delegate は oe-list 委譲）は owner 既決で不採用**（kickoff: delegate 行を本ツールに含める）。再 litigate しない（R2 breadth 指摘への回答）。
+
+### 8.3 audit-terminal reducer の確定仕様（grounding 反映）
+
+`audit/{ULID}.jsonl` の全イベントを走査し（**末尾行でない**。`cleanup`/`verification_*`/`polling_snapshot` は STATE 導出から除外）、終端シグナルを集めて **severity-max（worst が勝つ）**で 1 つの session-level STATE を導く:
+
+- 終端シグナル収集:
+  - `session_end` の各 `state`（success/blocked/partial/retryable_failure/protocol_error/timeout）。
+  - `circuit_breaker_triggered` の `payload.reason`（無ければ `payload.limit_type` にフォールバック＝schema 不一致 R2(e) への防御）:
+    - `timeout` → `timeout`
+    - `max_turns` / `max_panes` → `blocked`（circuit-breaker-design DI-4 の taxonomy 写像。受入1「blocked」文言に合わせる。R2(d)。reason は注記）
+    - `verification_timeout` → **session 終端に寄与しない**（verify フェーズは monitor 成功後＝target は session_end 済。R2(a) target lifecycle と verification lifecycle の混同を回避。「verify timeout」は注記）
+  - `interrupt` → `interrupted`。
+- severity 順（worst→best）: `protocol_error > timeout > blocked > retryable_failure > partial > interrupted > success`。終端が複数（multi-pane/部分完了+interrupt）でも worst を採るため **blocked/timeout/interrupt が success に隠れない**（R2(b)(c) 解消・受入1 を multi-pane でも満たす）。
+- 終端シグナル無し ＋ `session_start` あり → `running?`（in-flight **または** 孤児/クラッシュ＝read-only では区別不能。限界明記。wez 生存オーバーレイは DJ-5「wez 接続時」の follow-up に defer）。
+- いずれも無し → `?`（unknown）。
+- KVS の位置づけ（R1 緩和）: STATE は audit-terminal が権威（CB-only 終了は KVS 未書込）。KVS は outputs/blockers/verification_summary の**補足**（排除しない）。audit 不在で state file のみのセッションは KVS の `state` を表示し「kvs-only」注記。
+
+### 8.4 read-only / 非検出境界の確定（R2(g) 反映で preview を統一）
+
+- 「検出」（非スコープ）= ペイン**出力/内容**の走査（oe-capture の marker scan・polling 常駐）。
+- oe-status が触れるのは (1) state/audit **ファイル**、(2) tmux/wez **ペイン存在**（mux liveness query・oe-list/oe-select と同類）のみ。**ペイン出力は一切読まない**。
+- `--interactive` の preview: ENGINE 行=**audit timeline 表示**（DJ-6）/ DELEGATE 行=**registry メタ情報のみ**（label/source/pane。`tmux capture-pane` は使わない＝oe-select の借用をやめ、区画間で境界を統一）。これで「state/audit + ペイン存在のみ」を厳守し read-only を airtight にする。
+
+### 8.5 スコープ外として routing する発見（実装しない・implementer-contract）
+
+- **CB payload の schema↔実装ドリフト**（audit-log.schema.json は `limit_type` 記述・実装は `reason` emit）。#177（read-only 観測）の範囲外。reducer は `reason` 優先＋`limit_type` フォールバックで両対応し、ドリフト自体の是正は別 issue に routing（episode に記録）。
+- `--dry-run` 列検証（#188 handoff 残）は **fixture audit/state → 出力 assert のテストスイートが機械検証として代替**（dry-run フラグは v1 で作らない）。
+
+これらにより DJ-2/DJ-3 を再確定し、#177 実装に進む。DJ-2（read-only 俯瞰の境界＝検出を棄却した「なぜ」）の Decision 昇格は closure で判断（§5）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
@@ -1,0 +1,50 @@
+---
+id: "01KVJHAJ2N3RQ84SVNZ7BBK3YS"
+title: "#177 oe-status — cockpit 観測UI（read-only 俯瞰 + 監査ログ閲覧）実装"
+date: 2026-06-20
+type: episode
+status: in-development
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/177"
+    reason: "本 episode の対象 Issue（cockpit 観測UI: 子エージェント状態俯瞰と監査ログ閲覧）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md"
+    reason: "設計探索の正本。§8 で DJ-2/DJ-3 再設計を確定（本 episode が実装）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md"
+    reason: "identity は基盤ごと・read 時相関・永続マップ無し＝本俯瞰の前提"
+tags: [orchestration, cockpit, oe-status, observation, audit, read-only, episode]
+---
+
+# #177 oe-status — cockpit 観測UI 実装 episode
+
+> 本文は作業中リアルタイム追記（reconstructed ではない）。closure は `episode-retrospective`。
+
+## 設計フェーズ（2026-06-20）
+
+- kickoff（`.oe/kickoff-177-oe-status.md`）+ discussion §1-7 + decision-188 + schemas を読了。当初 plan（pane_id ジョイン）は §6 で撤回済 → #188 確定後の再設計が本タスク。
+- **駆動層フロー（engine 規約）**: discussion/DJ → 設計SO → 実装 → 実装SO（oe-review）→ Episode → PR。本 episode はその実行記録。
+- **設計SO（predecision-exploration 兼）= `oe-refute --rubric exploration --lanes 2`（codex+cursor）を 2 ラウンド**:
+  - R1（flat 1テーブル fusion + 素朴 audit-tail）→ refuted。**新カテゴリ「単一コマンド typed sections」が出現**。flat fusion の STATE/TIMELINE 列混同が判明。
+  - R2（typed sections + audit-terminal reducer）→ refuted だが**カテゴリ収束**（両レーン「typed sections 有望」）。残りは grounding 詳細（verification_timeout 誤分類 / multi-pane で blocked 隠れ / interrupt 誤分類 / max_turns→blocked 写像 / CB schema↔impl drift / 優位主張の未立証 / preview 境界）。
+  - 新カテゴリが出ない R2 で predecision-exploration の暫定停止条件を満たし、grounding を設計へ織り込んで**確定**（discussion §8）。証跡: `tmp/oe-refute-*`（揮発・verdict/reason は §8 へ転記）。
+- **確定（DJ-2再/DJ-3再）**: 単一コマンド・typed sections（`=== ENGINE ===` / `=== DELEGATE ===`）。engine=audit-terminal reducer（severity-max）由来 state、delegate=liveness のみ（timeline:none）。read-only airtight（ペイン出力を一切読まない・preview は ENGINE=audit timeline / DELEGATE=registry メタのみ）。優位主張は取り下げ（owner 既決方向の正直な描画＝十分性で確定）。
+
+## 実装フェーズ
+
+- **`bin/oe-status`**（新規）: 単一コマンド typed sections。`_oe_status_reduce`（jq・severity-max audit-terminal reducer）/ `_oe_status_engine_section` / `_oe_status_delegate_section`（oe_reg_list 投影・tmux 不在 degrade）/ `_oe_status_timeline`（受入2）/ `_oe_status_preview`（fzf 用 dispatch）/ `_oe_status_interactive`（DJ-1(b)）。`OE_DATA_DIR`/`OE_AUDIT_DIR`/`OE_STATE_DIR` override。bash 3.2 互換（declare -A/mapfile 不使用）。
+- **`tests/test_oe_status.sh`**（新規・27 assert）: fixture audit/state で 8 reducer ケース（success/blocked/timeout/running?/interrupted/multi-pane-blocked/verification_timeout/max_turns）/ 注記 / KVS 補足 / DJ-4 除外 / timeline start→end / 引数ハンドリング / tmux degrade。
+- **`bin/README.md` / `README.md`**: oe-status の節・索引・構成ツリーを追記。
+- **検証**: `shellcheck bin/oe-status tests/test_oe_status.sh` PASS。`bash tests/test_oe_status.sh` 27/27 PASS。**/bin/bash 3.2.57（macOS）でも 27/27 PASS**（ADR-005）。実 sample（`202605261208418AW8GCYGYGY6`）+ 実 tmux でも overview/timeline 動作確認。
+- **設計SO 反証の反映を実装で実証**（discussion §8.3）: timeout を CB audit-only から導出（last_event=cleanup でも state=timeout）/ multi-pane で blocked が success に隠れない（severity-max）/ verification_timeout は success のまま注記 / max_turns→blocked（limit_type フォールバック）。
+- **set -e バグをテストが捕捉**: `list="$(oe_reg_list)"` が tmux 不在（rc2）で abort → `|| rc=$?` で degrade に修正（reducer 抽出も `reduced='{}'` フォールバックで堅牢化）。
+- **R2(g) 反映**: preview の read-only 境界統一（DELEGATE preview は tmux capture を使わず registry メタのみ＝ペイン出力を一切読まない）。
+
+## 範囲外として routing した発見
+
+- **CB payload schema↔impl drift**: `schemas/audit-log.schema.json` は `payload.limit_type` と記述、実装（`lib/monitor.sh`）は `payload.reason` を emit。#177（read-only 観測）の範囲外。oe-status の reducer は `reason` 優先＋`limit_type` フォールバックで両対応。**ドリフト是正は別 issue に切るべき**（producer 側 or schema 側の統一）。
+
+## caveat routing（誤読防止・必須）
+
+- **oe-review.jsonl 駆動率測定は #177 v1 スコープ外（DJ-4）**。よって **#177 v1 単独では #24（L3 hook）/ Stage-B を unblock しない**（それらは別途の駆動率測定に依存）。「#177 で測定経路が揃った」と読まないこと。

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
@@ -3,7 +3,7 @@ id: "01KVJHAJ2N3RQ84SVNZ7BBK3YS"
 title: "#177 oe-status — cockpit 観測UI（read-only 俯瞰 + 監査ログ閲覧）実装"
 date: 2026-06-20
 type: episode
-status: in-development
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/177"
@@ -46,6 +46,54 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, episode
 - `oe-review --lanes 2 --base master`（codex+cursor）→ **verdict=survived**（exit 0）。`reviewed_sha=9fe1fdb`・`diff_base=master`・`changed_files_count=6`・`audit_id=20260620130225WHZKB2XA4A4M`。
 - 両レーンとも audit-terminal reducer・degrade・引数処理・ULID 拘束・read-only 境界を diff/実コード/27 テスト/shellcheck/bash3.2 で照合し material な correctness/堅牢性/セキュリティ欠陥なしと判定。
 - 設計SO（oe-refute・breadth/grounding レンズ）とは別レンズ・別ステップ・別 audit stream（oe-review.jsonl）。設計SO を回したことは実装SO の代替にならない（#192 false-pass 回避）。
+
+## PR & Copilot ラウンド
+
+- PR [#198](https://github.com/stlwolf/ai-development-hub/pull/198) 作成。%3（親コーディネータ）へ oe-send で一報（PR 番号 + query-side fusion 所感）。
+- Copilot レビュー（`--add-reviewer @copilot`）→ inline 1 件。**妥当な指摘**: degrade テストの `PATH="${PATHBIN}:/usr/bin:/bin"` は `/usr/bin/tmux` のある環境（Linux/CI）で degrade が発火せず不安定 → **PATH を stub のみに修正**（コミット `1cc3a93`）。bash 5.x/3.2 で 27/27 維持。スレッドへ返信済。1 ラウンドで停止（再リクエストはユーザー明示時のみ）。
+
+## Closure（episode-retrospective・heavy tier）
+
+### tier 判定 = heavy
+heavy トリガ複数該当: (1) 実行中の撤回（R1 flat fusion refuted → typed sections へ転回）/ (2) 意図起動の外部レビューレーン（oe-refute 設計SO ×2 + oe-review 実装SO）/ (3) 非自明な設計判断（typed sections vs flat fusion vs honest-2・棄却理由あり）/ (4) Decision 昇格候補（DJ-2）。
+
+### Step2 closure gate
+- **Context / なぜ**: #188 で identity が「基盤ごと・read 時相関・永続マップ無し」と確定し #177 が unblock。当初の pane_id ジョイン案は設計SOで破綻済 → read 時投影での俯瞰を作るのが本作業（冒頭で自己完結）。
+- **次の消費者**: cockpit 運用者（稼働中 session の blocked/timeout 俯瞰・監査ログ閲覧）/ 親コーディネータ %3（PR レビュー）/ 将来 Stage-B（横断観測 event bus の前史として本ツールの read-time 投影モデルを参照）。
+- **follow-up routing**（行き先必須）:
+  - CB payload schema↔impl drift（`limit_type` 記述 vs `reason` emit）→ **[#199](https://github.com/stlwolf/ai-development-hub/issues/199) 起票済**（producer/schema どちらかに統一）。本 PR は reducer 側フォールバックで両対応のみ。
+  - `running?` の孤児/クラッシュ判別（wez 生存オーバーレイ）→ **DJ-5「wez 接続時」の follow-up に defer**（v1 は read-only 限界として明記）。
+  - in-flight blocked の read-only 検出 → **全案共通の構造限界・Stage-B event bus 待ち**（追わない＝v1 は完了 session の blocked のみ）。
+  - oe-review.jsonl 駆動率測定 → **#177 v1 スコープ外（DJ-4）**。#24/Stage-B はこれに依存し #177 v1 単独では unblock しない（誤読防止・上記 caveat routing 節に明記）。
+- **status 確定**: in-development → **stable**（達成: 受入1〜3 全 PASS）。
+- **evidence anchor**: 揮発 tmp/ の SO 出力（oe-refute R1/R2・oe-review）の verdict/reason は discussion §8 と本 episode 実装SO 節へ転記済。oe-review `audit_id=20260620130225WHZKB2XA4A4M`。
+- **SO 証跡リンク**: 設計SO=discussion §8.1（audit_id 2 件）/ 実装SO=本 episode 実装SO 節 / closure SO=下記 Step4。
+
+### Step3 内容（出力型 × 消費チャネル）
+- **事実・失敗**（選択的省略しない）: (1) 設計SO R1 で flat 1テーブル fusion + 素朴 audit-tail が refuted（撤回・転回） / (2) 実装中に `set -e` × `oe_reg_list` rc2 の degrade abort バグをテストが捕捉→`|| rc=$?` 修正 / (3) Copilot 指摘で degrade テストの PATH 環境依存（`/usr/bin/tmux`）を stub のみに修正（`1cc3a93`）。いずれも本文（設計/実装フェーズ・PR&Copilot 節）に明記済。
+- **決定と根拠**: query-side fusion を flat 1テーブルでなく **単一コマンド typed sections** で実装（engine/delegate の STATE/TIMELINE 列意味が非対称＝混同を避ける）。honest-2 ビューとの優劣は証明せず、owner 既決方向の正直な描画＝十分性で確定（棄却: flat fusion=列混同 / engine-only scope-split=owner 既決で不採用）。
+- **わかったこと（W）**: engine session の最終状態は **audit-terminal reducer（severity-max・末尾行でない）** でしか read-only 完全には導けない（CB timeout/max_turns は audit のみ・KVS 未書込 / cleanup・verification_* が末尾に来る / interrupt は session_end 無し / multi-pane は worst を採らないと blocked が success に隠れる）。
+- **原則（Pattern/Anti-pattern）**: 「監査ログから state を導くなら**末尾行でなく lifecycle 終端イベントの precedence reduce**」（Anti: tail 一発。Pattern: severity-max reduce + verification/cleanup 除外）。「観測ツールの read-only は**ファイル+ペイン存在のみ・出力は読まない**で線引き」（Anti: capture で出力走査。Pattern: preview も audit timeline / registry メタに限定）。
+- **行動変更**: なし（hook/skill 化なし。本 PR は単機能ツール追加）。
+- **蒸留シグナル**: 下記 DJ-2 判断参照（今回は **Decision 非昇格**）。
+- **残課題**: 上記 follow-up routing に行き先付与済。
+
+### DJ-2 Decision 昇格判断（task #11）
+**判断 = 今回は非昇格（defer）**。理由:
+- DJ-2 の「read-only 俯瞰の境界＝検出を棄却した なぜ」と audit-terminal reducer の根拠は **discussion §8（永続 doc）に詳細記録済**で揮発しない。
+- 基盤となる identity アーキテクチャ決定は既に **#188 ADR（accepted）** が保持。別 Decision は §8+#188 と大幅重複。
+- v1 PoC 段階で境界はまだ運用再利用/争点化されていない（discussion §5 が「時期尚早なら非昇格でよい・判断を episode に残す」を許容）。
+- **再昇格トリガ**: Stage-B または別観測ツールがこの read-only 境界 / reducer 方式を再利用・再検討する時点で Decision 化を再検討する。
+
+### Step4 外部チェック（heavy・closure 品質 SO）
+- `so-compare -w . --with codex,claude`（closure 品質のみ・出力 `tmp/so-20260620-221558/`・揮発）。claude=4 観点 OK / codex=より厳格に 3 点 NG → **反映済**:
+  - (NG2) CB drift routing が「別 issue 推奨」止まり → **[#199](https://github.com/stlwolf/ai-development-hub/issues/199) を起票**して具体 routing 化。
+  - (NG4) #188 ADR に「1テーブル」推奨表現が残り typed-sections への精緻化が back-prop 未反映 → **decision-188 帰結に back-prop 注記を追加**。
+  - (NG1) closure に 事実・失敗 セクションが無い → **Step3 に 事実・失敗 を追記**（3 マーカー再掲）。
+  - (OK) 揮発パスは verdict/reason を §8.1 / 本 episode に転記済（両レーン一致）。
+- 残 soft spot（追わない）: discussion frontmatter `status: draft`（discussion の closure は本スキル対象外）/ Copilot スレッドのライブ照合は commit `1cc3a93` 整合で代替。
+
+**closure 完了**: status を in-development → **stable** に確定（受入1〜3 達成）。次の消費者・follow-up routing・evidence anchor すべて充足。
 
 ## 範囲外として routing した発見
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
@@ -41,6 +41,12 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, episode
 - **set -e バグをテストが捕捉**: `list="$(oe_reg_list)"` が tmux 不在（rc2）で abort → `|| rc=$?` で degrade に修正（reducer 抽出も `reduced='{}'` フォールバックで堅牢化）。
 - **R2(g) 反映**: preview の read-only 境界統一（DELEGATE preview は tmux capture を使わず registry メタのみ＝ペイン出力を一切読まない）。
 
+## 実装SO（oe-review・コード欠陥レンズ・設計SO とは別ステップ）
+
+- `oe-review --lanes 2 --base master`（codex+cursor）→ **verdict=survived**（exit 0）。`reviewed_sha=9fe1fdb`・`diff_base=master`・`changed_files_count=6`・`audit_id=20260620130225WHZKB2XA4A4M`。
+- 両レーンとも audit-terminal reducer・degrade・引数処理・ULID 拘束・read-only 境界を diff/実コード/27 テスト/shellcheck/bash3.2 で照合し material な correctness/堅牢性/セキュリティ欠陥なしと判定。
+- 設計SO（oe-refute・breadth/grounding レンズ）とは別レンズ・別ステップ・別 audit stream（oe-review.jsonl）。設計SO を回したことは実装SO の代替にならない（#192 false-pass 回避）。
+
 ## 範囲外として routing した発見
 
 - **CB payload schema↔impl drift**: `schemas/audit-log.schema.json` は `payload.limit_type` と記述、実装（`lib/monitor.sh`）は `payload.reason` を emit。#177（read-only 観測）の範囲外。oe-status の reducer は `reason` 優先＋`limit_type` フォールバックで両対応。**ドリフト是正は別 issue に切るべき**（producer 側 or schema 側の統一）。

--- a/projects/orchestration-engine/tests/test_oe_status.sh
+++ b/projects/orchestration-engine/tests/test_oe_status.sh
@@ -109,13 +109,16 @@ rc=0; "$OE_STATUS" "$RUN" extra >/dev/null 2>&1 || rc=$?; ck "余分な引数 rc
 rc=0; "$OE_STATUS" 202606209999999999999999ZZ >/dev/null 2>&1 || rc=$?; ck "存在しない session rc1" "1" "$rc"
 
 echo "[6] delegate degrade: tmux 不在でも ENGINE は出て exit 0"
-# jq を含む最小 PATH（tmux を含めない）を作る。oe_reg_list の command -v tmux が失敗 → degrade。
+# stub のみの PATH（tmux を含めない）を作り、oe-status が必要とするツールだけ symlink する。
+# Copilot #3446407858 反映: PATH に /usr/bin:/bin を残すと、その環境（Linux/CI 等）に
+# /usr/bin/tmux があると degrade せずテストが不安定になる。stub のみにして tmux を確実に隠す
+# （shebang の /usr/bin/env は絶対パスなので PATH の影響を受けない）。
 PATHBIN="$(mktemp -d)"
 for tool in jq awk sed sort basename dirname cat printf env bash grep; do
   p="$(command -v "$tool" 2>/dev/null || true)"
   if [[ -n "$p" ]]; then ln -sf "$p" "${PATHBIN}/${tool}" 2>/dev/null || true; fi
 done
-degrade_out="$(PATH="${PATHBIN}:/usr/bin:/bin" "$OE_STATUS" 2>/dev/null)"; drc=$?
+degrade_out="$(PATH="${PATHBIN}" "$OE_STATUS" 2>/dev/null)"; drc=$?
 ck "tmux 不在で exit 0" "0" "$drc"
 ck "ENGINE 区画は出る" "yes" "$(printf '%s\n' "$degrade_out" | grep -q "=== ENGINE" && echo yes || echo no)"
 ck "ENGINE 行（timeout）は出る" "yes" "$(printf '%s\n' "$degrade_out" | grep -E "^$TMO " | grep -q "timeout" && echo yes || echo no)"

--- a/projects/orchestration-engine/tests/test_oe_status.sh
+++ b/projects/orchestration-engine/tests/test_oe_status.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# test_oe_status.sh — oe-status の audit-terminal reducer / timeline / 区画 degrade の単体テスト
+#
+# engine 側（state/audit ファイル）は OE_DATA_DIR を mktemp で隔離して検証するため tmux 不要。
+# delegate 側の degrade は tmux 不在の PATH stub で検証する（test_oe_select 流）。
+# 設計の正本: docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md §8
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OE_STATUS="${SCRIPT_DIR}/../bin/oe-status"
+
+# --- 隔離した data dir（engine fixtures） ---
+FX="$(mktemp -d)"
+mkdir -p "${FX}/audit" "${FX}/state"
+trap 'rm -rf "$FX" "${PATHBIN:-/nonexistent-xyz}"' EXIT
+export OE_DATA_DIR="$FX"
+
+# --- 有効な Crockford ULID（14 桁日付 + 12 文字・I/L/O/U 除外） ---
+OK=202606200100000000000000AA   # success
+BLK=202606200200000000000000BB  # blocked
+TMO=202606200300000000000000TT  # timeout（CB audit-only・session_end/KVS 無し）
+RUN=202606200400000000000000RR  # running?（session_start のみ）
+INT=202606200500000000000000NT  # interrupted（session_end 無し）
+MUL=202606200600000000000000MP  # multi-pane: p1 blocked → p2 success（severity-max=blocked）
+VTO=202606200700000000000000VT  # verification_timeout（target success のまま・注記のみ）
+MTR=202606200800000000000000MT  # max_turns（limit_type フォールバック → blocked）
+KVO=202606200900000000000000KV  # KVS only（audit 不在）
+
+j() { printf '%s\n' "$@"; }
+
+j '{"ts":"2026-06-20T01:00:00+00:00","event_type":"session_start","session_id":"'"$OK"'","pane_id":3,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T01:01:00+00:00","event_type":"session_end","session_id":"'"$OK"'","pane_id":3,"state":"success","payload":{}}' \
+  '{"ts":"2026-06-20T01:01:01+00:00","event_type":"cleanup","session_id":"'"$OK"'","pane_id":0,"state":null,"payload":{"killed_pane_ids":[3]}}' > "${FX}/audit/${OK}.jsonl"
+printf '{"session_id":"%s","pane_id":3,"state":"success","last_updated":"2026-06-20T01:01:00+00:00","outputs":["a.md","b.md"],"blockers":[]}\n' "$OK" > "${FX}/state/${OK}.state.json"
+
+j '{"ts":"2026-06-20T02:00:00+00:00","event_type":"session_start","session_id":"'"$BLK"'","pane_id":4,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T02:01:00+00:00","event_type":"session_end","session_id":"'"$BLK"'","pane_id":4,"state":"blocked","payload":{}}' > "${FX}/audit/${BLK}.jsonl"
+
+j '{"ts":"2026-06-20T03:00:00+00:00","event_type":"session_start","session_id":"'"$TMO"'","pane_id":5,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T03:30:00+00:00","event_type":"circuit_breaker_triggered","session_id":"'"$TMO"'","pane_id":0,"state":null,"payload":{"reason":"timeout"}}' \
+  '{"ts":"2026-06-20T03:30:01+00:00","event_type":"cleanup","session_id":"'"$TMO"'","pane_id":0,"state":null,"payload":{}}' > "${FX}/audit/${TMO}.jsonl"
+
+j '{"ts":"2026-06-20T04:00:00+00:00","event_type":"session_start","session_id":"'"$RUN"'","pane_id":6,"state":null,"payload":{}}' > "${FX}/audit/${RUN}.jsonl"
+
+j '{"ts":"2026-06-20T05:00:00+00:00","event_type":"session_start","session_id":"'"$INT"'","pane_id":7,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T05:01:00+00:00","event_type":"interrupt","session_id":"'"$INT"'","pane_id":0,"state":null,"payload":{"method":"SIGINT"}}' > "${FX}/audit/${INT}.jsonl"
+
+j '{"ts":"2026-06-20T06:00:00+00:00","event_type":"session_start","session_id":"'"$MUL"'","pane_id":8,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T06:01:00+00:00","event_type":"session_end","session_id":"'"$MUL"'","pane_id":8,"state":"blocked","payload":{}}' \
+  '{"ts":"2026-06-20T06:02:00+00:00","event_type":"session_end","session_id":"'"$MUL"'","pane_id":9,"state":"success","payload":{}}' > "${FX}/audit/${MUL}.jsonl"
+
+j '{"ts":"2026-06-20T07:00:00+00:00","event_type":"session_start","session_id":"'"$VTO"'","pane_id":10,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T07:01:00+00:00","event_type":"session_end","session_id":"'"$VTO"'","pane_id":10,"state":"success","payload":{}}' \
+  '{"ts":"2026-06-20T07:02:00+00:00","event_type":"circuit_breaker_triggered","session_id":"'"$VTO"'","pane_id":10,"state":null,"payload":{"reason":"verification_timeout"}}' > "${FX}/audit/${VTO}.jsonl"
+
+j '{"ts":"2026-06-20T08:00:00+00:00","event_type":"session_start","session_id":"'"$MTR"'","pane_id":11,"state":null,"payload":{}}' \
+  '{"ts":"2026-06-20T08:01:00+00:00","event_type":"circuit_breaker_triggered","session_id":"'"$MTR"'","pane_id":0,"state":null,"payload":{"limit_type":"max_turns"}}' > "${FX}/audit/${MTR}.jsonl"
+
+# KVS-only（audit 不在）
+printf '{"session_id":"%s","pane_id":12,"state":"partial","last_updated":"2026-06-20T09:01:00+00:00","outputs":[],"blockers":["x"]}\n' "$KVO" > "${FX}/state/${KVO}.state.json"
+
+# DJ-4: 別スキーマの SO ログは session 行に混ぜない（ULID 不一致で除外されること）
+printf '{"ts":"2026-06-20T10:00:00+00:00","event_type":"oe_refute","audit_id":"x","verdict":"refuted"}\n' > "${FX}/audit/oe-refute.jsonl"
+
+# --- assert ヘルパ ---
+pass=0; fail=0
+ck() { # <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; pass=$((pass+1));
+  else echo "  FAIL: $1 (want='$2' got='$3')"; fail=$((fail+1)); fi
+}
+# overview の ENGINE 行から特定 session の STATE 列（2 列目）を取る
+state_of() { "$OE_STATUS" 2>/dev/null | awk -v s="$1" '$1==s {print $2; exit}'; }
+
+echo "[1] audit-terminal reducer: STATE 導出（severity-max・末尾行でない・caveat1）"
+ck "success（cleanup 末尾でも success）" "success"     "$(state_of "$OK")"
+ck "blocked（session_end）"              "blocked"      "$(state_of "$BLK")"
+ck "timeout（CB audit-only・KVS 無し）"  "timeout"      "$(state_of "$TMO")"
+ck "running?（session_start のみ）"      "running?"     "$(state_of "$RUN")"
+ck "interrupted（session_end 無し）"     "interrupted"  "$(state_of "$INT")"
+ck "multi-pane: blocked が success に隠れない" "blocked"  "$(state_of "$MUL")"
+ck "verification_timeout は success のまま"     "success"  "$(state_of "$VTO")"
+ck "max_turns（limit_type フォールバック）→ blocked" "blocked" "$(state_of "$MTR")"
+
+echo "[2] 注記 / multi-pane / KVS 補足"
+ck "verify-timeout 注記" "yes" "$("$OE_STATUS" 2>/dev/null | grep -E "^$VTO " | grep -q "verify-timeout" && echo yes || echo no)"
+ck "multi-pane PANES=2"  "2"   "$("$OE_STATUS" 2>/dev/null | awk -v s="$MUL" '$1==s {print $3; exit}')"
+ck "success に outputs=2 補足" "yes" "$("$OE_STATUS" 2>/dev/null | grep -E "^$OK " | grep -q "outputs=2" && echo yes || echo no)"
+KVO_ROW="$("$OE_STATUS" 2>/dev/null | grep -E "^$KVO " || true)"
+ck "KVS-only 行に partial" "yes" "$(printf '%s' "$KVO_ROW" | grep -q "partial" && echo yes || echo no)"
+ck "KVS-only 行に kvs-only 注記" "yes" "$(printf '%s' "$KVO_ROW" | grep -q "kvs-only" && echo yes || echo no)"
+
+echo "[3] DJ-4: oe-refute.jsonl（別スキーマ）は ENGINE 区画に出ない"
+# DELEGATE 区画は実 tmux 由来のラベルに 'refute' を含みうるため ENGINE 区画に限定して確認する
+ENGINE_SECTION="$("$OE_STATUS" 2>/dev/null | sed -n '/=== ENGINE/,/=== DELEGATE/p')"
+ck "ENGINE 区画に refute 行が無い" "" "$(printf '%s\n' "$ENGINE_SECTION" | grep -iE 'refute' || true)"
+
+echo "[4] timeline（受入2: start→end が追える）"
+TL="$("$OE_STATUS" "$OK" 2>/dev/null)"
+ck "derived state 行" "yes" "$(printf '%s\n' "$TL" | grep -q "derived state: success" && echo yes || echo no)"
+ck "session_start 行" "yes" "$(printf '%s\n' "$TL" | grep -q "session_start" && echo yes || echo no)"
+ck "session_end[success] 行" "yes" "$(printf '%s\n' "$TL" | grep -q "session_end  \[success\]" && echo yes || echo no)"
+ck "timeout timeline に CB reason" "yes" "$("$OE_STATUS" "$TMO" 2>/dev/null | grep -q '"reason":"timeout"' && echo yes || echo no)"
+
+echo "[5] 引数ハンドリング"
+"$OE_STATUS" --help >/dev/null 2>&1; ck "--help rc0" "0" "$?"
+rc=0; "$OE_STATUS" --bogus >/dev/null 2>&1 || rc=$?; ck "未知オプション rc2" "2" "$rc"
+rc=0; "$OE_STATUS" not-a-ulid >/dev/null 2>&1 || rc=$?; ck "非 ULID 引数 rc2" "2" "$rc"
+rc=0; "$OE_STATUS" "$RUN" extra >/dev/null 2>&1 || rc=$?; ck "余分な引数 rc2" "2" "$rc"
+rc=0; "$OE_STATUS" 202606209999999999999999ZZ >/dev/null 2>&1 || rc=$?; ck "存在しない session rc1" "1" "$rc"
+
+echo "[6] delegate degrade: tmux 不在でも ENGINE は出て exit 0"
+# jq を含む最小 PATH（tmux を含めない）を作る。oe_reg_list の command -v tmux が失敗 → degrade。
+PATHBIN="$(mktemp -d)"
+for tool in jq awk sed sort basename dirname cat printf env bash grep; do
+  p="$(command -v "$tool" 2>/dev/null || true)"
+  if [[ -n "$p" ]]; then ln -sf "$p" "${PATHBIN}/${tool}" 2>/dev/null || true; fi
+done
+degrade_out="$(PATH="${PATHBIN}:/usr/bin:/bin" "$OE_STATUS" 2>/dev/null)"; drc=$?
+ck "tmux 不在で exit 0" "0" "$drc"
+ck "ENGINE 区画は出る" "yes" "$(printf '%s\n' "$degrade_out" | grep -q "=== ENGINE" && echo yes || echo no)"
+ck "ENGINE 行（timeout）は出る" "yes" "$(printf '%s\n' "$degrade_out" | grep -E "^$TMO " | grep -q "timeout" && echo yes || echo no)"
+ck "DELEGATE は degrade 注記" "yes" "$(printf '%s\n' "$degrade_out" | grep -q "tmux unavailable" && echo yes || echo no)"
+
+echo ""
+echo "=== RESULT: pass=${pass} fail=${fail} ==="
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## 概要

cockpit 観測UI `oe-status` を追加（read-only 俯瞰 + 監査ログ閲覧）。`#188`（オーケストレーション2基盤の identity は pane 層で統一しない・read 時相関・永続マップ無し）確定を受けた `#177` の**再設計**。当初プラン（pane_id ジョイン）は設計SOで構造破綻が判明し撤回済（discussion §6）。

2 つの identity 空間（engine=wez 整数 pane_id / delegate=tmux `%N`）を **join せず read 時に投影**する**単一コマンド・typed sections** の観測ツール。

```text
=== ENGINE (wez · state/audit) ===
SESSION                     STATE        PANES  LAST_EVENT                 NOTE
2026...AA                   success      1      cleanup                    outputs=2
2026...TT                   timeout      0      cleanup
2026...MP                   blocked      2      session_end

=== DELEGATE (tmux · liveness) ===
PANE     SOURCE         LABEL
%3       pane-issue     #183 skill-oe-refute-integration
%32      pane-issue     #165 wez-layout
```

## 設計判断（駆動層フロー・予決定探索の証跡は discussion §8）

設計SO = `oe-refute --rubric exploration --lanes 2`（codex+cursor）を **2 ラウンド**。

- **R1**（flat 1テーブル fusion + 素朴 audit-tail）→ refuted。**新カテゴリ「typed sections」が出現**。flat fusion は engine/delegate の異質な STATE/TIMELINE 列を混同する欠陥が判明。
- **R2**（typed sections + audit-terminal reducer）→ refuted だが**カテゴリ収束**（両レーン「typed sections 有望」）。残りは grounding 詳細 → 設計へ反映。新カテゴリ非出現で predecision-exploration の暫定停止条件を満たし確定。
- **優位主張は取り下げ**: owner/cockpit が query-side fusion 方向を既決（%32 agree）。typed sections はそれを #188 制約下で正直に描画した**十分**な形（受入1〜3 を満たす）という根拠で確定（honest 2 ビューとの優劣証明には依らない）。

詳細トレイル: `projects/orchestration-engine/docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md` §8（揮発 SO 出力の verdict/reason を転記。本 PR diff に含む）。

### audit-terminal reducer（STATE 導出・severity-max・末尾行でない）

`audit/{sid}.jsonl` の全イベントを走査し severity-max で session-level STATE を導く（`cleanup`/`verification_*` は除外）:

- `circuit_breaker_triggered` reason=`timeout`/`verification_timeout` → `timeout`（verification_timeout は session 終端に寄与せず注記のみ）
- reason=`max_turns`/`max_panes` → `blocked`（DI-4。`limit_type` フォールバック）
- `session_end.state` / `interrupt`→`interrupted` / 終端無し+`session_start`→`running?` / それ以外→`?`
- multi-pane でも blocked/timeout が success に隠れない（severity-max）

## cockpit caveat 3点の反映

1. **blocked/timeout は audit-tail 必須**: CB timeout は `lib/monitor.sh` で audit のみ・KVS 未書込 → KVS だけだと取りこぼす。STATE は **audit-terminal reducer 由来**で導く。delegate 子は state/audit を持たない＝liveness のみ（timeline:none）。
2. **oe-review.jsonl 駆動率測定は v1 スコープ外（DJ-4）**。よって **本 PR（#177 v1）単独では `#24`（L3 hook）/ Stage-B を unblock しない**（それらは別途の駆動率測定に依存）。「#177 で測定経路が揃った」とは読まないこと（episode に明記）。
3. **read-only / 非検出維持**: 触れるのは state/audit ファイル + tmux/wez ペイン存在（mux query）のみ。**ペイン出力は読まない**（polling 常駐・capture マーカー走査＝検出をしない）。preview は ENGINE=audit timeline / DELEGATE=registry メタのみ。

## 受け入れ条件

- [x] 稼働中セッションが一覧俯瞰でき、**blocked/timeout が識別できる**（audit-tail 由来・fixture + 手動再現で確認）
- [x] 監査ログから 1 セッションの流れ（start→end）が追える（`oe-status <session_id>`）
- [x] `shellcheck` パス・**bash 3.2.57 / 5.x 両対応**（ADR-005）

## テスト / 検証

- `tests/test_oe_status.sh` — **27/27 PASS**（reducer 8 ケース / 注記 / KVS 補足 / DJ-4 除外 / timeline / 引数 / tmux degrade）。bash 5.x・3.2.57 両方で PASS。
- `shellcheck bin/oe-status tests/test_oe_status.sh` PASS。
- 実 sample（`202605261208418AW8GCYGYGY6`）+ 実 tmux で overview/timeline 動作確認。
- **実装SO** `oe-review --lanes 2 --base master`（codex+cursor）→ **verdict=survived**（material な欠陥なし・`audit_id=20260620130225WHZKB2XA4A4M`）。設計SO とは別レンズ・別ステップ。

## スコープ外として routing した発見（実装しない）

- **CB payload の schema↔実装ドリフト**: `schemas/audit-log.schema.json` は `payload.limit_type` 記述・実装は `payload.reason` emit。#177（read-only 観測）の範囲外。reducer は `reason` 優先 + `limit_type` フォールバックで両対応。**ドリフト是正は別 issue 推奨**。

## 変更ファイル

- `bin/oe-status`（新規）/ `tests/test_oe_status.sh`（新規・27 assert）
- `docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md`（§8 DJ-2/3 再設計確定）
- `docs/episodes/2026-06-20-episode-177-oe-status.md`（新規・実行記録）
- `bin/README.md` / `README.md`（索引・節）

Refs #177 #188
