### PR TITLE
feat(oe): add oe-kick oneshot delegate wrapper + harden delegate label/list

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -37,6 +37,7 @@ projects/orchestration-engine/
 │   ├── oe                     # 本体エンジン: 1 サイクル自律オーケストレーション（envelope→spawn→capture→verify→monitor）
 │   ├── oe-capture             # 既存ペインに attach して終端マーカーを capture→分類→KVS/audit
 │   ├── oe-delegate            # 子 Claude セッションを起動しタスクをキック（親子委譲: spawn + kick）
+│   ├── oe-kick                # #N / kickoff パスを 1 引数で受ける oe-delegate の薄いワンショットラッパー（#178）
 │   ├── oe-send                # 既存ペインへ 1 行を汎用送信（%N/ラベル・--kickoff・--no-enter・送信信頼化 finalize）
 │   ├── oe-list                # 委譲の宛先候補を一覧（spawn registry + pane-issue）
 │   ├── oe-report              # 親へ申し送り/レビュー依頼（legacy・戻しは oe-send に一本化）
@@ -85,6 +86,7 @@ docs 配置は [`projects/wezterm-ai-mode/docs/`](../wezterm-ai-mode/docs/) の�
 統括スレッドから子セッションへタスク・事前情報を渡す痛点（コピペ・誤送信）を解消する単機能コマンド群。自然言語層の `delegate-task` スキルから駆動する。
 
 - `oe-delegate` — 子を `tmux split-window` で起動し、タスク（または `--kickoff <doc>`）をキック（spawn + send の合成）
