### PR TITLE
feat(oe): add oe-ident for read-time pane identity on tmux border

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -6,7 +6,7 @@ scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
 - **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report` / `oe-jump`（通知→ペインへ focus）
-- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰）
+- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影）
 
 ---
 
@@ -200,6 +200,31 @@ oe-status -h | --help
 - データ源は `OE_DATA_DIR`（または `OE_AUDIT_DIR` / `OE_STATE_DIR`）で上書き可。
 
 設計の正本: [`../docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md`](../docs/discussions/2026-06-19-discussion-cockpit-observation-ui.md) §8 / [`../docs/decisions/2026-06-19-decision-188-identity-unification.md`](../docs/decisions/2026-06-19-decision-188-identity-unification.md)。関連 lib: `delegate-registry.sh`（`oe_reg_list`）。
+
+## oe-ident — ペインの識別子を read 時に投影（#202）
+
+`pane-border-format` の `#()` から呼ばれ、指定ペインの**オーケストレーション識別子**を 1 行で返す read-only 表示用ヘルパ。`@oe_id` のような stored 状態を作らず、既存ソース（pane-issue / spawn-registry）を**読み取り時に投影**する（#188 の read 時相関・永続マップ不採用に整合・新規 write path 無し）。`oe_reg_list` / `oe_reg_resolve` の宛先解決契約には一切触れない。
+
+```bash
+oe-ident <pane_id> [server_pid]
+```
+
+- `<pane_id>` … 対象ペイン `%N`。不正/欠落でも **空出力・exit 0**（border を壊さない）
+- `[server_pid]` … state キーの名前空間（tmux server pid）。省略時は `$TMUX` から導出。`#()` で TMUX env 不在に備え `#{pid}` を明示渡しできる
+- 出力 `<role> <label>`: `role`=`parent`（子を spawn した）/`child`（自身が被 spawn）は spawn 関係がある時のみ前置。`label`=pane-issue の `#N slug` 優先 → spawn registry の label。識別情報の無いペインは **空行**（honest）
+- 例: `parent #202 pane-identity` / `child #179` / `#204 toolkit`（spawn 関係なし） / （空）
+
+**表示の有効化は dotfiles 側で opt-in**（hub は強制しない・責務境界）。推奨スニペット（`~/.tmux.conf` 等）:
+
+```tmux
+set -g pane-border-status top
+set -g pane-border-format '#[align=left] #(/path/to/repo/projects/orchestration-engine/bin/oe-ident #{pane_id} #{pid}) '
+```
+
+- `#()` は tmux が**非同期実行しキャッシュ**（初回空・以降 `status-interval` 毎に更新）＝表示用途で問題なし。コマンドは小ファイル読みのみで高速。
+- pane_title（Claude セッション名が書く所）は**無傷**＝二重 writer の奪い合いが起きない。
+
+関連 lib: `delegate-registry.sh`（`_oe_reg_key` / pane-issue・spawn-registry の読取を共有）。設計経緯: [`../docs/discussions/2026-06-21-discussion-202-pane-identity.md`](../docs/discussions/2026-06-21-discussion-202-pane-identity.md)。
 
 ---
 

