### PR TITLE
fix(oe): oe-delegate の split を親ペイン基準にする

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -85,6 +85,7 @@ oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg 
 - `--label <#N|name>` … registry 登録ラベル（後で `oe-send <label>` で指す）
 - `--claude-arg <arg>` … 子 Claude 起動時に追加引数を渡す（repeatable）。例: `--claude-arg --permission-mode --claude-arg auto`
 - tmux 内必須（`TMUX_PANE` から親ペイン取得、`PARENT_TMUX_PANE` を子へ継承）
+- 子ペインは**親ペイン基準で split** する（`tmux split-window -t "$TMUX_PANE"`）。親が別ウィンドウを active にしている間に委譲しても、子は親のウィンドウに生える（`-d` は focus 移動の抑止のみ・#203）
 
 関連 lib: `delegate-registry.sh`（キック注入は `oe-send` 経由）
 
@@ -209,6 +210,7 @@ oe-status -h | --help
 | `OE_SEND_ENTER_DELAY` | 送信: リテラル送信 → Enter の小休止（秒） | `0.3` |
 | `OE_SEND_FINALIZE` | 送信後 finalize の有効/無効（`0` で無効） | 有効 |
 | `OE_SEND_FINALIZE_TIMEOUT` / `_INTERVAL` / `_STABLE` | finalize の settle 窓 / poll 間隔 / 終端安定回数 | `3` / `0.3` / `3` |
+| `OE_SEND_SIGNAL_MISS` | oe-send: 未着候補（stage miss）検出時に rc4 へ昇格し手動フォールバックを表示（opt-in） | 無効（`0`） |
 | `OE_DELEGATE_WAIT_SEC` | oe-delegate: 子 claude 起動待ち（秒） | `4` |
 | `PARENT_TMUX_PANE` | oe-delegate が子へ渡す親ペイン（戻し用） | （自動） |
 | `OE_JUMP_STATE_DIR` | oe-jump: `--record`/replay の state 置き場 | `~/.claude/state/oe-jump` |

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -129,9 +129,12 @@ build_child_command() {
   printf '%s\n' "$cmd"
 }
 
-# 子ペインを作成し claude を起動（PARENT_TMUX_PANE を env として渡す）
+# 子ペインを作成し claude を起動（PARENT_TMUX_PANE を env として渡す）。
+# split は親ペイン（$PARENT_PANE = oe-delegate を起動した pane）を -t で明示する。-t を省くと
+# tmux はフォーカス中ペインを分割するため、親が別ウィンドウを active にしている間に委譲すると
+# 子が無関係なウィンドウに生える（#203）。-d は focus 移動の抑止で、生える「場所」は -t が決める。
 CHILD_COMMAND="$(build_child_command)"
-CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -c "$WORKSPACE" "$CHILD_COMMAND")"
+CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -t "$PARENT_PANE" -c "$WORKSPACE" "$CHILD_COMMAND")"
 echo "oe-delegate: child pane ${CHILD_PANE} started (parent: ${PARENT_PANE}, workspace: ${WORKSPACE})" >&2
 
 # claude 起動待ち

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-203-oe-delegate-parent-pane-split.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-203-oe-delegate-parent-pane-split.md
@@ -1,0 +1,70 @@
+---
+id: 01KVM14NA3H55B82AHDA07P29S
+title: "#203 oe-delegate の split を親ペイン基準にする実装エピソード"
+date: 2026-06-21
+type: episode
+status: stable
+related:
+  - type: implements
+    ref: "#203"
+  - type: relates_to
+    ref: "#174"
+  - type: parent
+    ref: "#169"
+---
+
+# #203 oe-delegate の split を親ペイン基準にする実装エピソード
+
+> リアルタイム追記（reconstructed ではない）。cockpit 統括セッション（`%32`）が WORKTREE
+> `fix/#203_oe_delegate_parent_pane_split` で直接実装（委譲なし・最小修正）。
+
+## コンテキスト / 動機
+
+`oe-delegate` で子ペインを起動すると、親がいるウィンドウではなく **その時フォーカスが当たっている
+ウィンドウ**に新規ペインが生えていた。複数ウィンドウ運用（例: 2 番目のウィンドウの 2nd pane に親）で、
+親が別ウィンドウを active にしている間に委譲すると子が無関係なウィンドウに散り、人間が追えない。
+
+## 根本原因（一次確認）
+
+- `bin/oe-delegate:91` で親ペインを `PARENT_PANE="${TMUX_PANE:-}"` として捕捉・`:92` で非空検証済み。
+- だが `:134` の `tmux split-window` に **`-t "$PARENT_PANE"` を渡していなかった** → `split-window` は
+  既定で **アクティブ（フォーカス中）ペイン**を分割する。`-d` はフォーカス移動の抑止だけで、生える
+  「場所」は `-t` が決める（無ければ active 基準）。
+
+## 修正（最小・scope (a)）
+
+`bin/oe-delegate:134` に `-t "$PARENT_PANE"` を追加（1 トークン）。`PARENT_PANE` は `:92` で検証済みのため
+追加ガード不要。理由はインラインコメントに明記。
+
+```bash
+CHILD_PANE="$(tmux split-window -d -P -F "#{pane_id}" -t "$PARENT_PANE" -c "$WORKSPACE" "$CHILD_COMMAND")"
+```
+
+scope (b)（`#174` 同様の `--target self/parent-window/explicit` を delegate 経路にも持たせる）は
+**過剰のため見送り**（issue 既定）。`oe-kick`（`#178`）は `oe-delegate` の薄いラッパーで同経路 → 自動で恩恵。
+
+## 検証
+
+- `test_oe_delegate.sh` 拡張: mock tmux が `split-window` の**全 argv** を `split-argv.log` に記録するよう追加
+  （従来は最終引数=子コマンドのみ）。新テスト [11] で `-t %1`（親ペイン）が argv に含まれること + 子コマンド
+  文字列が非破壊であることをアサート。**fix が無ければ [11] は落ちる実ガード**。
+- shellcheck: `oe-delegate` / `test_oe_delegate.sh` ともに rc=0。
+- テスト: **bash 3.2.57 / 5.2.37 で 20/20 PASS**（新規 [11] 含む・既存非破壊）。
+
+## 同 PR に相乗りした doc 衛生（ユーザー承認）
+
+bin README 乖離チェック（read-only 監査）で見つかった唯一の実質ギャップ:
+- 環境変数表に `OE_SEND_SIGNAL_MISS` が欠落（oe-send の rc4 手動フォールバック分岐がこの変数依存）。
+  `delegate-send.sh:210`（既定 `0`・opt-in）/ `oe-send:76-80`（rc4→手動フォールバック表示）を一次確認のうえ
+  表へ 1 行追加。あわせて oe-delegate 項に親ペイン targeting の挙動を 1 行追記。
+- nits（oe-refute usage の `[--]` 省略 / README:45 の「so-compare 生出力」語）は見送り。
+
+## closure
+
+- status: `stable`。consumer = oe-delegate / oe-kick 利用者（委譲時の子ペイン位置）。
+- 実装SO（oe-review）は **スキップ**（ユーザー判断）: 既検証済み変数を既存フラグに渡す 1 トークン追加で
+  欠陥面がほぼゼロ・実挙動は mock テストが担保（Minimal Scope）。
+- tier: light（mock テスト + shellcheck + bash 両対応で十分）。
+- Decision 昇格: **なし**。`#174` の targeting 原則（split は親基準）の delegate 経路への適用に過ぎず、新しい
+  設計決定ではない。ADR 化の蒸留シグナル無し。
+- routing: 親（`%32`）が直接実装 → PR → Copilot レビューで締め。

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 log_dir="${OE_DELEGATE_TEST_LOG_DIR:?}"
 
 if [[ "${1:-}" == "split-window" ]]; then
