### PR TITLE
feat(skills): orchestration-toolkit 統合概観スキルを追加（oe-* パッケージ化）

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -7,7 +7,7 @@
 - **Rules**: English — ルール/原則はモデルの学習分布（CS 概念体系が英語ベース）と一致させるため英語で記述。断定的・厳格・端的な表現を使う
 - **Skills**: Japanese — スキルはドメイン知識・コンテキストを含むため、ユーザーの思考言語（日本語）で記述。description（frontmatter）も日本語
 
-## Skills (25)
+## Skills (26)
 
 | 名前 | 説明 | パス | depends |
 |------|------|------|---------|
@@ -25,6 +25,7 @@
 | issue-conventions | Issue作成の規約を適用する | `skills/issue-conventions/SKILL.md` | — |
 | kickoff-to-plan | Kickoff Documentを実行可能なプランに忠実変換する | `skills/kickoff-to-plan/SKILL.md` | skill: adversarial-review |
 | markdown-conventions | Markdown記法の規約を適用する | `skills/markdown-conventions/SKILL.md` | — |
+| orchestration-toolkit | oe-* オーケストレーションツール群（engine/委譲/SOゲート/選択・観測）と駆動層規律の統合概観。repo 走査でなく一貫理解する loadable パッケージ。詳細は bin/README へ routing | `skills/orchestration-toolkit/SKILL.md` | skill: delegate-task, skill: so-compare, skill: predecision-exploration, skill: episode-retrospective, skill: code-path-exhaustion |
 | oss-research-session | oss-researcher 調査セッションの起動・成果保存の標準化（パス規約・注入テンプレ・チェックリスト） | `skills/oss-research-session/SKILL.md` | — |
 | persistent-exploration | 原因探索の「諦めない」深掘り行動原則 | `skills/persistent-exploration/SKILL.md` | — |
 | plan-to-kickoff | Cursor Plan / プランMDをKickoff Document形式に変換する | `skills/plan-to-kickoff/SKILL.md` | skill: so-compare, skill: kickoff-to-plan, command: peer-ai-review |