--- a/projects/orchestration-engine/bin/oe-ident
+++ b/projects/orchestration-engine/bin/oe-ident
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# oe-ident — 指定 tmux ペインの「オーケストレーション識別子」を 1 行で返す read-only 表示用ヘルパ（#202 / c″）。
+#
+# pane-border-format の #() から呼ばれ、既存ソース（pane-issue / spawn-registry）を
+# **読み取り時に投影**する。新規 write path を持たない＝#188（read 時相関・永続マップ不採用）に整合。
+# `@oe_id` のような stored 状態を作らないので lifecycle/stale 問題が無く、oe_reg_list/oe_reg_resolve
+# の宛先解決契約にも一切触れない（read 専用・別経路）。
+#
+# usage: oe-ident <pane_id> [server_pid]
+#   <pane_id>     対象ペイン %N。不正/欠落でも border を壊さないよう空出力・exit 0。
+#   [server_pid]  state キーの名前空間（tmux server pid）。省略時は $TMUX から導出。
+#                 tmux の #() は env に TMUX を入れる実測だが、非同期実行の残存不確実性に備え
+#                 pane-border-format 側から #{pid} を明示渡しできる（TMUX 不在でも解決可能）。
+#
+#   出力: "<role> <label>"（role=parent/child は spawn 関係がある時のみ前置 / label=#N slug 等）。
+#         識別情報の無いペインは空行（honest — 無い物を捏造しない）。常に exit 0（表示用途）。
+#
+#   role 導出（registry 読取のみ・書込なし）:
+#     parent = この pane を parent_pane に持つ子 entry が在る（＝子を spawn した）
+#     child  = この pane 自身の spawn entry が在る（oe_reg_record が role:"child" で記録）
+#     （両方なら parent を優先）
+#
+# 例: parent #202 pane-identity / child #179 / #204 toolkit（spawn 関係なし=role 無し） / （空）
+
+set -uo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/delegate-registry.sh
+source "${BIN_DIR}/../lib/delegate-registry.sh"
+
+PANE="${1:-}"
+PID_OVERRIDE="${2:-}"
+
+# 表示用途: 不正引数でも border を壊さない（空出力・exit 0）
+[[ "$PANE" =~ ^%[0-9]+$ ]] || exit 0
+# jq 無し環境では識別子を出さない（border は空で描画継続）
+command -v jq >/dev/null 2>&1 || exit 0
+
+# state キーの namespace（server pid）。明示引数を優先し、無ければ $TMUX から。
+if [[ -n "$PID_OVERRIDE" ]]; then
+  pid="$PID_OVERRIDE"
+  key="$(TMUX="oe,${PID_OVERRIDE},0" _oe_reg_key "$PANE")"
+else
+  pid="$(_oe_reg_server_pid)"
+  key="$(_oe_reg_key "$PANE")"
+fi
+
+# --- label: pane-issue(.name) 優先 → spawn-registry(.label) ---
+label=""
+if [[ -f "${OE_PANE_ISSUE_DIR}/${key}" ]]; then
+  label="$(jq -r '.name // empty' "${OE_PANE_ISSUE_DIR}/${key}" 2>/dev/null)"
+fi
+own="${OE_DELEGATE_STATE_DIR}/${key}.json"
+is_child=0
+if [[ -f "$own" ]]; then
+  is_child=1
+  [[ -z "$label" ]] && label="$(jq -r '.label // empty' "$own" 2>/dev/null)"
+fi
+
+# --- role: 子を持つ(parent) > 自分が子(child) > なし ---
+# 現サーバ（pid）の子 entry だけを走査（別サーバの stale で pane-id 衝突しても誤検知しない）。
+# grep -F で per-file jq を避ける（#() の hot path・oe_reg_record の compact JSON は形が安定）。
+is_parent=0
+if [[ -n "$pid" ]] && grep -lF "\"parent_pane\":\"${PANE}\"" "${OE_DELEGATE_STATE_DIR}/${pid}"_*.json >/dev/null 2>&1; then
+  is_parent=1
+fi
+role=""
+if [[ "$is_parent" -eq 1 ]]; then
+  role="parent"
+elif [[ "$is_child" -eq 1 ]]; then
+  role="child"
+fi
+
+# --- 出力（role があれば前置・改行は畳む・honest に空なら空行）---
+label="${label//$'\n'/ }"
+label="${label//$'\r'/ }"
+if [[ -n "$role" && -n "$label" ]]; then
+  out="${role} ${label}"
+elif [[ -n "$role" ]]; then
+  out="$role"
+elif [[ -n "$label" ]]; then
+  out="$label"
+else
+  out=""
+fi
+printf '%s\n' "$out"
+exit 0