+  # 全 argv も記録する（targeting=-t の検証用 #203）。最終引数=子コマンドは split-command.log へ。
+  printf '%s\n' "$*" >> "${log_dir}/split-argv.log"
   last=""
   while [[ $# -gt 0 ]]; do
     last="$1"
@@ -147,6 +149,14 @@ rc=0
 bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --label $'bad\rlabel' "task" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
 ck "CR label rc=2" "2" "$rc"
 ck "CR label does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[11] split-window targets the parent pane (#203)"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --label "#152" "target task"
+# TMUX_PANE=%1（親）。split-window argv に親ペイン基準 -t %1 が含まれること（フォーカス中ペイン
+# ではなく親ペインを分割する）。子コマンド内の PARENT_TMUX_PANE='%1' とは別トークン（-t %1 で照合）。
+ck "split-window includes -t parent pane" "yes" "$(grep -q -- '-t %1' "$_TMP_DIR/logs/split-argv.log" && echo yes || echo no)"
+ck "split child command unchanged" "PARENT_TMUX_PANE='%1' claude" "$(cat "$_TMP_DIR/logs/split-command.log")"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -19,8 +19,9 @@ set -euo pipefail
 log_dir="${OE_DELEGATE_TEST_LOG_DIR:?}"
 
 if [[ "${1:-}" == "split-window" ]]; then
-  # 全 argv も記録する（targeting=-t の検証用 #203）。最終引数=子コマンドは split-command.log へ。
-  printf '%s\n' "$*" >> "${log_dir}/split-argv.log"
+  # 全 argv を 1 行 1 引数で記録する（targeting=-t の順序検証用 #203）。"$*" は argv を 1 文字列に
+  # 結合し境界/クォートを失うため "$@" で 1 引数ずつ出す。最終引数=子コマンドは split-command.log へ。
+  printf '%s\n' "$@" >> "${log_dir}/split-argv.log"
   last=""
   while [[ $# -gt 0 ]]; do
     last="$1"
@@ -153,9 +154,9 @@ ck "CR label does not split" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]
 echo "[11] split-window targets the parent pane (#203)"
 reset_logs
 run_delegate -w "$_TMP_DIR/ws" --label "#152" "target task"
-# TMUX_PANE=%1（親）。split-window argv に親ペイン基準 -t %1 が含まれること（フォーカス中ペイン
-# ではなく親ペインを分割する）。子コマンド内の PARENT_TMUX_PANE='%1' とは別トークン（-t %1 で照合）。
-ck "split-window includes -t parent pane" "yes" "$(grep -q -- '-t %1' "$_TMP_DIR/logs/split-argv.log" && echo yes || echo no)"
+# split-argv.log は 1 行 1 引数。-t の直後の引数が %1（親=TMUX_PANE）であることを順序込みで検証する
+# （フォーカス中ペインではなく親ペインを分割する）。子コマンド内の PARENT_TMUX_PANE='%1' と混同しない。
+ck "split-window -t targets parent pane" "%1" "$(awk '/^-t$/{getline; print; exit}' "$_TMP_DIR/logs/split-argv.log")"
 ck "split child command unchanged" "PARENT_TMUX_PANE='%1' claude" "$(cat "$_TMP_DIR/logs/split-command.log")"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="


### PR DESCRIPTION
## 目的

`oe-delegate` で子ペインを起動するとき、**その時フォーカス中のウィンドウ**ではなく**親ペイン基準**で split するように修正する（Refs #203）。

## 背景 / 根本原因

複数ウィンドウ運用（例: 2 番目のウィンドウの 2nd pane に親）で、親が別ウィンドウを active にしている間に委譲すると、子ペインが無関係なウィンドウに生えて人間が追えなかった。

- `bin/oe-delegate:91` で親ペインを `PARENT_PANE="${TMUX_PANE:-}"` として捕捉・`:92` で非空検証済み。
- だが `:134` の `tmux split-window` に `-t "$PARENT_PANE"` を渡していなかった → `split-window` は既定で **アクティブ（フォーカス中）ペイン**を分割する。`-d` はフォーカス移動の抑止だけで、生える「場所」は `-t` が決める。

## 変更内容

- `bin/oe-delegate:134` に `-t "$PARENT_PANE"` を追加（1 トークン・`PARENT_PANE` は検証済みのため追加ガード不要）。理由はインラインコメントに明記。
- `tests/test_oe_delegate.sh`: mock tmux が `split-window` の**全 argv** を `split-argv.log` に記録するよう拡張（従来は最終引数=子コマンドのみ）。新テスト `[11]` で `-t %1`（親ペイン）が argv に含まれること + 子コマンド文字列が非破壊であることをアサート。**fix が無ければ `[11]` は落ちる実ガード**。
- `docs/episodes/2026-06-21-episode-203-...md`: 実装エピソード（リアルタイム追記）。

### あわせて: bin README 乖離の是正（doc 衛生・同 PR 相乗り）

read-only 監査で見つかった唯一の実質ギャップを是正:
- 環境変数表に `OE_SEND_SIGNAL_MISS` を追加（oe-send の rc4 手動フォールバック分岐がこの変数依存。`delegate-send.sh:210` 既定 `0`・opt-in / `oe-send:76-80` rc4→表示 を一次確認）。
- `oe-delegate` 項に親ペイン targeting の挙動を 1 行追記。

## 検証

- `shellcheck`: `oe-delegate` / `test_oe_delegate.sh` ともに rc=0。
- テスト: **bash 3.2.57 / 5.2.37 で 20/20 PASS**（新規 `[11]` 含む・既存非破壊）。

## スコープ外（見送り）

- #174 同様の `--target self/parent-window/explicit` を delegate 経路にも持たせる案（issue scope (b)）は過剰のため見送り（最小 scope (a) のみ）。`oe-kick`（#178）は同経路ラッパーで自動恩恵。

Refs #169, #174, #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