--- a/canonical/skills/orchestration-toolkit/SKILL.md
+++ b/canonical/skills/orchestration-toolkit/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: orchestration-toolkit
+description: oe-* オーケストレーションツール群（engine 本体 / 親子委譲 / SO ゲート / 選択・観測）と駆動層規律の統合概観。複数エージェント委譲・設計SO/実装SO・read-only 観測・engine 1 サイクルを使うとき、ツール群の全体像をリポジトリ走査でなく一貫した形で把握したいときに使用する。
+---
+
+# Orchestration Toolkit (oe-*) — 統合概観
+
+oe-* ツール群を **1 つのパッケージとして一貫理解する**ための概観。個別スクリプトを repo 走査して断片把握すると齟齬が出るため、本スキルで全体像を取り、詳細は各 verb の README / focused スキルへ routing する。実体は `projects/orchestration-engine/bin/oe-*`（全 11 verb）。
+
+## ツール群（役割別）
+
+- **engine 本体**: `oe`（自律 1 サイクル: `board_apply`[盤面初期化=#175 layout]→spawn→envelope→send→**monitor loop（内部で capture/classify/KVS 書込）**→（monitor 成功時）verify→cleanup[trap EXIT]。状態 KVS ＋ audit jsonl ＋ circuit breaker[max_turns/max_panes/timeout]。**spawn=生成 / verify=別 reviewer spawn＝生成と反証を物理分離**）/ `oe-capture`（ペイン capture 補助）。
+- **親子委譲**: `oe-delegate`（子セッション起動 + 最初のキック）/ `oe-kick`（`#N` or kickoff パスを 1 引数で受け `oe-delegate` のフラグ列へ展開するワンショットラッパー）/ `oe-send`（既存ペインへ 1 行/キックオフ送信・戻しもこれ）/ `oe-list`（宛先候補を source 列付きで列挙）/ `oe-report`（legacy・戻しは oe-send に一本化）。詳細手順 → `delegate-task` スキル。
+- **SO ゲート**: `oe-refute`（**設計SO**・確定前の同期反証・`--rubric exploration|consensus`）/ `oe-review`（**実装SO**・reviewed diff バインドのコード欠陥レビュー・`lens=impl`）。いずれも `so-compare` を wrap。※engine 内の `verify`（単一 reviewer の compliance review）とは**別物**（同名注意）。
+- **選択 / 観測**: `oe-select`（`oe-list`+fzf で対話選択→`oe-send` 委譲する UX。preview で `tmux capture-pane` を読む）/ `oe-status`（**read-only 俯瞰**: engine の audit-terminal reducer 由来 state ＋ delegate liveness。**ペイン出力は読まない＝検出しない**）。
+
+## 駆動層規律（engine 作業の 1 サイクル）
+
+discussion/DJ → **設計SO（`oe-refute`）** → 実装 → **実装SO（`oe-review`）** → Episode → PR →（Copilot）→ closure。
+
+- **SO レーンポリシー（運用方針。verb 既定は `--lanes 2`）**: 設計SO=**`oe-refute --lanes 3` を明示**（3社=codex+cursor+claude。Claude/Opus を設計＝選択肢拡張に活かす）／実装SO=既定の **`oe-review`（2社=codex+cursor・実装者 Claude を抜き model 多様性で欠陥検出）**。観点が違うので**両方**実施（設計だけで実装SO を省略しない）。重い対象は都度 3社+3社 もありだが、なるべく分割して重くしない。※レーンの model（cursor=composer / claude=opus 等）は **so-compare 側の指定**で oe-* は固定しない。
+- 集約は **conservative**（1 レーンでも material な指摘 → 全体 refuted）。`refuted` は **exit 3（advisory・JSON が正本）**＝oe-* は機械的に PR/マージを止めない（確定保留は harness/運用判断）。
+- 蒸留パイプライン doc: discussion / kickoff / **episode（締めで必須・本文は随時追記・後追い再構成は `reconstructed` 明示）** / decision-ADR（任意・content 次第）。closure は `episode-retrospective`。
+- **完全移譲**: 自律委譲子は discussion/設計SO から 実装→実装SO→Episode→PR→Copilot→closure まで**一気通貫**（親は巻き取らない）。
+- **自律委譲子の権限（運用・opt-in）**: `oe-delegate`/`oe-kick` は既定で permission-mode を付けない。自律子には `--claude-arg --permission-mode --claude-arg auto` を**明示的に渡す**。`bypassPermissions` は委譲子では即死するため `auto` を使う（実機学び・コード強制ではない）。auto/full 権限の自律子はガードレールでユーザー明示承認が要る。
+
+## 重要な不変条件 / gotcha
+
+- oe-* は **PATH 未登録** → `projects/orchestration-engine/bin/oe-*` でパス起動（`so-compare`/`wez` 等は `~/bin` に sync 済で PATH 上）。
+- SO の audit は本体 per-session（`audit/{id}.jsonl`）と別系統: **`oe-refute.jsonl`（`event_type=oe_refute`・`rubric`）/ `oe-review.jsonl`（`event_type=oe_review`・`lens=impl`・diff バインド）**。`oe-status` の ENGINE 区画には SO audit は出ない（別 viewer）。
+- engine の state KVS は **初回=target 完了（`@@OE_EXIT` 検出）時に作成**・verify は完了後に同 KVS へ追記。**実行中 / CB timeout は KVS 不在**（観測は audit-tail から導く）。
+
+## 詳細への routing
+
+- 各 verb のフラグ/挙動: `projects/orchestration-engine/bin/README.md`
+- 委譲の操作手順: `delegate-task` スキル
+- 設計確定前のゼロベース探索: `predecision-exploration` / バグ調査のコードパス網羅: `code-path-exhaustion`
+- SO テンプレ（選択肢拡張）: `so-compare` スキル
+- closure の振り返り: `episode-retrospective` スキル

--- a/canonical/skills/orchestration-toolkit/SKILL.md
+++ b/canonical/skills/orchestration-toolkit/SKILL.md
@@ -5,7 +5,7 @@ description: oe-* オーケストレーションツール群（engine 本体 / �
 
 # Orchestration Toolkit (oe-*) — 統合概観
 
-oe-* ツール群を **1 つのパッケージとして一貫理解する**ための概観。個別スクリプトを repo 走査して断片把握すると齟齬が出るため、本スキルで全体像を取り、詳細は各 verb の README / focused スキルへ routing する。実体は `projects/orchestration-engine/bin/oe-*`（全 11 verb）。
+oe-* ツール群を **1 つのパッケージとして一貫理解する**ための概観。個別スクリプトを repo 走査して断片把握すると齟齬が出るため、本スキルで全体像を取り、詳細は各 verb の README / focused スキルへ routing する。実体は `projects/orchestration-engine/bin/`（`oe` ＋ `oe-*`・全 11 verb）。
 
 ## ツール群（役割別）
 
@@ -26,7 +26,7 @@ discussion/DJ → **設計SO（`oe-refute`）** → 実装 → **実装SO（`oe-
 
 ## 重要な不変条件 / gotcha
 
-- oe-* は **PATH 未登録** → `projects/orchestration-engine/bin/oe-*` でパス起動（`so-compare`/`wez` 等は `~/bin` に sync 済で PATH 上）。
+- `oe` / `oe-*` は **PATH 未登録** → `projects/orchestration-engine/bin/` のパスで起動（`so-compare`/`wez` 等は `~/bin` に sync 済で PATH 上）。
 - SO の audit は本体 per-session（`audit/{id}.jsonl`）と別系統: **`oe-refute.jsonl`（`event_type=oe_refute`・`rubric`）/ `oe-review.jsonl`（`event_type=oe_review`・`lens=impl`・diff バインド）**。`oe-status` の ENGINE 区画には SO audit は出ない（別 viewer）。
 - engine の state KVS は **初回=target 完了（`@@OE_EXIT` 検出）時に作成**・verify は完了後に同 KVS へ追記。**実行中 / CB timeout は KVS 不在**（観測は audit-tail から導く）。
 


### PR DESCRIPTION
## 目的

oe-* オーケストレーションツール群（全 11 verb）が成長したが、**loadable な「パッケージ」表現が無く**、セッションが `bin/README`（repo-local＝非 synced）を走査して断片把握する＝**齟齬の温床**だった（特に harness を共有する各サービス開発セッション）。新スキル `orchestration-toolkit` で **repo 走査でなく一貫理解できる loadable パッケージ概観**を与える。

## 変更内容

- **`canonical/skills/orchestration-toolkit/SKILL.md`（新規・A）**: oe-* を役割別（engine 本体 / 親子委譲 / SO ゲート / 選択・観測）に束ね、駆動層規律・不変条件/gotcha・focused スキル/README への routing を 1 画面で示す **client-agnostic** な統合概観。詳細は bin/README へ routing（複製しない）。
- **`canonical/CATALOG.md`（B）**: orchestration-toolkit を追加（Skills 25→26・発見可能性）。
- **SO レーンポリシー（B 確定）を encode**: 設計SO=`oe-refute --lanes 3`（3社・運用方針／verb 既定は 2）／実装SO=`oe-review` 既定 2社（codex+cursor・Claude 抜き）。

## ゲート: 3社 設計SO（policy B 初適用）

`so-compare --with codex,cursor,claude --cursor-model composer-2.5 --claude-model opus`（3/3 成功・収束）。**事実照合の material 指摘を全反映**:

- **oe-kick 追加**（完全性・3レーン）: 親子委譲に `oe-kick`（#N/kickoff を 1 引数でワンショット委譲）が抜けていた＝スキルの存在意義（齟齬防止）に直接反する穴 → 補完（※起票時の audit 漏れも本 SO が捕捉）。
- **engine 1 サイクル順の事実修正**（3レーン）: `envelope→capture→verify→monitor` は誤り → 実順 `board_apply→spawn→envelope→send→monitor(capture 内包)→verify→cleanup` に。
- **設計SO=3社の明確化**（3レーン）: verb 既定は `--lanes 2`・3社は `--lanes 3` 明示＝運用方針と明記。
- **`--permission-mode auto` を不変条件→駆動層規律へ移動**＋ incantation（`--claude-arg --permission-mode --claude-arg auto`）明示。bypassPermissions 即死は実機学び（コード強制でない）と位置づけ。
- **lens 表記修正**: refute=`rubric` / review=`lens=impl`（共有 lens ではない）。
- KVS 粒度（初回作成＋verify 追記）・refuted は advisory（機械的に止めない）・engine verify と SO ゲートの同名注意・oe-status の検出しない scope・CATALOG depends に code-path-exhaustion。

## follow-up（routing）

- **`bin/README.md` の engine 1 サイクル順も同じ誤記**（本スキルが踏襲元）→ engine 側の doc 修正は別途（cockpit トラック）。本スキルは正しい順に修正済（README と一時乖離・README 修正で解消）。

## スコープ外

- verb 既定 lanes 変更（oe-refute default 2→3 等）/ predecision-exploration 等への SO ポリシー反映は別途。

Refs #204