--- a/projects/orchestration-engine/docs/discussions/2026-06-21-discussion-202-pane-identity.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-21-discussion-202-pane-identity.md
@@ -1,0 +1,79 @@
+---
+id: 01KVMR8ZV8R2T2E4XQWJYQ7JWX
+title: "#202 人間可読なペイン識別 — 設計探索（c′ 反証 → c″ read-time ambient へピボット）"
+date: 2026-06-21
+type: discussion
+status: stable
+related:
+  - type: implements
+    ref: "#202"
+  - type: depends_on
+    ref: "#188"
+  - type: parent
+    ref: "#169"
+---
+
+# #202 人間可読なペイン識別 — 設計探索
+
+## 問題
+
+multi-session オーケストレーション（親=統括 / 子=delegate / peer）で、人間が tmux UI を見て **どのペインがどのセッション/role か区別できない**。一貫した `#issue slug` タイトルが付くのは `wt switch` 済みの Claude ペインだけで、素ペインは hostname に劣化、delegate 子は pane-title ノイズ、role 次元（parent/child/peer）はどこにも出ない。詳細な現状棚卸しは調査で file:line 付きで実施（`delegate-registry.sh:140-154` の 3 ソース・親スコープ等）。
+
+## 探索した選択肢
+
+- (a) session-name.sh / wt-pane-issue を wt-switch 非依存化し pane_title に role 折込（mutating・engine 子に届かず・session-name と二重 writer）
+- (b) read-time `session-map` コマンド（完全 read-only・pull 型・glance を直さない）
+- (c) spawn 時に pane_title を直接 set（pane_title 奪い合い）
+- (c′) `@oe_id`（tmux カスタムペインオプション）に stored 識別子を書き pane-border に表示（pane_title を汚さない ambient）
+- (d) ハイブリッド
+
+当初 (c′) を「主軸」候補とした（pane_title を奪わず ambient に出せることを tmux 3.5a 隔離サーバで実証）。
+
+## 設計SO（oe-refute --rubric exploration・3 レーン codex/claude/cursor）
+
+(c′) を claim として反証 → **3/3 refuted**（audit `202606210816320B6ZZ7CP9ZWX`）。主要な指摘:
+
+- **#188 思想との不整合**: #188 は「read 時相関・永続マップ不採用」（DJ-188-3）。stored `@oe_id` はその grain に逆らう。
+  - 一次照合（SO 主張を鵜呑みにせず確認）: #188 DJ-188-5 は「read-only は**観測者**を縛る制約・producer 書込は対象外・**本決定は新規 write path を導入しない**」。→ c′ の書込は #188 が**禁じてはいない**が、思想（read 時投影）には**逆らう**。SO の「逆走」は言い過ぎだが方向（read-time がより整合）は正しい。
+- **未検証前提**: `@oe_id` の永続性（pane 再利用/分割/copy-mode）・`--auto` role 自動導出。
+- **registry 契約への波及**: `oe_reg_list` に `@oe_id` を足すと oe-send targeting の parent-scope 封じ込めを壊す / stale 上書き事故。
+- **未探索カテゴリ**: `pane-border-format` の `#(shell-command)` で**表示時に既存ソースから計算**（＝書込なしの read-time ambient）。(b) read マップも未比較。
+
+## ピボット: c″ — read-time ambient
+
+SO が浮かせた `#()` 表示時計算カテゴリへ主軸を移す:
+
+- 新 read-only コマンド `oe-ident <pane> [server_pid]` が pane-issue / spawn-registry を読み role 込みの識別子を 1 行返す。
+- 表示は `pane-border-format '#(.../oe-ident #{pane_id} #{pid})'`（dotfiles opt-in・hub は doc のみ）。
+- **新規 write path ゼロ**（#188 read 時相関と同型・grain に沿う）。`@oe_id` の永続性/stale 問題が消える。`oe_reg_list`/`oe_reg_resolve` を改変しない → **SO 指摘の resolve 契約破壊リスクも構造的に解消**。
+
+これにより SO の 4 指摘（#188 不整合 / 未検証 stored 状態 / resolve 契約 / 未探索 read-time）が同時に解消。`exhaustion-before-conclusion` の所期どおり、設計SO が確定前に write-path 案の落とし穴と優位な代替を捕捉した。
+
+## tmux `#()` 実機検証（前提を組む前に確認）
+
+隔離 tmux 3.5a で確認:
+
+- 素のフォーマット変数 `#{pane_id} #{pid}` は展開される（`%0 55793`）[verified]。
+- コマンド引数内でも展開され、env に `TMUX` がセットされる（pid 一致）[verified・run-shell 経由]。
+- `#()` は **非同期/キャッシュ実行**（初回空・以降 `status-interval` 毎更新）[verified・display-message では同期発火せず空]。
+
+→ 表示用途では非同期キャッシュで問題なし。`#()` 環境の残存不確実性（async で直接 probe 不可）に備え、**`#{pid}` を明示引数で渡せる設計**にし TMUX 不在でも解決可能にした（防御）。
+
+## 決めたこと
+
+- 主軸 = c″（read-time ambient）。`oe-ident` を新規追加。
+- role 導出（read のみ）: parent=この pane を parent_pane に持つ子 entry が在る / child=自身の spawn entry が在る / 両方なら parent 優先。
+- label: pane-issue(`.name`) 優先 → spawn-registry(`.label`)。無ければ空（honest）。
+- 表示有効化は dotfiles 責務（hub は推奨スニペットを bin/README に明記）。
+
+## やらない / defer
+
+- (b) read-time マップコマンド: follow-up（`oe-ident` の読取ロジックを後で共有可）。
+- engine wez 子の human 識別: #188 トポロジで tmux 不可視 → 本 issue は **delegate/tmux 基盤**の識別に限定。
+- 素の非エージェントペイン: ソースが無ければ空表示（捏造しない）。
+
+## 参照
+
+- 設計SO 生出力: `tmp/oe-refute-202606210816320B6ZZ7CP9ZWX/`（worktree・gitignore）
+- `../decisions/2026-06-19-decision-188-identity-unification.md`（DJ-188-3/5）
+- 調査の現状棚卸し（識別サーフェス table）は本 discussion 冒頭に要約

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-202-pane-identity.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-202-pane-identity.md
@@ -15,59 +15,47 @@ related:
 
 # #202 ペイン識別（oe-ident / read-time ambient）実装エピソード
 