+- `oe-kick` — `oe-delegate` の薄いワンショットラッパー。`#N` or kickoff パスを 1 引数で受け妥当なフラグ列へ展開（`--label` 自動付与・workspace 既定化）（[#178](https://github.com/stlwolf/ai-development-hub/issues/178)）
 - `oe-send` — 既存ペインへ 1 行を汎用送信。親→子の追送、子→親の戻し（`oe-send "$PARENT_TMUX_PANE" ...`）、関連の薄い側道会話を一手に担う。`%N`/ラベル解決・`--kickoff`・`--no-enter`（投入のみ＝ステージ）
 - `oe-list` — 宛先候補を source 列付きで一覧
 - `oe-report` — legacy（戻しは `oe-send` に一本化済み）

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -5,7 +5,7 @@ orchestration-engine の実行可能エントリの簡易リファレンス（AI
 scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統」節）:
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
-- **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-send` / `oe-list` / `oe-select` / `oe-report`
+- **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report`
 - **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰）
 
 ---
@@ -87,6 +87,23 @@ oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg 
 - tmux 内必須（`TMUX_PANE` から親ペイン取得、`PARENT_TMUX_PANE` を子へ継承）
 
 関連 lib: `delegate-registry.sh`（キック注入は `oe-send` 経由）
+
+## oe-kick — kickoff/issue 参照からのワンショット委譲ラッパー（#178）
+
+`oe-delegate` の薄いワンショットラッパー。`#N`（or 素の番号）か kickoff パスを 1 引数で受け、妥当なフラグ列へ展開する（毎回フラグを組む手間を省く）。
+
+```bash
+oe-kick [-w WORKSPACE] [--claude-arg <arg>] [--] <#N|kickoff-path> [ad-hoc...]
+```
+
+- 既存ファイル → `--kickoff <path>` で渡し、ファイル名の `kickoff-<N>` から `--label '#N'` を自動導出（不検出はラベル無し）
+- `#N` / `N`（数字のみ） → Issue 参照。`--label '#N'` 自動付与 + `"gh issue view N で確認して進めて"` の task を組む
+- それ以外（非ファイル・非数値） → 曖昧回避のため明示エラー（exit 2）
+- 末尾 ad-hoc（任意・1行） … issue 時は既定 task に連結、kickoff 時は task として渡す
+- `-w WORKSPACE` 既定はカレント。tmux 内必須（`TMUX_PANE` 未設定は明示エラー）
+- 注意: 番号名ファイル（例 `./178`）は file 優先で kickoff 扱い。Issue を指すなら `#178`
+
+関連: `oe-delegate`（実体。`OE_DELEGATE_BIN` で差し替え可＝テスト seam）
 
 ## oe-send — 既存ペインへ 1 行を汎用送信
 

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -53,6 +53,13 @@ while [[ "${1:-}" == -* ]]; do
       KICKOFF="$2"; shift 2 ;;
     --label)
       [[ $# -ge 2 ]] || { echo "oe-delegate: --label requires a value" >&2; exit 2; }
+      # 改行（LF/CR）を含むラベルは registry 経由で oe_reg_list 出力を複数行化し、消費者
+      # （oe-list/oe-select/oe-status）の行パースに偽 %N 候補行を紛れ込ませ得る。
+      # --claude-arg と同様、書き込み前に fail-fast 拒否する（前例 lib/delegate-send.sh）。
+      if [[ "$2" == *$'\n'* || "$2" == *$'\r'* ]]; then
+        echo "oe-delegate: --label value must be a single line (no newline)" >&2
+        exit 2
+      fi
       LABEL="$2"; shift 2 ;;
     --claude-arg)
       [[ $# -ge 2 ]] || { echo "oe-delegate: --claude-arg requires a value" >&2; exit 2; }
@@ -110,7 +117,10 @@ build_child_command() {
   local cmd
   cmd="PARENT_TMUX_PANE=$(shell_quote "$PARENT_PANE") claude"
   local arg
-  for arg in "${CLAUDE_ARGS[@]}"; do
+  # bash 3.2 では set -u 下で空配列の "${arr[@]}" 展開が unbound variable になる
+  # （4.4+ は許容）。oe-kick 等が --claude-arg 無しで呼ぶと CLAUDE_ARGS は空のため、
+  # ${arr[@]+"${arr[@]}"} イディオムで空配列を安全に展開する（ADR-005・oe-select 前例）。
+  for arg in ${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}; do
     cmd="${cmd} $(shell_quote "$arg")"
   done
   if [[ -n "$KICKOFF" ]]; then

--- a/projects/orchestration-engine/bin/oe-kick
+++ b/projects/orchestration-engine/bin/oe-kick
@@ -97,7 +97,7 @@ fi
 if [[ -f "$REF" ]]; then
   # --- kickoff モード（既存ファイル優先） ---
   # ファイル名（basename）の kickoff-<N> から #N ラベルを導出。日付プレフィックス等に
-  # 引っかからないよう `kickoff-` にアンカーし、先頭ゼロは 10# で正規化する。
+  # 引っかからないよう `kickoff-` にアンカーし、先頭ゼロは strip_leading_zeros で正規化する。
   base="$(basename "$REF")"
   if [[ "$base" =~ kickoff-([0-9]+) ]]; then
     DELEGATE_ARGS+=(--label "#$(strip_leading_zeros "${BASH_REMATCH[1]}")")

--- a/projects/orchestration-engine/bin/oe-kick
+++ b/projects/orchestration-engine/bin/oe-kick
@@ -25,6 +25,15 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 # oe-delegate 実体（既定=兄弟）。テストは OE_DELEGATE_BIN でモックに差し替える。
 OE_DELEGATE_BIN="${OE_DELEGATE_BIN:-${BIN_DIR}/oe-delegate}"
 
+# 番号の先頭ゼロを除去する（最低 1 桁は残す）。Bash 算術（$((10#N))）は固定幅整数で
+# 桁数無制限の巨大値を silently overflow させ別 issue/ラベルに化けるため使わない（実装SO 指摘）。
+# 文字列操作で正規化＝巨大値も欠損なく保持し、誤値は下流（gh issue view）で loud に失敗する。
+strip_leading_zeros() {
+  local n="$1"
+  while [[ "$n" == 0* && "${#n}" -gt 1 ]]; do n="${n#0}"; done
+  printf '%s' "$n"
+}
+
 usage() {
   cat >&2 <<'EOF'
 usage: oe-kick [-w WORKSPACE] [--claude-arg <arg>] [--] <#N|kickoff-path> [ad-hoc...]
@@ -91,13 +100,13 @@ if [[ -f "$REF" ]]; then
   # 引っかからないよう `kickoff-` にアンカーし、先頭ゼロは 10# で正規化する。
   base="$(basename "$REF")"
   if [[ "$base" =~ kickoff-([0-9]+) ]]; then
-    DELEGATE_ARGS+=(--label "#$((10#${BASH_REMATCH[1]}))")
+    DELEGATE_ARGS+=(--label "#$(strip_leading_zeros "${BASH_REMATCH[1]}")")
   fi
   DELEGATE_ARGS+=(--kickoff "$REF" --)
   [[ -n "$ADHOC" ]] && DELEGATE_ARGS+=("$ADHOC")
 elif [[ "$REF" =~ ^#?([0-9]+)$ ]]; then
   # --- issue モード（#N / 素の番号） ---
-  num="$((10#${BASH_REMATCH[1]}))"
+  num="$(strip_leading_zeros "${BASH_REMATCH[1]}")"
   task="Issue #${num} の内容を gh issue view ${num} で確認して作業を進めて。リポジトリ: ${WORKSPACE}"
   [[ -n "$ADHOC" ]] && task="${task} ${ADHOC}"
   DELEGATE_ARGS+=(--label "#${num}" -- "$task")

--- a/projects/orchestration-engine/bin/oe-kick
+++ b/projects/orchestration-engine/bin/oe-kick
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# oe-kick — kickoff/issue 参照からのワンショット委譲ラッパー（tmux）
+#
+# usage: oe-kick [-w WORKSPACE] [--claude-arg <arg>] [--] <#N|kickoff-path> [ad-hoc...]
+#
+# bin/oe-delegate の薄いワンショットラッパー。`#N`（or 素の番号）か kickoff パスを
+# 1 引数で受け、oe-delegate の妥当なフラグ列へ展開する（毎回フラグを組み立てる手間を省く）。
+#
+#   - 既存ファイル        → kickoff doc として渡す（--kickoff <abs>）。ファイル名の
+#                           `kickoff-<N>` から `--label '#N'` を自動導出（不検出はラベル無し）。
+#   - `#N` / `N`（数字のみ）→ Issue 参照。`--label '#N'` を自動付与し、
+#                           "Issue #N を gh issue view N で確認して進めて" の task を組む。
+#   - それ以外            → 曖昧回避のため明示エラー（usage / exit 2）。
+#
+# 末尾の ad-hoc 1 行（任意）は issue 時は既定 task に連結、kickoff 時は oe-delegate の
+# task として渡す（改行は oe-delegate / oe_send_line が拒否する）。
+#
+# tmux 前提（TMUX_PANE）。tmux 外は明示エラー（oe-delegate を踏襲し、本ラッパーでも
+# task 組立前に fail-fast する）。実体の oe-delegate は OE_DELEGATE_BIN で差し替え可能
+# （既定は兄弟スクリプト。テストでモックに置換するためのシーム）。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# oe-delegate 実体（既定=兄弟）。テストは OE_DELEGATE_BIN でモックに差し替える。
+OE_DELEGATE_BIN="${OE_DELEGATE_BIN:-${BIN_DIR}/oe-delegate}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: oe-kick [-w WORKSPACE] [--claude-arg <arg>] [--] <#N|kickoff-path> [ad-hoc...]
+
+  <#N|kickoff-path>   委譲対象を 1 引数で指定:
+                        - 既存ファイル → kickoff doc として渡す（--kickoff）。
+                          ファイル名の kickoff-<N> から --label '#N' を自動導出
+                        - #N / N（数字のみ） → Issue 参照。--label '#N' 自動付与 +
+                          "gh issue view N で確認して進めて" の task を組む
+                        - それ以外 → エラー（曖昧回避のため明示）
+  ad-hoc...           子へ渡す補足の 1 行（任意・複数語は空白連結・改行不可）。
+                        issue 時は既定 task に連結、kickoff 時は task として渡す
+  -w, --workspace DIR 子の作業ディレクトリ（既定: カレント）。task 文にも埋める
+  --claude-arg <arg>  子 claude へ渡す追加引数（repeatable）。oe-delegate へ素通し。
+                        例: --claude-arg --permission-mode --claude-arg auto
+  -h, --help          このヘルプを表示
+
+注意: 既存ファイルが番号名（例 ./178）だと file 優先で kickoff 扱いになる。
+      Issue を指すなら `#178`、または cwd にその名のファイルが無い状態で `178` を渡す。
+EOF
+}
+
+WORKSPACE="$(pwd)"
+CLAUDE_ARGS=()
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -w|--workspace)
+      [[ $# -ge 2 ]] || { echo "oe-kick: --workspace requires a value" >&2; exit 2; }
+      WORKSPACE="$2"; shift 2 ;;
+    --claude-arg)
+      [[ $# -ge 2 ]] || { echo "oe-kick: --claude-arg requires a value" >&2; exit 2; }
+      # 値の検証/quote は oe-delegate に委ねる（改行拒否含む）。ここでは素通し。
+      CLAUDE_ARGS+=(--claude-arg "$2"); shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) echo "oe-kick: unknown option: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+REF="${1:-}"
+if [[ -z "$REF" ]]; then
+  echo "oe-kick: a kickoff path or issue ref (#N) is required" >&2
+  usage; exit 2
+fi
+shift
+ADHOC="$*"
+
+# tmux 前提の preflight（受入条件: tmux 外は明示エラー）。oe-delegate も再検査するが、
+# gh task 文の組立前にここで fail-fast し、エラー主体を oe-kick として明示する。
+[[ -n "${TMUX_PANE:-}" ]] || {
+  echo "oe-kick: TMUX_PANE is not set — must run inside a tmux session" >&2
+  exit 1
+}
+
+# oe-delegate へ渡すフラグ列を組み立てる。
+DELEGATE_ARGS=(-w "$WORKSPACE")
+if [[ ${#CLAUDE_ARGS[@]} -gt 0 ]]; then
+  DELEGATE_ARGS+=("${CLAUDE_ARGS[@]}")
+fi
+
+if [[ -f "$REF" ]]; then
+  # --- kickoff モード（既存ファイル優先） ---
+  # ファイル名（basename）の kickoff-<N> から #N ラベルを導出。日付プレフィックス等に
+  # 引っかからないよう `kickoff-` にアンカーし、先頭ゼロは 10# で正規化する。
+  base="$(basename "$REF")"
+  if [[ "$base" =~ kickoff-([0-9]+) ]]; then
+    DELEGATE_ARGS+=(--label "#$((10#${BASH_REMATCH[1]}))")
+  fi
+  DELEGATE_ARGS+=(--kickoff "$REF" --)
+  [[ -n "$ADHOC" ]] && DELEGATE_ARGS+=("$ADHOC")
+elif [[ "$REF" =~ ^#?([0-9]+)$ ]]; then
+  # --- issue モード（#N / 素の番号） ---
+  num="$((10#${BASH_REMATCH[1]}))"
+  task="Issue #${num} の内容を gh issue view ${num} で確認して作業を進めて。リポジトリ: ${WORKSPACE}"
+  [[ -n "$ADHOC" ]] && task="${task} ${ADHOC}"
+  DELEGATE_ARGS+=(--label "#${num}" -- "$task")
+else
+  # --- 第三分類: 非ファイル・非数値 → 明示エラー（黙って誤ルーティングしない） ---
+  echo "oe-kick: '$REF' is neither an existing kickoff file nor an issue ref (#N)" >&2
+  usage; exit 2
+fi
+
+exec "$OE_DELEGATE_BIN" "${DELEGATE_ARGS[@]}"

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
@@ -1,0 +1,99 @@
+---
+id: "01KVJQJG9XJ3RBBV5QZ11NYX4N"
+title: "#178 oe-kick — kickoff/issue 参照からのワンショット委譲ラッパー（tmux）実装"
+date: 2026-06-20
+type: episode
+status: in-development
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/178"
+    reason: "本 episode の対象 Issue（oe-delegate の薄いワンショットラッパー + 対話委譲レイヤ hardening 2点）"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/episodes/2026-06-17-episode-oe-select.md"
+    reason: "hardening 2点（--label 改行 fail-fast / oe_reg_list sanitize）の出自＝oe-select 実装SO の follow-up routing"
+  - type: design_context
+    ref: "canonical/skills/delegate-task/SKILL.md"
+    reason: "ラッパーが展開する oe-delegate のフラグ列・基本パターン（--label '#N' + task 文）の正本"
+tags: [orchestration, delegate, oe-kick, oneshot, hardening, episode]
+---
+
+# #178 oe-kick — ワンショット委譲ラッパー 実装 episode
+
+> 本文は作業中リアルタイム追記（reconstructed ではない）。closure は `episode-retrospective`。
+> 親 = `%32`。本セッションは worktree（`feature/#178_oneshot_delegate_wrapper`）で並行子（#199）と非衝突に作業。
+
+## ミッション（kickoff `.oe/2026-06-20-kickoff-178-oneshot-delegate.md`）
+
+- `oe-delegate`（tmux 子 spawn + kick）の薄いワンショットラッパー。`#N` or kickoff パスを 1 引数で受け、`oe-delegate` の妥当なフラグ列に展開（`--label` 自動付与＝Issue 番号→ラベル / workspace 既定化）。
+- 実装時 hardening（#178 本文・oe-select 実装SO 由来）併せて対応:
+  - `oe-delegate --label` が改行（LF/CR）を含む値を fail-fast 拒否。
+  - `oe_reg_list` 出力でラベル / pane_title の改行を sanitize（消費者 `oe-list`/`oe-select` で偽 `%N` 行を防ぐ）。
+
+## 設計フェーズ（2026-06-20）
+
+駆動層フロー（engine 規約）: kickoff/DJ → 設計SO（predecision 兼）→ 実装 → 実装SO（oe-review）→ Episode → PR → Copilot。
+
+### 設計判断と探索（predecision-exploration の確定前証跡）
+
+初期案セットと暗黙の前提を列挙し、ゼロベース代替を `oe-refute --rubric exploration` で1回反証する（証跡＝本節 + tmp/oe-refute 出力の verdict/reason 転記）。
+
+```text
+DJ-1: verb 名
+├── oe-kick（初期） → 差分軸: 既存「キック」用語（oe-send が "キック" 注入）と一致・短い・spawn/delegate と非衝突 → 採用候補
+├── oe-oneshot → 差分軸: 説明的だが冗長・他 verb（list/send/select）と語感不一致 → ❌
+├── oe-spawn → 差分軸: lib/spawn.sh（engine 非対話 claude -p）と語が衝突＝誤解の元 → ❌
+├── oe-run / oe-go → 差分軸: 汎用すぎ・engine 本体 oe と紛らわしい → ❌
+└── verb を作らず oe-delegate のモード（--issue N）に畳む → 差分軸: 責務分界。issue は「薄い別ラッパー」を明示要求 → ❌（kickoff 指定に反する）
+
+DJ-2: 1引数 ref の判定優先順位
+├── 明示モードフラグ（--issue / --kickoff）必須 → 差分軸: 明示的だが「1引数ワンショット」目標に反する → ❌
+└── 自動判定: 既存ファイル → kickoff / それ以外で ^#?[0-9]+$ → issue（初期・採用） → 差分軸: file-exists 優先で「178 という名のファイル」も直観的に解決
+
+DJ-3: kickoff パス時の label 自動導出
+├── ファイル名から kickoff-<N> 抽出 → #N ラベル（初期・採用） → 差分軸: 命名規約 kickoff-<N> にアンカー・日付誤検出を回避
+├── kickoff doc の frontmatter/body を解析 → 差分軸: 脆弱・スコープ増 → ❌
+└── kickoff 時はラベル無し（wt switch 後の pane-issue に委ねる）→ フォールバックとして採用（kickoff-<N> 不検出時）
+
+DJ-4: フラグ範囲（薄さの境界）
+├── <ref> + -w + --claude-arg passthrough + -h（採用） → 差分軸: --claude-arg は純 passthrough（oe-delegate が検証/quote）・cockpit 自律導線で必須
+├── 最小（<ref> + -w のみ） → 差分軸: 自律 spawn（--permission-mode）が組めない → ❌
+└── 最大（--label override / --dry-run 追加） → 差分軸: スコープ増・auto-label が spec → ❌（defer）
+
+DJ-5: tmux 前提の扱い
+├── oe-kick 側で軽量 preflight（TMUX_PANE 空ならエラー・初期/採用） → 差分軸: 受入条件「tmux 外で明示エラー」を踏襲・gh task 文組立前に fail-fast
+└── oe-delegate の検査に委譲（inherit のみ） → 差分軸: エラー文が oe-delegate 主体になる・薄いが UX 劣 → 併用（oe-kick で先に弾く）
+
+テスト seam: oe-kick は `OE_DELEGATE_BIN`（既定=兄弟 oe-delegate）経由で exec。テストはモック oe-delegate に差し替えて argv 展開を検証（OE_SELECT_TTY と同型の seam・ユーザ向けフラグではない）。
+```
+
+### 設計SO（predecision 兼）= `oe-refute --rubric exploration --lanes 2`（codex+cursor）R1
+
+- verdict=**refuted**（2/2 material・conservative 集約）。reason: 「1引数判定の失敗系・oe_reg_list 消費者範囲・sanitize 脅威モデル・OE_DELEGATE_BIN seam のテスト到達範囲が未確定」（codex）/「第三分類エラー未設計・hardening/実装/設計SO が一次未検証・seam 単独でラッパー核心をテスト不能」（cursor）。
+- 証跡（揮発）: `tmp/oe-refute-202606201441234C6G4CH847AZ/`（codex-stdout / cursor-stdout）。audit_id=`202606201441234C6G4CH847AZ`。verdict/reason は本節へ転記済。
+- **生き残り（survived）**: verb `oe-kick` / `--claude-arg` passthrough / tmux 二段 preflight / hardening を delegate 入力 + registry 出力に置く大枠（いずれも一次情報で支持・棄却なし）。
+- **反証の織り込み（確定前に design を更新）**:
+  1. **DJ-2 第三分類**: `-f`→kickoff / `^#?[0-9]+$`→issue / **それ以外→明示エラー（usage + exit 2）**。壊れ symlink・`kickoff-178`(dir)・`abc`/`178a` は第三分類でエラー。`0178` は `10#` で先頭ゼロ正規化（label/コマンドの `#N` ドリフト回避）。file-first の tradeoff（`./178` が issue 意図を潰す可能性）は意図的・受入条件準拠で許容、help に明記。
+  2. **oe-status も消費者**: sanitize を**消費者ごとでなく producer `oe_reg_list` の出力チョークポイント**に置くことで oe-list/oe-select/**oe-status**（`:174/:181/:247` awk）を一括防御（確認済）。
+  3. **脅威モデル境界（過剰主張の訂正）**: CR/LF は消費者の `while read`/`awk RS=\n` のレコード境界＝**偽 `%N` 行注入の主経路**。U+2028/ANSI/TAB は consumer のレコード分割に影響せず `%N` 行を偽造**しない**（視覚偽装のみ・低リスク）→ #178 は CR/LF を断ち、視覚偽装は scope 外 follow-up と明記（「断つ」→「文書化された偽行注入経路を断つ」へ後退）。
+  4. **書き込み側 hardening は #178 外**: `oe_reg_record`/`wt-pane-issue.sh`(branch 由来・git ref に改行不可)/`oe_reg_resolve`(出力は list-panes 由来の信頼 `%N` のみ・label を出さない＝偽造ベクタでない)。issue スコープ（delegate 入力 fail-fast + list 出力 sanitize）と oe-select episode の cross-cutting routing に従い follow-up。
+  5. **テスト到達**: モック `oe-delegate` への展開 argv を assert することで ref 判定 / `kickoff-<N>` 抽出 / issue task 文 / **tmux preflight 順序（mock 呼出前に fail）** まで覆う（argv は核心ロジックの出力＝exec のみではない）。第三分類エラーも直接ケース化。
+  6. **task 非対称の解消**: issue/kickoff 双方で**末尾 ad-hoc 1行を任意受理**（issue=既定テンプレに連結 / kickoff=oe-delegate の task へ）。delegate-task の可変 task 例と整合。
+  7. frontmatter `status` を作業中 `in-development`→closure で `stable`。
+- **停止判断**: 核心カテゴリは survived・反証は breadth/grounding 補完（再方向づけではない）。1回ゼロベース完了し全点を design に織込済 → 確定に進む。実装の正否は**実装SO `oe-review`（diff-bound）**で検証（#192/#175 の教訓＝設計SO は実装SO の代替にならない）。
+
+## 実装フェーズ
+
+- **`bin/oe-kick`**（新規）: 薄いワンショットラッパー。1引数 ref を `-f`→kickoff / `^#?[0-9]+$`→issue / それ以外→明示エラー(exit 2) で判定。issue は `--label '#N'` + gh task 文、kickoff は `kickoff-<N>` 抽出ラベル(不検出は空) + `--kickoff`。末尾 ad-hoc を両モードで任意受理。`TMUX_PANE` preflight(空→exit 1)。`OE_DELEGATE_BIN` seam で実体を差替可。`exec "$OE_DELEGATE_BIN" ...`。bash 3.2 互換（空配列ガード `${#CLAUDE_ARGS[@]}`・declare -A/mapfile 不使用）。
+- **hardening-1 `bin/oe-delegate`**: `--label` 値の LF/CR を spawn 前に fail-fast 拒否（既存 `--claude-arg` と同型）。
+- **hardening-2 `lib/delegate-registry.sh`**: `oe_reg_list` 出力チョークポイントで label の LF/CR を空白へ畳む（消費者 oe-list/oe-select/**oe-status** を producer 1点で一括防御）。
+- **付随修正（実機 3.2 検証で検出した既存バグ）**: `oe-delegate` の `build_child_command` が `for arg in "${CLAUDE_ARGS[@]}"`（空配列）で bash 3.2 + `set -u` 下 `unbound variable` 落ち。`oe-kick #N`（--claude-arg 無し）は CLAUDE_ARGS 空で必ずこの経路 → ADR-005 環境で feature が壊れる。`${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}` イディオム（oe-select 前例）で修正。**master にも存在する pre-existing バグ**で、本機能の 3.2 動作に直結するため #178 で吸収（PR で明示）。
+- **テスト**:
+  - `tests/test_oe_kick.sh`（新規・24 assert）: モック `oe-delegate`（`OE_DELEGATE_BIN`）への展開 argv を assert＝ref 判定 / `kickoff-<N>` 抽出 / 0178 正規化 / issue task 文 / ad-hoc 連結 / `--claude-arg` passthrough / workspace 既定 / 第三分類・178a・ref 省略・tmux 外・unknown option・file 優先 の各エラー経路（mock 未呼出含む）。
+  - `tests/test_oe_delegate.sh`（+4 assert）: `--label` LF/CR 拒否（rc2・未 spawn）。
+  - `tests/test_delegate_registry.sh`（+4 assert）: `oe_reg_list` sanitize（pane_title 由来 / pane-issue .name 由来の両経路で偽 `%N` 行非注入・本来 label 保持）。
+- **ドキュメント**: `bin/README.md`（oe-kick 節 + 索引）/ `README.md`（構成ツリー + delegate CLI リスト）。canonical `delegate-task` SKILL は更新せず（sibling 便利 verb の oe-select も未収録＝先例踏襲・Minimal Scope）。
+- **検証**: `shellcheck bin/oe-kick bin/oe-delegate lib/delegate-registry.sh tests/*` PASS。bash **5.x** で test_oe_kick 24 / test_oe_delegate 18 / test_delegate_registry 20 / **回帰 test_oe_select 35 / test_oe_status 27** 全 PASS。**/bin/bash 3.2.57（macOS・runner+inner 双方を 3.2 強制）でも 24/18/20 PASS**（ADR-005。付随修正前は test_oe_delegate が CLAUDE_ARGS[@] で fail＝修正を実証）。
+
+### 実装SO = `oe-review`（diff-bound・code-defect/到達可能性レンズ）
+
+(commit 後に実行・verdict をここへ転記)

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
@@ -3,7 +3,7 @@ id: "01KVJQJG9XJ3RBBV5QZ11NYX4N"
 title: "#178 oe-kick — kickoff/issue 参照からのワンショット委譲ラッパー（tmux）実装"
 date: 2026-06-20
 type: episode
-status: in-development
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/178"
@@ -72,7 +72,7 @@ DJ-5: tmux 前提の扱い
 - 証跡（揮発）: `tmp/oe-refute-202606201441234C6G4CH847AZ/`（codex-stdout / cursor-stdout）。audit_id=`202606201441234C6G4CH847AZ`。verdict/reason は本節へ転記済。
 - **生き残り（survived）**: verb `oe-kick` / `--claude-arg` passthrough / tmux 二段 preflight / hardening を delegate 入力 + registry 出力に置く大枠（いずれも一次情報で支持・棄却なし）。
 - **反証の織り込み（確定前に design を更新）**:
-  1. **DJ-2 第三分類**: `-f`→kickoff / `^#?[0-9]+$`→issue / **それ以外→明示エラー（usage + exit 2）**。壊れ symlink・`kickoff-178`(dir)・`abc`/`178a` は第三分類でエラー。`0178` は `10#` で先頭ゼロ正規化（label/コマンドの `#N` ドリフト回避）。file-first の tradeoff（`./178` が issue 意図を潰す可能性）は意図的・受入条件準拠で許容、help に明記。
+  1. **DJ-2 第三分類**: `-f`→kickoff / `^#?[0-9]+$`→issue / **それ以外→明示エラー（usage + exit 2）**。壊れ symlink・`kickoff-178`(dir)・`abc`/`178a` は第三分類でエラー。`0178` は先頭ゼロ正規化（label/コマンドの `#N` ドリフト回避）。**※ 設計時は `10#` 算術で正規化する案だったが、後述の実装SO R1 でこれが桁数無制限入力で silent overflow する欠陥と判明し、文字列操作 `strip_leading_zeros` へ改修した（「実装SO」節参照）。** file-first の tradeoff（`./178` が issue 意図を潰す可能性）は意図的・受入条件準拠で許容、help に明記。
   2. **oe-status も消費者**: sanitize を**消費者ごとでなく producer `oe_reg_list` の出力チョークポイント**に置くことで oe-list/oe-select/**oe-status**（`:174/:181/:247` awk）を一括防御（確認済）。
   3. **脅威モデル境界（過剰主張の訂正）**: CR/LF は消費者の `while read`/`awk RS=\n` のレコード境界＝**偽 `%N` 行注入の主経路**。U+2028/ANSI/TAB は consumer のレコード分割に影響せず `%N` 行を偽造**しない**（視覚偽装のみ・低リスク）→ #178 は CR/LF を断ち、視覚偽装は scope 外 follow-up と明記（「断つ」→「文書化された偽行注入経路を断つ」へ後退）。
   4. **書き込み側 hardening は #178 外**: `oe_reg_record`/`wt-pane-issue.sh`(branch 由来・git ref に改行不可)/`oe_reg_resolve`(出力は list-panes 由来の信頼 `%N` のみ・label を出さない＝偽造ベクタでない)。issue スコープ（delegate 入力 fail-fast + list 出力 sanitize）と oe-select episode の cross-cutting routing に従い follow-up。
@@ -88,12 +88,52 @@ DJ-5: tmux 前提の扱い
 - **hardening-2 `lib/delegate-registry.sh`**: `oe_reg_list` 出力チョークポイントで label の LF/CR を空白へ畳む（消費者 oe-list/oe-select/**oe-status** を producer 1点で一括防御）。
 - **付随修正（実機 3.2 検証で検出した既存バグ）**: `oe-delegate` の `build_child_command` が `for arg in "${CLAUDE_ARGS[@]}"`（空配列）で bash 3.2 + `set -u` 下 `unbound variable` 落ち。`oe-kick #N`（--claude-arg 無し）は CLAUDE_ARGS 空で必ずこの経路 → ADR-005 環境で feature が壊れる。`${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}` イディオム（oe-select 前例）で修正。**master にも存在する pre-existing バグ**で、本機能の 3.2 動作に直結するため #178 で吸収（PR で明示）。
 - **テスト**:
-  - `tests/test_oe_kick.sh`（新規・24 assert）: モック `oe-delegate`（`OE_DELEGATE_BIN`）への展開 argv を assert＝ref 判定 / `kickoff-<N>` 抽出 / 0178 正規化 / issue task 文 / ad-hoc 連結 / `--claude-arg` passthrough / workspace 既定 / 第三分類・178a・ref 省略・tmux 外・unknown option・file 優先 の各エラー経路（mock 未呼出含む）。
+  - `tests/test_oe_kick.sh`（新規・29 assert＝初版 24 + 実装SO 反映 5）: モック `oe-delegate`（`OE_DELEGATE_BIN`）への展開 argv を assert＝ref 判定 / `kickoff-<N>` 抽出 / 0178 正規化 / 巨大番号 overflow 非発生 / all-zeros→#0 / issue task 文 / ad-hoc 連結 / `--claude-arg` passthrough / workspace 既定 / 第三分類・178a・ref 省略・tmux 外・unknown option・file 優先 の各エラー経路（mock 未呼出含む）。
   - `tests/test_oe_delegate.sh`（+4 assert）: `--label` LF/CR 拒否（rc2・未 spawn）。
   - `tests/test_delegate_registry.sh`（+4 assert）: `oe_reg_list` sanitize（pane_title 由来 / pane-issue .name 由来の両経路で偽 `%N` 行非注入・本来 label 保持）。
 - **ドキュメント**: `bin/README.md`（oe-kick 節 + 索引）/ `README.md`（構成ツリー + delegate CLI リスト）。canonical `delegate-task` SKILL は更新せず（sibling 便利 verb の oe-select も未収録＝先例踏襲・Minimal Scope）。
-- **検証**: `shellcheck bin/oe-kick bin/oe-delegate lib/delegate-registry.sh tests/*` PASS。bash **5.x** で test_oe_kick 24 / test_oe_delegate 18 / test_delegate_registry 20 / **回帰 test_oe_select 35 / test_oe_status 27** 全 PASS。**/bin/bash 3.2.57（macOS・runner+inner 双方を 3.2 強制）でも 24/18/20 PASS**（ADR-005。付随修正前は test_oe_delegate が CLAUDE_ARGS[@] で fail＝修正を実証）。
+- **検証**: `shellcheck bin/oe-kick bin/oe-delegate lib/delegate-registry.sh tests/*` PASS。bash **5.x** で test_oe_kick 29 / test_oe_delegate 18 / test_delegate_registry 20 / **回帰 test_oe_select 35 / test_oe_status 27** 全 PASS。**/bin/bash 3.2.57（macOS・runner+inner 双方を 3.2 強制）でも 29/18/20 PASS**（ADR-005。付随修正前は test_oe_delegate が CLAUDE_ARGS[@] で fail＝修正を実証）。
 
-### 実装SO = `oe-review`（diff-bound・code-defect/到達可能性レンズ）
+### 実装SO = `oe-review`（diff-bound・code-defect/到達可能性レンズ・lanes 2）
 
-(commit 後に実行・verdict をここへ転記)
+- **R1（commit 334f670 / diff base master）= refuted**（1/2 material）。codex が到達可能な correctness 欠陥を検出: `oe-kick` の番号正規化が `$((10#N))` の **Bash 算術**で、桁数無制限の入力に固定幅整数を silently overflow させ別番号へ化ける（実証 `999…9`(39桁)→`6873995514006732799`）。誤 `#N` で `--label`/`gh issue view`/登録ラベルが作られ `oe-send #N` で誤ルーティングし得る。cursor は survived（material 欠陥なし）。証跡: `tmp/oe-review-20260620145855DCC6GRF4DZC6/`、audit_id 同名。
+- **修正（commit 2474c30）**: 算術を廃し先頭ゼロ除去を文字列操作（`strip_leading_zeros`）に変更＝巨大値も欠損なく保持し無効番号は下流 `gh issue view` で loud に失敗。`0178→178` 正規化意図は維持。`test_oe_kick` に overflow 境界 + 先頭ゼロ（all-zeros→#0）ケースを追加（+5 assert・計 29）。
+- **R2（commit 2474c30）= survived**（2/2・codex/cursor とも material 欠陥なし・exit 0）。証跡: `tmp/oe-review-20260620150347R2N0GPYJN3B6/`。**実装SO ゲート PASS → PR へ。**
+- 設計SO（exploration）と実装SO（impl）は別レンズ・別ステップ（#192/#175 の教訓どおり、設計SO だけでは impl 欠陥＝算術 overflow を捕捉できず、実装SO が捕捉した）。
+
+## Closure（episode-retrospective・tier=heavy）
+
+tier 判定 = **heavy**（heavy トリガ該当: ①実装SO で refuted→修正の方針転回 ②意図起動の外部レビュー oe-refute/oe-review ③非自明な設計判断 DJ-1..5）。
+
+### closure gate
+
+- **Context/なぜ**: 冒頭「ミッション」に自己完結（毎回フラグを手組みする手間を省く oe-delegate 薄ラッパー + oe-select 実装SO 由来の hardening 2点）。
+- **次の消費者**: cockpit 本線の人間運用者（`oe-kick #N` でワンショット委譲）/ 親 #169 cockpit イニシアチブ / delegate-task 系の今後の拡張者。
+- **follow-up routing**（全件行き先付与）:
+  - 視覚偽装 hardening（ANSI / U+2028 等）→ **追わない**（#178 scope 外・消費者の `read`/`awk` レコード境界にならず偽 `%N` 不可・低リスク。必要時に別 issue）。
+  - 書き込み側 hardening（`oe_reg_record` / `wt-pane-issue.sh` / `oe_reg_resolve`）→ **別 follow-up**（oe-select episode の cross-cutting routing 準拠・#178 外）。`resolve` は出力が list-panes 由来の信頼 `%N` のみで偽造ベクタでない旨を本文に記録（back-propagation）。issue 化要否は親 #169/#177 系の判断に委ねる（前方参照）。
+  - bin script の bash 3.2 検証が runner のみで spawned bin を覆っていなかった（test harness の穴・本作業で発覚し付随修正で実証）→ **harness 改善候補**（別 issue 候補・今回は追わない＝観測記録に留める）。
+  - canonical `delegate-task` SKILL に oe-kick/oe-select 未収録 → 先例踏襲で今回未対応。**追わない**（SKILL 拡張は low priority・別途）。
+- **status 確定**: `in-development` → **`stable`**（達成）。
+- **evidence anchor**: 設計SO/実装SO の verdict・reason・audit_id を本文へ転記済（`tmp/` 揮発パスに非依存）。
+- **SO 証跡リンク**: 設計SO `tmp/oe-refute-202606201441234C6G4CH847AZ/` / 実装SO R1 `tmp/oe-review-20260620145855DCC6GRF4DZC6/` ・R2 `tmp/oe-review-20260620150347R2N0GPYJN3B6/`（いずれも揮発・要点は本文転記済）。
+
+### 内容（出力型 × 消費チャネル）
+
+- **事実・失敗**: 設計SO R1 refuted（breadth/grounding gaps）→ design 更新。実装SO R1 refuted（番号正規化の算術 overflow＝到達可能 correctness 欠陥）→ 文字列化で修正→ R2 survived。実機 3.2 検証で `oe-delegate` の pre-existing `CLAUDE_ARGS[@]` unbound バグ検出→修正。
+- **決定と根拠**: DJ-1..5（設計探索木に棄却案・棄却理由）。追加で「番号正規化＝算術→文字列」（実装SO 由来の DJ）。
+- **わかったこと**: 設計SO（exploration レンズ）は実装SO（impl レンズ）を代替しない実証（算術 overflow は exploration で出ず impl で出た）。列出力 sanitize は producer 単一チョークポイントで複数消費者を一括防御できる。bash 3.2 の空配列 `set -u` footgun は spawned bin に潜伏し、runner のみの 3.2 検証では漏れる。
+- **原則（Pattern / Anti-pattern）**:
+  - Pattern: 表形式出力の sanitize は consumer 各所でなく **producer の出力点**に置く（防御の単一化）。
+  - Anti-pattern: 桁数無制限の外部入力を **Bash 算術で正規化**（固定幅 silent overflow）。OK: 文字列操作で正規化し巨大値は下流で loud に失敗。
+  - Pattern: 空になり得る配列は `${arr[@]+"${arr[@]}"}` で展開（bash 3.2 + `set -u`）。
+- **行動変更**: 機構確定の新規 hook/skill は無し。「bin script の 3.2 検証を spawned bin にも当てる」は機構未確定のため残課題（routing 済）へ降格。
+- **蒸留シグナル**: Decision/ADR 昇格 = **なし**（薄いラッパー・既存パターン踏襲で昇格価値の新規決定なし）。negative knowledge 候補（→ #62）= 「算術正規化の silent overflow」「bash 3.2 空配列 footgun」（前方参照・今回は非昇格）。
+- **残課題**: 上記 routing 済（視覚偽装 / 書込側 hardening / harness 3.2 穴 / SKILL 収録）。
+
+### Step 4（heavy 外部チェック・closure 品質）
+
+- `so-compare`（codex + claude・lanes 2）で closure 品質を focused チェック（証跡 `tmp/so-20260621-000952/`・揮発・要点は本節へ転記）。確認対象 = 失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation。
+- **結果**: 軸(1) 失敗省略なし=PASS（設計SO refuted / 実装SO R1 算術 overflow / pre-existing 3.2 バグ いずれも事実・失敗欄に明記）、軸(2) follow-up routing 4件全付与=PASS、軸(3) tmp/ 揮発要点の本文転記=PASS（両レーンが SO 証跡 dir の消失を実機確認した上で本文が非依存と判定）。
+- **指摘（修正済）**: 軸(4) back-propagation で claude レーンが 1 件検出 — 設計フェーズ記述（DJ-2）が撤回済みの `10#` 算術を現行設計のまま記述（自己矛盾）＋ `bin/oe-kick` kickoff 節コメントも `10#` で stale。→ 本コミットで episode DJ-2 に前方注記を追加し、コメントを `strip_leading_zeros` へ訂正（同根の stale 2 箇所を解消）。
+- 残りは Step4 欄自体の未転記（codex 指摘）＝本節の記入で解消。**closure 品質ゲート PASS。**

--- a/projects/orchestration-engine/lib/delegate-registry.sh
+++ b/projects/orchestration-engine/lib/delegate-registry.sh
@@ -152,6 +152,14 @@ oe_reg_list() {
       label="$(tmux display-message -p -t "$p" '#{pane_title}' 2>/dev/null)"
       source="pane-title"
     fi
+    # 出力チョークポイントでの sanitize（消費者 oe-list/oe-select/oe-status を一括防御）。
+    # label に改行（LF/CR）が混じると 1 行構成のこの表が複数行化し、消費側の行パース
+    # （`while read` / `awk '{print $1}'`）に偽の %N 候補行が紛れ込み別ペインへ誤送信し得る。
+    # 出力直前で改行を空白へ畳んで偽行注入経路を断つ（pane_title 由来の細工を含む）。
+    # 注: LF/CR のみ対象。U+2028 等 / ANSI / TAB は消費者のレコード境界にならず %N 行を
+    # 偽造しない（視覚偽装は別軸・scope 外）。書き込み側 hardening は #178 外（follow-up）。
+    label="${label//$'\n'/ }"
+    label="${label//$'\r'/ }"
     printf '%-8s %-14s %s\n' "$p" "$source" "$label"
   done <<< "$live"
 }

--- a/projects/orchestration-engine/tests/test_delegate_registry.sh
+++ b/projects/orchestration-engine/tests/test_delegate_registry.sh
@@ -27,7 +27,7 @@ tmux() {
       if [[ -n "${MOCK_TMUX_FAIL:-}" ]]; then echo "no server running on socket" >&2; return 1; fi
       # shellcheck disable=SC2086
       printf '%s\n' $MOCK_LIVE_PANES ;;
-    "display-message"*) echo "mock-pane-title" ;;
+    "display-message"*) printf '%s\n' "${MOCK_PANE_TITLE:-mock-pane-title}" ;;
     *) return 0 ;;
   esac
 }
@@ -98,6 +98,25 @@ ck "list-panes 失敗 → resolve rc=2 (環境エラー)" "2" "$rrc"
 oe_reg_gc 2>/dev/null
 ck "list-panes 失敗 → gc が entry を残す(誤削除なし)" "yes" "$( [[ -e "${OE_DELEGATE_STATE_DIR}/${keyB}.json" ]] && echo yes || echo no)"
 unset MOCK_TMUX_FAIL
+
+echo "[9] oe_reg_list: 改行混入ラベルを sanitize（偽 %N 行注入を断つ・#178 hardening-2）"
+# (a) pane_title 由来（tmux の untrusted ソース）: 改行 + 偽 %99 行を仕込む
+MOCK_LIVE_PANES="%8"
+MOCK_PANE_TITLE=$'safe\n%99 forged-injection'
+LIST="$(oe_reg_list 2>/dev/null)"
+ck "pane-title: 偽 %99 行が無い" "0" "$(printf '%s\n' "$LIST" | grep -c '^%99')"
+ck "pane-title: 改行を空白へ畳み 1 行化" "yes" \
+  "$(printf '%s\n' "$LIST" | grep -q '^%8 .*pane-title .*safe %99 forged-injection' && echo yes || echo no)"
+unset MOCK_PANE_TITLE
+# (b) pane-issue .name 由来（jq デコードで実改行になるデータ経路）
+MOCK_LIVE_PANES="%8"
+key8="$(_oe_reg_key '%8')"
+printf '{"name":"#142 redesign\\n%%99 evil"}\n' > "${OE_PANE_ISSUE_DIR}/${key8}"
+LIST="$(oe_reg_list 2>/dev/null)"
+ck "pane-issue: 偽 %99 行が無い" "0" "$(printf '%s\n' "$LIST" | grep -c '^%99')"
+ck "pane-issue: sanitize 後も #142 を保持" "yes" \
+  "$(printf '%s\n' "$LIST" | grep -q '^%8 .*pane-issue .*#142 redesign' && echo yes || echo no)"
+rm -f "${OE_PANE_ISSUE_DIR}/${key8}"
 
 echo "=== RESULT: pass=${pass} fail=${fail} ==="
 [[ "$fail" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -134,5 +134,19 @@ bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg $'bad\rarg' "
 ck "CR claude arg rc=2" "2" "$rc"
 ck "CR claude arg does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
 
+echo "[9] --label rejects LF before spawn"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --label $'bad\nlabel' "task" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "LF label rc=2" "2" "$rc"
+ck "LF label does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[10] --label rejects CR before spawn"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --label $'bad\rlabel' "task" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "CR label rc=2" "2" "$rc"
+ck "CR label does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_kick.sh
+++ b/projects/orchestration-engine/tests/test_oe_kick.sh
@@ -148,5 +148,26 @@ rc=0; run_kick --bogus "#178" || rc=$?
 ck "unknown option rc=2" "2" "$rc"
 ck "unknown option did not call delegate" "no" "$(called)"
 
+echo "[17] 巨大番号: 算術 overflow による silent 別 issue 化を防ぐ（番号を欠損なく保持）"
+reset
+BIG="999999999999999999999999999999999999999"
+run_kick -w "$WS" "#$BIG"
+ck "issue huge label preserved (no overflow)" "#$BIG" "$(argv | sed -n '4p')"
+ck "issue huge task preserved" \
+  "Issue #$BIG の内容を gh issue view $BIG で確認して作業を進めて。リポジトリ: $WS" \
+  "$(argv | sed -n '6p')"
+reset
+KOBIG="$_TMP_DIR/kickoff-$BIG-x.md"; printf 'x\n' > "$KOBIG"
+run_kick -w "$WS" "$KOBIG"
+ck "kickoff huge label preserved (no overflow)" "#$BIG" "$(argv | sed -n '4p')"
+
+echo "[18] 先頭ゼロ正規化は文字列操作で（巨大でも崩れない）"
+reset
+run_kick -w "$WS" "#0000178"
+ck "0000178 -> #178" "#178" "$(argv | sed -n '4p')"
+reset
+run_kick -w "$WS" "#000"
+ck "all-zeros -> #0 (最低1桁)" "#0" "$(argv | sed -n '4p')"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_kick.sh
+++ b/projects/orchestration-engine/tests/test_oe_kick.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_kick.sh — oe-kick の 1 引数判定とフラグ展開を検証する
+#
+# 実 tmux / Claude / oe-delegate は起動しない。OE_DELEGATE_BIN をモックに差し替え、
+# oe-kick が組み立てて exec する argv（モックが 1 引数 1 行で記録）を assert する。
+# モック argv の検証で ref 判定 / kickoff-<N> 抽出 / issue task 文 / tmux preflight 順序
+# まで覆う（exec 展開のみではない）。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/ws"
+
+# モック oe-delegate: 受け取った argv を 1 引数 1 行で記録して即終了。
+cat > "$_TMP_DIR/bin/oe-delegate-mock" <<'EOF'
+#!/usr/bin/env bash
+: > "${OE_KICK_TEST_ARGV:?}"
+for a in "$@"; do printf '%s\n' "$a" >> "${OE_KICK_TEST_ARGV}"; done
+exit 0
+EOF
+chmod +x "$_TMP_DIR/bin/oe-delegate-mock"
+
+export OE_DELEGATE_BIN="$_TMP_DIR/bin/oe-delegate-mock"
+export OE_KICK_TEST_ARGV="$_TMP_DIR/argv.log"
+export TMUX_PANE="%1"
+WS="$_TMP_DIR/ws"
+
+PASS=0
+FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"; printf '    want=[%s]\n    got =[%s]\n' "$expected" "$actual"; FAIL=$((FAIL + 1))
+  fi
+}
+
+reset() { rm -f "$OE_KICK_TEST_ARGV"; }
+run_kick() { bash "$PROJECT_DIR/bin/oe-kick" "$@" >"$_TMP_DIR/out.log" 2>"$_TMP_DIR/err.log"; }
+argv() { cat "$OE_KICK_TEST_ARGV" 2>/dev/null; }
+called() { [[ -e "$OE_KICK_TEST_ARGV" ]] && echo yes || echo no; }
+
+# 期待 argv を 1 引数 1 行で組む（NUL 不要・改行を含む引数は無い）。
+expect() { printf '%s\n' "$@"; }
+
+echo "[1] issue mode: #178 -> --label '#178' + gh task"
+reset
+run_kick -w "$WS" "#178"
+ck "issue #178 argv" \
+  "$(expect -w "$WS" --label "#178" -- "Issue #178 の内容を gh issue view 178 で確認して作業を進めて。リポジトリ: $WS")" \
+  "$(argv)"
+
+echo "[2] issue mode: 素の番号 178 も #178 と同じ展開"
+reset
+run_kick -w "$WS" "178"
+ck "bare 178 == #178" \
+  "$(expect -w "$WS" --label "#178" -- "Issue #178 の内容を gh issue view 178 で確認して作業を進めて。リポジトリ: $WS")" \
+  "$(argv)"
+
+echo "[3] issue mode: leading zero 0178 を 178 に正規化"
+reset
+run_kick -w "$WS" "#0178"
+ck "0178 -> #178 (label)"  "#178" "$(argv | sed -n '4p')"
+ck "0178 -> view 178 (task)" "Issue #178 の内容を gh issue view 178 で確認して作業を進めて。リポジトリ: $WS" "$(argv | sed -n '6p')"
+
+echo "[4] issue mode: 末尾 ad-hoc を既定 task に連結"
+reset
+run_kick -w "$WS" "#178" "テストも書いて"
+ck "issue ad-hoc appended" \
+  "Issue #178 の内容を gh issue view 178 で確認して作業を進めて。リポジトリ: $WS テストも書いて" \
+  "$(argv | sed -n '6p')"
+
+echo "[5] kickoff mode: ファイル名 kickoff-<N> から #N ラベル導出"
+reset
+KO="$_TMP_DIR/2026-06-20-kickoff-178-foo.md"; printf '# k\n' > "$KO"
+run_kick -w "$WS" "$KO"
+ck "kickoff argv" "$(expect -w "$WS" --label "#178" --kickoff "$KO" --)" "$(argv)"
+
+echo "[6] kickoff mode: 番号無しファイル名 -> ラベル無し"
+reset
+KO2="$_TMP_DIR/notes.md"; printf '# n\n' > "$KO2"
+run_kick -w "$WS" "$KO2"
+ck "kickoff no-label argv" "$(expect -w "$WS" --kickoff "$KO2" --)" "$(argv)"
+
+echo "[7] kickoff mode: 末尾 ad-hoc は oe-delegate task として渡る"
+reset
+run_kick -w "$WS" "$KO" "補足あり"
+ck "kickoff ad-hoc argv" "$(expect -w "$WS" --label "#178" --kickoff "$KO" -- "補足あり")" "$(argv)"
+
+echo "[8] --claude-arg passthrough（issue より前・repeatable）"
+reset
+run_kick -w "$WS" --claude-arg --permission-mode --claude-arg auto "#178"
+ck "claude-arg passthrough argv" \
+  "$(expect -w "$WS" --claude-arg --permission-mode --claude-arg auto --label "#178" -- "Issue #178 の内容を gh issue view 178 で確認して作業を進めて。リポジトリ: $WS")" \
+  "$(argv)"
+
+echo "[9] workspace 既定（-w 省略時は cwd）"
+reset
+( cd "$WS" && bash "$PROJECT_DIR/bin/oe-kick" "#178" >/dev/null 2>&1 )
+ck "default workspace = cwd" "$WS" "$(argv | sed -n '2p')"
+
+echo "[10] 第三分類（非ファイル・非数値）-> rc2・oe-delegate 未呼出"
+reset
+rc=0; run_kick -w "$WS" "abc" || rc=$?
+ck "third-class rc=2" "2" "$rc"
+ck "third-class did not call delegate" "no" "$(called)"
+
+echo "[11] 数字混じり 178a も第三分類"
+reset
+rc=0; run_kick -w "$WS" "178a" || rc=$?
+ck "178a rc=2" "2" "$rc"
+ck "178a did not call delegate" "no" "$(called)"
+
+echo "[12] ref 省略 -> rc2・未呼出"
+reset
+rc=0; run_kick -w "$WS" || rc=$?
+ck "missing ref rc=2" "2" "$rc"
+ck "missing ref did not call delegate" "no" "$(called)"
+
+echo "[13] tmux 外（TMUX_PANE 未設定）-> rc1・未呼出（task 組立前に fail）"
+reset
+rc=0; ( unset TMUX_PANE; bash "$PROJECT_DIR/bin/oe-kick" -w "$WS" "#178" >/dev/null 2>"$_TMP_DIR/err.log" ) || rc=$?
+ck "no tmux rc=1" "1" "$rc"
+ck "no tmux did not call delegate" "no" "$(called)"
+
+echo "[14] -h -> rc0・未呼出"
+reset
+rc=0; run_kick -h || rc=$?
+ck "help rc=0" "0" "$rc"
+ck "help did not call delegate" "no" "$(called)"
+
+echo "[15] file 優先: 番号名ファイルが cwd にあれば kickoff 扱い"
+reset
+NUMF="$_TMP_DIR/178"; printf 'x\n' > "$NUMF"
+run_kick -w "$WS" "$NUMF"
+# basename=178 は kickoff-<N> に当たらない -> ラベル無し・kickoff 経路
+ck "numeric-name file -> kickoff path" "$NUMF" "$(argv | sed -n '4p')"
+ck "numeric-name file -> --kickoff verb" "--kickoff" "$(argv | sed -n '3p')"
+
+echo "[16] unknown option -> rc2・未呼出"
+reset
+rc=0; run_kick --bogus "#178" || rc=$?
+ck "unknown option rc=2" "2" "$rc"
+ck "unknown option did not call delegate" "no" "$(called)"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 概要

`oe-delegate`（tmux 子 spawn + kick）の薄いワンショットラッパー `oe-kick` を新設。`#N`（or 素の番号）か kickoff パスを **1 引数**で受け、妥当な `oe-delegate` フラグ列へ展開する（毎回フラグを手組みする手間を省く）。cockpit 本線（WezTerm + tmux）の人間介入フローを軽くする。併せて #178 本文の hardening 2 点（oe-select 実装 SO 由来）を吸収。

## 変更内容

### `bin/oe-kick`（新規）
- 1 引数 ref の判定: 既存ファイル → kickoff（`--kickoff` で渡し、ファイル名 `kickoff-<N>` から `--label '#N'` 自動導出・不検出はラベル無し） / `^#?[0-9]+$` → issue（`--label '#N'` 自動付与 + `"gh issue view N で確認して進めて"` の task） / **それ以外 → 明示エラー（exit 2）**。
- 末尾 ad-hoc（任意・1 行）を両モードで受理（issue=既定 task に連結 / kickoff=task として渡す）。
- `-w/--workspace`（既定 cwd）/ `--claude-arg`（repeatable・passthrough）/ `-h`。
- tmux 前提を踏襲（`TMUX_PANE` 未設定は明示エラー・exit 1）。実体は `OE_DELEGATE_BIN` で差し替え可（テスト seam）。
- bash 3.2/5.2 両対応（ADR-005）。

### hardening（#178 本文・oe-select 実装 SO 由来）
- **`bin/oe-delegate`**: `--label` 値の改行（LF/CR）を spawn 前に fail-fast 拒否（既存 `--claude-arg` と同型）。
- **`lib/delegate-registry.sh`**: `oe_reg_list` の**出力チョークポイント**で label の改行を空白へ畳む。producer 1 点で消費者 `oe-list` / `oe-select` / `oe-status` を一括防御し、偽 `%N` 行注入＝誤送信を断つ。

### 付随修正（実機 bash 3.2 検証で発覚した pre-existing バグ）
- `oe-delegate` の `build_child_command` が `for arg in "${CLAUDE_ARGS[@]}"`（空配列）で bash 3.2 + `set -u` 下 `unbound variable` 落ち。`oe-kick #N`（`--claude-arg` 無し）は必ずこの経路を踏むため ADR-005 環境で feature が壊れる。`${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}` イディオム（`oe-select` 前例）で修正。master にも存在する既存バグ。

## 設計 SO / 実装 SO（駆動層フロー）

- **設計 SO**（`oe-refute --rubric exploration`・predecision 兼）: R1 refuted → 反証点（第三分類エラー設計 / sanitize 脅威モデル境界 / 書込側 hardening の分界 / oe-status 消費者）を確定前に design へ織り込み。
- **実装 SO**（`oe-review` diff-bound・impl レンズ）: R1 **refuted** — codex が到達可能な correctness 欠陥を検出（番号正規化の `$((10#N))` 算術が桁数無制限入力で silent overflow＝別 issue/ラベルに化け `oe-send #N` で誤ルーティング）。→ 文字列操作 `strip_leading_zeros` に修正し overflow 境界テストを追加 → R2 **survived**（2/2）。
- closure: `episode-retrospective` tier=heavy（Step4 closure 品質 SO で stale `10#` 記述の back-prop 漏れを検出→訂正）。経緯は `projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md`。

## テスト・検証

- `tests/test_oe_kick.sh`（新規・29 assert）: ref 判定 / `kickoff-<N>` 抽出 / 先頭ゼロ正規化 / **巨大番号 overflow 非発生** / issue task 文 / ad-hoc 連結 / `--claude-arg` passthrough / workspace 既定 / 第三分類・`178a`・ref 省略・tmux 外・unknown option・file 優先 の各エラー経路。
- `tests/test_oe_delegate.sh`（+4）: `--label` LF/CR 拒否。
- `tests/test_delegate_registry.sh`（+4）: `oe_reg_list` sanitize（pane_title / pane-issue .name 由来）。
- `shellcheck` 全対象 PASS。bash **5.x** で test_oe_kick 29 / test_oe_delegate 18 / test_delegate_registry 20 / 回帰 test_oe_select 35 / test_oe_status 27 全 PASS。**/bin/bash 3.2.57（runner+inner 双方 3.2 強制）でも PASS**（付随修正前は CLAUDE_ARGS で fail＝修正を実証）。
- 受け入れ条件: `oe-kick #N`（or kickoff パス）で子起動・キック ✅ / tmux 外で明示エラー ✅ / shellcheck PASS ✅。

## follow-up（行き先付与済・本 PR 外）

- 視覚偽装 hardening（ANSI / U+2028 等）→ 追わない（消費者の `read`/`awk` レコード境界にならず偽 `%N` 不可・低リスク）。
- 書込側 hardening（`oe_reg_record` / `wt-pane-issue.sh` / `oe_reg_resolve`）→ 別 follow-up（oe-select episode の cross-cutting routing 準拠。`resolve` は信頼 `%N` のみ出力で偽造ベクタでない）。
- bin script の bash 3.2 検証が runner のみで spawned bin を覆っていなかった（harness の穴）→ harness 改善候補。
- canonical `delegate-task` SKILL への oe-kick/oe-select 収録 → 先例踏襲で今回未対応。

Refs #178
