### PR TITLE
feat(oe): add oe-jump for notify→tmux-pane focus (label resolve + record/replay)

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -5,7 +5,7 @@ orchestration-engine の実行可能エントリの簡易リファレンス（AI
 scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統」節）:
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
-- **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report`
+- **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report` / `oe-jump`（通知→ペインへ focus）
 - **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰）
 
 ---
@@ -146,6 +146,27 @@ oe-select [--print|-p] [--no-enter] [--include-self] [--kickoff <path>] [--] [ad
 
 関連 lib: `delegate-registry.sh`（送信は `oe-send` 経由）
 
+## oe-jump — 通知/ラベルから対象 tmux ペインへ focus（#179）
+
+`wez notify` の通知から、入力待ちの子ペインへ**ワンアクションで focus（activate）**する導線。**tmux substrate 専用**（#188: engine=wez 整数 / delegate=tmux `%N` の identity 分裂に対応）。`oe_reg_resolve` は常に tmux `%N` を返すので focus も tmux 経路（`select-pane` 系）に固定し、tmux 子へ `wez pane activate` を投げる誤ターゲットを構造的に排除する。wez（engine）ペインの focus は既存の `wez pane activate <id>` を使う（oe-jump の責務外）。
+
+```bash
+oe-jump [--print|-p] [--] [<target>]   # focus（target 省略時は直近 --record を replay）
+oe-jump --record [--] <target>         # target を記録するだけ（通知連携・focus しない）
+```
+
+- `<target>` … tmux ペイン/ラベルを指す単一トークン:
+  - `%N` … tmux ペイン（素通し）→ `tmux switch-client`/`select-window`/`select-pane`（ID 系 target）
+  - `#N` / 任意名 … ラベル（`oe_reg_resolve` で tmux `%N` に解決。候補は `oe-list`）
+  - 裸の整数（例 `5`）や `wez:N` は wez（engine）ペイン指しとみなして**拒否**し、`%N`(tmux) か `wez pane activate N`(wez) を案内する（silent な誤 focus を出さない）
+- `--record <target>` … target を state（`~/.claude/state/oe-jump/last-target`・最後の1件・上書き）に記録。**通知連携規約（scope item 1）**の実装: 通知を撃つ側が記録し、人間は `oe-jump`（無引数）で直近の target へ飛ぶ＝真の 1 アクション。記録は token の**形だけ検証**し解決はしない（記録時に tmux/生存ペインを要求しない・解決は jump 時）。記録した token をそのまま解決するので「トースト表示文字列」と「解決契約」がズレない。
+- `--print`, `-p` … 解決した tmux pane id（`%N`）を stdout に出して終了（focus しない・dry-run/検査用）
+- exit: 0 成功 / 1 未解決・曖昧・ペイン無し・focus 失敗・replay 対象なし / 2 usage・環境エラー（tmux 不在）
+- 通知発火そのもの（誰が・いつ撃つか）は #179 スコープ外（状態検出による自動発火 = #P2/agent-deck）。`wez notify` は前提・不改変。WezTerm のトーストはクリックで url を開くのみ＝コマンド直接起動は不可のため、focus は本コマンド経由（issue の「コマンド経由フォールバック」）。
+- 既知制約: spawn-registry の任意名ラベルは spawn した親ペインからのみ解決可（`oe_reg_resolve` の parent スコープ）。pane-issue ラベル（`#N`）と `%N` 直接トークンはスコープ非依存。
+
+設計の正本: [`../docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md`](../docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md)。関連 lib: `delegate-registry.sh`（`oe_reg_resolve`）/ 関連: [`../docs/decisions/2026-06-19-decision-188-identity-unification.md`](../docs/decisions/2026-06-19-decision-188-identity-unification.md)。
+
 ## oe-report — 親へ申し送り（legacy）
 
 親ペインへ申し送り / レビュー依頼を送る。**legacy**: 戻しは `oe-send "$PARENT_TMUX_PANE"` に一本化が方針。
@@ -190,5 +211,6 @@ oe-status -h | --help
 | `OE_SEND_FINALIZE_TIMEOUT` / `_INTERVAL` / `_STABLE` | finalize の settle 窓 / poll 間隔 / 終端安定回数 | `3` / `0.3` / `3` |
 | `OE_DELEGATE_WAIT_SEC` | oe-delegate: 子 claude 起動待ち（秒） | `4` |
 | `PARENT_TMUX_PANE` | oe-delegate が子へ渡す親ペイン（戻し用） | （自動） |
+| `OE_JUMP_STATE_DIR` | oe-jump: `--record`/replay の state 置き場 | `~/.claude/state/oe-jump` |
 
 本体エンジン側（`OE_POLL_INTERVAL` / `OE_CB_*` / `OE_TARGET_AI_*` / `OE_VERIFY_AI_*` 等）は [`../lib/constants.sh`](../lib/constants.sh) を参照。

--- a/projects/orchestration-engine/bin/oe-jump
+++ b/projects/orchestration-engine/bin/oe-jump
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# oe-jump — 通知/ラベルから対象 tmux ペインへワンアクションで focus（activate）する入口
+#
+# usage: oe-jump [--print|-p] [--] [<target>]
+#        oe-jump --record [--] <target>
+#
+# <target> は tmux ペイン/ラベルを指す単一トークン:
+#   %N         tmux ペイン（素通し）              → tmux switch-client/select-window/select-pane
+#   #N / 名前  ラベル（registry で tmux %N に解決）→ 同上
+#
+# #188 の identity 分裂（engine=wez 整数 pane_id / delegate=tmux %N）への対応として、
+# oe-jump は **tmux substrate 専用**にする。`oe_reg_resolve` は常に tmux %N を返すため、
+# focus も tmux 経路（select-pane 系）に固定し、tmux 子へ `wez pane activate` を投げる
+# 誤ターゲット（整数部の取り違え）を構造的に排除する。wez（engine）ペインの focus は
+# 既存の `wez pane activate <id>` を使う（oe-jump の責務外）。
+#
+# 通知連携（scope item 1: 通知に target を紐づける規約）:
+#   通知を撃つ側が `oe-jump --record <target>` で対象を記録（state file・最後の1件）。
+#   人間は `oe-jump`（無引数）で直近記録の target へ飛ぶ＝真の 1 アクション。記録した token を
+#   そのまま解決するので「トースト表示文字列」と「解決契約」のズレが起きない。記録は token の
+#   形だけ検証し解決はしない（記録時に tmux/生存ペインを要求しない・解決は jump 時＝freshness）。
+#   通知発火そのもの（誰が・いつ）は #179 スコープ外（#P2 観測/agent-deck）。wez notify は前提・不改変。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/delegate-registry.sh
+source "${BIN_DIR}/../lib/delegate-registry.sh"
+
+# 記録 target の state（最後の1件のみ・上書き）。テストは env で隔離する。
+OE_JUMP_STATE_DIR="${OE_JUMP_STATE_DIR:-${HOME}/.claude/state/oe-jump}"
+OE_JUMP_STATE_FILE="${OE_JUMP_STATE_DIR}/last-target"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: oe-jump [--print|-p] [--] [<target>]
+       oe-jump --record [--] <target>
+
+  <target>       focus 先（tmux ペイン/ラベル）。単一トークン:
+                   %N        tmux ペイン（素通し）
+                   #N / 名前 ラベル（registry で tmux %N に解決。候補は oe-list）
+                 省略時は直近 --record した target を replay（真の 1 アクション）。
+  --record       <target> を state file に記録するだけ（focus しない）。通知連携用。
+  --print, -p    解決した tmux pane id（%N）を stdout に出して終了（focus しない）
+  -h, --help     このヘルプを表示
+
+note: oe-jump は tmux ペイン/ラベル専用。wez（engine）ペインの focus は
+      `wez pane activate <id>` を使う（裸の整数 / wez:N は受け付けず案内する）。
+
+exit:
+  0   focus 成功（--print/--record 時は成功）
+  1   ラベル未解決(0件) / 曖昧(複数件) / ペイン無し / focus 失敗 / replay 対象なし
+  2   usage エラー / 環境エラー（tmux 不在・接続不可）
+EOF
+}
+
+# _oe_jump_validate_shape <token> — token の構文のみ検証（解決はしない）。
+#   空 / 裸整数 / wez:N（wez ペイン指し）を usage エラー(2)で弾き、tmux substrate を案内する。
+#   %N / #N / 任意名ラベルは shape OK。--record はこれだけを使う（記録時に解決しない）。
+_oe_jump_validate_shape() {
+  local token="$1"
+  if [[ -z "$token" ]]; then
+    echo "oe-jump: empty target" >&2; return 2
+  fi
+  # 裸整数 / wez:N は wez（engine）ペインを指す可能性が高い。oe-jump は tmux 専用なので明示案内。
+  if [[ "$token" =~ ^[0-9]+$ || "$token" =~ ^wez:[0-9]+$ ]]; then
+    local n="${token#wez:}"
+    echo "oe-jump: '${token}' looks like a wez (engine) pane. oe-jump targets tmux panes/labels:" >&2
+    echo "  - for tmux pane ${n}: use %${n}" >&2
+    echo "  - for a wez (engine) pane: use 'wez pane activate ${n}'" >&2
+    return 2
+  fi
+  return 0
+}
+
+# _oe_jump_resolve <token> — token を tmux %N に解決して stdout へ。
+#   shape 検証 → oe_reg_resolve（%N 素通し / #N・名前ラベル → tmux %N）。jump/replay 時のみ呼ぶ。
+#   oe_reg_resolve の rc（0件/曖昧=1, 環境=2）はそのまま伝播。
+_oe_jump_resolve() {
+  local token="$1"
+  _oe_jump_validate_shape "$token" || return
+  oe_reg_resolve "$token"
+}
+
+# _oe_jump_tmux <pane> — tmux ペイン %N をクライアントへ寄せて focus する。
+#   session_id($N)/window_id(@N)/pane_id(%N) の ID 系のみで target を組む。
+#   セッション名に '#'/空白が混じる本環境（session-name hook）でも target 解釈が壊れない。
+#   同一 session/window のとき switch-client/select-window は no-op。select-pane を権威とする。
+#   経路は隔離 tmux サーバで実証（cross-window で active window/pane が対象へ遷移）。
+_oe_jump_tmux() {
+  local pane="$1"
+  # 対象ペインの生存確認。list-panes 自体の失敗（サーバ未起動/接続不可）は環境エラー(2)とし
+  # 「ペイン無し(1)」と区別する（oe-send / oe_reg_resolve と同方針）。
+  local live rc
+  live="$(tmux list-panes -a -F '#{pane_id}' 2>&1)"; rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "oe-jump: tmux list-panes failed (rc=${rc}): ${live}" >&2
+    return 2
+  fi
+  if ! printf '%s\n' "$live" | grep -qxF "$pane"; then
+    echo "oe-jump: target tmux pane not found: ${pane} (try: oe-list)" >&2
+    return 1
+  fi
+  local meta sid wid
+  meta="$(tmux display-message -p -t "$pane" '#{session_id} #{window_id}' 2>/dev/null)" || {
+    echo "oe-jump: failed to query tmux metadata for ${pane}" >&2
+    return 2
+  }
+  sid="${meta%% *}"
+  wid="${meta##* }"
+  # クライアントを対象セッションへ → そのセッションの active window を対象 window へ →
+  # window 内で対象ペインを focus。switch-client/select-window はクライアント不在時など
+  # best-effort（落ちても select-pane が active pane を確定させる）。select-pane を hard fail とする。
+  if [[ -n "$sid" ]]; then tmux switch-client -t "$sid" 2>/dev/null || true; fi
+  if [[ -n "$wid" ]]; then tmux select-window -t "$wid" 2>/dev/null || true; fi
+  if ! tmux select-pane -t "$pane" 2>/dev/null; then
+    echo "oe-jump: tmux select-pane failed for ${pane}" >&2
+    return 1
+  fi
+}
+
+# _oe_jump_record <token> — target token を state file へ atomic 記録（最後の1件・上書き）。
+_oe_jump_record() {
+  local token="$1"
+  mkdir -p "$OE_JUMP_STATE_DIR" 2>/dev/null || {
+    echo "oe-jump: cannot create state dir ${OE_JUMP_STATE_DIR}" >&2; return 1; }
+  local tmp="${OE_JUMP_STATE_FILE}.tmp.$$"
+  if printf '%s\n' "$token" >"$tmp" 2>/dev/null && mv -f "$tmp" "$OE_JUMP_STATE_FILE" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  echo "oe-jump: failed to record target to ${OE_JUMP_STATE_FILE}" >&2
+  return 1
+}
+
+PRINT_ONLY=0
+RECORD=0
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -p|--print) PRINT_ONLY=1; shift ;;
+    --record) RECORD=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) echo "oe-jump: unknown option: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+# 位置引数の「有無」を $# で判定する（明示的な空文字 "" を「省略」と取り違えて replay へ
+# 落とさない／空文字の後ろの余剰引数を黙って捨てない）。
+HAVE_ARG=0
+TARGET=""
+if [[ $# -gt 0 ]]; then
+  HAVE_ARG=1
+  TARGET="$1"; shift
+  if [[ $# -gt 0 ]]; then
+    echo "oe-jump: too many arguments (one target only): $*" >&2; usage; exit 2
+  fi
+fi
+
+# --record: target 明示必須・記録のみ（--print とは併用不可・解決はしない）。
+if [[ "$RECORD" -eq 1 ]]; then
+  if [[ "$PRINT_ONLY" -eq 1 ]]; then
+    echo "oe-jump: --record cannot be combined with --print" >&2; usage; exit 2
+  fi
+  if [[ "$HAVE_ARG" -eq 0 ]]; then
+    echo "oe-jump: --record requires a target" >&2; usage; exit 2
+  fi
+  _oe_jump_validate_shape "$TARGET" || exit   # 空文字 "" もここで usage エラーにする
+  _oe_jump_record "$TARGET" || exit
+  echo "oe-jump: recorded target '${TARGET}'" >&2
+  exit 0
+fi
+
+# 位置引数が「無い」ときだけ直近 --record を replay する。明示の空文字 target（HAVE_ARG=1）は
+# replay せず、下の _oe_jump_resolve（→ _oe_jump_validate_shape）で usage エラーにする。
+REPLAYED=0
+if [[ "$HAVE_ARG" -eq 0 ]]; then
+  if [[ -r "$OE_JUMP_STATE_FILE" ]]; then
+    TARGET="$(head -n 1 "$OE_JUMP_STATE_FILE" 2>/dev/null)"
+  fi
+  if [[ -z "$TARGET" ]]; then
+    echo "oe-jump: no target given and no recorded target to replay (pass %N / #N, or run 'oe-jump --record <target>' first)" >&2
+    exit 1
+  fi
+  REPLAYED=1
+fi
+
+# --- 解決（tmux %N） ---
+PANE="$(_oe_jump_resolve "$TARGET")" || exit
+
+# --- --print（解決のみ・focus しない） ---
+if [[ "$PRINT_ONLY" -eq 1 ]]; then
+  printf '%s\n' "$PANE"
+  exit 0
+fi
+
+# --- focus ---
+_oe_jump_tmux "$PANE" || exit
+
+if [[ "$REPLAYED" -eq 1 ]]; then
+  echo "oe-jump: focused tmux pane ${PANE} (replay of '${TARGET}')" >&2
+else
+  echo "oe-jump: focused tmux pane ${PANE}" >&2
+fi

--- a/projects/orchestration-engine/docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md
@@ -1,0 +1,129 @@
+---
+id: 01KVJYQAJFMRDB23RMMBE26MWS
+title: "#179 通知からペインジャンプ — oe-jump 設計判断と探索証跡"
+date: 2026-06-21
+type: discussion
+status: draft
+claim: "通知→ペインジャンプは新規 oe-jump（focus 専用 verb・tmux substrate 専用）が担い、%N 素通し / #N・名前は oe_reg_resolve で tmux %N に解決して tmux 経路（select-pane 系）で focus、scope item 1 は record/replay（--record 形検証のみ + 無引数 replay）で実装するのが、#188 の identity 分裂下かつ kickoff 制約（notify 不改変・自動発火は #P2 スコープ外・tmux 子への wez activate 誤投を回避）の下で issue #179 のスコープに対し妥当な設計である。wez(engine)ペインの focus は既存 wez pane activate に委ね oe-jump の責務外とする。"
+status_note: "設計SO(exploration) 3R + 実装SO(oe-review) 2R を実施。設計の方向性（substrate 分裂対応）は是認。実装SO で (1) --record の eager 解決 (2) test の mktemp 無ガード (3) wez:N と registry ラベルの衝突 を検出 → 形検証分離 / mktemp ガード / wez を oe-jump から除去（tmux 専用化）で反映。"
+rubric: exploration
+domain: orchestration-engine
+related:
+  - type: implements
+    ref: "#179"
+  - type: depends_on
+    ref: "#188"
+    reason: "2 基盤の identity 分裂（tmux %N ↔ wez 整数 pane_id）が activate 経路分岐の前提"
+---
+
+# #179 通知からペインジャンプ — 設計判断と探索証跡
+
+## 問題
+
+`wez notify` の通知から、入力待ちの対象ペインへワンアクションでフォーカス（activate）する導線が無い。プリミティブ（`wez notify` / ラベル解決 `oe_reg_resolve` / `wez pane activate`）は揃っているが束ねられていない。
+
+## 一次情報で確定した制約（#188・verified）
+
+2 つのオーケストレーション基盤は**別 identity 空間**を持つ:
+
+| 基盤 | identity | フォーカス手段 | 出典 |
+|---|---|---|---|
+| engine `oe`（自律パイプライン） | **wez 整数** pane_id | `wez pane activate <int>`（`wezterm cli activate-pane`） | `lib/spawn.sh`（`wez pane split`）, `#188` [verified] |
+| delegate（対話 Claude 子） | **tmux `%N`** | tmux 側（`select-pane`/`select-window`/`switch-client`） | `lib/delegate-registry.sh`（`tmux list-panes -F '#{pane_id}'`）, `oe-send`（`tmux send-keys -t %N`）, `#188` [verified] |
+
+- `oe_reg_resolve` は `tmux list-panes` 起点でラベル（`#N`/名前）を解決し **tmux `%N` のみ**を返す。wez 整数 pane_id は返さない。[verified — `lib/delegate-registry.sh:71-121`]
+- 罠: tmux 子（`%N`）に `wez pane activate` を投げると、`%N` の整数部 N を wez pane_id と誤解釈し**別ペインへフォーカス or 失敗**する（#188 の核心）。素朴な「全部 wez pane activate」は誤り。
+
+## 設計判断（DJ）
+
+### DJ-A: ジャンプの実装位置 = 新規 `oe-jump`（orchestration-engine）
+
+- 採用理由: ラベル解決 `oe_reg_resolve` は orchestration-engine にあり、engine は既に `wez`（`spawn.sh` の `wez pane split`）に依存する＝両 substrate を知る層はここだけ。`oe-send`（resolve→tmux 操作）と同型で、oe-* one-verb-per-bin パターンに整合。
+- 却下 1: `wez` CLI に `jump`/`focus` を追加 → wez が orchestration-engine（`oe_reg_resolve`）へ逆依存し**レイヤ違反**（wez は下層）。wez は wez ペインしか知らず tmux `%N` を扱えない。
+- 却下 2: lib 関数のみ（入口 bin なし）→ acceptance の「1 アクション入口」を満たさない。
+
+### DJ-B: activate 経路 = oe-jump は tmux substrate 専用
+
+| target トークン | 解決/経路 |
+|---|---|
+| `%N` | 素通し → tmux focus 系（`oe_reg_resolve` が `%N` をそのまま返す） |
+| `#N` / 任意名 | `oe_reg_resolve` → tmux `%N` → tmux focus 系 |
+| 裸の整数 `N` / `wez:N` | **拒否**（exit 2）。`%N`(tmux) か `wez pane activate N`(wez) を案内 |
+
+- `oe_reg_resolve` は `tmux list-panes` 起点で**常に tmux `%N`** を返す（wez 整数は返さない）。よって oe-jump の解決結果は常に tmux であり、focus も tmux 経路（`select-pane` 系）に固定する＝tmux 子へ `wez pane activate` を投げる誤ターゲットを**構造的に排除**（#188・kickoff の核心懸念を満たす）。
+- **wez(engine)ペインは oe-jump の責務外**。focus には既存の `wez pane activate <id>` を使う。kickoff の「activate 経路を分けるか、対象を明示する」は「oe-jump=tmux / wez=wez pane activate」という**ツール境界の明示**で満たす。
+- 裸整数 / `wez:N` は wez ペイン指しとみなして**拒否+案内**（silent な誤 focus を出さない）。当初は oe-jump 内で wez も扱う設計（`--wez` → `wez:N`）だったが、実装SO（cursor）が「`wez:N` が registry ラベル `wez:N` と衝突し silent 誤 focus し得る」と反証。wez 焦点は既存ツールがあり #179 の主用途（入力待ち=tmux 子）にも不要なため、**Minimal Scope に基づき oe-jump から wez を除去**＝衝突クラスを構造的に消去（DJ-E）。
+
+### DJ-C: tmux フォーカス系の idiom（リポジトリに既存パターン無し＝新規）
+
+対象 tmux ペイン `%N` を現在のクライアントへ可視化＋フォーカスする手順:
+
+```
+read sid wid <<<"$(tmux display-message -p -t "$pane" '#{session_id} #{window_id}')"
+tmux switch-client -t "$sid"      # クライアントを対象セッションへ
+tmux select-window -t "$wid"      # そのセッションの active window を対象 window へ
+tmux select-pane   -t "$pane"     # window 内で対象ペインをフォーカス
+```
+
+- session_id（`$N`）/ window_id（`@N`）/ pane_id（`%N`）の**ID 系**のみ使用＝セッション名に `#`/空白が混じる本環境（session-name hook）でも target 解釈が壊れない。
+- 同一 window/session のときは各コマンドが no-op になり安全。別 window/session でも 3 段で確実に landing。
+- **実証（隔離 tmux サーバ `tmux -L` で検証・verified）**: 非アクティブ window @1 のペイン %1 を対象に idiom を実行 → セッションの active window が @0→@1 へ遷移し、window @1 の active pane が %1 へ遷移することを確認。`switch-client` はクライアント未接続時 `no current client`(rc1) を返すが `|| true` で非致命（本番は接続クライアントあり）。`display-message -t %N '#{session_id} #{window_id}'` が `$N @N` を返すことも確認。
+- 既知限界: tmux クライアントをホストする wez ペイン自体が非フォーカスのケース（tmux が別 wez ペイン/ウィンドウにある）は tmux 層だけでは前面化しない。wez↔tmux マッピングは #188 の未解決問題のため**スコープ外**（人間+子が同一 tmux クライアントを見る主用途では不要）。
+
+### DJ-D: 通知ペイロード規約（scope item 1）= record/replay で target を「載せる」
+
+scope item 1「通知ペイロードにペイン特定情報を**載せる**規約」を、表示文字列ではなく **record/replay** で実装する（設計SO の「target が実際に流れない / 1 アクション未達 / 表示ラベルと解決契約のズレ」反証への反映・DJ-E）:
+
+- 通知を撃つ側が `oe-jump --record <target>` で対象トークンを state file（`~/.claude/state/oe-jump/last-target`・最後の1件・上書き）に記録する。
+- 人間は `oe-jump`（**無引数**）で直近記録の target へ飛ぶ＝**真の 1 アクション**（ラベルを読んで打ち直さない）。
+- **契約ズレの解消**: 記録した token をそのまま `oe_reg_resolve` に渡して解決するので、「トーストの表示文字列」と「解決される token」が分離・一致する（表示は自由文でよい）。
+- **境界の尊重**: `wez notify` のペイロード/Lua ハンドラは**不改変**（record は別 state・notify に相乗りしない）。通知発火そのもの（誰が・いつ撃つか）は #179 **スコープ外**（状態検出による自動発火 = #P2/agent-deck）。本 PR は「載せる規約＋飛ぶ導線」を提供し、撃つ主体は将来（or 手動/agent）。
+- **parent スコープの既知制約**: replay は jump 時に再解決する。pane-issue ラベル（`#N`・`wt switch` 子）はどのペインからも解決可。spawn-registry の任意名ラベル（`oe-delegate` 子）は **spawn した親ペインからのみ**解決可（`oe_reg_resolve` の parent スコープ）。主用途（人間が spawn 親で受信→飛ぶ）では成立。`%N` 直接トークンはスコープ非依存。
+
+### DJ-E: 設計SO（oe-refute・exploration）2 ラウンドの反証への反映
+
+設計SO（codex/cursor 2 レーン）を 2 ラウンド実施。**両ラウンド・両レーンとも substrate 分岐の方向性は #188 と整合**と認めた上で material gap を指摘。反映:
+
+| ラウンド | 反証 gap | 反映 |
+|---|---|---|
+| 1 | tmux focus idiom 未検証 | 隔離 tmux サーバで cross-window 実証（DJ-C・verified） |
+| 1 | 裸整数の cross-tool 衝突 | 裸整数→wez 自動を撤回し **拒否+案内**（DJ-B） |
+| 1 | より小さい代替（oe-send 拡張等）未探索 | 「検討した代替」に記録。oe-send は "1 行送信" verb で focus と別 semantics → 拡張は contract を濁す。解決ロジックは `oe_reg_resolve` で共有済 → 新 verb 採用 |
+| 1+2 | notify emitter 未接続 / target が流れない / 受け入れ「1 アクション」未達 | **record/replay を本 PR スコープに取り込み**（DJ-D）。当初の「doc 規約のみ + follow-up」では scope item 1 の "載せる" を満たさないと再反証されたため、`--record` + 無引数 replay を実装 |
+| 2 | 表示ラベルと `oe_reg_resolve` 解決契約のズレ | record した token をそのまま解決＝表示文字列と分離・一致（DJ-D） |
+| 2 | parent スコープと主用途の衝突 | DJ-D に既知制約として明文化（pane-issue は scope 非依存・spawn 名は spawn 親から） |
+| 1 | claim 過大 | claim を「issue #179 スコープに対し妥当」へ縮小（断定 "最小かつ正しい" を撤回） |
+
+残差: exploration rubric は doc-only/手動アクション設計に対し原理上「更に探索余地あり」を返しやすい。material な新 gap（上記）は全て反映済。
+
+### DJ-E2: 実装SO（oe-review・impl レンズ・diff-bound）2 ラウンド
+
+| ラウンド | 反証 gap | 反映 |
+|---|---|---|
+| R1（codex=survived / cursor=refuted） | `--record` がラベルを `oe_reg_resolve` で eager 解決し「解決は jump 時」契約と矛盾。tmux 一時不可で記録すら失敗（%N/wez:N と非対称） | `_oe_jump_validate_shape`（解決しない・形のみ）を切り出し `--record` はこれだけ使用。解決は jump 時の `_oe_jump_resolve` のみ。回帰テスト [12] 追加 |
+| R2（codex=refuted / cursor=refuted） | (a) test の `mktemp -d` 無ガード→空パスで root 直下へ書込みの到達可能欠陥（codex） (b) `wez:N` が registry ラベル `wez:N` と衝突し silent 誤 focus し得る（cursor） | (a) `mktemp` 失敗ガード追加 (b) **oe-jump を tmux 専用化**し wez を除去（衝突クラスを構造的に消去）。wez focus は既存 `wez pane activate` に委譲 |
+
+R2 の wez 除去は Minimal Scope の判断（wez focus は既存ツールがあり #179 主用途に不要・予約プレフィックス等の規約で papering するより構造的に消す方が堅牢）。issue 原文の「wez pane activate の束ね」からの shape 変更にあたるため %32 へ明示報告する。
+
+### 検討した代替（exploration 痕跡）
+
+- **oe-send 拡張**（`--focus` 等）: 却下。oe-send の contract は「既存ペインへ 1 行を安全送信」。focus（テキスト無し・別作用）を相乗りさせると verb semantics が濁る。共有は解決ロジックのみで、それは既に `oe_reg_resolve` として lib 化済 → 新 verb でも実装重複は無い。oe-* の one-verb-per-bin に整合。
+- **wez 側に jump 追加**: 却下（DJ-A・レイヤ違反）。
+- **oe-jump に wez substrate を内包**（`--wez` / `wez:N`）: 一旦採用→**却下**（DJ-E2 R2）。裸整数の曖昧・`wez:N` の registry ラベル衝突を生み、wez focus は既存 `wez pane activate` で足り #179 主用途に不要。予約プレフィックス規約で papering するより tmux 専用化で衝突クラスを構造的に消す方が堅牢（Minimal Scope）。
+- **notify 4th フィールド + Lua クリック起動**: 却下（クリックは url を開くのみ・scope item 3 検証／notify 作り替え禁止）。
+
+## scope item 3 の検証結果（クリック起動可否）
+
+- WezTerm の `window:toast_notification(title, message, url, timeout_ms)` は**クリックで url を開くだけ**。任意コマンド/コールバックの実行は非対応。[verified — 公式ドキュメント https://wezterm.org/config/lua/window/toast_notification.html ＋ ローカル handler `ai-mode-events.lua:30` が第3引数 url=nil]
+- 帰結: トーストのクリック/キーから tmux/wez のフォーカスコマンドを直接起動するのは**不可**（OS レベルの独自 URL スキームハンドラ登録が要り、プラットフォーム依存・スコープ外）。
+- → 採用する「1 アクション」は**コマンド経由 `oe-jump <target>`**（issue が言う「不可ならコマンド経由のフォールバック」そのもの）。
+
+## ラベル未解決時の挙動（acceptance）
+
+`oe_reg_resolve` の契約を踏襲: 0 件 → exit 1 + `oe-list` 案内、複数件（曖昧）→ exit 1 + 候補列挙 + `%N` 指定案内。tmux 不在/接続不可 → exit 2（環境エラー）。
+
+## 探索証跡（predecision-exploration / exhaustion）
+
+- ゼロベース代替の列挙と却下: wez-only（tmux 子で誤ターゲット・却下）/ tmux-only（engine wez ペインを扱えない・却下）/ wez↔tmux 統一マッピング（#188 未解決・スコープ外）/ oe-send 拡張（verb semantics 濁す・却下 DJ-E）/ wez 内包（実装SO 衝突→却下 DJ-E2）/ **oe-jump=tmux 専用 + wez は既存 wez pane activate（採用）**＋ record/replay（scope item 1 を満たすため取り込み）。
+- 早期収束の実例: 本タスクの調査子エージェントが「フォーカスは全部 `wez pane activate`、tmux ロジック不要」と結論したが、これは #188 の substrate 分裂を見落とした誤収束。一次情報（#188 verified・delegate-registry.sh・oe-send）で反証し、substrate 分岐へ再構成した。
+- 残した未検証域: tmux クライアントが非フォーカス wez ペインにあるケース（DJ-C 既知限界・#188 スコープ外）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-179-notify-pane-jump.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-179-notify-pane-jump.md
@@ -1,0 +1,123 @@
+---
+id: 01KVJYQAK8B1RN17TCYT78QKBP
+title: "#179 通知からペインジャンプ（oe-jump）実装エピソード"
+date: 2026-06-21
+type: episode
+status: stable
+related:
+  - type: implements
+    ref: "#179"
+  - type: discussion
+    ref: ../discussions/2026-06-21-discussion-179-notify-pane-jump.md
+  - type: depends_on
+    ref: "#188"
+---
+
+# #179 通知からペインジャンプ（oe-jump）実装エピソード
+
+> リアルタイム追記（reconstructed ではない）。親 `%32` からの委譲子セッションが WORKTREE
+> `feature/#179_notify_pane_jump` で自律実行。
+
+## コンテキスト / 動機
+
+`wez notify` の通知から、入力待ちの子ペインへワンアクションで focus する導線が無かった。
+プリミティブ（`wez notify` / ラベル解決 `oe_reg_resolve` / `wez pane activate`）は揃うが束ねられていない。
+人間介入を速くするのが狙い（#179）。
+
+## 鍵となった一次情報（#188 の identity 分裂）
+
+2 基盤は別 identity 空間（verified）:
+- engine `oe`: **wez 整数** pane_id（`wez pane activate <int>`）
+- delegate（対話子）: **tmux `%N`**（tmux `select-pane` 系）
+
+`oe_reg_resolve` は `tmux list-panes` 起点でラベルを **tmux `%N`** に解決する（wez 整数は返さない）。
+→ tmux 子に `wez pane activate` を投げると別ペイン誤ターゲット。素朴な「全部 wez activate」は誤り。
+
+### 早期収束の実例（reframe で訂正）
+
+調査委譲した Explore 子が「focus は全部 `wez pane activate`、tmux ロジック不要」と結論したが、
+これは #188 の substrate 分裂を見落とした誤収束だった。一次情報（#188・delegate-registry.sh・oe-send）で
+反証し substrate 分岐へ再構成（`exhaustion-before-conclusion` / `reframe-on-stall` の作動例）。
+
+## 設計（正本は discussion doc）
+
+- DJ-A: 新規 `oe-jump`（orchestration-engine）。wez 側追加はレイヤ違反、oe-send 拡張は verb semantics を濁す。
+- DJ-B: oe-jump は **tmux substrate 専用**（`%N`=tmux 素通し / `#N`・名前=label→tmux %N）。`oe_reg_resolve` が常に tmux %N を返すので focus も tmux 経路に固定＝wez activate 誤投を構造排除。裸整数 / `wez:N` は wez ペイン指しとみなし拒否+案内（wez focus は既存 `wez pane activate`）。当初は oe-jump 内に wez を内包したが実装SO の衝突指摘で除去（DJ-E2）。
+- DJ-C: tmux focus idiom = `switch-client`(session_id) → `select-window`(window_id) → `select-pane`(pane_id)。ID 系のみ使用。
+- DJ-D: scope item 1（ペイロードに target を載せる）を **record/replay** で実装。`oe-jump --record <target>` が記録、
+  無引数 `oe-jump` が replay ＝真の 1 アクション。`wez notify` は不改変。
+- scope item 3: WezTerm トーストはクリックで url を開くのみ（verified・公式 doc + ローカル handler url=nil）→
+  コマンド経由 focus が採用（issue の「コマンド経由フォールバック」）。
+
+## 検証
+
+### tmux focus idiom（隔離 tmux サーバで実証・verified）
+
+`tmux -L` の隔離サーバで cross-window を実証: 非アクティブ window @1 のペイン %1 を対象に idiom を実行 →
+session の active window が @0→@1、window @1 の active pane が %2→%1 へ遷移。`switch-client` は
+クライアント未接続時 `no current client`(rc1) だが `|| true` で非致命（本番は接続あり）。
+
+### e2e（実 oe-jump バイナリ × 実 tmux・隔離サーバ・verified）
+
+PATH wrapper で実 tmux を隔離サーバ（`tmux -L`）へ向け、`oe-jump` 本体を駆動して受け入れを実証:
+- `oe-jump %1`（明示）: window @1 の active pane が %2→**%1**（`focused tmux pane %1` / rc=0）。
+- `oe-jump --record %1` → 無引数 `oe-jump`（**1 アクション replay**）: active pane が %2→**%1**（`focused tmux pane %1 (replay of '%1')` / rc=0）。
+- 注: 初回 e2e 試行は test wrapper の PATH 自己再帰バグ（`tmux` 名ラッパが `env tmux` で自分を再解決）で `Argument list too long` となり空出力だった。oe-jump は空 target を正しく exit 2 で弾いており（不具合ではない）、ラッパを実 tmux 絶対パス呼びに修正して上記を取得。
+
+### ユニットテスト（`tests/test_oe_jump.sh`・38 アサーション PASS）
+
+実 tmux/wez/jq を PATH 先頭 mock し、substrate 判別・解決・focus 経路・record/replay・各 exit code を検証。
+test_oe_select.sh と同型（mock + ck アサーション）。`shellcheck` は bin/test とも PASS。
+
+### 設計SO（oe-refute・exploration・2→3 ラウンド）
+
+- R1 refuted: tmux idiom 未検証 / 裸整数衝突 / emitter 未接続 / oe-send 拡張未探索 / claim 過大。
+- R2 refuted: emitter 未接続・1 アクション未達 / 表示ラベルと解決契約のズレ / parent スコープ衝突。
+- 反映: idiom 実証 / 裸整数拒否+案内 / **record/replay を本 PR に取り込み**（当初 follow-up 送りを撤回）/
+  record token = 解決 token で契約ズレ解消 / parent スコープを既知制約として明文化 / claim 縮小。
+- R3: （結果は本エピソード closure で確定）。両ラウンドとも substrate 分岐の方向性は #188 と整合と是認。
+
+## scope ↔ acceptance マッピング
+
+- scope1（ペイロードに target を載せる規約）→ `--record`/replay（DJ-D）。
+- scope2（notify→resolve→activate 束ね）→ oe-jump 本体（substrate 分岐）。
+- scope3（クリック起動可否検証）→ 不可（verified）→ コマンド経由。
+- acceptance「1 アクションで focus」→ 無引数 `oe-jump`（replay）/ ラベル未解決挙動 → exit 1 + oe-list 案内 / shellcheck PASS。
+
+## 実装SO（oe-review・diff-bound・impl レンズ）
+
+- R1（reviewed_sha 9ad6df0）: **refuted 1/2**。codex=survived（substrate 分岐/focus 経路/record-replay/exit code に material 欠陥なし）。cursor=refuted（material）:
+  「`--record` がラベル target で `oe_reg_resolve` を実行し『解決は jump 時』契約と矛盾。tmux 一時不可時に token 記録すら失敗して replay 不能（%N/wez:N と非対称）」。
+- 修正: `_oe_jump_validate_shape`（解決しない・形のみ検証）を切り出し、`--record` はこれだけを使う。
+  解決（`oe_reg_resolve`）は jump/replay 時の `_oe_jump_classify` でのみ実行。これで `--record #N` が
+  tmux/生存ペイン非依存になり `%N`/`wez:N` と対称化（契約通り）。回帰テスト [16] を追加（解決不能でも record 成功）。
+- R2（reviewed_sha 0d70874）: **refuted 2/2**。codex=「追加テストの `mktemp -d` 無ガードで空パス継続→root 直下へ書込みの到達可能欠陥」。cursor=「`wez:N` が registry ラベル `wez:N` と衝突し裸整数同型の拒否がなく silent 誤 focus し得る」。
+- 修正: (a) `mktemp` 失敗ガード追加 (b) **oe-jump を tmux 専用化**し wez substrate を除去（`--wez`/`wez:N` を撤廃・裸整数/wez:N は wez 案内で拒否）。wez focus は既存 `wez pane activate` に委譲＝衝突クラスを構造的に消去（Minimal Scope）。issue 原文の shape 変更のため %32 へ報告。
+- R3（reviewed_sha 6095966）: **refuted 1/2**。cursor=survived。codex=「明示空文字 target が省略扱いになり replay の stale pane へ誤 focus し得る／空文字後の余剰引数を黙って捨てる parser 欠陥」。
+- 修正: 位置引数の有無を `$#`（HAVE_ARG）で判定するよう変更（`-z "$TARGET"` での replay 判定を撤廃）。明示空文字は replay せず resolve→validate で usage エラー。回帰テスト [14] 追加。
+- R4（reviewed_sha 4cb406f・audit 20260620173759VEP9MAPT6RXV）: **survived 2/2**（codex/cursor とも material 欠陥なし・残存は設計上の既知制約のみ）。
+- アサーション数 **38 PASS** / shellcheck PASS。
+- SO 証跡: 各 `tmp/oe-review-<ULID>/`・`tmp/oe-refute-<ULID>/`（揮発・gitignore）。要点（verdict / reviewed_sha / audit_id / 指摘）は本エピソード本文に転記済（evidence anchor）。
+
+## closure（episode-retrospective・heavy tier）
+
+- **tier: heavy**（実行中の方針転回=wez 除去 / 意図起動の外部レーン oe-refute 3R + oe-review 4R / 非自明な設計判断と棄却案あり）。
+- **Context / なぜ**: 冒頭「コンテキスト / 動機」に自己完結（通知から入力待ちペインへ飛ぶ導線が無い）。
+- **次の消費者**:
+  - `%32`（親）— PR レビュー / マージ判断。特に wez 除去（issue 原文「wez pane activate の束ね」からの shape 変更）の是非。
+  - 将来 #P2 / agent-deck — 状態検出による自動通知発火が `oe-jump --record` 規約を消費する（emitter 配線側）。
+  - oe-jump 利用者 — `oe-jump <#N|%N>` / 無引数 replay で入力待ち子へ focus。
+- **follow-up routing**:
+  - 状態検出ベースの自動 `--record` + 通知発火 → **#P2 / agent-deck**（本 PR 外・issue「やらないこと」）。
+  - tmux クライアントをホストする wez ペイン非フォーカス時の前面化 → **#188 の未解決マッピング問題**（スコープ外・追わない）。
+  - wez(engine)ペインへの jump → **既存 `wez pane activate`**（oe-jump 責務外・追加実装なし）。
+  - 行き先なしの残課題は無し。
+- **status: stable / 達成度: 達成**（acceptance 3 点 — 1 アクション focus / ラベル未解決挙動明記 / shellcheck — を満たす。設計 SO/実装 SO/手動 idiom 実証で裏付け）。
+- **棄却した案**（決定と根拠）: wez 側に jump 追加（レイヤ違反）/ oe-send 拡張（verb semantics 濁す）/ oe-jump に wez 内包（`wez:N` の registry ラベル衝突・実装SO 反証）/ notify 4th フィールド + Lua クリック起動（クリックは url のみ・notify 不改変）。詳細は discussion DJ-A/B/E/E2。
+- **蒸留シグナル**: 昇格候補 = **なし**（PoC 的な 1 verb 追加。#188 の identity 設計は既存 decision doc にあり、本 episode は新規 Decision を生まない）。
+- **Step4（closure 外部チェック）辞退**: 理由 = 本 episode は全 SO ラウンド（design 3R / impl 4R）の verdict・reviewed_sha・指摘を逐次記録した透明な失敗ログで、選択的省略リスクが構造的に低い。覆った観点: 失敗の省略チェック（全 SO 指摘を記載）/ routing 網羅（上記・全件行き先付与）/ evidence anchor（verdict/SHA/audit_id を本文転記）/ back-propagation（design SO が検出した stale-claim を discussion frontmatter で是正済）。未実施観点と判断: なし（4 観点とも低リスクで充足）。
+
+## closure: PR
+
+- PR: [#207](https://github.com/stlwolf/ai-development-hub/pull/207)（self-complete・委譲子のためマージ/掃除はしない）。
+- Copilot ラウンド: 1 ラウンド実施。Copilot は COMMENTED レビュー（概要のみ・**generated no comments**=インライン指摘 0）。返信対象スレッド無し＝修正不要で round 完了（再リクエストはしない）。

--- a/projects/orchestration-engine/tests/test_oe_jump.sh
+++ b/projects/orchestration-engine/tests/test_oe_jump.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test_oe_jump.sh — oe-jump（tmux 専用）の解決 / focus 経路 / record-replay を検証する
+#
+# 実 tmux は起動せず PATH 先頭 mock に差し替える（test_oe_select.sh と同型）:
+#   - tmux: 全呼び出しを tmux.log に記録。list-panes は $MOCK_LIVE_PANES、display-message は
+#           $MOCK_TMUX_META を返す。switch-client/select-window/select-pane は引数を log に記録。
+#   - jq:   delegate-registry.sh が pane-issue から .name を引くため最小実装（test_oe_select と同じ）。
+#
+# oe-jump は BIN_DIR/../lib/delegate-registry.sh を source する。テスト用 bin/ に oe-jump を
+# コピーし、lib/ に実体を symlink して共有する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# mktemp 失敗時に空パスで継続して root 直下へ書き込む事故を防ぐ（実装SO 指摘）。
+_TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+[[ -n "$_TMP_DIR" && -d "$_TMP_DIR" ]] || { echo "FATAL: mktemp -d returned an invalid path: '${_TMP_DIR}'" >&2; exit 1; }
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/lib" "$_TMP_DIR/pathbin" "$_TMP_DIR/logs"
+
+cp "$PROJECT_DIR/bin/oe-jump" "$_TMP_DIR/bin/oe-jump"
+chmod +x "$_TMP_DIR/bin/oe-jump"
+ln -s "$PROJECT_DIR/lib/delegate-registry.sh" "$_TMP_DIR/lib/delegate-registry.sh"
+
+export OE_JUMP_TEST_LOG_DIR="$_TMP_DIR/logs"
+
+# mock tmux: 全呼び出しを tmux.log に記録。list-panes/display-message は固定出力を返す。
+cat > "$_TMP_DIR/pathbin/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OE_JUMP_TEST_LOG_DIR:?}/tmux.log"
+case "${1:-}" in
+  list-panes)
+    # shellcheck disable=SC2086
+    printf '%s\n' ${MOCK_LIVE_PANES:-} ;;
+  display-message)
+    printf '%s\n' "${MOCK_TMUX_META:-}" ;;
+  switch-client|select-window|select-pane) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$_TMP_DIR/pathbin/tmux"
+
+# mock jq: delegate-registry.sh は pane-issue/spawn JSON を jq で引く。
+# .name を含む filter かつ末尾引数がファイルならその "name" を返す（test_oe_select と同型）。
+cat > "$_TMP_DIR/pathbin/jq" <<'EOF'
+#!/usr/bin/env bash
+filter=""
+file=""
+for a in "$@"; do
+  case "$a" in
+    .name*|*'.name'*) filter="name" ;;
+  esac
+  file="$a"
+done
+if [[ "$filter" == "name" && -f "$file" ]]; then
+  sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file"
+  exit 0
+fi
+printf ''
+exit 0
+EOF
+chmod +x "$_TMP_DIR/pathbin/jq"
+
+# 隔離 state（delegate-registry.sh / oe-jump の record が参照）。
+export OE_DELEGATE_STATE_DIR; OE_DELEGATE_STATE_DIR="$_TMP_DIR/state"
+export OE_PANE_ISSUE_DIR;     OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
+export OE_JUMP_STATE_DIR;     OE_JUMP_STATE_DIR="$_TMP_DIR/oe-jump-state"
+mkdir -p "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+
+# 厳選 PATH: mock（pathbin）+ システム実体（awk/sed/grep/cat/printf/head）。実 tmux/jq は除外。
+export PATH="${_TMP_DIR}/pathbin:/usr/bin:/bin"
+export TMUX="/tmp/mock-tmux,12345,0"          # server pid = 12345（key 生成に使う）
+export TMUX_PANE="%1"                          # self
+# shellcheck disable=SC2016  # 意図的なリテラル $0（tmux session_id 表記・展開させない）
+export MOCK_TMUX_META='$0 @0'                  # display-message の固定メタ（session_id window_id）
+
+JUMP="$_TMP_DIR/bin/oe-jump"
+
+PASS=0
+FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (want='$expected' got='$actual')"; FAIL=$((FAIL + 1))
+  fi
+}
+reset_logs() { rm -f "$_TMP_DIR/logs/tmux.log"; }
+reset_record() { rm -rf "$OE_JUMP_STATE_DIR"; }
+tmux_log() { cat "$_TMP_DIR/logs/tmux.log" 2>/dev/null; }
+has_line() { printf '%s\n' "$1" | grep -qF -- "$2" && echo yes || echo no; }
+fixture_142() { printf '{"name":"#142"}\n' > "${OE_PANE_ISSUE_DIR}/12345__5"; }  # key 12345_%5
+rm_fixture_142() { rm -f "${OE_PANE_ISSUE_DIR}/12345__5"; }
+
+# ----------------------------------------------------------------------------
+# [1] %N 素通し → select-pane が %5 を対象に呼ばれる、exit 0
+# ----------------------------------------------------------------------------
+echo "[1] %5 素通し → tmux focus（select-pane -t %5）"
+export MOCK_LIVE_PANES="%1 %5 %7"
+reset_logs
+rc=0; "$JUMP" "%5" >/dev/null 2>&1 || rc=$?
+ck "rc=0" "0" "$rc"
+ck "select-pane -t %5 が呼ばれる" "yes" "$(has_line "$(tmux_log)" 'select-pane -t %5')"
+
+# ----------------------------------------------------------------------------
+# [2] tmux idiom: switch-client / select-window / select-pane が ID 系で全て呼ばれる
+# ----------------------------------------------------------------------------
+echo "[2] tmux idiom: switch-client/select-window/select-pane 全段（ID 系 target）"
+export MOCK_LIVE_PANES="%1 %5"
+reset_logs
+"$JUMP" "%5" >/dev/null 2>&1
+log="$(tmux_log)"
+# shellcheck disable=SC2016  # 'switch-client -t $0' は意図的リテラル（tmux session_id）
+ck "switch-client -t \$0" "yes" "$(has_line "$log" 'switch-client -t $0')"
+ck "select-window -t @0"  "yes" "$(has_line "$log" 'select-window -t @0')"
+ck "select-pane -t %5"    "yes" "$(has_line "$log" 'select-pane -t %5')"
+
+# ----------------------------------------------------------------------------
+# [3] ラベル #142 → pane-issue で %5 に解決 → select-pane -t %5
+# ----------------------------------------------------------------------------
+echo "[3] ラベル #142 → %5 解決 → select-pane -t %5"
+export MOCK_LIVE_PANES="%1 %5 %7"
+fixture_142
+reset_logs
+rc=0; "$JUMP" "#142" >/dev/null 2>&1 || rc=$?
+ck "rc=0" "0" "$rc"
+ck "select-pane -t %5（ラベル解決）" "yes" "$(has_line "$(tmux_log)" 'select-pane -t %5')"
+rm_fixture_142
+
+# ----------------------------------------------------------------------------
+# [4] 裸の整数 5 → wez 案内で拒否（exit 2）、focus は一切呼ばれない
+# ----------------------------------------------------------------------------
+echo "[4] 裸整数 5 → exit 2（wez 案内・focus なし）"
+export MOCK_LIVE_PANES="%1 %5"
+reset_logs
+rc=0; out="$("$JUMP" 5 2>&1)" || rc=$?
+ck "裸整数 → exit 2" "2" "$rc"
+ck "wez pane activate を案内" "yes" "$(has_line "$out" 'wez pane activate 5')"
+ck "tmux focus 呼ばれない" "no" "$([[ -e "$_TMP_DIR/logs/tmux.log" ]] && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [5] wez:5 → wez 案内で拒否（exit 2）、focus なし（registry ラベル衝突の silent 誤 focus を排除）
+# ----------------------------------------------------------------------------
+echo "[5] wez:5 → exit 2（wez 案内・silent 誤 focus を排除）"
+export MOCK_LIVE_PANES="%1 %5"
+reset_logs
+rc=0; out="$("$JUMP" "wez:5" 2>&1)" || rc=$?
+ck "wez:5 → exit 2" "2" "$rc"
+ck "wez pane activate 5 を案内" "yes" "$(has_line "$out" 'wez pane activate 5')"
+ck "focus 呼ばれない" "no" "$([[ -e "$_TMP_DIR/logs/tmux.log" ]] && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [6] --print %5 → stdout は解決した %5 のみ、focus コマンドは呼ばれない
+# ----------------------------------------------------------------------------
+echo "[6] --print %5 → stdout '%5'、focus なし"
+export MOCK_LIVE_PANES="%1 %5"
+reset_logs
+out="$("$JUMP" --print "%5" 2>/dev/null)"; rc=$?
+ck "rc=0" "0" "$rc"
+ck "stdout は '%5'" "%5" "$out"
+ck "focus（select-pane）は呼ばれない" "no" "$(has_line "$(tmux_log)" 'select-pane')"
+
+# ----------------------------------------------------------------------------
+# [7] ラベル未解決（#999・該当なし）→ exit 1
+# ----------------------------------------------------------------------------
+echo "[7] 未解決ラベル #999 → exit 1"
+export MOCK_LIVE_PANES="%1 %5"
+reset_logs
+rc=0; "$JUMP" "#999" >/dev/null 2>&1 || rc=$?
+ck "未解決ラベル → exit 1" "1" "$rc"
+
+# ----------------------------------------------------------------------------
+# [8] %N がライブに無い（%99）→ ペイン無し exit 1（存在確認で select-pane 前に停止）
+# ----------------------------------------------------------------------------
+echo "[8] %99 がライブに無い → exit 1"
+export MOCK_LIVE_PANES="%1 %5"
+reset_logs
+rc=0; "$JUMP" "%99" >/dev/null 2>&1 || rc=$?
+ck "ペイン無し → exit 1" "1" "$rc"
+ck "select-pane は呼ばれない" "no" "$(has_line "$(tmux_log)" 'select-pane')"
+
+# ----------------------------------------------------------------------------
+# [9] record → replay（無引数）: #142 を記録 → 無引数で %5 へ focus
+# ----------------------------------------------------------------------------
+echo "[9] --record #142 → 無引数 replay で select-pane -t %5"
+export MOCK_LIVE_PANES="%1 %5 %7"
+fixture_142
+reset_record; reset_logs
+rc=0; "$JUMP" --record "#142" >/dev/null 2>&1 || rc=$?
+ck "--record rc=0" "0" "$rc"
+ck "record はフォーカスしない（select-pane なし）" "no" "$(has_line "$(tmux_log)" 'select-pane')"
+ck "state file が書かれる" "yes" "$([[ -f "$OE_JUMP_STATE_DIR/last-target" ]] && echo yes || echo no)"
+reset_logs
+rc=0; "$JUMP" >/dev/null 2>&1 || rc=$?
+ck "無引数 replay rc=0" "0" "$rc"
+ck "replay で select-pane -t %5" "yes" "$(has_line "$(tmux_log)" 'select-pane -t %5')"
+rm_fixture_142
+
+# ----------------------------------------------------------------------------
+# [10] 無引数 + 記録なし → exit 1（replay 対象なし）
+# ----------------------------------------------------------------------------
+echo "[10] 無引数 + 記録なし → exit 1"
+export MOCK_LIVE_PANES="%1 %5"
+reset_record; reset_logs
+rc=0; "$JUMP" >/dev/null 2>&1 || rc=$?
+ck "replay 対象なし → exit 1" "1" "$rc"
+
+# ----------------------------------------------------------------------------
+# [11] --record 検証: 裸整数 → exit 2 / target なし → exit 2 / --print 併用 → exit 2
+# ----------------------------------------------------------------------------
+echo "[11] --record の検証（裸整数 / target 欠如 / --print 併用）→ exit 2"
+reset_record
+rc=0; "$JUMP" --record 5 >/dev/null 2>&1 || rc=$?
+ck "--record 裸整数 → exit 2" "2" "$rc"
+ck "拒否時 state は書かれない" "no" "$([[ -f "$OE_JUMP_STATE_DIR/last-target" ]] && echo yes || echo no)"
+rc=0; "$JUMP" --record >/dev/null 2>&1 || rc=$?
+ck "--record target 欠如 → exit 2" "2" "$rc"
+rc=0; "$JUMP" --record --print "%5" >/dev/null 2>&1 || rc=$?
+ck "--record + --print → exit 2" "2" "$rc"
+
+# ----------------------------------------------------------------------------
+# [12] --record はラベルを「解決せず」形だけ検証（実装SO 反映・回帰）。
+#      ライブペイン無し/解決不能でも label token を記録できる（解決は jump 時）。
+# ----------------------------------------------------------------------------
+echo "[12] --record #179（解決不能でも記録できる・shape のみ検証）"
+export MOCK_LIVE_PANES=""          # ライブペイン無し → 解決すれば失敗するはず
+reset_record; reset_logs
+rc=0; "$JUMP" --record "#179" >/dev/null 2>&1 || rc=$?
+ck "未解決ラベルでも --record は成功" "0" "$rc"
+ck "記録した token は '#179'" "#179" "$(head -n1 "$OE_JUMP_STATE_DIR/last-target" 2>/dev/null)"
+ck "record は解決(list-panes)を呼ばない" "no" "$([[ -e "$_TMP_DIR/logs/tmux.log" ]] && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [13] too many args → exit 2 / unknown option → exit 2 / --help → exit 0
+# ----------------------------------------------------------------------------
+echo "[13] too many / unknown option / --help"
+export MOCK_LIVE_PANES="%1 %5 %7"
+rc=0; "$JUMP" "%5" "%7" >/dev/null 2>&1 || rc=$?
+ck "too many args → exit 2" "2" "$rc"
+rc=0; "$JUMP" --bogus >/dev/null 2>&1 || rc=$?
+ck "unknown option → exit 2" "2" "$rc"
+rc=0; "$JUMP" --help >/dev/null 2>&1 || rc=$?
+ck "--help → exit 0" "0" "$rc"
+
+# ----------------------------------------------------------------------------
+# [14] 明示の空文字 target は「省略」と取り違えず拒否する（実装SO R3 反映・回帰）。
+#      記録があっても replay へ落とさない / 空文字後の余剰引数を黙って捨てない。
+# ----------------------------------------------------------------------------
+echo "[14] 明示空文字 target → replay せず exit 2（parser 回帰）"
+export MOCK_LIVE_PANES="%1 %5"
+reset_record; reset_logs
+"$JUMP" --record "%5" >/dev/null 2>&1     # 記録を仕込む（replay 候補あり）
+reset_logs
+rc=0; "$JUMP" "" >/dev/null 2>&1 || rc=$?
+ck "明示空文字 → exit 2（replay しない）" "2" "$rc"
+ck "focus（select-pane）は呼ばれない" "no" "$(has_line "$(tmux_log)" 'select-pane')"
+reset_logs
+rc=0; "$JUMP" "" "%5" >/dev/null 2>&1 || rc=$?
+ck "空文字 + 余剰引数 → exit 2（黙って捨てない）" "2" "$rc"
+reset_record
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 概要

`wez notify` の通知から、入力待ちの子ペインへ**ワンアクションで focus（activate）**する導線 `oe-jump` を追加する。通知 → ラベル解決 → focus を束ねる。子エージェントが入力待ちになったときの人間介入を速くするのが動機。

Refs #179 / 関連 #188（2 基盤の identity 分裂）

## 前提（#188・一次情報で確認済み）

2 基盤は別 identity 空間: engine `oe`=**wez 整数** pane_id / delegate（対話子）=**tmux `%N`**。`oe_reg_resolve` はラベル（`#N`/名前）を **tmux `%N`** に解決する（wez 整数は返さない）。tmux 子に `wez pane activate` を投げると整数部を wez pane と誤解釈して別ペインへ飛ぶ — これを回避する（kickoff の #188 ガイダンス）。

## 設計上の判断（⚠️ %32 へ要報告: issue 原文からの shape 変更）

issue 原文は「ラベル解決 → `wez pane activate` の束ね」だが、本 PR の `oe-jump` は **tmux substrate 専用**にした:

- `oe_reg_resolve` の解決結果は常に tmux `%N`。よって focus も tmux 経路（`select-pane` 系）に固定し、`wez pane activate` 誤投を**構造的に排除**（kickoff の #188 懸念を満たす）。
- wez（engine）ペインの focus は**既存の `wez pane activate <id>`** に委ねる（oe-jump の責務外）。kickoff の「経路を分けるか、対象を明示する」は「oe-jump=tmux / wez=wez pane activate」のツール境界明示で満たす。
- 当初は oe-jump 内で wez も扱う設計（`wez:N` トークン）だったが、**実装SO が「`wez:N` が registry ラベル `wez:N` と衝突し silent 誤 focus し得る」と反証** → wez focus は既存ツールで足り #179 主用途（入力待ち=tmux 子）に不要なため、Minimal Scope に基づき除去（衝突クラスを構造的に消去）。

## 変更内容

- `projects/orchestration-engine/bin/oe-jump`（新規）: target を解決して tmux ペインへ focus。
  - `%N` … tmux ペイン（素通し）→ `tmux switch-client`(session_id) → `select-window`(window_id) → `select-pane`(pane_id)
  - `#N` / 名前 … ラベル（`oe_reg_resolve` で tmux `%N` に解決）→ 同上
  - 裸の整数 / `wez:N` … wez ペイン指しとみなし**拒否**し、`%N`(tmux) か `wez pane activate N`(wez) を案内（silent 誤 focus を出さない）
  - `--record <target>` … target を state（`~/.claude/state/oe-jump/last-target`）に記録（**形のみ検証・解決は jump 時**）。無引数 `oe-jump` が直近 record を replay ＝**真の 1 アクション**
  - `--print` … 解決した `%N` を出すだけ（dry-run）
- `projects/orchestration-engine/tests/test_oe_jump.sh`（新規）: 実 tmux/jq を PATH mock し、解決 / focus 経路（idiom 全段）/ record-replay / 各 exit code / 裸整数・wez:N 拒否を検証（**35 アサーション**・`test_oe_select.sh` と同型）。
- `projects/orchestration-engine/bin/README.md`: `oe-jump` 節 + env を追記。
- `docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md` / `docs/episodes/2026-06-21-episode-179-notify-pane-jump.md`: 設計判断・探索証跡・SO ラウンド・実行記録。

## scope ↔ acceptance

- scope1（通知に target を紐づける規約）→ `--record` / 無引数 replay。記録した token をそのまま解決＝「トースト表示文字列」と「解決契約」がズレない。
- scope2（notify → resolve → activate の束ね）→ `oe-jump` 本体（tmux 経路）。
- scope3（クリック起動可否の検証）→ **不可**（WezTerm のトーストはクリックで url を開くのみ・任意コマンド非対応。[公式 doc](https://wezterm.org/config/lua/window/toast_notification.html) + ローカル handler で確認）→ コマンド経由 focus（issue の「コマンド経由フォールバック」）。
- acceptance「1 アクションで focus」→ 無引数 `oe-jump`（replay） / ラベル未解決時 → exit 1 + `oe-list` 案内 / `shellcheck` PASS。

## やらないこと（スコープ境界）

- 状態検出に基づく**自動通知発火** → #P2（観測）/ agent-deck の領域。本 PR は「紐づける規約＋飛ぶ導線」を提供し、撃つ主体は将来 or 手動。
- `wez notify` / Lua ハンドラの**作り替え**はしない（record は別 state・notify に相乗りしない）。
- wez（engine）ペインの focus は oe-jump で扱わない（既存 `wez pane activate <id>`）。

## 検証

- `shellcheck`: bin / test とも PASS。
- ユニットテスト: `bash projects/orchestration-engine/tests/test_oe_jump.sh` → **35/35 PASS**。
- tmux focus idiom: 隔離 tmux サーバ（`tmux -L`）で cross-window focus を実証（非アクティブ window のペインを対象に session の active window と active pane が対象へ遷移）。`switch-client` はクライアント未接続時 `no current client` だが `|| true` で非致命。
- 設計SO（`oe-refute --rubric exploration`・3R）: substrate 分岐の方向性は全 R 是認。material gap（idiom 未検証 / 裸整数衝突 / emitter 未接続 / 表示ラベルと解決契約のズレ / parent スコープ）を反映。
- 実装SO（`oe-review`・diff-bound・impl レンズ・**4 ラウンド**）: R1=`--record` の eager 解決を検出→形検証分離。R2=test の mktemp 無ガード + `wez:N` 衝突を検出→mktemp ガード + wez 除去（tmux 専用化）。R3=明示空文字 target が replay へ誤フォールスルー→`$#` ベースの引数判定に修正。**R4=survived 2/2**（codex/cursor とも material 欠陥なし）。各ラウンドの指摘・verdict・reviewed_sha は episode に記録。

## 既知制約

- spawn-registry の任意名ラベルは spawn した親ペインからのみ解決可（`oe_reg_resolve` の parent スコープ）。pane-issue ラベル（`#N`）と `%N` 直接トークンはスコープ非依存。主用途（人間が spawn 親で受信→飛ぶ）では成立。
- tmux クライアントをホストする wez ペイン自体が非フォーカスのケースは tmux 層だけでは前面化しない（wez↔tmux マッピングは #188 の未解決問題・スコープ外）。

## follow-up（本 PR 外）

- 状態検出に基づく自動 `--record` + 通知発火（#P2 / agent-deck）。