-> リアルタイム追記（reconstructed ではない）。cockpit 統括セッション（`%32`）が WORKTREE
-> `feature/#202_pane_identity` で直接実装（委譲なし）。
+> **reconstructed**（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。
+> cockpit 統括セッション（`%32`）が WORKTREE `feature/#202_pane_identity` で直接実装（委譲なし）。
 
-## コンテキスト / 動機
+## コンテキスト / なぜ
 
-multi-session オーケストレーションで人間が tmux UI を見て **どのペインがどのセッション/role か
-区別できない**（#202）。一貫した識別子が付くのは `wt switch` 済み Claude ペインだけ。
+multi-session オーケストレーションで人間が tmux UI を見て「どのペインがどのセッション/role か」
+区別できない（#202）。一貫した識別子が付くのは `wt switch` 済み Claude ペインだけ。
 
-## 設計探索（discussion doc が正本）
+## 決定と根拠（diff から復元不能なコア）
 
-調査 → 選択肢 (a)〜(d) → 当初 (c′) stored `@oe_id` を主軸候補に → **設計SO（oe-refute
-exploration 3 レーン）が 3/3 refuted**（#188 思想との不整合 / stored 状態の未検証 lifecycle /
-resolve 契約破壊リスク / 未探索の read-time 表示案）→ **(c″) read-time ambient へピボット**。
-詳細は `../discussions/2026-06-21-discussion-202-pane-identity.md`。
+当初 (c′) stored `@oe_id` を主軸候補にしたが、**設計SO（oe-refute exploration 3 レーン）が 3/3 refuted**
+→ **(c″) read-time ambient へピボット**。棄却理由が本 episode の保存価値:
 
-**学び（設計SO の実価値・再掲）**: 実装前に write-path 案の落とし穴と、2 日前 accepted の
-#188 思想に沿う優位な代替（`#()` 表示時計算）を捕捉。`exhaustion-before-conclusion` どおり、
-収束をモデル任意でなく SO で構造的に阻止できた。SO 主張（#188「逆走」）は鵜呑みにせず #188 を
-一次照合し「禁止ではないが grain に逆らう」と補正（過去 #114 の SO 主張未検証の反省を適用）。
+- #188 思想（read 時相関・永続マップ不採用）に逆らう（一次照合: DJ-188-5 で producer 書込は
+  「禁止ではないが grain に逆らう」と補正）
+- stored 状態の lifecycle（pane 再利用/分割）未検証 / `oe_reg_list`・`oe_reg_resolve` の宛先解決
+  契約を壊すリスク / 未探索の `#()` 表示時計算（書込なし read-time）
+- c″ は上記すべてを**構造的に解消**（write path 無し・契約不変）
 
-## 実装
+選択肢 (a)〜(d) の全比較・tmux `#()` 実機検証（引数展開 / TMUX env / 非同期キャッシュ）・現状の識別
+サーフェス棚卸しは **discussion doc が正本**（重複を避けここでは再掲しない）:
+`../discussions/2026-06-21-discussion-202-pane-identity.md`。
 
-- **`bin/oe-ident <pane> [server_pid]`**（新規・read-only）: pane-issue(`.name`) → spawn-registry
-  (`.label`) を読み role+label を 1 行返す。role= parent（子を spawn）/ child（被 spawn）を
-  registry 読取のみで導出。識別情報無→空出力。常に exit 0（border を壊さない）。
-  - `delegate-registry.sh` の `_oe_reg_key` / ソース読取を再利用（キー契約を共有）。
-  - `server_pid` を明示引数で受けられる（`#()` で TMUX env 不在に備え `#{pid}` を渡せる）。
-- **`bin/README.md`**: oe-ident 節 + dotfiles 用 `pane-border-status`/`pane-border-format` スニペット。
-  表示有効化は dotfiles 責務（hub は強制せず doc のみ）。
-- **触らないもの**: `oe-delegate` / `oe_reg_list` / `oe_reg_resolve`（→ 宛先解決契約は不変・
-  SO 指摘の resolve 破壊リスクは構造的に解消）。`@oe_id` 書込なし。
+## 検証（要点・SO 証跡）
 
