### PR TITLE
docs(oe): merged episode の偽 real-time ラベルを reconstructed に是正

### DIFF
--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
@@ -19,7 +19,7 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, episode
 
 # #177 oe-status — cockpit 観測UI 実装 episode
 
-> 本文は作業中リアルタイム追記（reconstructed ではない）。closure は `episode-retrospective`。
+> 本文は reconstructed（closure 一括執筆と推定・追記タイミングは親で未検証＝real-time とは断定しない）。closure は `episode-retrospective`。
 
 ## 設計フェーズ（2026-06-20）
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-177-oe-status.md
@@ -19,7 +19,7 @@ tags: [orchestration, cockpit, oe-status, observation, audit, read-only, episode
 
 # #177 oe-status — cockpit 観測UI 実装 episode
 
-> 本文は reconstructed（closure 一括執筆と推定・追記タイミングは親で未検証＝real-time とは断定しない）。closure は `episode-retrospective`。
+> 本文は `reconstructed`（closure 一括執筆と推定・追記タイミングは親で未検証＝real-time とは断定しない）。closure は `episode-retrospective`。
 
 ## 設計フェーズ（2026-06-20）
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
@@ -19,7 +19,7 @@ tags: [orchestration, delegate, oe-kick, oneshot, hardening, episode]
 
 # #178 oe-kick — ワンショット委譲ラッパー 実装 episode
 
-> 本文は作業中リアルタイム追記（reconstructed ではない）。closure は `episode-retrospective`。
+> 本文は reconstructed（closure 一括執筆と推定・追記タイミングは親で未検証＝real-time とは断定しない）。closure は `episode-retrospective`。
 > 親 = `%32`。本セッションは worktree（`feature/#178_oneshot_delegate_wrapper`）で並行子（#199）と非衝突に作業。
 
 ## ミッション（kickoff `.oe/2026-06-20-kickoff-178-oneshot-delegate.md`）

--- a/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-20-episode-178-oneshot-delegate-wrapper.md
@@ -19,7 +19,7 @@ tags: [orchestration, delegate, oe-kick, oneshot, hardening, episode]
 
 # #178 oe-kick — ワンショット委譲ラッパー 実装 episode
 
-> 本文は reconstructed（closure 一括執筆と推定・追記タイミングは親で未検証＝real-time とは断定しない）。closure は `episode-retrospective`。
+> 本文は `reconstructed`（closure 一括執筆と推定・追記タイミングは親で未検証＝real-time とは断定しない）。closure は `episode-retrospective`。
 > 親 = `%32`。本セッションは worktree（`feature/#178_oneshot_delegate_wrapper`）で並行子（#199）と非衝突に作業。
 
 ## ミッション（kickoff `.oe/2026-06-20-kickoff-178-oneshot-delegate.md`）

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-179-notify-pane-jump.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-179-notify-pane-jump.md
@@ -15,7 +15,7 @@ related:
 
 # #179 通知からペインジャンプ（oe-jump）実装エピソード
 
-> reconstructed（子セッション執筆・closure 一括執筆と推定／追記タイミングは親で未検証・real-time とは断定しない）。親 `%32` からの委譲子セッションが WORKTREE
+> `reconstructed`（子セッション執筆・closure 一括執筆と推定／追記タイミングは親で未検証・real-time とは断定しない）。親 `%32` からの委譲子セッションが WORKTREE
 > `feature/#179_notify_pane_jump` で自律実行。
 
 ## コンテキスト / 動機

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-179-notify-pane-jump.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-179-notify-pane-jump.md
@@ -15,7 +15,7 @@ related:
 
 # #179 通知からペインジャンプ（oe-jump）実装エピソード
 
-> リアルタイム追記（reconstructed ではない）。親 `%32` からの委譲子セッションが WORKTREE
+> reconstructed（子セッション執筆・closure 一括執筆と推定／追記タイミングは親で未検証・real-time とは断定しない）。親 `%32` からの委譲子セッションが WORKTREE
 > `feature/#179_notify_pane_jump` で自律実行。
 
 ## コンテキスト / 動機

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-203-oe-delegate-parent-pane-split.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-203-oe-delegate-parent-pane-split.md
@@ -15,7 +15,7 @@ related:
 
 # #203 oe-delegate の split を親ペイン基準にする実装エピソード
 
-> reconstructed（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。cockpit 統括セッション（`%32`）が WORKTREE
+> `reconstructed`（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。cockpit 統括セッション（`%32`）が WORKTREE
 > `fix/#203_oe_delegate_parent_pane_split` で直接実装（委譲なし・最小修正）。
 
 ## コンテキスト / 動機

--- a/projects/orchestration-engine/docs/episodes/2026-06-21-episode-203-oe-delegate-parent-pane-split.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-21-episode-203-oe-delegate-parent-pane-split.md
@@ -15,7 +15,7 @@ related:
 
 # #203 oe-delegate の split を親ペイン基準にする実装エピソード
 
-> リアルタイム追記（reconstructed ではない）。cockpit 統括セッション（`%32`）が WORKTREE
+> reconstructed（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。cockpit 統括セッション（`%32`）が WORKTREE
 > `fix/#203_oe_delegate_parent_pane_split` で直接実装（委譲なし・最小修正）。
 
 ## コンテキスト / 動機


### PR DESCRIPTION
## 目的

merged 済み episode の冒頭ラベル「リアルタイム追記（reconstructed ではない）」が、実際には **closure 時に一括執筆（後追い再構成）** されたものに付いており、**証拠価値を偽って嵩上げ**していた。これを正直なラベルに是正する（`episode-retrospective` / `orchestration-toolkit` / `spec-card` が「後追い再構成は `reconstructed` 明示」を規定）。

自己監査（`/episode-retrospective` 適用）で発覚。#202 episode は当該 PR で是正済み。本 PR は **過去分（merged）** をまとめて是正する。

## 変更内容（doc のみ・4 ファイル）

| episode | 是正 |
|---|---|
| #203 | 私（cockpit）が締めで一括執筆＝確実に reconstructed → `reconstructed（締めで一括執筆…）` |
| #179 / #178 / #177 | 子/委譲セッション執筆で **追記タイミングを親で未検証** → `reconstructed（closure 一括執筆と推定・親で未検証・real-time とは断定しない）` |

- 検証できない強い主張（real-time）は載せず、弱い既定（reconstructed）+ 未検証を明示する（evidence-verification-rule: 最も弱い正直なステータスへ）。
- **#175 は対象外**: 既に正しく `reconstructed` を明示していた（むしろ模範）ため非変更。

## やらないこと

- 各 episode の closure 内容（tier / Step4 / 棄却理由等）の再監査・書き換えは本 PR の範囲外（ラベル honesty に限定）。

## 背景 / 恒久対策

- feedback memory `feedback_episode_reconstructed_honesty`（user memory）に「締め執筆は `reconstructed` 明示」を恒久ルール化し前方適用。

Refs #169