-## tmux #() 実機検証（前提を組む前に確認）
-
-隔離 tmux 3.5a で: `#{pane_id}`/`#{pid}` は引数内で展開 / env に `TMUX` セット / `#()` は
-非同期キャッシュ（初回空）。残存不確実性に備え `#{pid}` 明示渡し設計で防御。
-
-## 検証
-
-- shellcheck: `oe-ident` / `test_oe_ident.sh` rc=0。
-- テスト: **bash 3.2.57 / 5.2.37 で test_oe_ident 11/11**（pane-issue / child / parent /
-  standalone / unknown / 不正引数 / pane-issue 優先 / parent 優先 / 引数欠落）。
-- **実装SO（oe-review・2 レーン codex/cursor）survived 2/2**（audit `20260621093204NV8VKKJ0B9S6` /
-  diff_base origin/master / reviewed_sha b4a27ec）。material 欠陥なし。codex「新規テスト未実行」は
-  本セッションで 11/11 実行済みでカバー。cursor「stale registry 表示」は既知 tradeoff（欠陥でない・
-  `oe_reg_gc` が掃除）。
+- shellcheck rc=0 / **bash 3.2.57・5.2.37 で test_oe_ident 11/11**。
+- **設計SO** oe-refute exploration 3 レーン: **refuted**（audit `202606210816320B6ZZ7CP9ZWX`・c′→c″ の起点）。
+- **実装SO** oe-review 2 レーン: **survived 2/2**（audit `20260621093204NV8VKKJ0B9S6` / diff_base
+  origin/master / reviewed_sha b4a27ec）。cursor「stale registry 表示」は既知 tradeoff（欠陥でない）。
+- Copilot: テストの key 生成を `_oe_reg_key` の source 共有へ（契約ドリフト解消・1 指摘対応）。
 
 ## closure
 
-- status: `stable`。consumer = cockpit を見る人間（pane-border の識別子）+ dotfiles 設定者。
-- tier: 中（新規コマンド + role 導出 + tmux 連携検証）。設計SO + 実装SO 両方実施。
-- routing: 親（`%32`）が直接実装 → PR → Copilot。
-- Decision 昇格: **なし**。c″（read-time ambient・write path 無し）は #188（read 時相関・
-  永続マップ不採用）の **display への適用**であり、新しい設計決定ではない。discussion doc + #188 で足りる。
-- defer: (b) read-time マップコマンド（`oe-ident` の読取を共有して別 issue）/ engine wez 子の
-  human 識別（#188 トポロジで tmux 不可視・本 issue 範囲外）。
+- status: `stable` / **達成度: 達成**（oe-ident 実装・テスト・SO 通過。表示有効化は dotfiles 側 opt-in で別途）。
+- tier: **heavy**（方針転回 c′→c″ / 意図的 SO 2 本 / 非自明な設計棄却）。
+- 次の消費者: cockpit を見る人間（pane-border の識別子）+ dotfiles 設定者（pane-border-format 設定）。
+- 蒸留シグナル: **昇格なし**。c″ は #188（read 時相関）の display への適用で新規決定でない（discussion + #188 で足りる）。
+- follow-up routing:
+  - (b) read-time マップコマンド → **別 issue（未起票）**・`oe-ident` の読取ロジックを共有
+  - engine wez 子の human 識別 → **追わない**（#188 トポロジで tmux 不可視・本 issue 範囲外）
+- **Step4 辞退（heavy 外部チェック）**: closure 品質 4 観点を自己点検し小機能・低リスクと判断して辞退。
+  覆った観点= 失敗の選択的省略なし（c′ refuted を明記）／ routing 網羅（上記 defer 2 件に行き先）／
+  evidence anchor（SO audit id を本文転記）／ back-propagation 漏れなし（#188 と非矛盾・discussion に保全）。
+  未実施観点と判断= so-compare 再チェックは小機能 + 自己点検で覆えるため不実施（重複ゲート回避）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-202-pane-identity.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-202-pane-identity.md
@@ -15,7 +15,7 @@ related:
 
 # #202 ペイン識別（oe-ident / read-time ambient）実装エピソード
 
-> **reconstructed**（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。
+> `reconstructed`（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。
 > cockpit 統括セッション（`%32`）が WORKTREE `feature/#202_pane_identity` で直接実装（委譲なし）。
 
 ## コンテキスト / なぜ

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-202-pane-identity.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-202-pane-identity.md
@@ -1,0 +1,73 @@
+---
+id: 01KVMRHZ8TSBA8KZYZDW55AKW2
+title: "#202 ペイン識別（oe-ident / read-time ambient）実装エピソード"
+date: 2026-06-21
+type: episode
+status: stable
+related:
+  - type: implements
+    ref: "#202"
+  - type: discussion
+    ref: ../discussions/2026-06-21-discussion-202-pane-identity.md
+  - type: depends_on
+    ref: "#188"
+---
+
+# #202 ペイン識別（oe-ident / read-time ambient）実装エピソード
+
+> リアルタイム追記（reconstructed ではない）。cockpit 統括セッション（`%32`）が WORKTREE
+> `feature/#202_pane_identity` で直接実装（委譲なし）。
+
+## コンテキスト / 動機
+
+multi-session オーケストレーションで人間が tmux UI を見て **どのペインがどのセッション/role か
+区別できない**（#202）。一貫した識別子が付くのは `wt switch` 済み Claude ペインだけ。
+
+## 設計探索（discussion doc が正本）
+
+調査 → 選択肢 (a)〜(d) → 当初 (c′) stored `@oe_id` を主軸候補に → **設計SO（oe-refute
+exploration 3 レーン）が 3/3 refuted**（#188 思想との不整合 / stored 状態の未検証 lifecycle /
+resolve 契約破壊リスク / 未探索の read-time 表示案）→ **(c″) read-time ambient へピボット**。
+詳細は `../discussions/2026-06-21-discussion-202-pane-identity.md`。
+
+**学び（設計SO の実価値・再掲）**: 実装前に write-path 案の落とし穴と、2 日前 accepted の
+#188 思想に沿う優位な代替（`#()` 表示時計算）を捕捉。`exhaustion-before-conclusion` どおり、
+収束をモデル任意でなく SO で構造的に阻止できた。SO 主張（#188「逆走」）は鵜呑みにせず #188 を
+一次照合し「禁止ではないが grain に逆らう」と補正（過去 #114 の SO 主張未検証の反省を適用）。
+
+## 実装
+
+- **`bin/oe-ident <pane> [server_pid]`**（新規・read-only）: pane-issue(`.name`) → spawn-registry
+  (`.label`) を読み role+label を 1 行返す。role= parent（子を spawn）/ child（被 spawn）を
+  registry 読取のみで導出。識別情報無→空出力。常に exit 0（border を壊さない）。
+  - `delegate-registry.sh` の `_oe_reg_key` / ソース読取を再利用（キー契約を共有）。
+  - `server_pid` を明示引数で受けられる（`#()` で TMUX env 不在に備え `#{pid}` を渡せる）。
+- **`bin/README.md`**: oe-ident 節 + dotfiles 用 `pane-border-status`/`pane-border-format` スニペット。
+  表示有効化は dotfiles 責務（hub は強制せず doc のみ）。
+- **触らないもの**: `oe-delegate` / `oe_reg_list` / `oe_reg_resolve`（→ 宛先解決契約は不変・
+  SO 指摘の resolve 破壊リスクは構造的に解消）。`@oe_id` 書込なし。
+
+## tmux #() 実機検証（前提を組む前に確認）
+
+隔離 tmux 3.5a で: `#{pane_id}`/`#{pid}` は引数内で展開 / env に `TMUX` セット / `#()` は
+非同期キャッシュ（初回空）。残存不確実性に備え `#{pid}` 明示渡し設計で防御。
+
+## 検証
+
+- shellcheck: `oe-ident` / `test_oe_ident.sh` rc=0。
+- テスト: **bash 3.2.57 / 5.2.37 で test_oe_ident 11/11**（pane-issue / child / parent /
+  standalone / unknown / 不正引数 / pane-issue 優先 / parent 優先 / 引数欠落）。
+- **実装SO（oe-review・2 レーン codex/cursor）survived 2/2**（audit `20260621093204NV8VKKJ0B9S6` /
+  diff_base origin/master / reviewed_sha b4a27ec）。material 欠陥なし。codex「新規テスト未実行」は
+  本セッションで 11/11 実行済みでカバー。cursor「stale registry 表示」は既知 tradeoff（欠陥でない・
+  `oe_reg_gc` が掃除）。
+
+## closure
+
+- status: `stable`。consumer = cockpit を見る人間（pane-border の識別子）+ dotfiles 設定者。
+- tier: 中（新規コマンド + role 導出 + tmux 連携検証）。設計SO + 実装SO 両方実施。
+- routing: 親（`%32`）が直接実装 → PR → Copilot。
+- Decision 昇格: **なし**。c″（read-time ambient・write path 無し）は #188（read 時相関・
+  永続マップ不採用）の **display への適用**であり、新しい設計決定ではない。discussion doc + #188 で足りる。
+- defer: (b) read-time マップコマンド（`oe-ident` の読取を共有して別 issue）/ engine wez 子の
+  human 識別（#188 トポロジで tmux 不可視・本 issue 範囲外）。

--- a/projects/orchestration-engine/tests/test_oe_ident.sh
+++ b/projects/orchestration-engine/tests/test_oe_ident.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_ident.sh — oe-ident（#202 / c″ read-time ambient 識別子）の検証。
+#
+# 実 tmux は不要（oe-ident は pane を引数で受け state ファイルだけ読む）。pid override を渡して
+# キー名前空間を固定し、mock の pane-issue / spawn-registry を読ませる。jq は実体を使う。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OE_IDENT="$PROJECT_DIR/bin/oe-ident"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+export OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
+export OE_DELEGATE_STATE_DIR="$_TMP_DIR/oe-delegate"
+mkdir -p "$OE_PANE_ISSUE_DIR" "$OE_DELEGATE_STATE_DIR"
+
+PID=9999
+# delegate-registry.sh の _oe_reg_key と同一サニタイズ（<pid>_<pane> の非英数を _ に）
+keyfor() { local k="${PID}_$1"; printf '%s' "${k//[^A-Za-z0-9]/_}"; }
+
+PASS=0
+FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (want=[$expected] got=[$actual])"; FAIL=$((FAIL + 1))
+  fi
+}
+run() { bash "$OE_IDENT" "$1" "$PID" 2>/dev/null; }
+
+echo "[1] pane-issue のみ -> label（spawn 関係無しなので role 無し）"
+printf '{"name":"#202 pane-identity"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %5)"
+ck "pane-issue label" "#202 pane-identity" "$(run %5)"
+
+echo "[2] spawn child entry -> child <label>"
+jq -cn '{pane:"%6",label:"#179",workspace:"/w",parent_pane:"%5",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %6).json"
+ck "child role+label" "child #179" "$(run %6)"
+
+echo "[3] parent（%6 の parent_pane=%5）-> parent + pane-issue label"
+ck "parent role + pane-issue label" "parent #202 pane-identity" "$(run %5)"
+
+echo "[4] standalone pane-issue（spawn 関係無し）-> label のみ"
+printf '{"name":"#204 toolkit"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %7)"
+ck "standalone label only" "#204 toolkit" "$(run %7)"
+
+echo "[5] 未知ペイン（ソース無し）-> 空"
+ck "unknown empty" "" "$(run %99)"
+
+echo "[6] 不正引数 -> 空・exit 0（border を壊さない）"
+rc=0; out="$(bash "$OE_IDENT" "notapane" "$PID" 2>/dev/null)" || rc=$?
+ck "invalid empty" "" "$out"
+ck "invalid exit0" "0" "$rc"
+
+echo "[7] pane-issue label が spawn label に優先（role は child のまま）"
+printf '{"name":"#179 notify-jump"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %6)"
+ck "pane-issue beats spawn label" "child #179 notify-jump" "$(run %6)"
+
+echo "[8] child かつ parent -> parent 優先"
+jq -cn '{pane:"%8",label:"#g",workspace:"/w",parent_pane:"%6",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %8).json"
+ck "parent beats child" "parent #179 notify-jump" "$(run %6)"
+
+echo "[9] 引数欠落 -> 空・exit 0"
+rc=0; out="$(bash "$OE_IDENT" 2>/dev/null)" || rc=$?
+ck "missing arg empty" "" "$out"
+ck "missing arg exit0" "0" "$rc"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_ident.sh
+++ b/projects/orchestration-engine/tests/test_oe_ident.sh
@@ -18,9 +18,14 @@ export OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
 export OE_DELEGATE_STATE_DIR="$_TMP_DIR/oe-delegate"
 mkdir -p "$OE_PANE_ISSUE_DIR" "$OE_DELEGATE_STATE_DIR"
 
+# キー生成は本体と同じ契約を使う（手書き複製のドリフトを避ける・Copilot 指摘）。
+# _oe_reg_key は $TMUX から server pid を導出するため、固定 pid を TMUX 経由で注入する
+# （oe-ident の pid-override 経路と同一イディオム）。
+# shellcheck source=../lib/delegate-registry.sh
+source "$PROJECT_DIR/lib/delegate-registry.sh"
+
 PID=9999
-# delegate-registry.sh の _oe_reg_key と同一サニタイズ（<pid>_<pane> の非英数を _ に）
-keyfor() { local k="${PID}_$1"; printf '%s' "${k//[^A-Za-z0-9]/_}"; }
+keyfor() { TMUX="oe,${PID},0" _oe_reg_key "$1"; }
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## 目的

cockpit のマルチセッション運用で人間がペインを区別できない問題（Refs #202）を、Claude セッション名（`pane_title`）と独立した **read-time ambient 識別子**で解決する。

## 設計の経緯（c′ → c″ ピボット）

当初は stored `@oe_id`（tmux カスタムペインオプション）案（c′）だったが、**設計SO（`oe-refute --rubric exploration` 3 レーン）が 3/3 refuted**:
- #188（read 時相関・永続マップ不採用）の思想に逆らう（一次照合: DJ-188-5 は producer 書込を禁じないが grain に逆らう）
- stored 状態の lifecycle（pane 再利用/分割）が未検証
- `oe_reg_list`/`oe_reg_resolve` の宛先解決契約を壊すリスク
- 未探索の `#()` 表示時計算カテゴリ

→ **read-time ambient（c″）へピボット**。経緯は `docs/discussions/2026-06-21-discussion-202-pane-identity.md`。

## 変更内容

- **`bin/oe-ident <pane_id> [server_pid]`**（新規・read-only）: `pane-border-format` の `#()` から呼ばれ、既存ソース（pane-issue / spawn-registry）を**読み取り時に投影**して `<role> <label>` を 1 行返す。
  - role 導出は registry 読取のみ（parent=子を spawn / child=被 spawn / 両方なら parent 優先）。
  - label = pane-issue(`.name`) 優先 → spawn-registry(`.label`)。識別情報無→**空出力**（honest）。不正/欠落引数でも **exit 0**（border を壊さない）。
  - `delegate-registry.sh` の `_oe_reg_key` / ソース読取を再利用。`#{pid}` を明示渡しでき TMUX env 不在でも解決可能。
- **`bin/README.md`**: oe-ident 節 + dotfiles 用 `pane-border-status`/`pane-border-format` スニペット（表示有効化は dotfiles 責務・hub は doc のみ）。
- **`docs/discussions/...`**: 設計探索（SO ピボット + tmux `#()` 実機検証）。
- **`docs/episodes/...`**: 実装エピソード（closure）。

### 設計上の安全性
- **新規 write path 無し**（#188 read 時相関に整合）。stored `@oe_id` を作らないので lifecycle/stale 問題が無い。
- **`oe-delegate` / `oe_reg_list` / `oe_reg_resolve` 不変** → oe-send の宛先解決/targeting 契約に影響なし。
- `pane_title`（Claude セッション名が書く所）を汚さない → 二重 writer の奪い合いが起きない。

## tmux `#()` 実機検証（隔離 tmux 3.5a）
- `#{pane_id}`/`#{pid}` は引数内で展開される
- `#()` コマンド env に `TMUX` がセットされる（残存不確実性に備え `#{pid}` 明示渡し設計）
- `#()` は非同期キャッシュ実行（初回空・以降 `status-interval` 毎更新）＝表示用途で問題なし

## 検証
- `shellcheck`: `oe-ident` / `test_oe_ident.sh` rc=0
- テスト: **bash 3.2.57 / 5.2.37 で `test_oe_ident` 11/11**（pane-issue / child / parent / standalone / unknown / 不正引数 / pane-issue 優先 / parent 優先 / 引数欠落）
- **実装SO（`oe-review` 2 レーン codex/cursor）survived 2/2**（material 欠陥なし・diff_base origin/master）

## やらない / defer
- (b) read-time マップコマンド: follow-up（`oe-ident` の読取ロジックを共有可）
- engine wez 子の human 識別: #188 トポロジで tmux 不可視 → 本 issue は delegate/tmux 基盤に限定

Refs #169, #188, #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
