### PR TITLE
feat(oe): add oe-view clickable markdown doc viewer

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -268,7 +268,7 @@ set -g pane-border-format '#[align=left] #(/path/to/repo/projects/orchestration-
 | `OE_DELEGATE_WAIT_SEC` | oe-delegate: 子 claude 起動待ち（秒） | `4` |
 | `PARENT_TMUX_PANE` | oe-delegate が子へ渡す親ペイン（戻し用） | （自動） |
 | `OE_JUMP_STATE_DIR` | oe-jump: `--record`/replay の state 置き場 | `~/.claude/state/oe-jump` |
-| `OE_VIEW_ROOTS` | oe-view: allowlist 許可ルート（コロン区切り。`--from-link` 時に強制） | リポジトリルートの `projects/` |
+| `OE_VIEW_ROOTS` | oe-view: allowlist 許可ルート（コロン区切り。`--from-link` 時に強制） | 各プロジェクトの `projects/*/docs` のみ（クリック境界を doc に限定。該当無しなら空＝fail-closed） |
 | `OE_VIEW_STATE_DIR` | oe-view: viewer pane id の state 置き場 | `~/.claude/state/oe-view` |
 
 本体エンジン側（`OE_POLL_INTERVAL` / `OE_CB_*` / `OE_TARGET_AI_*` / `OE_VERIFY_AI_*` 等）は [`../lib/constants.sh`](../lib/constants.sh) を参照。

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -168,6 +168,35 @@ oe-jump --record [--] <target>         # target を記録するだけ（通知�
 
 設計の正本: [`../docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md`](../docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md)。関連 lib: `delegate-registry.sh`（`oe_reg_resolve`）/ 関連: [`../docs/decisions/2026-06-19-decision-188-identity-unification.md`](../docs/decisions/2026-06-19-decision-188-identity-unification.md)。
 
+## oe-view — 生成 doc のクリッカブル md ビューア（#210）
+
+パス（plan/kickoff/episode 等）から Finder/手動ペイン操作なしで即ビューする入口。**md（`*.md`・拡張子/大小無視）→ viewer ペインを解決して `glow` で描画 / 非 md → `open -- <path>`**。クリック層（WezTerm の `hyperlink_rules` + `open-uri`・dotfiles 別 PR）に**非依存で単体動作**する（`--here`/手動で即有用）。
+
+配置（DJ-1）の根拠は **cockpit UX glue**（`wez pane` + `open` + 種別ディスパッチ）であり、`wez` は下層プリミティブのまま使う（ADR-001/004 の wez=下層方針を守る・上方依存を作らない）。viewer 解決ロジックは [`../lib/oe-viewer.sh`](../lib/oe-viewer.sh) に切り出す。
+
+```bash
+oe-view [--here] [--from-link] [--json] [--] <path>   # 既定: md→glow viewer / 非md→open
+oe-view --help
+```
+
+- `<path>` … 表示対象のファイル（必須）。実体存在 + 通常ファイルを常に確認する。
+- `--here` … 分割せず現ペインのページャで表示（md は `glow -p`、無ければ `bat`）。**degrade 本線**（tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映時）。
+- `--from-link` … クリック経由フラグ。**allowlist 強制・非 md 拒否（md のみ）**を有効化（直叩きより厳格）。クリック経由で任意アプリ/スクリプト起動（非 md `open`）を許さない。
+- `--json` … 結果を JSON で出力: `{status, kind:"md"|"other", action:"glow"|"open", pane_id?}`。
+- viewer ペイン（DJ-4） … state（`~/.claude/state/oe-view/viewer-pane-id`・`OE_VIEW_STATE_DIR` で隔離可）に pane_id を保存し、生存（`wez pane list`）なら **再利用**（send）/ stale・無しなら **split で新規作成 + state 更新**。新規作成時は `wez pane activate <source>` で**作業ペインへ focus を戻す**（#111）。viewer の glow は非ページャ形（`glow -- <file>`＝描画して復帰）で、次回 send と衝突しない（`-p` ページャは `--here` 限定）。
+- セキュリティ（§5・P0） … (1) **送信層のシェル注入対策**: viewer への送信は `wez pane send`＝受信シェルで再トークナイズされるため、送信文字列を組む直前に `printf %q` でシェルクォートする（実在ファイル名 `a$(whoami).md` でも `$(whoami)` が評価されない）。(2) **allowlist**: `--from-link` 時に `realpath` 正規化後 `OE_VIEW_ROOTS` 配下 prefix を判定（`..`/symlink トラバーサル対策）。(3) **入力サニタイズ**: 改行・CR・制御文字を含むパスを拒否。
+- exit: `0` 成功 / `1` 対象不在・allowlist 外・サニタイズ違反・`--from-link` で非 md・glow/open 失敗 / `2` usage・**環境エラー（wez 不在・glow 不在を含む。依存不足は独立コードにせず `2` に統一し導入案内を出す）**。
+
+3 段の degrade（環境に応じた表示経路）:
+
+| 環境 | 表示経路 | 備考 |
+|------|----------|------|
+| WezTerm + `wez` + `glow`（dotfiles 反映済） | クリック or `oe-view <md>` → viewer ペイン `glow`（再利用 split・focus は作業ペイン維持） | 本線。クリック層は dotfiles 別 PR |
+| tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映 | `oe-view --here <md>` → 現ペイン `glow -p` | 手動・分割しない degrade 本線 |
+| `glow` 未導入 | `oe-view --here <md>` → 現ペイン `bat` | bat フォールバック。両方不在は exit 2 + 導入案内 |
+
+設計の正本: [`../docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md`](../docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md)。関連 lib: [`../lib/oe-viewer.sh`](../lib/oe-viewer.sh)（viewer 解決）/ 下層: [`../../wezterm-ai-mode/lib/pane.sh`](../../wezterm-ai-mode/lib/pane.sh)（`wez pane split/send/activate`・`_wez_pane_exists`）。クリック層（`wezterm.lua` の `hyperlink_rules` + `open-uri`）は dotfiles 側の別 PR（hub は手順 doc のみ・lua 本体は置かない）。
+
 ## oe-report — 親へ申し送り（legacy）
 
 親ペインへ申し送り / レビュー依頼を送る。**legacy**: 戻しは `oe-send "$PARENT_TMUX_PANE"` に一本化が方針。
@@ -239,5 +268,7 @@ set -g pane-border-format '#[align=left] #(/path/to/repo/projects/orchestration-
 | `OE_DELEGATE_WAIT_SEC` | oe-delegate: 子 claude 起動待ち（秒） | `4` |
 | `PARENT_TMUX_PANE` | oe-delegate が子へ渡す親ペイン（戻し用） | （自動） |
 | `OE_JUMP_STATE_DIR` | oe-jump: `--record`/replay の state 置き場 | `~/.claude/state/oe-jump` |
+| `OE_VIEW_ROOTS` | oe-view: allowlist 許可ルート（コロン区切り。`--from-link` 時に強制） | リポジトリルートの `projects/` |
+| `OE_VIEW_STATE_DIR` | oe-view: viewer pane id の state 置き場 | `~/.claude/state/oe-view` |
 
 本体エンジン側（`OE_POLL_INTERVAL` / `OE_CB_*` / `OE_TARGET_AI_*` / `OE_VERIFY_AI_*` 等）は [`../lib/constants.sh`](../lib/constants.sh) を参照。

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -183,19 +183,19 @@ oe-view --help
 - `--here` … 分割せず現ペインのページャで表示（md は `glow -p`、無ければ `bat`）。**degrade 本線**（tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映時）。
 - `--from-link` … クリック経由フラグ。**allowlist 強制・非 md 拒否（md のみ）**を有効化（直叩きより厳格）。クリック経由で任意アプリ/スクリプト起動（非 md `open`）を許さない。
 - `--json` … 結果を JSON で出力: `{status, kind:"md"|"other", action:"glow"|"open", pane_id?}`。
-- viewer ペイン（DJ-4） … state（`~/.claude/state/oe-view/viewer-pane-id`・`OE_VIEW_STATE_DIR` で隔離可）に pane_id を保存し、生存（`wez pane list`）なら **再利用**（send）/ stale・無しなら **split で新規作成 + state 更新**。新規作成時は `wez pane activate <source>` で**作業ペインへ focus を戻す**（#111）。viewer の glow は非ページャ形（`glow -- <file>`＝描画して復帰）で、次回 send と衝突しない（`-p` ページャは `--here` 限定）。
-- セキュリティ（§5・P0） … (1) **送信層のシェル注入対策**: viewer への送信は `wez pane send`＝受信シェルで再トークナイズされるため、送信文字列を組む直前に `printf %q` でシェルクォートする（実在ファイル名 `a$(whoami).md` でも `$(whoami)` が評価されない）。(2) **allowlist**: `--from-link` 時に `realpath` 正規化後 `OE_VIEW_ROOTS` 配下 prefix を判定（`..`/symlink トラバーサル対策）。(3) **入力サニタイズ**: 改行・CR・制御文字を含むパスを拒否。
+- viewer ペイン（DJ-4・argv-spawn replace モデル・§11） … **ペインのプログラムとして `glow` を直接起動**する（`wez pane split … -- glow -p -- <path>`・シェル/tmux 非経由）。実機検証で旧「split したシェルへ glow をタイプ送信」モデルが破綻（新規 wez ペインのシェル rc が tmux 自動アタッチしタイプ送信が実行されず描画されない）したため確定した方式。再利用は **replace**: state（`~/.claude/state/oe-view/viewer-pane-id`・`OE_VIEW_STATE_DIR` で隔離可）の viewer が生存（`wez pane list`）なら **kill → 新 glow ペインを spawn → state 更新** / stale・無しなら **spawn + state 更新**（glow `-p` はページャ＝シェルでないため send 再利用不可）。spawn 後は `wez pane activate <source>` で**作業ペインへ focus を戻す**（#111）。
+- セキュリティ（§5・P0） … (1) **シェル注入面の構造的解消**: viewer 起動は `wez pane send`（受信シェルへタイプ→再トークナイズ）を廃し、path を `wez pane split … -- glow -p -- <path>` の **argv 要素**として渡す（シェルを一切経由しない）。再トークナイズが起きないため `printf %q` 不要・注入面が消滅（実在ファイル名 `a$(whoami).md` でも安全）。`glow -p` と `<path>` の間に `--` を置きパスがオプション解釈されないようにする。(2) **allowlist**: `--from-link` 時に `realpath` 正規化後 `OE_VIEW_ROOTS` 配下 prefix を判定（`..`/symlink トラバーサル対策）。(3) **入力サニタイズ**: 改行・CR・制御文字を含むパスを拒否。
 - exit: `0` 成功 / `1` 対象不在・allowlist 外・サニタイズ違反・`--from-link` で非 md・glow/open 失敗 / `2` usage・**環境エラー（wez 不在・glow 不在を含む。依存不足は独立コードにせず `2` に統一し導入案内を出す）**。
 
 3 段の degrade（環境に応じた表示経路）:
 
 | 環境 | 表示経路 | 備考 |
 |------|----------|------|
-| WezTerm + `wez` + `glow`（dotfiles 反映済） | クリック or `oe-view <md>` → viewer ペイン `glow`（再利用 split・focus は作業ペイン維持） | 本線。クリック層は dotfiles 別 PR |
+| WezTerm + `wez` + `glow`（dotfiles 反映済） | クリック or `oe-view <md>` → viewer ペインのプログラムとして `glow` を argv-spawn（replace モデル・focus は作業ペイン維持） | 本線。クリック層は dotfiles 別 PR |
 | tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映 | `oe-view --here <md>` → 現ペイン `glow -p` | 手動・分割しない degrade 本線 |
 | `glow` 未導入 | `oe-view --here <md>` → 現ペイン `bat` | bat フォールバック。両方不在は exit 2 + 導入案内 |
 
-設計の正本: [`../docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md`](../docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md)。関連 lib: [`../lib/oe-viewer.sh`](../lib/oe-viewer.sh)（viewer 解決）/ 下層: [`../../wezterm-ai-mode/lib/pane.sh`](../../wezterm-ai-mode/lib/pane.sh)（`wez pane split/send/activate`・`_wez_pane_exists`）。クリック層（`wezterm.lua` の `hyperlink_rules` + `open-uri`）は dotfiles 側の別 PR（hub は手順 doc のみ・lua 本体は置かない）。
+設計の正本: [`../docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md`](../docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md)。関連 lib: [`../lib/oe-viewer.sh`](../lib/oe-viewer.sh)（viewer 解決・argv-spawn replace）/ 下層: [`../../wezterm-ai-mode/lib/pane.sh`](../../wezterm-ai-mode/lib/pane.sh)（`wez pane split`（trailing `-- PROG` パススルー）`/kill/activate`・`_wez_pane_exists`）。クリック層（`wezterm.lua` の `hyperlink_rules` + `open-uri`）は dotfiles 側の別 PR（hub は手順 doc のみ・lua 本体は置かない）。
 
 ## oe-report — 親へ申し送り（legacy）
 

--- a/projects/orchestration-engine/bin/oe-view
+++ b/projects/orchestration-engine/bin/oe-view
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# oe-view — 生成 doc のクリッカブル md ビューア（cockpit UX glue・#210）
+#
+# usage: oe-view [--here] [--from-link] [--json] [--] <path>
+#        oe-view --help
+#
+# パスから Finder/手動ペイン操作なしで即ビューする入口:
+#   md（*.md・拡張子/大小無視）→ viewer ペインを解決して glow で描画（lib/oe-viewer.sh）
+#   非 md → `open -- <path>`（既定のアプリで開く）
+#
+# クリック層（wezterm.lua の hyperlink_rules + open-uri）に非依存で単体動作する。クリック経由は
+# `--from-link` を立てて起動され、allowlist 強制・非 md 拒否で厳格化する（任意アプリ/スクリプト
+# 起動を防ぐ）。直叩き（--from-link 無し）はユーザー起点として allowlist を強制しない。
+#
+# 配置（DJ-1）: engine に置くのは cockpit UX glue（wez pane + open + 種別ディスパッチ）だから。
+# `wez` は下層プリミティブのまま（ADR-001/004 の wez=下層方針を守る・上方依存を作らない）。
+# viewer 解決ロジックは lib/oe-viewer.sh に切り出す（テスト mock 容易化）。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/oe-viewer.sh
+source "${BIN_DIR}/../lib/oe-viewer.sh"
+
+# allowlist（DJ-2/§5・P0）の許可ルート。コロン区切り。未設定時の既定は hub リポの
+# projects/*/docs 相当＝リポジトリルート配下の projects/。bin/ は
+# projects/orchestration-engine/bin なので 3 階層上がリポジトリルート。
+_OE_VIEW_DEFAULT_ROOT="$(cd "${BIN_DIR}/../../.." && pwd)/projects"
+OE_VIEW_ROOTS="${OE_VIEW_ROOTS:-${_OE_VIEW_DEFAULT_ROOT}}"
+
+oe_view_usage() {
+  cat >&2 <<'EOF'
+usage: oe-view [--here] [--from-link] [--json] [--] <path>
+       oe-view --help
+
+  <path>         表示対象のファイルパス（必須）。
+  --here         分割せず現ペインのページャで表示（md は `glow -p`、無ければ `bat`）。
+                 tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映時の degrade 本線。
+  --from-link    クリック経由フラグ。allowlist 強制・非 md 拒否（md のみ表示）を有効化。
+  --json         結果を JSON で出力: {status, kind, action, pane_id?}
+  -h, --help     このヘルプを表示
+
+既定: md（*.md・大小無視）→ viewer ペインを解決して glow で表示 / 非 md → `open -- <path>`。
+
+env:
+  OE_VIEW_ROOTS        allowlist 許可ルート（コロン区切り。--from-link 時に強制）
+  OE_VIEW_STATE_DIR    viewer pane id の state 置き場（既定 ~/.claude/state/oe-view）
+
+exit:
+  0   成功
+  1   対象不在 / allowlist 外 / 入力サニタイズ違反 / --from-link で非 md / glow・open 失敗
+  2   usage エラー / 環境エラー（wez 不在・glow 不在を含む。導入案内を stderr に出す）
+EOF
+}
+
+# _oe_view_canonicalize <path> — symlink/.. を解決した絶対パスを stdout へ。
+#   realpath があれば優先（macOS 標準には無いため homebrew coreutils 等）。無ければ
+#   ディレクトリを cd -P で解決し basename を足す移植性フォールバック。rc 0=成功 / 1=失敗。
+_oe_view_canonicalize() {
+  local path="$1"
+  if command -v realpath >/dev/null 2>&1; then
+    realpath -- "$path" 2>/dev/null
+    return
+  fi
+  # フォールバック: dir を物理解決（symlink/.. を解消）して basename を足す。
+  local dir base
+  dir="$(dirname -- "$path")"
+  base="$(basename -- "$path")"
+  local resolved_dir
+  resolved_dir="$(cd -P -- "$dir" 2>/dev/null && pwd -P)" || return 1
+  printf '%s/%s\n' "$resolved_dir" "$base"
+}
+
+# _oe_view_within_roots <canonical_path> — canonical_path が OE_VIEW_ROOTS のいずれかの
+#   ルート配下（prefix・境界考慮）にあるか。rc 0=許可 / 1=範囲外。
+#   各ルートも canonical 化してから prefix 判定する（.. / symlink トラバーサル対策）。
+_oe_view_within_roots() {
+  local target="$1" root canon_root
+  local IFS=':'
+  for root in $OE_VIEW_ROOTS; do
+    [[ -n "$root" ]] || continue
+    canon_root="$(_oe_view_canonicalize "$root")" || continue
+    [[ -n "$canon_root" ]] || continue
+    # 完全一致、または "<root>/" で始まる（"/a/docs" が "/a/docs-x" を誤許可しない境界）。
+    if [[ "$target" == "$canon_root" || "$target" == "${canon_root}/"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# _oe_view_is_md <path> — 拡張子が .md（大小無視）か。rc 0=md / 1=非 md。
+#   bash 3.2 互換（stock macOS）のため ${var,,} は使わず tr で小文字化する。
+_oe_view_is_md() {
+  local lower
+  lower="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  [[ "$lower" == *.md ]]
+}
+
+# _oe_view_json <status> <kind> <action> [pane_id] — 結果を JSON で stdout へ。
+_oe_view_json() {
+  local status="$1" kind="$2" action="$3" pane_id="${4:-}"
+  if command -v jq >/dev/null 2>&1; then
+    if [[ -n "$pane_id" ]]; then
+      jq -n --arg status "$status" --arg kind "$kind" --arg action "$action" --arg pane_id "$pane_id" \
+        '{status:$status, kind:$kind, action:$action, pane_id:($pane_id|tonumber)}'
+    else
+      jq -n --arg status "$status" --arg kind "$kind" --arg action "$action" \
+        '{status:$status, kind:$kind, action:$action}'
+    fi
+  else
+    if [[ -n "$pane_id" ]]; then
+      printf '{"status":"%s","kind":"%s","action":"%s","pane_id":%s}\n' "$status" "$kind" "$action" "$pane_id"
+    else
+      printf '{"status":"%s","kind":"%s","action":"%s"}\n' "$status" "$kind" "$action"
+    fi
+  fi
+}
+
+oe_view_cli() {
+  local opt_here=0 opt_from_link=0 opt_json=0
+  local target="" have_arg=0
+
+  while [[ "${1:-}" == -* ]]; do
+    case "$1" in
+      --here)      opt_here=1; shift ;;
+      --from-link) opt_from_link=1; shift ;;
+      --json)      opt_json=1; shift ;;
+      -h|--help)   oe_view_usage; return 0 ;;
+      --)          shift; break ;;
+      *)           echo "oe-view: unknown option: $1" >&2; oe_view_usage; return 2 ;;
+    esac
+  done
+
+  # 位置引数の「有無」を $# で判定する（明示的な空文字 "" を「省略」と取り違えない）。
+  if [[ $# -gt 0 ]]; then
+    have_arg=1
+    target="$1"; shift
+    if [[ $# -gt 0 ]]; then
+      echo "oe-view: too many arguments (one path only): $*" >&2; oe_view_usage; return 2
+    fi
+  fi
+  if [[ "$have_arg" -eq 0 ]]; then
+    echo "oe-view: a path is required" >&2; oe_view_usage; return 2
+  fi
+
+  # --- 入力サニタイズ（§5）: 空 / 改行・CR・NUL・制御文字を拒否（exit 1） ---
+  if [[ -z "$target" ]]; then
+    echo "oe-view: empty path" >&2; return 1
+  fi
+  # NUL は bash 変数に格納できない（代入時に剥がれる）ため、ここでは表現可能な制御文字
+  # （改行・CR を含む C0 範囲・DEL）を拒否する。C0 範囲 \x01-\x1f が \n(\x0a)/\r(\x0d) を含む。
+  if [[ "$target" == *[$'\x01'-$'\x1f\x7f']* ]]; then
+    echo "oe-view: path must not contain control characters (newlines, CR, etc.)" >&2; return 1
+  fi
+
+  # --- 実体確認（常に）: 存在 + 通常ファイル ---
+  if [[ ! -e "$target" ]]; then
+    echo "oe-view: path does not exist: ${target}" >&2; return 1
+  fi
+  if [[ ! -f "$target" ]]; then
+    echo "oe-view: not a regular file: ${target}" >&2; return 1
+  fi
+
+  # --- canonical 化（allowlist 判定 / glow 送信に使う絶対パス） ---
+  local canonical
+  if ! canonical="$(_oe_view_canonicalize "$target")" || [[ -z "$canonical" ]]; then
+    echo "oe-view: failed to resolve path: ${target}" >&2; return 1
+  fi
+
+  local is_md=0
+  _oe_view_is_md "$canonical" && is_md=1
+
+  # --- --from-link: allowlist 強制 + 非 md 拒否（§5・P0） ---
+  if [[ "$opt_from_link" -eq 1 ]]; then
+    if [[ "$is_md" -eq 0 ]]; then
+      echo "oe-view: --from-link only opens markdown (.md) files; refusing to open: ${canonical}" >&2
+      return 1
+    fi
+    if ! _oe_view_within_roots "$canonical"; then
+      echo "oe-view: path is outside the allowed roots (OE_VIEW_ROOTS): ${canonical}" >&2
+      return 1
+    fi
+  fi
+
+  # --- 非 md（直叩きのみここに来る）: open -- <path> ---
+  if [[ "$is_md" -eq 0 ]]; then
+    if ! command -v open >/dev/null 2>&1; then
+      echo "oe-view: 'open' not found (required to open non-markdown files)" >&2
+      return 2
+    fi
+    if ! open -- "$canonical"; then
+      echo "oe-view: failed to open: ${canonical}" >&2; return 1
+    fi
+    [[ "$opt_json" -eq 1 ]] && _oe_view_json "ok" "other" "open"
+    return 0
+  fi
+
+  # --- md: --here は現ペインのページャ（glow -p、無ければ bat）。degrade 本線。 ---
+  if [[ "$opt_here" -eq 1 ]]; then
+    if command -v glow >/dev/null 2>&1; then
+      if ! glow -p -- "$canonical"; then
+        echo "oe-view: glow failed for: ${canonical}" >&2; return 1
+      fi
+    elif command -v bat >/dev/null 2>&1; then
+      if ! bat -- "$canonical"; then
+        echo "oe-view: bat failed for: ${canonical}" >&2; return 1
+      fi
+    else
+      echo "oe-view: neither 'glow' nor 'bat' found in PATH (required for --here)." >&2
+      echo "  install: brew install glow  (or brew install bat)" >&2
+      return 2
+    fi
+    [[ "$opt_json" -eq 1 ]] && _oe_view_json "ok" "md" "glow"
+    return 0
+  fi
+
+  # 既定 md: viewer ペインを解決して glow を送る（glow + wez 必須）。
+  if ! command -v glow >/dev/null 2>&1; then
+    echo "oe-view: 'glow' not found in PATH (required to render markdown)." >&2
+    echo "  install: brew install glow  (or use --here with bat installed)" >&2
+    return 2
+  fi
+  if ! command -v wez >/dev/null 2>&1; then
+    echo "oe-view: 'wez' not found in PATH (required to render markdown in a viewer pane)." >&2
+    echo "  use --here to render in the current pane instead." >&2
+    return 2
+  fi
+
+  # oe_viewer_resolve は split 失敗時に rc 2（環境エラー）/ state 失敗時に rc 1。rc を
+  # そのまま伝播する。`if ! cmd; then return $?` は `!` が $? を 0 に潰すため使わず、
+  # 直接 rc を捕捉する。
+  local pane_id rc
+  pane_id="$(oe_viewer_resolve)"; rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    return "$rc"
+  fi
+
+  # 送信文字列は %q 済（lib/oe-viewer.sh の oe_viewer_render_command・注入対策 P0）。
+  local cmd
+  cmd="$(oe_viewer_render_command "$canonical")"
+  if ! wez pane send "$pane_id" "$cmd" >/dev/null 2>&1; then
+    echo "oe-view: failed to send render command to viewer pane ${pane_id}" >&2
+    return 1
+  fi
+
+  [[ "$opt_json" -eq 1 ]] && _oe_view_json "ok" "md" "glow" "$pane_id"
+  return 0
+}
+
+# 直接実行時のみ CLI を起動（test から source した場合は自動実行しない・oe-capture 同型）。
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  oe_view_cli "$@"
+fi

--- a/projects/orchestration-engine/bin/oe-view
+++ b/projects/orchestration-engine/bin/oe-view
@@ -23,11 +23,21 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../lib/oe-viewer.sh
 source "${BIN_DIR}/../lib/oe-viewer.sh"
 
-# allowlist（DJ-2/§5・P0）の許可ルート。コロン区切り。未設定時の既定は hub リポの
-# projects/*/docs 相当＝リポジトリルート配下の projects/。bin/ は
+# allowlist（DJ-2/§5・P0）の許可ルート。コロン区切り。未設定時の既定は plan §3 のとおり
+# hub リポ各プロジェクトの docs/ のみ（クリック安全境界を doc に限定）。projects/ 全体だと
+# bin/ 等の非 doc も許可してしまい仕様より広い（#210 実装SO=oe-review 指摘）。bin/ は
 # projects/orchestration-engine/bin なので 3 階層上がリポジトリルート。
-_OE_VIEW_DEFAULT_ROOT="$(cd "${BIN_DIR}/../../.." && pwd)/projects"
-OE_VIEW_ROOTS="${OE_VIEW_ROOTS:-${_OE_VIEW_DEFAULT_ROOT}}"
+_oe_view_default_roots() {
+  local repo d out=""
+  repo="$(cd "${BIN_DIR}/../../.." 2>/dev/null && pwd)" || true
+  [[ -n "$repo" ]] || return 0
+  for d in "$repo"/projects/*/docs; do
+    [[ -d "$d" ]] || continue
+    out="${out:+$out:}$d"
+  done
+  printf '%s' "$out"
+}
+OE_VIEW_ROOTS="${OE_VIEW_ROOTS:-$(_oe_view_default_roots)}"
 
 oe_view_usage() {
   cat >&2 <<'EOF'
@@ -214,11 +224,13 @@ oe_view_cli() {
 
   # --- md: --here は現ペインのページャ（glow -p、無ければ bat）。degrade 本線。 ---
   if [[ "$opt_here" -eq 1 ]]; then
+    local here_action="glow"
     if command -v glow >/dev/null 2>&1; then
       if ! glow -p -- "$canonical"; then
         echo "oe-view: glow failed for: ${canonical}" >&2; return 1
       fi
     elif command -v bat >/dev/null 2>&1; then
+      here_action="bat"
       if ! bat -- "$canonical"; then
         echo "oe-view: bat failed for: ${canonical}" >&2; return 1
       fi
@@ -227,7 +239,8 @@ oe_view_cli() {
       echo "  install: brew install glow  (or brew install bat)" >&2
       return 2
     fi
-    [[ "$opt_json" -eq 1 ]] && _oe_view_json "ok" "md" "glow"
+    # JSON の action は実際に使ったレンダラを反映する（bat フォールバック時は "bat"）。
+    [[ "$opt_json" -eq 1 ]] && _oe_view_json "ok" "md" "$here_action"
     return 0
   fi
 

--- a/projects/orchestration-engine/bin/oe-view
+++ b/projects/orchestration-engine/bin/oe-view
@@ -63,11 +63,26 @@ _oe_view_canonicalize() {
     realpath -- "$path" 2>/dev/null
     return
   fi
-  # フォールバック: dir を物理解決（symlink/.. を解消）して basename を足す。
-  local dir base
+  # フォールバック: まず最終要素（ファイル）の symlink を追跡解決してから dir を物理解決する。
+  # cd -P は dir の symlink/.. を解消するが「最終要素＝ファイル symlink」は解かない。これを
+  # 怠ると、許可ルート内の symlink が **ルート外の実体** を指すケースで allowlist（--from-link
+  # の P0 境界）をバイパスできてしまう（#210 実装SO=oe-review で検出）。bounded loop で最終要素
+  # symlink を辿り（BSD readlink は 1 段ずつ・循環は上限で打ち切り）、実体の dir を物理解決する。
+  # realpath 主経路では起きない（フォールバック専用の fail-safe）。
+  local dir base resolved_dir target i=0
+  while [[ -L "$path" ]]; do
+    i=$((i + 1))
+    if [[ "$i" -gt 40 ]]; then
+      echo "oe-view: too many levels of symbolic links: $1" >&2; return 1
+    fi
+    target="$(readlink -- "$path")" || return 1
+    case "$target" in
+      /*) path="$target" ;;
+      *)  path="$(dirname -- "$path")/${target}" ;;
+    esac
+  done
   dir="$(dirname -- "$path")"
   base="$(basename -- "$path")"
-  local resolved_dir
   resolved_dir="$(cd -P -- "$dir" 2>/dev/null && pwd -P)" || return 1
   printf '%s/%s\n' "$resolved_dir" "$base"
 }

--- a/projects/orchestration-engine/bin/oe-view
+++ b/projects/orchestration-engine/bin/oe-view
@@ -5,7 +5,8 @@
 #        oe-view --help
 #
 # パスから Finder/手動ペイン操作なしで即ビューする入口:
-#   md（*.md・拡張子/大小無視）→ viewer ペインを解決して glow で描画（lib/oe-viewer.sh）
+#   md（*.md・拡張子/大小無視）→ viewer ペインのプログラムとして glow を直接起動して描画
+#                                 （argv-spawn replace モデル・lib/oe-viewer.sh・DJ-4/§11）
 #   非 md → `open -- <path>`（既定のアプリで開く）
 #
 # クリック層（wezterm.lua の hyperlink_rules + open-uri）に非依存で単体動作する。クリック経由は
@@ -215,7 +216,7 @@ oe_view_cli() {
     return 0
   fi
 
-  # 既定 md: viewer ペインを解決して glow を送る（glow + wez 必須）。
+  # 既定 md: viewer ペインのプログラムとして glow を直接起動（argv-spawn・glow + wez 必須）。
   if ! command -v glow >/dev/null 2>&1; then
     echo "oe-view: 'glow' not found in PATH (required to render markdown)." >&2
     echo "  install: brew install glow  (or use --here with bat installed)" >&2
@@ -227,21 +228,14 @@ oe_view_cli() {
     return 2
   fi
 
-  # oe_viewer_resolve は split 失敗時に rc 2（環境エラー）/ state 失敗時に rc 1。rc を
-  # そのまま伝播する。`if ! cmd; then return $?` は `!` が $? を 0 に潰すため使わず、
-  # 直接 rc を捕捉する。
+  # oe_viewer_resolve は (生存 viewer を kill して) glow を argv-spawn する replace モデル。
+  # path は argv 要素として渡るので %q 不要・注入面なし（§5）。spawn 失敗時 rc 2（環境エラー）/
+  # state 更新失敗時 rc 1。rc をそのまま伝播する。`if ! cmd; then return $?` は `!` が $? を
+  # 0 に潰すため使わず、直接 rc を捕捉する。
   local pane_id rc
-  pane_id="$(oe_viewer_resolve)"; rc=$?
+  pane_id="$(oe_viewer_resolve "$canonical")"; rc=$?
   if [[ "$rc" -ne 0 ]]; then
     return "$rc"
-  fi
-
-  # 送信文字列は %q 済（lib/oe-viewer.sh の oe_viewer_render_command・注入対策 P0）。
-  local cmd
-  cmd="$(oe_viewer_render_command "$canonical")"
-  if ! wez pane send "$pane_id" "$cmd" >/dev/null 2>&1; then
-    echo "oe-view: failed to send render command to viewer pane ${pane_id}" >&2
-    return 1
   fi
 
   [[ "$opt_json" -eq 1 ]] && _oe_view_json "ok" "md" "glow" "$pane_id"

--- a/projects/orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md
@@ -45,16 +45,18 @@ UI 機能ひとつで、**上流の検証ゲートが全部 green でも実欠�
 - **次の消費者**: pane 描画/spawn を伴う engine ツールを次に作る人（real-e2e を先例ゲートとして）／#210 マージ実行者。
 - **follow-up routing**:
   - Cmd+Click → oe-view 発火の実 e2e → 両 PR マージ後に親が実施（本 episode の持ち越し）
-  - 昇格候補 2 件（下記「蒸留シグナル」）→ 可否はユーザー判断（本ターンで提起済・未確定）
+  - 昇格（下記「蒸留シグナル」で基準判定済）: 候補2=ADR-004 DJ-10 へ昇格済 / 候補1=ADR 対象外・rule 昇格は時期尚早で defer
   - 非material 残差（`OE_VIEW_ROOTS` 空白パス・稀な state 書込失敗）→ **追わない**（Minimal Scope 宣言）
   - worktree 掃除（hub / dotfiles 子）→ マージ時
 - **status**: stable（達成度＝**部分**: hub 側は実機 e2e まで完結／Cmd+Click 実 e2e はマージ後）
 - **evidence anchor**: 実装SO 4 巡の verdict・reviewed_sha・e2e 結果は PR #212 のコメントに転記済（`tmp/` 出力は揮発のため PR コメントを正本アンカーとする）
 
-## 蒸留シグナル（昇格候補）
+## 蒸留シグナル（昇格基準に照らした判定）
 
-- 候補1: 「**pane 描画/レンダラ起動系は実機 e2e を必須ゲートに**」→ rule もしくは Decision（mock の限界が起点）。
-- 候補2: 「**新ペイン描画は argv-spawn（`split-pane -- PROG`）／シェルへの send は使わない**」→ wezterm-ai-mode の ADR 候補。
+昇格基準＝「非自明な設計判断（選択肢比較・棄却案あり）」（`episode-retrospective:40`）に当てて判定:
+
+- 候補1「pane 描画系は実機 e2e 必須ゲート」→ **ADR 対象外**。選択肢比較・棄却案を伴う設計判断ではなく、検証規律＝**negative knowledge**（#62 注入先候補）。rule への昇格は 1 事例では時期尚早 → **defer**（非昇格判断を本 episode に記録・`episode-flow-discipline:19`）。
+- 候補2「新ペイン描画は argv-spawn（`split-pane -- PROG`）／shell send 棄却」→ **昇格済**。shell-send を実機で棄却 → argv-spawn 採用＝「選択肢比較・棄却案あり」に該当。pane 設計判断なので慣習どおり **ADR-004 に DJ-10 として追記**（`projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md`・DJ-8/#174・DJ-9/#165 と同じ追記方式）。
 
 ## Step4（heavy 外部チェック）辞退
 

--- a/projects/orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md
@@ -1,71 +1,61 @@
 ---
 id: "01KVQA86WVXQQVPFSB65NE5ZP0"
-title: "oe-view クリッカブル md ビューア — 実装と『mock では見えない実結合欠陥』の記録"
+title: "oe-view #210 — 上流ゲートが全部 green でも実欠陥は残った、の記録"
 date: 2026-06-22
 type: episode
-status: draft
+status: stable
 related:
   - type: target_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/210"
-    reason: "本 episode の対象 Issue"
+    reason: "対象 Issue"
   - type: pr
     ref: "https://github.com/stlwolf/ai-development-hub/pull/212"
-    reason: "PR1（hub oe-view + wez PROG passthrough）"
+    reason: "PR1（実装SO 4巡の verdict/sha・e2e 結果はここのコメントが正本アンカー）"
   - type: pr
     ref: "https://github.com/stlwolf/dotfiles/pull/21"
-    reason: "PR2（dotfiles wezterm.lua クリック層 + glow Brewfile）"
+    reason: "PR2（dotfiles クリック層）"
   - type: plan
     ref: "projects/orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md"
-    reason: "設計・設計SO reconcile・DJ-4 argv-spawn 改定（§11）"
-tags: [oe-view, cockpit, wezterm, episode, negative-knowledge, mock-vs-e2e, implementation-so]
+    reason: "設計・DJ・argv-spawn 改定（§11）— 技術 how の正本"
+tags: [oe-view, cockpit, episode, negative-knowledge, mock-vs-e2e, implementation-so]
 ---
 
-# oe-view クリッカブル md ビューア — 実装と「mock では見えない実結合欠陥」の記録
+# oe-view #210 — 上流ゲートが全部 green でも実欠陥は残った、の記録
 
-> **reconstructed**: 本 episode は作業中のリアルタイム追記ではなく、作業後にまとめて再構成した（episode-flow-discipline 違反の自己申告・証拠価値は real-time 追記より低い）。時刻順の細部より、再利用価値のある学び（Negative Knowledge）の保全を主目的とする。
-> closure（episode-retrospective: 消費者明示・routing・status 確定・tier 判定・Decision 昇格検討）は **両 PR マージ時に実施**（本時点は draft）。
+> **reconstructed**: 作業後の再構成（リアルタイム追記を怠った自己申告・証拠価値は real-time より低い）。
+> closure は plan 完了＋実装SO 4 巡 survived 後・**マージ前**に実施。tier=heavy。技術詳細（コマンド仕様・argv-spawn 機構・allowlist 実装）は plan §11 / PR #212 / コードにあるので本書では再掲しない。
 
-## 何をやったか（要約）
+## なぜ始まったか
 
-生成 doc の md を Finder/手動ペイン操作なしで即ビューする `oe-view`（クリック起点）。痛点ヒアリング → レンダラ/起動 DJ 確定（glow + クリック）→ 設計SO(3者) reconcile → 実装 → 実機 e2e → 実装SO(oe-review 4巡) → 2 PR（hub #212 / dotfiles #21）。クロスセッション委譲（親=PR1 / 子=dotfiles PR2 / 実装サブエージェント）。
+cockpit（#169）で生成 doc の md を Finder/手動ペイン操作なしで即ビューしたい。
 
-## 核心の学び（Negative Knowledge）
+## この episode の価値（他ファイルから復元できない接続）
 
-### L1. mock-shim テストは「実結合」を原理的に検証できない（最重要）
+UI 機能ひとつで、**上流の検証ゲートが全部 green でも実欠陥が 3 件残った**——うち 1 件は P0（allowlist バイパス）。
 
-`test_oe_view.sh` は 61 件 pass（bash 4/3.2）だが、**実機でしか出ない欠陥が 3 つ**出た。mock は「呼び出し引数」を記録するだけで、シェル実行・tmux 自動アタッチ・PATH 解決・タイミングを再現しない。
+- green だったのに通り抜けた上流: mock 単体 61 件 / 親のコード read / **設計SO 3 者**。
+- 実欠陥を捕捉したのは下流の **実機 e2e と実装SO（oe-review）だけ**。しかも実機 e2e に踏み込んだ契機は、人の「**実地テストした？**」の一言だった（それが無ければ green のままマージしていた）。
+- 見逃しの理由は共通: mock は呼び出し引数しか見ず実行・tmux 自動アタッチ・PATH 実体・タイミングを再現しない。設計SO とコード read は「コードが正しいか」を見て「実環境で動くか」を見ない。実装SO は設計SO と別レンズ（reviewed diff の到達可能性）なので P0 を拾えた。
+- 実装SO が 4 巡を要したのは、各修正が次の層を露出させたから（P0 コード → 既定が仕様より広い → **その修正で生じた doc/code drift**＝自分の取りこぼし → clean）。3 巡目は自己誘発。
 
-- **(a) shell-send→glow が描画しない**: 初版は `wez pane split`（シェル）→ `wez pane send "glow -- <path>"`。実 wezterm+tmux では新規ペインのシェル rc が **tmux に自動アタッチ**し、send したコマンドが実行されず glow が描画されない（capture に tmux ステータスバー＋生コマンドのみ・marker 未生成で確定）。#144/#188 系統。
-- **(b) PATH の wez 実体取り違え**: 修正で `wez pane split` に PROG パススルーを足したが、`oe-view` は **PATH の `wez`（`~/bin/wez`＝main repo への symlink・master 版＝PROG 非対応）** を呼ぶため失敗。worktree の wez を PATH 前置すると成功。「どの wez 実体が PATH に乗るか」は mock の外。
-- **(c) P0 allowlist symlink バイパス**: `--from-link` の canonicalize フォールバック（realpath 不在時の `cd -P dir`+basename）が**最終要素のファイル symlink を解かず**、許可 root 内 symlink で root 外 md を開けた。mock・親 spot-check・**設計SO すべて見逃し**、実装SO だけが捕捉。
+→ 結論（転用可能）: **pane 描画/レンダラ起動を伴う機能では、real e2e と実装SO が load-bearing。green な mock を結合の証拠として扱わない。**
 
-→ **対策（plan §6/§11 に反映）**: pane 描画・レンダラ起動を伴う機能は **実機 e2e を必須ゲート**化。mock は logic 検証に留め、render/spawn/timing は実機で確認する。
+## closure
 
-### L2. 実装SO（oe-review）は設計SO と別レンズで load-bearing
+- **次の消費者**: pane 描画/spawn を伴う engine ツールを次に作る人（real-e2e を先例ゲートとして）／#210 マージ実行者。
+- **follow-up routing**:
+  - Cmd+Click → oe-view 発火の実 e2e → 両 PR マージ後に親が実施（本 episode の持ち越し）
+  - 昇格候補 2 件（下記「蒸留シグナル」）→ 可否はユーザー判断（本ターンで提起済・未確定）
+  - 非material 残差（`OE_VIEW_ROOTS` 空白パス・稀な state 書込失敗）→ **追わない**（Minimal Scope 宣言）
+  - worktree 掃除（hub / dotfiles 子）→ マージ時
+- **status**: stable（達成度＝**部分**: hub 側は実機 e2e まで完結／Cmd+Click 実 e2e はマージ後）
+- **evidence anchor**: 実装SO 4 巡の verdict・reviewed_sha・e2e 結果は PR #212 のコメントに転記済（`tmp/` 出力は揮発のため PR コメントを正本アンカーとする）
 
-設計SO（so-compare 3者・選択肢拡張）は方向・反証に有効だが、**コード欠陥の到達可能性**は別レンズ。実装SO（`oe-review --lanes 3`・reviewed diff バインド）が設計SO の見逃した P0(c) を捕捉。4 巡で P0→spec(既定広すぎ)→doc/code 不整合 と収束し survived。conservative 集約（1レーン material→全体 refuted）が効いた。「設計SO を回しても実装SO の代替にならない」（#192 false-pass 回避）の実例。
+## 蒸留シグナル（昇格候補）
 
-### L3. argv-spawn が新ペイン描画の正解
+- 候補1: 「**pane 描画/レンダラ起動系は実機 e2e を必須ゲートに**」→ rule もしくは Decision（mock の限界が起点）。
+- 候補2: 「**新ペイン描画は argv-spawn（`split-pane -- PROG`）／シェルへの send は使わない**」→ wezterm-ai-mode の ADR 候補。
 
-「シェルにコマンドをタイプ送信」ではなく **ペインのプログラムとして直接起動**（`wezterm cli split-pane [PROG]` = シェルの代わりに PROG 実行）。`wez pane split … -- glow -p -- <path>`。シェルも tmux も経由せず確実に描画し、path が **argv 要素**で渡るため再トークナイズが起きず **シェル注入面も消滅**（`%q` 不要化）。viewer 再利用は send 不可（pager はシェルでない）ため **replace**（kill→spawn）。
+## Step4（heavy 外部チェック）辞退
 
-### L4. デプロイ結合（worktree と PATH 実体のズレ）
-
-hub のツールは PATH の実体（`~/bin/*` = main repo への symlink）を呼ぶため、**worktree 上の変更はマージ前は PATH に乗らない**。ローカル実機 e2e では worktree の bin を PATH 前置する必要がある。逆に、同一 PR に同梱した wez(PROG)+oe-view は **master マージで symlink 経由同時有効化**される。
-
-## 効いた進め方（Positive）
-
-- **クロスセッション委譲**: 親=PR1（hub）/ 子=dotfiles PR2（auto 権限・HG は親へエスカレーション）/ 実装サブエージェント（implementer-contract）。契約（`oe-view --from-link <path>` IF）を固定したため、内部を argv-spawn に作り直しても **dotfiles PR2 は無改修**で済んだ。
-- **段階を分けない判断**: 「core とクリック層を分割出荷しない」をユーザーと合意（issue 1 / PR 2）。
-- **トリガ再計量の確定前トレース**: 設計SO がゼロベースで QuickSelect/record-replay を提示 → クリック維持＋全緩和で確定（predecision-exploration）。
-
-## 未確認 / 持ち越し
-
-- **Cmd+Click → oe-view 発火**の end-to-end は両 PR マージ後に実機確認。
-- 非material 残差（`OE_VIEW_ROOTS` の空白パス・稀な state 書込失敗）は Minimal Scope で非対応。
-
-## closure（マージ時に実施・現時点 TODO）
-
-- [ ] 消費者明示 / routing / status 確定（episode-retrospective）
-- [ ] Decision 昇格検討: 「pane 描画系は実機 e2e 必須」「argv-spawn for new-pane render」は汎用原則になりうる（L1/L3）→ Decision or 既存ルールへの反映を判断
-- [ ] worktree 掃除（hub / dotfiles 子）
+Step4 辞退: オーナーが本 closure を対面レビュー中＋失敗 3 件と実装SO 4 巡は PR #212 コメントに durable 記録済 / 既存チェックで覆った観点: routing・evidence anchor・選択的省略チェック（失敗は隠していない）・back-propagation（plan §11 に反映済）/ 未実施観点と判断: なし

--- a/projects/orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md
@@ -1,0 +1,71 @@
+---
+id: "01KVQA86WVXQQVPFSB65NE5ZP0"
+title: "oe-view クリッカブル md ビューア — 実装と『mock では見えない実結合欠陥』の記録"
+date: 2026-06-22
+type: episode
+status: draft
+related:
+  - type: target_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/210"
+    reason: "本 episode の対象 Issue"
+  - type: pr
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/212"
+    reason: "PR1（hub oe-view + wez PROG passthrough）"
+  - type: pr
+    ref: "https://github.com/stlwolf/dotfiles/pull/21"
+    reason: "PR2（dotfiles wezterm.lua クリック層 + glow Brewfile）"
+  - type: plan
+    ref: "projects/orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md"
+    reason: "設計・設計SO reconcile・DJ-4 argv-spawn 改定（§11）"
+tags: [oe-view, cockpit, wezterm, episode, negative-knowledge, mock-vs-e2e, implementation-so]
+---
+
+# oe-view クリッカブル md ビューア — 実装と「mock では見えない実結合欠陥」の記録
+
+> **reconstructed**: 本 episode は作業中のリアルタイム追記ではなく、作業後にまとめて再構成した（episode-flow-discipline 違反の自己申告・証拠価値は real-time 追記より低い）。時刻順の細部より、再利用価値のある学び（Negative Knowledge）の保全を主目的とする。
+> closure（episode-retrospective: 消費者明示・routing・status 確定・tier 判定・Decision 昇格検討）は **両 PR マージ時に実施**（本時点は draft）。
+
+## 何をやったか（要約）
+
+生成 doc の md を Finder/手動ペイン操作なしで即ビューする `oe-view`（クリック起点）。痛点ヒアリング → レンダラ/起動 DJ 確定（glow + クリック）→ 設計SO(3者) reconcile → 実装 → 実機 e2e → 実装SO(oe-review 4巡) → 2 PR（hub #212 / dotfiles #21）。クロスセッション委譲（親=PR1 / 子=dotfiles PR2 / 実装サブエージェント）。
+
+## 核心の学び（Negative Knowledge）
+
+### L1. mock-shim テストは「実結合」を原理的に検証できない（最重要）
+
+`test_oe_view.sh` は 61 件 pass（bash 4/3.2）だが、**実機でしか出ない欠陥が 3 つ**出た。mock は「呼び出し引数」を記録するだけで、シェル実行・tmux 自動アタッチ・PATH 解決・タイミングを再現しない。
+
+- **(a) shell-send→glow が描画しない**: 初版は `wez pane split`（シェル）→ `wez pane send "glow -- <path>"`。実 wezterm+tmux では新規ペインのシェル rc が **tmux に自動アタッチ**し、send したコマンドが実行されず glow が描画されない（capture に tmux ステータスバー＋生コマンドのみ・marker 未生成で確定）。#144/#188 系統。
+- **(b) PATH の wez 実体取り違え**: 修正で `wez pane split` に PROG パススルーを足したが、`oe-view` は **PATH の `wez`（`~/bin/wez`＝main repo への symlink・master 版＝PROG 非対応）** を呼ぶため失敗。worktree の wez を PATH 前置すると成功。「どの wez 実体が PATH に乗るか」は mock の外。
+- **(c) P0 allowlist symlink バイパス**: `--from-link` の canonicalize フォールバック（realpath 不在時の `cd -P dir`+basename）が**最終要素のファイル symlink を解かず**、許可 root 内 symlink で root 外 md を開けた。mock・親 spot-check・**設計SO すべて見逃し**、実装SO だけが捕捉。
+
+→ **対策（plan §6/§11 に反映）**: pane 描画・レンダラ起動を伴う機能は **実機 e2e を必須ゲート**化。mock は logic 検証に留め、render/spawn/timing は実機で確認する。
+
+### L2. 実装SO（oe-review）は設計SO と別レンズで load-bearing
+
+設計SO（so-compare 3者・選択肢拡張）は方向・反証に有効だが、**コード欠陥の到達可能性**は別レンズ。実装SO（`oe-review --lanes 3`・reviewed diff バインド）が設計SO の見逃した P0(c) を捕捉。4 巡で P0→spec(既定広すぎ)→doc/code 不整合 と収束し survived。conservative 集約（1レーン material→全体 refuted）が効いた。「設計SO を回しても実装SO の代替にならない」（#192 false-pass 回避）の実例。
+
+### L3. argv-spawn が新ペイン描画の正解
+
+「シェルにコマンドをタイプ送信」ではなく **ペインのプログラムとして直接起動**（`wezterm cli split-pane [PROG]` = シェルの代わりに PROG 実行）。`wez pane split … -- glow -p -- <path>`。シェルも tmux も経由せず確実に描画し、path が **argv 要素**で渡るため再トークナイズが起きず **シェル注入面も消滅**（`%q` 不要化）。viewer 再利用は send 不可（pager はシェルでない）ため **replace**（kill→spawn）。
+
+### L4. デプロイ結合（worktree と PATH 実体のズレ）
+
+hub のツールは PATH の実体（`~/bin/*` = main repo への symlink）を呼ぶため、**worktree 上の変更はマージ前は PATH に乗らない**。ローカル実機 e2e では worktree の bin を PATH 前置する必要がある。逆に、同一 PR に同梱した wez(PROG)+oe-view は **master マージで symlink 経由同時有効化**される。
+
+## 効いた進め方（Positive）
+
+- **クロスセッション委譲**: 親=PR1（hub）/ 子=dotfiles PR2（auto 権限・HG は親へエスカレーション）/ 実装サブエージェント（implementer-contract）。契約（`oe-view --from-link <path>` IF）を固定したため、内部を argv-spawn に作り直しても **dotfiles PR2 は無改修**で済んだ。
+- **段階を分けない判断**: 「core とクリック層を分割出荷しない」をユーザーと合意（issue 1 / PR 2）。
+- **トリガ再計量の確定前トレース**: 設計SO がゼロベースで QuickSelect/record-replay を提示 → クリック維持＋全緩和で確定（predecision-exploration）。
+
+## 未確認 / 持ち越し
+
+- **Cmd+Click → oe-view 発火**の end-to-end は両 PR マージ後に実機確認。
+- 非material 残差（`OE_VIEW_ROOTS` の空白パス・稀な state 書込失敗）は Minimal Scope で非対応。
+
+## closure（マージ時に実施・現時点 TODO）
+
+- [ ] 消費者明示 / routing / status 確定（episode-retrospective）
+- [ ] Decision 昇格検討: 「pane 描画系は実機 e2e 必須」「argv-spawn for new-pane render」は汎用原則になりうる（L1/L3）→ Decision or 既存ルールへの反映を判断
+- [ ] worktree 掃除（hub / dotfiles 子）

--- a/projects/orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md
+++ b/projects/orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md
@@ -63,14 +63,13 @@ oe-view --help
 - **DJ-1 配置 = engine `projects/orchestration-engine/bin/oe-view`**。ただし根拠を訂正: oe-jump の engine 配置理由（`oe_reg_resolve`=tmux↔registry glue）は oe-view に転用しない（oe-view は registry/tmux 不使用）。配置理由は「**cockpit UX glue**（wez pane + open + 種別ディスパッチ）であり、`wez` は下層プリミティブのまま（ADR-001/004 の wez=下層方針を守る・上方依存を作らない）」。viewer 解決ロジックは `lib/oe-viewer.sh` に切り出してテスト mock 容易化。
 - **DJ-2 クリッカブル化 = `hyperlink_rules` 自動マッチ**。必須: `config.hyperlink_rules` 代入はデフォルト規則を全消しするため `wezterm.default_hyperlink_rules()` に `table.insert`。regex は doc ルート＋サブdir＋拡張子で厳格に絞る（例: `…/ai-development-hub/projects/[^/]+/docs/(plans|episodes|kickoffs|discussions|decisions)/[^[:space:]]+\.md`）。空白なしパスのみ対象（本リポは kebab パス規約）。OSC 8 明示出力は tmux で落ちやすい（hyperlink_rules は描画グリッド層で tmux 下も効く）ため v1 では採らない（将来 precision 層候補）。
 - **DJ-3 click→command = wezterm.lua `open-uri` ハンドラ**。条件: ハンドラは `oeview:` 以外を無視・URI を厳格 parse（`oeview:///<abs-path>` 三スラッシュ）・**argv 配列**で `oe-view --from-link <path>` を起動（`wezterm.background_child_process`/`run_child_process`、shell 非経由）。GUI プロセスは PATH が痩せるため `oe-view`/`glow` は**絶対パス**指定。UX は Cmd+Click（`CompleteSelectionOrOpenLinkAtMouseCursor`）と明記。
-- **DJ-4 viewer ペイン = state file 追跡で再利用**。`~/.claude/state/oe-view/viewer-pane-id`（oe-jump の last-target 同型）に pane_id 保存 → `_wez_pane_exists` 相当で生存確認 → 生存なら send / 無効なら split+state 更新。**glow の TUI ページャと send の衝突**を避けるため、再利用は「前回プロセス終了＝プロンプト復帰」を保証できる起動形に限定（非ページャ or 表示後復帰）。できない場合は「毎回 split + 古い viewer kill」に倒す。**新規作成時は `wez pane activate <source>`** でフォーカス奪取（#111）を回避（既定 focus=作業ペイン維持）。
+- **DJ-4 viewer ペイン = argv-spawn の replace モデル**（実機検証で確定・§10）。当初の「split したシェルへ glow をタイプ送信して再利用」は **cockpit で新規ペインが tmux 自動アタッチするため送信コマンドが実行されず glow が描画されない**ことが実機で判明（mock 不可視）。代わりに **ペインのプログラムとして glow を直接起動**する: `wez pane split --right --percent 40 --cwd <dir> -- glow -p <path>`（`wezterm cli split-pane [PROG]`＝シェルの代わりに PROG 実行・公式仕様、実機で描画確認済）。シェルも tmux も経由しない。再利用は **replace**: state（`~/.claude/state/oe-view/viewer-pane-id`）の viewer が生存なら **kill → 新 glow ペインを spawn → state 更新**（glow -p はページャでシェルでないため send 再利用不可）。**spawn 後に `wez pane activate <source>`** で #111 フォーカス奪取を回避。
+  - 前提作業: `wez pane split`（`projects/wezterm-ai-mode`）に **trailing `-- <PROG>...` パススルー**を追加（現状は方向/percent/cwd のみで PROG 非対応）。`wezterm cli split-pane` の PROG をそのまま通す薄い拡張。oe-view が `wezterm cli` を直接叩かず wez 抽象（socket 解決込み）を保つため。
 - **DJ-5 fallback**: `--here` で `glow -p` / `bat`（導入済）。glow 不在・wez 不在は exit 2 + 導入案内。素 install 検証 → 採用なら dotfiles codify。
 
 ## 5. セキュリティ / 堅牢性（実装必須・設計SO で格上げ）
 
-- **送信層のシェル注入（P0・最重要）**: viewer 表示が `wez pane send <id> "glow -- <path>"` の場合、`send-text`（`projects/wezterm-ai-mode/lib/pane.sh:465`）は受信シェルに**行入力としてタイプ→再トークナイズ**される。実在ファイル名 `a$(whoami).md` でも `$(whoami)` がペインのシェルで評価される（`\n` 拒否はメタ文字を防がない）。
-  - v1 修正: 送信文字列を組む直前に `printf %q` でシェルクォート（`glow -- <quoted>`）。
-  - 本筋（follow-up 候補）: `wez` に argv spawn verb（`wezterm cli spawn -- glow <path>`）を足し、shell を経由しない。実装時に v1（%q）か本筋（spawn 追加）かを再評価。
+- **送信層のシェル注入（P0）→ argv-spawn 採用で構造的に解消**（DJ-4 改定）。当初案は `wez pane send` でシェルへタイプ→再トークナイズの注入面があり `printf %q` で緩和予定だった。実機検証の結果 send 経路自体を廃し、path を **`wezterm cli split-pane -- glow -p <path>` の argv 要素**として渡す（shell を一切経由しない）→ 再トークナイズが起きないため `%q` 不要・注入面が消滅。`--here` も `glow -p -- <path>` / `bat -- <path>` の argv 起動で同様に安全。
 - **allowlist 実装必須（P0）**: `oe-view`（特に `--from-link`）は `realpath` 正規化後に doc ルート配下 prefix を判定（`..`/symlink トラバーサル対策）。範囲外は exit 1。
 - **入力サニタイズ**: URI decode 後の改行・NUL・制御文字を拒否。実体存在＋通常ファイル確認。
 - **クリック経由は md 限定**: `--from-link` では非 md `open`（任意アプリ/スクリプト起動）を禁止。CLI 直叩きの非 md `open` とは分ける。
@@ -81,14 +80,16 @@ oe-view --help
 
 `oe-view`（hub・shell・mock shim で wez/glow/open を差し替え）:
 
-- [ ] md 判定 → viewer 解決 + glow 表示の引数列 / 非 md → `open -- <path>`
-- [ ] **注入**: `a$(whoami).md` 等メタ文字ファイル名で送信文字列が `%q` 済（or argv 起動で shell 非経由）であること
+- [ ] md 判定 → `wez pane split … -- glow -p <path>`（argv）の引数列 / 非 md → `open -- <path>`
+- [ ] **注入**: `a$(whoami).md` 等メタ文字ファイル名でも path が **argv 要素**として渡る（shell 非経由・送信文字列を組まない）こと
 - [ ] **allowlist**: doc ルート外パス・symlink 経由の範囲外・`..` → exit 1
-- [ ] 入力サニタイズ: 改行/NUL/制御文字を拒否
+- [ ] 入力サニタイズ: 改行/制御文字を拒否
 - [ ] `--from-link` で非 md `open` が拒否される
-- [ ] viewer 再利用: state の pane 生存→send / stale→split+state 更新 / 新規作成時 source へ activate
+- [ ] viewer replace: state の pane 生存→**kill→spawn→state 更新** / stale・無し→spawn+state / spawn 後 source へ activate
 - [ ] 不在パス→exit 1 / usage 不正→exit 2 / wez・glow 不在→exit 2 + 案内
 - [ ] `--here`（`glow -p`/`bat`）/ `--json` スキーマ（`jq -e`）/ `shellcheck`
+- [ ] `wez pane split -- <PROG>` パススルー（wezterm-ai-mode 側）の単体テスト（PROG 有無で引数列が変わる）
+- [ ] **実機 e2e**: 実 wezterm で `oe-view <md>` → 新ペインで glow が**描画**されること（mock では不可視・必須ゲート）
 
 wezterm.lua 連携（手動・実機ゲート）:
 
@@ -130,3 +131,12 @@ wezterm.lua 連携（手動・実機ゲート）:
 - **DJ-5 exit code 矛盾**: Codex 指摘。環境エラーを `2` に統一で解消。
 - **トリガ再計量**: 3者がキーボードトリガ（QuickSelect/fzf/record-replay）をリスク低減案として提示。ユーザー判断で**クリック維持＋全緩和**に確定。QuickSelect は将来の追加トリガ候補として記録（v1 範囲外）。
 - **1 issue 一括 vs 分割**: issue 1 / PR 2 で合意（§8）。
+
+## 11. 実機 e2e 検証で判明した DJ-4 改定（2026-06-22）
+
+PR1 初版（split したシェルへ `wez pane send "glow -- <path>"`）を実 wezterm+tmux で検証した結果、**glow が描画されない**ことを確認（capture に tmux ステータスバー＋生コマンドのみ・marker ファイル未生成＝コマンド未実行）。
+
+- 根本原因: 新規 wez ペインのシェル rc が **tmux に自動アタッチ**し、`wez pane send` でタイプした命令が tmux 起動タイミングと衝突して実行されない（#144 / ADR-003 / #188 系統）。mock shim は send 引数を記録するだけで実行・tmux・タイミングを再現しないため不可視だった。
+- 検証で確定した修正: **argv-spawn**。`wezterm cli split-pane [PROG]`（公式: シェルの代わりに PROG 実行）で `glow -p <path>` を**ペインのプログラムとして直接起動**。実機で描画を確認（`SPAWN_RENDER_OK` レンダ）。シェル/tmux 非経由ゆえ確実、かつ path が argv で渡り注入面も消滅（§5 改定）。
+- 併せて確認できた動作（実機）: `--here`+bat 描画 / allowlist 通過・非md拒否 / サニタイズ / realpath 正規化 / viewer split・state 再利用解決 / #111 focus 復帰。
+- 教訓: viewer 描画系は mock では検証不能。**実機 e2e を必須ゲート化**（§6）。

--- a/projects/orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md
+++ b/projects/orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md
@@ -1,0 +1,132 @@
+---
+id: "01KVMXY9NKS11MSMHCN5F6QSKP"
+title: "oe-view 実装計画 — 生成doc のクリッカブル md ビューア（hyperlink_rules + open-uri）"
+date: 2026-06-21
+type: plan
+status: draft
+related:
+  - type: target_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/210"
+    reason: "本計画の対象 Issue"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/169"
+    reason: "CLI cockpit リッチ UI ツール群（親）"
+  - type: reference
+    ref: "projects/orchestration-engine/docs/discussions/2026-06-21-discussion-179-notify-pane-jump.md"
+    reason: "#179 はトーストclick=url-onlyでスキームハンドラを避けた。#210 は出力hyperlink=open-uri横取り可で前提が異なる"
+tags: [cockpit, oe-view, markdown, viewer, wezterm, hyperlink]
+---
+
+# oe-view 実装計画 — 生成doc のクリッカブル md ビューア
+
+> 駆動層: 痛点ヒアリング → レンダラ/起動 DJ 確定 → open-uri 機構 一次確認(verified) → 計画 draft → **設計SO(cc+codex+cursor) reconcile（§10）** → 本改訂 → 承認 → 実装 → 実装SO(oe-review) → episode → PR。
+> 実装はユーザーのプラン承認後。Issue 起点なのでブランチ/worktree は承認後に自律作成。
+
+## 1. 痛点 / 成果物
+
+plan/kickoff/episode 等の md を生成するとパスは表示されるが、見るたびに Finder/手動ペイン操作が要る。これを「パスから Finder/手動操作なしで即ビュー（md=端末内 glow / 非md=open）」にする。ターミナル完結が理想。成果物は2層・PR は2本（§8）:
+
+- `oe-view <path>`（hub・新規 CLI）: `.md` → viewer ペインで `glow` 描画 / 非 md → `open`。クリック層に非依存で単体動作（`--here`/手動）。
+- WezTerm 連携（dotfiles・wezterm.lua）: 出力中の doc パスをクリッカブル化し、クリック（Cmd+Click）を横取りして `oe-view` を argv 起動。
+
+## 2. 機構（一次確認済み・verified）
+
+WezTerm 公式 doc で確認:
+
+- `hyperlink_rules`: 正規表現で出力テキストをカスタムスキーム URI 化可（`$0`/`$1`）。https://wezterm.org/config/lua/config/hyperlink_rules.html
+- `open-uri` イベント: ハイパーリンククリックで `(window, pane, uri)` を受け、`false` 返却でブラウザ起動を抑止し任意アクション実行可。カスタムスキーム対応。https://wezterm.org/config/lua/window-events/open-uri.html
+
+→ 経路: 出力パス →(hyperlink_rules)→ `oeview://<path>` →(Cmd+Click)→ `open-uri` 横取り → `oe-view <path>` argv 起動 → md=viewer pane+glow / 非md=open。**macOS LaunchServices スキーム登録(.app)は不要**。#179 は対象が「トースト通知click=url-only」で escape hatch が無く CLI replay に逃げたが、#210 は「出力 viewport hyperlink」で open-uri が使える（設計SO 3者で確認）。
+
+## 3. コマンド仕様（oe-view）
+
+```
+oe-view [--here] [--from-link] [--json] [--] <path>
+oe-view --help
+```
+
+- 既定: 対象が `*.md`（拡張子・大小無視）→ viewer ペインを解決して `glow` で表示（送信は注入安全化・§5）。非 md → `open -- <path>`。
+- `--here`: 分割せず現ペインのページャ（`glow -p`、無ければ `bat`）。tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映時の degrade 本線。
+- `--from-link`: クリック経由フラグ。**allowlist 強制・非 md 拒否（md のみ）**を有効化（直叩きより厳格)。
+- `--json`: `{status, kind:"md"|"other", action:"glow"|"open", pane_id?}`。
+- exit code（DJ-5 reconcile・矛盾解消）: `0`=成功 / `1`=対象不在・allowlist 外・glow/open 失敗 / `2`=usage・環境エラー（wez 不在・glow 未導入を含む。依存不足を独立コードにせず環境エラーに統一し案内文を出す）。
+
+## 4. 設計判断（DJ・設計SO reconcile 反映済 / §10）
+
+確定（ユーザー選択・代替提示 = predecision-exploration トレース）:
+
+- **DJ-A レンダラ = `glow`**。代替 bat/qlmanage 提示の上で不採用。
+- **DJ-B 起動 = クリッカブルリンク**。設計SO がゼロベースで QuickSelect / record-replay / fzf picker を「リスク束を構造的に回避する対抗」として提示したが、**マウスクリックの体験を保ち緩和策フル適用で確定**（再計量済の確定前トレース）。
+
+確定（設計SO reconcile）:
+
+- **DJ-1 配置 = engine `projects/orchestration-engine/bin/oe-view`**。ただし根拠を訂正: oe-jump の engine 配置理由（`oe_reg_resolve`=tmux↔registry glue）は oe-view に転用しない（oe-view は registry/tmux 不使用）。配置理由は「**cockpit UX glue**（wez pane + open + 種別ディスパッチ）であり、`wez` は下層プリミティブのまま（ADR-001/004 の wez=下層方針を守る・上方依存を作らない）」。viewer 解決ロジックは `lib/oe-viewer.sh` に切り出してテスト mock 容易化。
+- **DJ-2 クリッカブル化 = `hyperlink_rules` 自動マッチ**。必須: `config.hyperlink_rules` 代入はデフォルト規則を全消しするため `wezterm.default_hyperlink_rules()` に `table.insert`。regex は doc ルート＋サブdir＋拡張子で厳格に絞る（例: `…/ai-development-hub/projects/[^/]+/docs/(plans|episodes|kickoffs|discussions|decisions)/[^[:space:]]+\.md`）。空白なしパスのみ対象（本リポは kebab パス規約）。OSC 8 明示出力は tmux で落ちやすい（hyperlink_rules は描画グリッド層で tmux 下も効く）ため v1 では採らない（将来 precision 層候補）。
+- **DJ-3 click→command = wezterm.lua `open-uri` ハンドラ**。条件: ハンドラは `oeview:` 以外を無視・URI を厳格 parse（`oeview:///<abs-path>` 三スラッシュ）・**argv 配列**で `oe-view --from-link <path>` を起動（`wezterm.background_child_process`/`run_child_process`、shell 非経由）。GUI プロセスは PATH が痩せるため `oe-view`/`glow` は**絶対パス**指定。UX は Cmd+Click（`CompleteSelectionOrOpenLinkAtMouseCursor`）と明記。
+- **DJ-4 viewer ペイン = state file 追跡で再利用**。`~/.claude/state/oe-view/viewer-pane-id`（oe-jump の last-target 同型）に pane_id 保存 → `_wez_pane_exists` 相当で生存確認 → 生存なら send / 無効なら split+state 更新。**glow の TUI ページャと send の衝突**を避けるため、再利用は「前回プロセス終了＝プロンプト復帰」を保証できる起動形に限定（非ページャ or 表示後復帰）。できない場合は「毎回 split + 古い viewer kill」に倒す。**新規作成時は `wez pane activate <source>`** でフォーカス奪取（#111）を回避（既定 focus=作業ペイン維持）。
+- **DJ-5 fallback**: `--here` で `glow -p` / `bat`（導入済）。glow 不在・wez 不在は exit 2 + 導入案内。素 install 検証 → 採用なら dotfiles codify。
+
+## 5. セキュリティ / 堅牢性（実装必須・設計SO で格上げ）
+
+- **送信層のシェル注入（P0・最重要）**: viewer 表示が `wez pane send <id> "glow -- <path>"` の場合、`send-text`（`projects/wezterm-ai-mode/lib/pane.sh:465`）は受信シェルに**行入力としてタイプ→再トークナイズ**される。実在ファイル名 `a$(whoami).md` でも `$(whoami)` がペインのシェルで評価される（`\n` 拒否はメタ文字を防がない）。
+  - v1 修正: 送信文字列を組む直前に `printf %q` でシェルクォート（`glow -- <quoted>`）。
+  - 本筋（follow-up 候補）: `wez` に argv spawn verb（`wezterm cli spawn -- glow <path>`）を足し、shell を経由しない。実装時に v1（%q）か本筋（spawn 追加）かを再評価。
+- **allowlist 実装必須（P0）**: `oe-view`（特に `--from-link`）は `realpath` 正規化後に doc ルート配下 prefix を判定（`..`/symlink トラバーサル対策）。範囲外は exit 1。
+- **入力サニタイズ**: URI decode 後の改行・NUL・制御文字を拒否。実体存在＋通常ファイル確認。
+- **クリック経由は md 限定**: `--from-link` では非 md `open`（任意アプリ/スクリプト起動）を禁止。CLI 直叩きの非 md `open` とは分ける。
+- **Lua 側は parse のみ**: 実行判断（種別/allowlist/存在）は全て `oe-view` に集約。
+- **フォーカス**: viewer 作成時のみ source へ activate（#111）。
+
+## 6. テスト
+
+`oe-view`（hub・shell・mock shim で wez/glow/open を差し替え）:
+
+- [ ] md 判定 → viewer 解決 + glow 表示の引数列 / 非 md → `open -- <path>`
+- [ ] **注入**: `a$(whoami).md` 等メタ文字ファイル名で送信文字列が `%q` 済（or argv 起動で shell 非経由）であること
+- [ ] **allowlist**: doc ルート外パス・symlink 経由の範囲外・`..` → exit 1
+- [ ] 入力サニタイズ: 改行/NUL/制御文字を拒否
+- [ ] `--from-link` で非 md `open` が拒否される
+- [ ] viewer 再利用: state の pane 生存→send / stale→split+state 更新 / 新規作成時 source へ activate
+- [ ] 不在パス→exit 1 / usage 不正→exit 2 / wez・glow 不在→exit 2 + 案内
+- [ ] `--here`（`glow -p`/`bat`）/ `--json` スキーマ（`jq -e`）/ `shellcheck`
+
+wezterm.lua 連携（手動・実機ゲート）:
+
+- [ ] doc パスがクリッカブル化（`default_hyperlink_rules()`+追加規則・既存 https 等が消えない）
+- [ ] Cmd+Click → ブラウザに飛ばず `oe-view` 発火（open-uri `false`）
+- [ ] **tmux 下**: `terminal-features hyperlinks` 有効 + Shift/Cmd+Click で wez 直下 shell と wez→tmux 子の両方でクリック→発火
+- [ ] GUI プロセス起動でも絶対パスで `oe-view`/`glow` 解決
+- [ ] 細工リンク（範囲外/メタ文字/非oeview）が無害化
+
+## 7. 触るファイル
+
+- 追加（hub）: `bin/oe-view`、`lib/oe-viewer.sh`、`tests/test_oe_view.sh`（すべて `projects/orchestration-engine/`）
+- 変更（hub）: `bin/README.md`（oe-view 節 + 3段 degrade 表）。必要なら `wez` に argv spawn verb（本筋採用時・`projects/wezterm-ai-mode`）
+- 追加/変更（dotfiles・別リポ）: `wezterm.lua` の `hyperlink_rules`（default ベース）+ `open-uri` ハンドラ。hub には設定スニペット/手順を doc 化（hub に lua 本体は置かない）
+- 流用（read）: `bin/oe-jump`（state/解決の作法）、`projects/wezterm-ai-mode/lib/pane.sh`（split/activate/send/`_wez_pane_exists`）
+
+## 8. スコープガード / PR 単位
+
+- md=glow / 非md=open のみ。通知起点ジャンプ（#179）とは別レンズ＝出力テキスト起点。
+- **issue は #210 の1本、PR は2本**（dotfiles が別リポ・検証モードが別=機械ゲート vs 実機手動のため）:
+  - PR1（hub）: `oe-view` + tests + 手順 doc。`--here`/手動で即有用・機械ゲートで land。
+  - PR2（dotfiles）: `hyperlink_rules` + `open-uri` ハンドラ。実機手動ゲート。PR1 を前提にリンク。
+- wezterm.lua 正本は dotfiles（hub は手順 doc のみ）。glow 常設は dotfiles provisioning（素 install は検証フェーズ限定）。
+
+## 9. ゲート
+
+- 設計SO（§10）reconcile 済 → 本改訂で DJ 確定 → **ユーザー承認**で実装着手。
+- 実装後: 実装SO（`oe-review`・コード欠陥/到達可能性レンズ・設計SO とは別レンズ）。verdict=refuted なら PR 保留。
+- closure: `episode-retrospective`（消費者明示・routing・status・Decision 昇格判断）。
+
+## 10. 設計SO reconcile（cc + codex + cursor・2026-06-21）
+
+3者の verdict（出力は `tmp/so-20260621-201231/`・gitignore）:
+
+- **機構（open-uri・scheme不要）**: 3者「妥当」。確定。
+- **送信層のシェル注入**: Codex/Claude「重大・要修正」、Cursor は「`\n` 拒否で安全」と**誤判定**。実体（`pane.sh:465` send-text＝シェルへタイプ→再トークナイズ）照合により Codex/Claude を採用（vote でなく証拠で判定・evidence-verification-rule）。→ §5 P0。
+- **DJ-1 配置**: Codex/Cursor「engine 妥当」、Claude「oe-jump 根拠は転用不可→`wez view`」。reconcile=engine 維持＋根拠訂正（cockpit UX glue・wez は下層維持）。
+- **DJ-2/DJ-4/security**: 3者一致で要修正（default_hyperlink_rules・regex 厳格化 / state追跡+pager衝突+#111 activate / allowlist realpath 必須化）。反映済。
+- **DJ-5 exit code 矛盾**: Codex 指摘。環境エラーを `2` に統一で解消。
+- **トリガ再計量**: 3者がキーボードトリガ（QuickSelect/fzf/record-replay）をリスク低減案として提示。ユーザー判断で**クリック維持＋全緩和**に確定。QuickSelect は将来の追加トリガ候補として記録（v1 範囲外）。
+- **1 issue 一括 vs 分割**: issue 1 / PR 2 で合意（§8）。

--- a/projects/orchestration-engine/lib/oe-viewer.sh
+++ b/projects/orchestration-engine/lib/oe-viewer.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# oe-viewer.sh — viewer ペイン解決ロジック（oe-view 用・source 専用）
+#
+# Sourced by bin/oe-view. Not intended for standalone execution.
+# 責務: viewer ペイン（md を glow で描画する固定ペイン）の state file 追跡・生存確認・
+#       再利用 / 新規 split・注入安全な glow 送信文字列の組み立て。
+# Naming: oe_viewer_* for public, _oe_viewer_* for private。wez（engine）ペインの操作は
+#         すべて下層プリミティブ `wez pane …` 経由（ADR-001/004 の wez=下層方針を守る）。
+#
+# viewer 解決（DJ-4）:
+#   state file（OE_VIEW_STATE_FILE）に pane_id を保存 → `wez pane list` で生存確認 →
+#   生存なら send で再利用 / stale・無しなら split で新規作成し state 更新。
+#   新規 split 時は作成後に source ペインへ activate（#111: split は新ペインへ focus を奪う）。
+#   glow ページャと send の衝突回避: viewer ペインでは glow を非ページャ形（`glow <file>`＝
+#   レンダして終了/プロンプト復帰）で起動する。`-p`（ページャ）は --here 限定（bin/oe-view 側）。
+
+# viewer state（最後の viewer pane_id 1 件のみ・上書き）。テストは env で隔離する。
+OE_VIEW_STATE_DIR="${OE_VIEW_STATE_DIR:-${HOME}/.claude/state/oe-view}"
+OE_VIEW_STATE_FILE="${OE_VIEW_STATE_DIR}/viewer-pane-id"
+
+# 新規 viewer split のジオメトリ（既定: 右 40%）。
+OE_VIEW_SPLIT_DIR="${OE_VIEW_SPLIT_DIR:---right}"
+OE_VIEW_SPLIT_PERCENT="${OE_VIEW_SPLIT_PERCENT:-40}"
+
+# _oe_viewer_read_state — state file から viewer pane_id を stdout へ（無ければ空・常に rc 0）。
+_oe_viewer_read_state() {
+  [[ -r "$OE_VIEW_STATE_FILE" ]] || return 0
+  head -n 1 "$OE_VIEW_STATE_FILE" 2>/dev/null || true
+}
+
+# _oe_viewer_write_state <pane_id> — viewer pane_id を state file へ atomic 記録（oe-jump 同型）。
+_oe_viewer_write_state() {
+  local pane_id="$1"
+  mkdir -p "$OE_VIEW_STATE_DIR" 2>/dev/null || {
+    echo "oe-view: cannot create state dir ${OE_VIEW_STATE_DIR}" >&2; return 1; }
+  local tmp="${OE_VIEW_STATE_FILE}.tmp.$$"
+  if printf '%s\n' "$pane_id" >"$tmp" 2>/dev/null && mv -f "$tmp" "$OE_VIEW_STATE_FILE" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$tmp" 2>/dev/null
+  echo "oe-view: failed to record viewer pane id to ${OE_VIEW_STATE_FILE}" >&2
+  return 1
+}
+
+# _oe_viewer_pane_exists <pane_id> — pane が生存しているか（`wez pane list` JSON を引く・
+#   pane.sh:_wez_pane_exists 相当）。rc 0=生存 / 1=不在・非数値・list 失敗。
+_oe_viewer_pane_exists() {
+  local pane_id="$1"
+  [[ "$pane_id" =~ ^[0-9]+$ ]] || return 1
+  local json
+  json="$(wez pane list 2>/dev/null)" || return 1
+  if command -v jq >/dev/null 2>&1; then
+    jq -e --arg id "$pane_id" 'map(select((.pane_id | tostring) == $id)) | length > 0' \
+      <<< "$json" >/dev/null 2>&1
+  else
+    [[ "$json" == *"\"pane_id\":${pane_id},"* ]] \
+      || [[ "$json" == *"\"pane_id\":${pane_id}}"* ]] \
+      || [[ "$json" == *"\"pane_id\": ${pane_id},"* ]] \
+      || [[ "$json" == *"\"pane_id\": ${pane_id}}"* ]]
+  fi
+}
+
+# _oe_viewer_split — 新規 viewer ペインを split で作り、新 pane_id を stdout へ。
+#   作成後に source ペイン（WEZTERM_PANE）へ activate して focus 奪取を回避（#111）。
+#   rc 0=成功（pane_id 出力）/ 2=split 失敗（環境エラー）。
+_oe_viewer_split() {
+  local new_pane source_pane
+  source_pane="${WEZTERM_PANE:-}"
+  if ! new_pane="$(wez pane split "$OE_VIEW_SPLIT_DIR" --percent "$OE_VIEW_SPLIT_PERCENT" 2>/dev/null)"; then
+    echo "oe-view: failed to split viewer pane (wez pane split)" >&2
+    return 2
+  fi
+  if ! [[ "$new_pane" =~ ^[0-9]+$ ]]; then
+    echo "oe-view: unexpected pane id from wez pane split: ${new_pane}" >&2
+    return 2
+  fi
+  # #111: split は新ペインへ focus を奪うため、作業ペインへ focus を戻す（best-effort）。
+  if [[ -n "$source_pane" && "$source_pane" =~ ^[0-9]+$ ]]; then
+    wez pane activate "$source_pane" 2>/dev/null || true
+  fi
+  printf '%s\n' "$new_pane"
+}
+
+# oe_viewer_resolve — 表示に使う viewer ペイン id を stdout へ解決する。
+#   state の pane が生存 → 再利用（その id）/ stale・無し → split で新規作成し state 更新。
+#   rc 0=成功（pane_id 出力）/ 2=新規作成失敗（環境エラー）。
+oe_viewer_resolve() {
+  local cached
+  cached="$(_oe_viewer_read_state)"
+  if [[ -n "$cached" ]] && _oe_viewer_pane_exists "$cached"; then
+    printf '%s\n' "$cached"
+    return 0
+  fi
+  local new_pane
+  new_pane="$(_oe_viewer_split)" || return
+  _oe_viewer_write_state "$new_pane" || return 1
+  printf '%s\n' "$new_pane"
+}
+
+# oe_viewer_render_command <path> — viewer ペインへ送る glow コマンド文字列を組み立てて
+#   stdout へ。**送信層のシェル注入対策（P0）**: パスを `printf %q` でシェルクォートして
+#   受信シェルの再トークナイズ（`a$(whoami).md` の `$(whoami)` 評価等）を防ぐ。
+#   非ページャ形（`glow -- <quoted>`）で、表示後プロンプトに復帰する＝次回 send と衝突しない。
+oe_viewer_render_command() {
+  local path="$1" quoted
+  printf -v quoted '%q' "$path"
+  printf 'glow -- %s\n' "$quoted"
+}

--- a/projects/orchestration-engine/lib/oe-viewer.sh
+++ b/projects/orchestration-engine/lib/oe-viewer.sh
@@ -3,16 +3,22 @@
 #
 # Sourced by bin/oe-view. Not intended for standalone execution.
 # 責務: viewer ペイン（md を glow で描画する固定ペイン）の state file 追跡・生存確認・
-#       再利用 / 新規 split・注入安全な glow 送信文字列の組み立て。
+#       argv-spawn の replace モデル（生存なら kill→新規 spawn / stale・無しなら spawn）。
 # Naming: oe_viewer_* for public, _oe_viewer_* for private。wez（engine）ペインの操作は
 #         すべて下層プリミティブ `wez pane …` 経由（ADR-001/004 の wez=下層方針を守る）。
 #
-# viewer 解決（DJ-4）:
-#   state file（OE_VIEW_STATE_FILE）に pane_id を保存 → `wez pane list` で生存確認 →
-#   生存なら send で再利用 / stale・無しなら split で新規作成し state 更新。
-#   新規 split 時は作成後に source ペインへ activate（#111: split は新ペインへ focus を奪う）。
-#   glow ページャと send の衝突回避: viewer ペインでは glow を非ページャ形（`glow <file>`＝
-#   レンダして終了/プロンプト復帰）で起動する。`-p`（ページャ）は --here 限定（bin/oe-view 側）。
+# viewer 解決（DJ-4・argv-spawn replace モデル・実機検証で確定・§11）:
+#   実機検証で「split したシェルへ glow をタイプ送信」する旧モデルが破綻していた
+#   （新規 wez ペインのシェル rc が tmux に自動アタッチし、send したコマンドが実行されず
+#    glow が描画されない）。代わりに **ペインのプログラムとして glow を直接起動**する:
+#     wez pane split --right --percent <P> --cwd <dir> -- glow -p -- <path>
+#   （wezterm cli split-pane [PROG]＝シェルの代わりに PROG を実行・公式仕様）。
+#   シェルも tmux も経由しないため確実に描画され、path が argv 要素として渡るので
+#   再トークナイズが起きず注入面が消滅する（§5・%q 不要）。
+#   glow -p はページャ（シェルではない）ため send による再利用ができない。よって再利用は
+#   **replace**: state（OE_VIEW_STATE_FILE）の viewer が生存なら kill → 新 glow ペインを
+#   spawn → state 更新 / stale・無しなら spawn + state 更新。spawn 後に source ペイン
+#   （WEZTERM_PANE）へ activate して focus 奪取を回避（#111）。
 
 # viewer state（最後の viewer pane_id 1 件のみ・上書き）。テストは env で隔離する。
 OE_VIEW_STATE_DIR="${OE_VIEW_STATE_DIR:-${HOME}/.claude/state/oe-view}"
@@ -60,14 +66,19 @@ _oe_viewer_pane_exists() {
   fi
 }
 
-# _oe_viewer_split — 新規 viewer ペインを split で作り、新 pane_id を stdout へ。
+# _oe_viewer_spawn <path> — viewer ペインを argv-spawn で新規作成し、新 pane_id を stdout へ。
+#   ペインのプログラムとして glow を直接起動する（DJ-4・shell/tmux 非経由）:
+#     wez pane split --right --percent <P> --cwd <dir> -- glow -p -- <path>
+#   --cwd は path の dirname（glow の相対参照・cwd 表示の整合用）。path は argv 要素で渡す
+#   （`-- glow -p -- <path>`）ため再トークナイズが起きず %q 不要・注入面が消滅（§5）。
 #   作成後に source ペイン（WEZTERM_PANE）へ activate して focus 奪取を回避（#111）。
-#   rc 0=成功（pane_id 出力）/ 2=split 失敗（環境エラー）。
-_oe_viewer_split() {
-  local new_pane source_pane
+#   rc 0=成功（pane_id 出力）/ 2=spawn 失敗（環境エラー）。
+_oe_viewer_spawn() {
+  local path="$1" new_pane source_pane dir
   source_pane="${WEZTERM_PANE:-}"
-  if ! new_pane="$(wez pane split "$OE_VIEW_SPLIT_DIR" --percent "$OE_VIEW_SPLIT_PERCENT" 2>/dev/null)"; then
-    echo "oe-view: failed to split viewer pane (wez pane split)" >&2
+  dir="$(dirname -- "$path")"
+  if ! new_pane="$(wez pane split "$OE_VIEW_SPLIT_DIR" --percent "$OE_VIEW_SPLIT_PERCENT" --cwd "$dir" -- glow -p -- "$path" 2>/dev/null)"; then
+    echo "oe-view: failed to spawn viewer pane (wez pane split -- glow)" >&2
     return 2
   fi
   if ! [[ "$new_pane" =~ ^[0-9]+$ ]]; then
@@ -81,28 +92,22 @@ _oe_viewer_split() {
   printf '%s\n' "$new_pane"
 }
 
-# oe_viewer_resolve — 表示に使う viewer ペイン id を stdout へ解決する。
-#   state の pane が生存 → 再利用（その id）/ stale・無し → split で新規作成し state 更新。
-#   rc 0=成功（pane_id 出力）/ 2=新規作成失敗（環境エラー）。
+# oe_viewer_resolve <path> — viewer ペインに <path> を glow で表示し、使った viewer
+#   pane id を stdout へ出す（argv-spawn replace モデル）。
+#   state の viewer が生存 → kill → 新 glow ペインを spawn → state 更新 /
+#   stale・無し → spawn + state 更新。
+#   glow -p はページャ（シェルではない）ため send による再利用はできず、毎回 replace する。
+#   rc 0=成功（pane_id 出力）/ 2=spawn 失敗（環境エラー）。
 oe_viewer_resolve() {
-  local cached
+  local path="$1" cached
   cached="$(_oe_viewer_read_state)"
+  # 生存している旧 viewer は kill（replace モデル: 新 glow ペインで置き換える）。
+  # best-effort: kill 失敗（既に消えた等）は新規 spawn を妨げない。
   if [[ -n "$cached" ]] && _oe_viewer_pane_exists "$cached"; then
-    printf '%s\n' "$cached"
-    return 0
+    wez pane kill "$cached" 2>/dev/null || true
   fi
   local new_pane
-  new_pane="$(_oe_viewer_split)" || return
+  new_pane="$(_oe_viewer_spawn "$path")" || return
   _oe_viewer_write_state "$new_pane" || return 1
   printf '%s\n' "$new_pane"
-}
-
-# oe_viewer_render_command <path> — viewer ペインへ送る glow コマンド文字列を組み立てて
-#   stdout へ。**送信層のシェル注入対策（P0）**: パスを `printf %q` でシェルクォートして
-#   受信シェルの再トークナイズ（`a$(whoami).md` の `$(whoami)` 評価等）を防ぐ。
-#   非ページャ形（`glow -- <quoted>`）で、表示後プロンプトに復帰する＝次回 send と衝突しない。
-oe_viewer_render_command() {
-  local path="$1" quoted
-  printf -v quoted '%q' "$path"
-  printf 'glow -- %s\n' "$quoted"
 }

--- a/projects/orchestration-engine/tests/test_oe_view.sh
+++ b/projects/orchestration-engine/tests/test_oe_view.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test_oe_view.sh — oe-view（md=glow viewer / 非md=open）の判定・注入安全化・allowlist・
+# サニタイズ・viewer 再利用・degrade・--json を検証する（#210）。
+#
+# 実 wez/glow/open は呼ばず PATH 先頭 mock に差し替える（test_oe_jump.sh / test_pane_split_targeting.sh
+# と同型）:
+#   - wez:  全呼び出しを wez.log に記録。`wez pane list` は $MOCK_PANE_LIST_JSON、
+#           `wez pane split` は $MOCK_SPLIT_PANE_ID を返す。send/activate は引数を log に記録。
+#   - glow: 引数を glow.log に記録。
+#   - open: 引数を open.log に記録。
+#   - bat:  引数を bat.log に記録（--here の glow 不在フォールバック検証用）。
+#   各 shim の在/不在をテストごとに切り替えるため shim は専用ディレクトリに置き、PATH 先頭の
+#   "$_TMP_DIR/pathbin" へ symlink を張る/外すで「不在」を再現する。
+#
+# oe-view は BIN_DIR/../lib/oe-viewer.sh を source する。テスト用 bin/ に oe-view をコピーし、
+# lib/ に実体を symlink して共有する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+_TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+[[ -n "$_TMP_DIR" && -d "$_TMP_DIR" ]] || { echo "FATAL: mktemp -d returned an invalid path: '${_TMP_DIR}'" >&2; exit 1; }
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/lib" "$_TMP_DIR/pathbin" "$_TMP_DIR/shimsrc" "$_TMP_DIR/logs" "$_TMP_DIR/docroot/sub" "$_TMP_DIR/outside"
+
+cp "$PROJECT_DIR/bin/oe-view" "$_TMP_DIR/bin/oe-view"
+chmod +x "$_TMP_DIR/bin/oe-view"
+ln -s "$PROJECT_DIR/lib/oe-viewer.sh" "$_TMP_DIR/lib/oe-viewer.sh"
+
+export OE_VIEW_TEST_LOG_DIR="$_TMP_DIR/logs"
+
+# --- mock 実体（shimsrc）。pathbin への symlink 有無で「在/不在」を切り替える ---
+cat > "$_TMP_DIR/shimsrc/wez" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OE_VIEW_TEST_LOG_DIR:?}/wez.log"
+case "${1:-} ${2:-}" in
+  "pane list")     printf '%s\n' "${MOCK_PANE_LIST_JSON:-[]}" ;;
+  "pane split")    printf '%s\n' "${MOCK_SPLIT_PANE_ID:-9}" ;;
+  "pane send")     exit 0 ;;
+  "pane activate") exit 0 ;;
+  *)               exit 0 ;;
+esac
+EOF
+cat > "$_TMP_DIR/shimsrc/glow" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OE_VIEW_TEST_LOG_DIR:?}/glow.log"
+EOF
+cat > "$_TMP_DIR/shimsrc/open" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OE_VIEW_TEST_LOG_DIR:?}/open.log"
+EOF
+cat > "$_TMP_DIR/shimsrc/bat" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OE_VIEW_TEST_LOG_DIR:?}/bat.log"
+EOF
+chmod +x "$_TMP_DIR/shimsrc/wez" "$_TMP_DIR/shimsrc/glow" "$_TMP_DIR/shimsrc/open" "$_TMP_DIR/shimsrc/bat"
+
+# 厳選 PATH: mock（pathbin）+ システム最小（/usr/bin:/bin・awk/sed/grep/cat/head 等）。
+# 実 wez/glow/open/bat を確実に除外する（/usr/bin/open・homebrew bat・~/bin/wez の漏れ防止。
+# test_oe_jump.sh と同型）。realpath / jq は実体を pathbin に symlink して常時供給する
+# （macOS 標準に realpath が無く、本テストは canonical 前提＝allowlist/送信パスのため必須）。
+export PATH="${_TMP_DIR}/pathbin:/usr/bin:/bin"
+_link_real() {  # <name> — 実体を探して pathbin に symlink（無ければ FATAL）
+  local name="$1" p
+  for p in /opt/homebrew/bin /usr/local/bin /usr/bin /bin; do
+    if [[ -x "$p/$name" ]]; then ln -sf "$p/$name" "$_TMP_DIR/pathbin/$name"; return 0; fi
+  done
+  echo "FATAL: required tool '$name' not found for test isolation" >&2; exit 1
+}
+_link_real realpath
+_link_real jq
+
+# 各 shim の在/不在を切り替える。
+shim_on()  { ln -sf "$_TMP_DIR/shimsrc/$1" "$_TMP_DIR/pathbin/$1"; }
+shim_off() { rm -f "$_TMP_DIR/pathbin/$1"; }
+all_shims_on() { shim_on wez; shim_on glow; shim_on open; shim_on bat; }
+
+# 隔離 state / allowlist root。
+export OE_VIEW_STATE_DIR="$_TMP_DIR/oe-view-state"
+export OE_VIEW_ROOTS="$_TMP_DIR/docroot"
+export WEZTERM_PANE="3"            # source pane（activate-back 検証）
+export MOCK_PANE_LIST_JSON="[]"
+export MOCK_SPLIT_PANE_ID="9"
+
+VIEW="$_TMP_DIR/bin/oe-view"
+
+# fixtures。
+MD_IN_ROOT="$_TMP_DIR/docroot/sub/plan.md"            # allowlist 内 md
+MD_INJECT="$_TMP_DIR/docroot/sub/a\$(whoami).md"      # 注入メタ文字名（実在 md・allowlist 内）
+TXT_IN_ROOT="$_TMP_DIR/docroot/sub/note.txt"          # 非 md
+MD_OUTSIDE="$_TMP_DIR/outside/leak.md"                # allowlist 外 md
+printf '# plan\n'  > "$MD_IN_ROOT"
+printf '# inject\n' > "$MD_INJECT"
+printf 'plain\n'   > "$TXT_IN_ROOT"
+printf '# leak\n'  > "$MD_OUTSIDE"
+
+PASS=0
+FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (want='$expected' got='$actual')"; FAIL=$((FAIL + 1))
+  fi
+}
+reset_logs() { rm -f "$_TMP_DIR/logs/"*.log; }
+reset_state() { rm -rf "$OE_VIEW_STATE_DIR"; }
+wez_log()  { cat "$_TMP_DIR/logs/wez.log"  2>/dev/null; }
+glow_log() { cat "$_TMP_DIR/logs/glow.log" 2>/dev/null; }
+open_log() { cat "$_TMP_DIR/logs/open.log" 2>/dev/null; }
+bat_log()  { cat "$_TMP_DIR/logs/bat.log"  2>/dev/null; }
+has_line() { printf '%s\n' "$1" | grep -qF -- "$2" && echo yes || echo no; }
+
+# ----------------------------------------------------------------------------
+# [1] md 既定 → viewer 解決（state 無し=split）+ glow 送信。新規時 source(3) へ activate。
+# ----------------------------------------------------------------------------
+echo "[1] md 既定 → split + activate(source) + glow send"
+all_shims_on; reset_state; reset_logs
+export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
+rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+log="$(wez_log)"
+ck "rc=0" "0" "$rc"
+ck "pane split が呼ばれる"            "yes" "$(has_line "$log" 'pane split')"
+ck "source(3) へ activate（#111）"    "yes" "$(has_line "$log" 'pane activate 3')"
+ck "pane send 9 が呼ばれる"           "yes" "$(has_line "$log" 'pane send 9')"
+ck "state file に新 pane 9 が書かれる" "9" "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
+
+# ----------------------------------------------------------------------------
+# [2] 注入: メタ文字名 'a$(whoami).md' の送信文字列が %q 済（シェル安全）であること。
+#     生の "$(whoami)" が send 行にそのまま現れず、クォート済みリテラルになっている。
+# ----------------------------------------------------------------------------
+echo "[2] 注入: 送信文字列が %q クォート済（再トークナイズ防止）"
+all_shims_on; reset_state; reset_logs
+export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
+rc=0; "$VIEW" -- "$MD_INJECT" >/dev/null 2>&1 || rc=$?
+log="$(wez_log)"
+ck "rc=0" "0" "$rc"
+# %q は '(' ')' '$' をバックスラッシュエスケープする。クォート済みリテラルが送信行に在ること。
+ck "送信行が %q 済リテラルを含む" "yes" "$(has_line "$log" 'a\$\(whoami\).md')"
+# 生（未クォート）の '$(whoami)' が単独で送信行に現れないこと（バックスラッシュ無しの裸）。
+send_line="$(printf '%s\n' "$log" | grep 'pane send' || true)"
+# shellcheck disable=SC2016  # 単一引用は grep -F のリテラルパターン（展開させない）
+if printf '%s\n' "$send_line" | grep -qF 'a$(whoami)' && ! printf '%s\n' "$send_line" | grep -qF 'a\$\(whoami\)'; then
+  raw_unquoted=yes
+else
+  raw_unquoted=no
+fi
+ck "生の未クォート \$(whoami) は送信行に無い" "no" "$raw_unquoted"
+
+# ----------------------------------------------------------------------------
+# [3] viewer 再利用: state の pane が生存 → split せず send（同 id）。
+# ----------------------------------------------------------------------------
+echo "[3] 再利用: state pane 7 生存 → split なし・send 7"
+all_shims_on; reset_state; reset_logs
+mkdir -p "$OE_VIEW_STATE_DIR"; printf '7\n' > "$OE_VIEW_STATE_DIR/viewer-pane-id"
+export MOCK_PANE_LIST_JSON='[{"pane_id":7,"is_active":true}]'
+rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+log="$(wez_log)"
+ck "rc=0" "0" "$rc"
+ck "pane list で生存確認"   "yes" "$(has_line "$log" 'pane list')"
+ck "split は呼ばれない"     "no"  "$(has_line "$log" 'pane split')"
+ck "pane send 7（再利用）"  "yes" "$(has_line "$log" 'pane send 7')"
+
+# ----------------------------------------------------------------------------
+# [4] viewer stale: state の pane が不在 → split+state 更新（新 pane 11）。
+# ----------------------------------------------------------------------------
+echo "[4] stale: state pane 7 不在（list に無い）→ split + state 更新"
+all_shims_on; reset_state; reset_logs
+mkdir -p "$OE_VIEW_STATE_DIR"; printf '7\n' > "$OE_VIEW_STATE_DIR/viewer-pane-id"
+export MOCK_PANE_LIST_JSON='[{"pane_id":99,"is_active":true}]'   # 7 は不在
+export MOCK_SPLIT_PANE_ID="11"
+rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+log="$(wez_log)"
+ck "rc=0" "0" "$rc"
+ck "split で新規作成"            "yes" "$(has_line "$log" 'pane split')"
+ck "state が新 pane 11 に更新"   "11" "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
+
+# ----------------------------------------------------------------------------
+# [5] 非 md 直叩き → open -- <path>（canonical パス）。
+# ----------------------------------------------------------------------------
+echo "[5] 非 md 直叩き → open -- <path>"
+all_shims_on; reset_state; reset_logs
+rc=0; "$VIEW" -- "$TXT_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "rc=0" "0" "$rc"
+# open shim は引数（$*）のみ記録する＝"-- <canonical path>"。canonical な basename を含むこと。
+ck "open に -- 付きで渡る"     "yes" "$(has_line "$(open_log)" '-- ')"
+ck "open に note.txt が渡る"   "yes" "$(has_line "$(open_log)" 'note.txt')"
+ck "glow は呼ばれない（非md）" "no"  "$([[ -e "$_TMP_DIR/logs/glow.log" ]] && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [6] --from-link で非 md → 拒否（exit 1）・open しない。
+# ----------------------------------------------------------------------------
+echo "[6] --from-link 非 md → exit 1（open しない）"
+all_shims_on; reset_state; reset_logs
+rc=0; "$VIEW" --from-link -- "$TXT_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "--from-link 非 md → exit 1" "1" "$rc"
+ck "open は呼ばれない"          "no" "$([[ -e "$_TMP_DIR/logs/open.log" ]] && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [7] allowlist: --from-link で root 外 md → exit 1。
+# ----------------------------------------------------------------------------
+echo "[7] allowlist: --from-link root 外 md → exit 1"
+all_shims_on; reset_state; reset_logs
+rc=0; "$VIEW" --from-link -- "$MD_OUTSIDE" >/dev/null 2>&1 || rc=$?
+ck "root 外 → exit 1" "1" "$rc"
+ck "send されない"    "no" "$([[ -e "$_TMP_DIR/logs/wez.log" ]] && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+# [8] allowlist: symlink で root 内 → root 外実体を指す → realpath 解決後 exit 1。
+# ----------------------------------------------------------------------------
+echo "[8] allowlist: root 内 symlink → root 外実体 → exit 1（realpath 解決）"
+all_shims_on; reset_state; reset_logs
+ln -sf "$MD_OUTSIDE" "$_TMP_DIR/docroot/sub/link-to-outside.md"
+rc=0; "$VIEW" --from-link -- "$_TMP_DIR/docroot/sub/link-to-outside.md" >/dev/null 2>&1 || rc=$?
+ck "symlink で root 外実体 → exit 1" "1" "$rc"
+rm -f "$_TMP_DIR/docroot/sub/link-to-outside.md"
+
+# ----------------------------------------------------------------------------
+# [9] allowlist: '..' トラバーサルで root 外 → exit 1。
+# ----------------------------------------------------------------------------
+echo "[9] allowlist: '..' トラバーサルで root 外 → exit 1"
+all_shims_on; reset_state; reset_logs
+rc=0; "$VIEW" --from-link -- "$_TMP_DIR/docroot/sub/../../outside/leak.md" >/dev/null 2>&1 || rc=$?
+ck "'..' で root 外 → exit 1" "1" "$rc"
+
+# ----------------------------------------------------------------------------
+# [9b] allowlist: --from-link で root 内 md → 許可（exit 0・send される）。
+# ----------------------------------------------------------------------------
+echo "[9b] allowlist: --from-link root 内 md → 許可（exit 0・send）"
+all_shims_on; reset_state; reset_logs
+export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
+rc=0; "$VIEW" --from-link -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "root 内 → exit 0" "0" "$rc"
+ck "pane send が呼ばれる" "yes" "$(has_line "$(wez_log)" 'pane send')"
+
+# ----------------------------------------------------------------------------
+# [10] 入力サニタイズ: 改行・CR・制御文字を含むパス → 拒否（exit 1）。
+# ----------------------------------------------------------------------------
+echo "[10] サニタイズ: 改行/CR/制御文字 → exit 1"
+all_shims_on; reset_state; reset_logs
+rc=0; "$VIEW" -- $'foo\nbar.md' >/dev/null 2>&1 || rc=$?
+ck "改行入りパス → exit 1" "1" "$rc"
+rc=0; "$VIEW" -- $'foo\rbar.md' >/dev/null 2>&1 || rc=$?
+ck "CR 入りパス → exit 1" "1" "$rc"
+rc=0; "$VIEW" -- $'foo\x01bar.md' >/dev/null 2>&1 || rc=$?
+ck "制御文字入りパス → exit 1" "1" "$rc"
+
+# ----------------------------------------------------------------------------
+# [11] 不在パス → exit 1 / ディレクトリ（非通常ファイル）→ exit 1。
+# ----------------------------------------------------------------------------
+echo "[11] 不在パス → exit 1 / ディレクトリ → exit 1"
+all_shims_on; reset_state; reset_logs
+rc=0; "$VIEW" -- "$_TMP_DIR/docroot/sub/nope.md" >/dev/null 2>&1 || rc=$?
+ck "不在パス → exit 1" "1" "$rc"
+rc=0; "$VIEW" -- "$_TMP_DIR/docroot" >/dev/null 2>&1 || rc=$?
+ck "ディレクトリ → exit 1" "1" "$rc"
+
+# ----------------------------------------------------------------------------
+# [12] usage: 引数なし → 2 / unknown option → 2 / too many → 2 / --help → 0。
+# ----------------------------------------------------------------------------
+echo "[12] usage: 引数なし / unknown / too many / --help"
+all_shims_on
+rc=0; "$VIEW" >/dev/null 2>&1 || rc=$?
+ck "引数なし → exit 2" "2" "$rc"
+rc=0; "$VIEW" --bogus -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "unknown option → exit 2" "2" "$rc"
+rc=0; "$VIEW" -- "$MD_IN_ROOT" "$TXT_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "too many args → exit 2" "2" "$rc"
+rc=0; "$VIEW" --help >/dev/null 2>&1 || rc=$?
+ck "--help → exit 0" "0" "$rc"
+
+# ----------------------------------------------------------------------------
+# [13] 環境エラー: glow 不在（md 既定）→ exit 2 + 案内 / wez 不在（md 既定）→ exit 2 + 案内。
+# ----------------------------------------------------------------------------
+echo "[13] 環境エラー: glow 不在 / wez 不在 → exit 2 + 案内"
+all_shims_on; reset_state; reset_logs
+shim_off glow
+rc=0; out="$("$VIEW" -- "$MD_IN_ROOT" 2>&1)" || rc=$?
+ck "glow 不在 → exit 2" "2" "$rc"
+ck "glow 導入案内"     "yes" "$(has_line "$out" 'glow')"
+all_shims_on
+shim_off wez
+rc=0; out="$("$VIEW" -- "$MD_IN_ROOT" 2>&1)" || rc=$?
+ck "wez 不在 → exit 2" "2" "$rc"
+ck "--here 案内"       "yes" "$(has_line "$out" '--here')"
+all_shims_on
+
+# ----------------------------------------------------------------------------
+# [14] --here: glow 在 → glow -p / glow 不在 + bat 在 → bat / 両方不在 → exit 2。
+# ----------------------------------------------------------------------------
+echo "[14] --here: glow -p / bat フォールバック / 両不在 → exit 2"
+all_shims_on; reset_logs
+rc=0; "$VIEW" --here -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "--here glow 在 → exit 0" "0" "$rc"
+ck "glow -p が呼ばれる"      "yes" "$(has_line "$(glow_log)" '-p')"
+ck "split は呼ばれない（here）" "no" "$([[ -e "$_TMP_DIR/logs/wez.log" ]] && echo yes || echo no)"
+reset_logs
+shim_off glow
+rc=0; "$VIEW" --here -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "--here glow 不在 + bat → exit 0" "0" "$rc"
+ck "bat が呼ばれる"                  "yes" "$(has_line "$(bat_log)" "$MD_IN_ROOT")"
+reset_logs
+shim_off bat
+rc=0; "$VIEW" --here -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "--here glow/bat 両不在 → exit 2" "2" "$rc"
+all_shims_on
+
+# ----------------------------------------------------------------------------
+# [15] --json: md（glow・pane_id 付き）/ 非 md（open）の schema を jq -e で検証。
+# ----------------------------------------------------------------------------
+echo "[15] --json schema（jq -e）"
+all_shims_on; reset_state; reset_logs
+export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
+json="$("$VIEW" --json -- "$MD_IN_ROOT" 2>/dev/null)"; rc=$?
+ck "md --json rc=0" "0" "$rc"
+echo "$json" | jq -e '.status=="ok" and .kind=="md" and .action=="glow" and .pane_id==9' >/dev/null 2>&1 \
+  && r=yes || r=no
+ck "md JSON schema 一致（pane_id=9）" "yes" "$r"
+json="$("$VIEW" --json -- "$TXT_IN_ROOT" 2>/dev/null)"; rc=$?
+ck "非md --json rc=0" "0" "$rc"
+echo "$json" | jq -e '.status=="ok" and .kind=="other" and .action=="open" and (has("pane_id")|not)' >/dev/null 2>&1 \
+  && r=yes || r=no
+ck "非md JSON schema 一致（pane_id 無し）" "yes" "$r"
+
+# ----------------------------------------------------------------------------
+# [16] split 失敗（環境エラー）→ exit 2。
+# ----------------------------------------------------------------------------
+echo "[16] split 失敗 → exit 2"
+all_shims_on; reset_state; reset_logs
+export MOCK_PANE_LIST_JSON="[]"   # state pane を不在にして split 経路へ
+# wez split を失敗させる専用 shim を別ファイルに置く（pathbin/wez は symlink なので
+# 上書きでなく symlink を外してから実体ファイルを置く＝共有 shimsrc を壊さない）。
+shim_off wez
+cat > "$_TMP_DIR/pathbin/wez" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OE_VIEW_TEST_LOG_DIR:?}/wez.log"
+case "${1:-} ${2:-}" in
+  "pane list") printf '[]\n' ;;
+  "pane split") exit 5 ;;     # split 失敗（環境エラー）
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$_TMP_DIR/pathbin/wez"
+rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "split 失敗 → exit 2" "2" "$rc"
+shim_off wez; shim_on wez   # 実体 shim（symlink）に戻す
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_view.sh
+++ b/projects/orchestration-engine/tests/test_oe_view.sh
@@ -330,6 +330,9 @@ shim_off glow
 rc=0; "$VIEW" --here -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
 ck "--here glow 不在 + bat → exit 0" "0" "$rc"
 ck "bat が呼ばれる"                  "yes" "$(has_line "$(bat_log)" "$MD_IN_ROOT")"
+jb="$("$VIEW" --here --json -- "$MD_IN_ROOT" 2>/dev/null)"
+echo "$jb" | jq -e '.action=="bat"' >/dev/null 2>&1 && r=yes || r=no
+ck "--here bat 時 JSON action=bat"   "yes" "$r"
 reset_logs
 shim_off bat
 rc=0; "$VIEW" --here -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
@@ -375,6 +378,16 @@ chmod +x "$_TMP_DIR/pathbin/wez"
 rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
 ck "split 失敗 → exit 2" "2" "$rc"
 shim_off wez; shim_on wez   # 実体 shim（symlink）に戻す
+
+# ----------------------------------------------------------------------------
+# [17] 既定 OE_VIEW_ROOTS: 未設定時は projects/*/docs 限定で、permissive な projects/ に
+#      フォールバックしない（#210 実装SO 指摘）。テスト repo に projects/*/docs は無いため
+#      既定は空=fail-closed となり、明示 root にしか無い MD_IN_ROOT も --from-link で拒否される。
+# ----------------------------------------------------------------------------
+echo "[17] 既定 OE_VIEW_ROOTS: 未設定→docs限定/fail-closed（permissiveでない）"
+all_shims_on; reset_state; reset_logs
+rc=0; env -u OE_VIEW_ROOTS "$VIEW" --from-link -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
+ck "未設定既定で permissive にならず拒否" "1" "$rc"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_view.sh
+++ b/projects/orchestration-engine/tests/test_oe_view.sh
@@ -232,6 +232,21 @@ ck "symlink で root 外実体 → exit 1" "1" "$rc"
 rm -f "$_TMP_DIR/docroot/sub/link-to-outside.md"
 
 # ----------------------------------------------------------------------------
+# [8b] allowlist: realpath 不在フォールバックでも root 内 symlink → root 外実体 → exit 1。
+#      oe-review（#210 実装SO）検出の P0 バイパス回帰: フォールバックが最終要素の symlink を
+#      解かないと、許可 root 内の symlink で root 外 md を開けてしまう。fail-safe で塞ぐ。
+# ----------------------------------------------------------------------------
+echo "[8b] allowlist: realpath 不在でも symlink → root 外実体 → exit 1（フォールバック）"
+all_shims_on; reset_state; reset_logs
+ln -sf "$MD_OUTSIDE" "$_TMP_DIR/docroot/sub/link-to-outside.md"
+rm -f "$_TMP_DIR/pathbin/realpath"   # realpath を外してフォールバック経路を強制
+rc=0; "$VIEW" --from-link -- "$_TMP_DIR/docroot/sub/link-to-outside.md" >/dev/null 2>&1 || rc=$?
+ck "realpath 不在 symlink → exit 1" "1" "$rc"
+ck "send されない" "no" "$([[ -e "$_TMP_DIR/logs/wez.log" ]] && echo yes || echo no)"
+_link_real realpath                  # 後続テストのため realpath を復帰
+rm -f "$_TMP_DIR/docroot/sub/link-to-outside.md"
+
+# ----------------------------------------------------------------------------
 # [9] allowlist: '..' トラバーサルで root 外 → exit 1。
 # ----------------------------------------------------------------------------
 echo "[9] allowlist: '..' トラバーサルで root 外 → exit 1"

--- a/projects/orchestration-engine/tests/test_oe_view.sh
+++ b/projects/orchestration-engine/tests/test_oe_view.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# test_oe_view.sh — oe-view（md=glow viewer / 非md=open）の判定・注入安全化・allowlist・
-# サニタイズ・viewer 再利用・degrade・--json を検証する（#210）。
+# test_oe_view.sh — oe-view（md=glow viewer / 非md=open）の判定・注入安全化（argv-spawn）・
+# allowlist・サニタイズ・viewer replace・degrade・--json を検証する（#210）。
+#
+# DJ-4/§11: 既定 md 経路は「split したシェルへ glow を send」から「ペインのプログラムとして
+# glow を直接 argv-spawn する replace モデル」に改定済。検証も `wez pane split … -- glow -p
+# -- <path>` の引数列（PROG が argv で渡る）と replace（生存 viewer の kill→spawn）を見る。
 #
 # 実 wez/glow/open は呼ばず PATH 先頭 mock に差し替える（test_oe_jump.sh / test_pane_split_targeting.sh
 # と同型）:
-#   - wez:  全呼び出しを wez.log に記録。`wez pane list` は $MOCK_PANE_LIST_JSON、
-#           `wez pane split` は $MOCK_SPLIT_PANE_ID を返す。send/activate は引数を log に記録。
-#   - glow: 引数を glow.log に記録。
+#   - wez:  全呼び出しを wez.log に記録（$* を 1 行）。`wez pane list` は $MOCK_PANE_LIST_JSON、
+#           `wez pane split` は $MOCK_SPLIT_PANE_ID を返す。kill/activate は引数を log に記録。
+#   - glow: 引数を glow.log に記録（--here の glow -p / 既存 fallback 検証用）。
 #   - open: 引数を open.log に記録。
 #   - bat:  引数を bat.log に記録（--here の glow 不在フォールバック検証用）。
 #   各 shim の在/不在をテストごとに切り替えるため shim は専用ディレクトリに置き、PATH 先頭の
@@ -38,7 +42,7 @@ printf '%s\n' "$*" >> "${OE_VIEW_TEST_LOG_DIR:?}/wez.log"
 case "${1:-} ${2:-}" in
   "pane list")     printf '%s\n' "${MOCK_PANE_LIST_JSON:-[]}" ;;
   "pane split")    printf '%s\n' "${MOCK_SPLIT_PANE_ID:-9}" ;;
-  "pane send")     exit 0 ;;
+  "pane kill")     exit 0 ;;
   "pane activate") exit 0 ;;
   *)               exit 0 ;;
 esac
@@ -115,59 +119,67 @@ bat_log()  { cat "$_TMP_DIR/logs/bat.log"  2>/dev/null; }
 has_line() { printf '%s\n' "$1" | grep -qF -- "$2" && echo yes || echo no; }
 
 # ----------------------------------------------------------------------------
-# [1] md 既定 → viewer 解決（state 無し=split）+ glow 送信。新規時 source(3) へ activate。
+# [1] md 既定 → viewer 解決（state 無し=spawn）。glow を argv で渡す。新規時 source(3) へ activate。
+#     argv-spawn replace モデル: `wez pane split … -- glow -p -- <path>`（PROG が argv で渡る）。
 # ----------------------------------------------------------------------------
-echo "[1] md 既定 → split + activate(source) + glow send"
+echo "[1] md 既定 → spawn（-- glow -p -- <path>）+ activate(source)"
 all_shims_on; reset_state; reset_logs
 export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
 rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
 log="$(wez_log)"
 ck "rc=0" "0" "$rc"
-ck "pane split が呼ばれる"            "yes" "$(has_line "$log" 'pane split')"
-ck "source(3) へ activate（#111）"    "yes" "$(has_line "$log" 'pane activate 3')"
-ck "pane send 9 が呼ばれる"           "yes" "$(has_line "$log" 'pane send 9')"
-ck "state file に新 pane 9 が書かれる" "9" "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
+ck "pane split が呼ばれる"               "yes" "$(has_line "$log" 'pane split')"
+# PROG が argv で渡る: split 行に "-- glow -p --" と canonical path が含まれる（送信文字列でない）。
+ck "split に PROG (-- glow -p --)"        "yes" "$(has_line "$log" '-- glow -p --')"
+ck "split に対象 md path が argv で渡る"  "yes" "$(has_line "$log" "$MD_IN_ROOT")"
+ck "source(3) へ activate（#111）"        "yes" "$(has_line "$log" 'pane activate 3')"
+ck "pane send は呼ばれない（argv-spawn）" "no"  "$(has_line "$log" 'pane send')"
+ck "state 無し→kill されない"            "no"  "$(has_line "$log" 'pane kill')"
+ck "state file に新 pane 9 が書かれる"   "9"   "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
 
 # ----------------------------------------------------------------------------
-# [2] 注入: メタ文字名 'a$(whoami).md' の送信文字列が %q 済（シェル安全）であること。
-#     生の "$(whoami)" が send 行にそのまま現れず、クォート済みリテラルになっている。
+# [2] 注入: メタ文字名 'a$(whoami).md' が **argv 要素**として渡る（shell 非経由・%q 不要）。
+#     argv-spawn では送信文字列を一切組まないため、path は `wez pane split … -- glow -p --
+#     <path>` の引数としてリテラルに渡る。受信シェルで再トークナイズされないので注入面が無い。
+#     mock wez は受け取った引数値（$*）をそのまま記録するため、リテラル 'a$(whoami).md' が
+#     split 行に現れ、`pane send` 経路は存在しない（送信文字列を組まないことの証跡）。
 # ----------------------------------------------------------------------------
-echo "[2] 注入: 送信文字列が %q クォート済（再トークナイズ防止）"
+echo "[2] 注入: path が argv 要素として渡る（送信文字列を組まない・shell 非経由）"
 all_shims_on; reset_state; reset_logs
 export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
 rc=0; "$VIEW" -- "$MD_INJECT" >/dev/null 2>&1 || rc=$?
 log="$(wez_log)"
 ck "rc=0" "0" "$rc"
-# %q は '(' ')' '$' をバックスラッシュエスケープする。クォート済みリテラルが送信行に在ること。
-ck "送信行が %q 済リテラルを含む" "yes" "$(has_line "$log" 'a\$\(whoami\).md')"
-# 生（未クォート）の '$(whoami)' が単独で送信行に現れないこと（バックスラッシュ無しの裸）。
-send_line="$(printf '%s\n' "$log" | grep 'pane send' || true)"
+# path はメタ文字を含むファイル名そのもの。argv で渡るのでリテラルが split 行に在る。
+split_line="$(printf '%s\n' "$log" | grep 'pane split' || true)"
 # shellcheck disable=SC2016  # 単一引用は grep -F のリテラルパターン（展開させない）
-if printf '%s\n' "$send_line" | grep -qF 'a$(whoami)' && ! printf '%s\n' "$send_line" | grep -qF 'a\$\(whoami\)'; then
-  raw_unquoted=yes
-else
-  raw_unquoted=no
-fi
-ck "生の未クォート \$(whoami) は送信行に無い" "no" "$raw_unquoted"
+ck "split 行に 'a\$(whoami).md' が argv で渡る" "yes" \
+  "$(printf '%s\n' "$split_line" | grep -qF 'a$(whoami).md' && echo yes || echo no)"
+# 送信文字列を組む経路（pane send）が存在しないこと＝再トークナイズ面が無いことの証跡。
+ck "pane send は呼ばれない（注入面なし）" "no" "$(has_line "$log" 'pane send')"
 
 # ----------------------------------------------------------------------------
-# [3] viewer 再利用: state の pane が生存 → split せず send（同 id）。
+# [3] viewer replace: state の pane が生存 → kill → 新 glow ペインを spawn → state 更新。
+#     glow -p はページャ（シェルでない）ため send 再利用できず、毎回 replace する（DJ-4）。
 # ----------------------------------------------------------------------------
-echo "[3] 再利用: state pane 7 生存 → split なし・send 7"
+echo "[3] replace: state pane 7 生存 → kill 7 → spawn（新 pane 9）"
 all_shims_on; reset_state; reset_logs
 mkdir -p "$OE_VIEW_STATE_DIR"; printf '7\n' > "$OE_VIEW_STATE_DIR/viewer-pane-id"
 export MOCK_PANE_LIST_JSON='[{"pane_id":7,"is_active":true}]'
+export MOCK_SPLIT_PANE_ID="9"
 rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
 log="$(wez_log)"
 ck "rc=0" "0" "$rc"
-ck "pane list で生存確認"   "yes" "$(has_line "$log" 'pane list')"
-ck "split は呼ばれない"     "no"  "$(has_line "$log" 'pane split')"
-ck "pane send 7（再利用）"  "yes" "$(has_line "$log" 'pane send 7')"
+ck "pane list で生存確認"      "yes" "$(has_line "$log" 'pane list')"
+ck "生存 viewer 7 を kill"     "yes" "$(has_line "$log" 'pane kill 7')"
+ck "新 glow ペインを spawn"    "yes" "$(has_line "$log" 'pane split')"
+ck "state が新 pane 9 に更新"  "9"   "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
+ck "pane send は呼ばれない"    "no"  "$(has_line "$log" 'pane send')"
 
 # ----------------------------------------------------------------------------
 # [4] viewer stale: state の pane が不在 → split+state 更新（新 pane 11）。
 # ----------------------------------------------------------------------------
-echo "[4] stale: state pane 7 不在（list に無い）→ split + state 更新"
+echo "[4] stale: state pane 7 不在（list に無い）→ kill なし・spawn + state 更新"
 all_shims_on; reset_state; reset_logs
 mkdir -p "$OE_VIEW_STATE_DIR"; printf '7\n' > "$OE_VIEW_STATE_DIR/viewer-pane-id"
 export MOCK_PANE_LIST_JSON='[{"pane_id":99,"is_active":true}]'   # 7 は不在
@@ -175,8 +187,9 @@ export MOCK_SPLIT_PANE_ID="11"
 rc=0; "$VIEW" -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
 log="$(wez_log)"
 ck "rc=0" "0" "$rc"
-ck "split で新規作成"            "yes" "$(has_line "$log" 'pane split')"
-ck "state が新 pane 11 に更新"   "11" "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
+ck "stale → kill されない"       "no"  "$(has_line "$log" 'pane kill')"
+ck "spawn で新規作成"            "yes" "$(has_line "$log" 'pane split')"
+ck "state が新 pane 11 に更新"   "11"  "$(head -n1 "$OE_VIEW_STATE_DIR/viewer-pane-id" 2>/dev/null)"
 
 # ----------------------------------------------------------------------------
 # [5] 非 md 直叩き → open -- <path>（canonical パス）。
@@ -229,12 +242,12 @@ ck "'..' で root 外 → exit 1" "1" "$rc"
 # ----------------------------------------------------------------------------
 # [9b] allowlist: --from-link で root 内 md → 許可（exit 0・send される）。
 # ----------------------------------------------------------------------------
-echo "[9b] allowlist: --from-link root 内 md → 許可（exit 0・send）"
+echo "[9b] allowlist: --from-link root 内 md → 許可（exit 0・spawn）"
 all_shims_on; reset_state; reset_logs
 export MOCK_PANE_LIST_JSON="[]"; export MOCK_SPLIT_PANE_ID="9"
 rc=0; "$VIEW" --from-link -- "$MD_IN_ROOT" >/dev/null 2>&1 || rc=$?
 ck "root 内 → exit 0" "0" "$rc"
-ck "pane send が呼ばれる" "yes" "$(has_line "$(wez_log)" 'pane send')"
+ck "pane split（spawn）が呼ばれる" "yes" "$(has_line "$(wez_log)" 'pane split')"
 
 # ----------------------------------------------------------------------------
 # [10] 入力サニタイズ: 改行・CR・制御文字を含むパス → 拒否（exit 1）。

--- a/projects/wezterm-ai-mode/README.md
+++ b/projects/wezterm-ai-mode/README.md
@@ -97,7 +97,7 @@ Options:
 #### `wez pane split`
 
 ```
-Usage: wez pane split [options]
+Usage: wez pane split [options] [-- PROG [ARGS...]]
 
 Options:
   --right          Split horizontally, new pane on the right (default)
@@ -113,6 +113,17 @@ Options:
 ```
 
 `--wait-ready` はポーリングで新ペインの出力が安定するまで待機する（tmux auto-attach のタイミング問題を吸収）。
+
+##### PROG パススルー（trailing `-- PROG ...`）
+
+リテラル `--` 以降の引数は、新ペインが**デフォルトシェルの代わりに実行するプログラム（PROG）**として `wezterm cli split-pane -- PROG ...` にそのまま（argv で）渡される。`--` を付けなければ従来どおりデフォルトシェルを起動する（**完全後方互換**）。
+
+```bash
+# 新ペインのプログラムとして glow を直接起動（シェル/tmux 非経由・確実に描画される）
+wez pane split --right --percent 40 --cwd "$dir" -- glow -p -- "$file"
+```
+
+PROG は argv 要素として渡るため、シェルを介さず（再トークナイズが起きず）メタ文字を含むパスも安全に渡せる。`oe-view`（`orchestration-engine`）の viewer ペインがこの経路で `glow` を起動する（新規 wez ペインのシェル rc が tmux 自動アタッチしてタイプ送信が実行されない問題を回避・DJ-4 #210）。`pane_id` / `--json` 出力は PROG の有無で不変。
 
 ##### ターゲティング規約（`--target`）
 

--- a/projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md
+++ b/projects/wezterm-ai-mode/docs/decisions/ADR-004-pane-design-decisions.md
@@ -1,6 +1,6 @@
 ---
 title: "ADR-004: pane サブコマンド群の設計判断集"
-date: 2026-04-20
+date: 2026-06-22
 type: decision
 related:
   - type: implements
@@ -12,6 +12,9 @@ related:
   - type: relates_to
     ref: "https://github.com/stlwolf/ai-development-hub/issues/165"
     reason: "DJ-9 wez layout 宣言的盤面構築規約 (preset schema / 非冪等 / rollback) の判断を追記"
+  - type: relates_to
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/210"
+    reason: "DJ-10 split PROG パススルー / 新ペインでのプログラム起動方式 (shell send 棄却 → argv-spawn) の判断を追記"
   - type: depends_on
     ref: ADR-001-cli-file-structure.md
     reason: "ファイル構成・命名規約を踏襲"
@@ -112,3 +115,12 @@ layout 固有の追加コードは無く、既存定数を再利用する: prese
 #### スコープガード
 
 盤面構築のみ（エージェント起動コマンドを持たない）/ wez 専用（tmux 非対応）/ 非冪等（明記）/ `spawn.sh`（`#175`）は触らない / grid は schema v2。
+
+## DJ-10: split の PROG パススルーと新ペインでのプログラム起動方式（#210）
+
+`wez pane split` に trailing `-- <PROG>...` パススルーを追加し、**新ペインでプログラムを動かす場合はペインのプログラムとして直接起動する**（split したシェルへ `wez pane send` でコマンドをタイプ送信しない）ことを規約とする。消費側は oe-view（`#210`）の viewer ペイン（`wez pane split … -- glow -p -- <path>`）。設計探索・実機検証は `../../orchestration-engine/docs/episodes/2026-06-22-episode-210-oe-view-clickable-md.md` / `../../orchestration-engine/docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md` §11 を正本とする。
+
+- **PROG パススルー（DJ-a）**: `wez pane split [...flags] -- <PROG>...` の `--` 以降を `wezterm cli split-pane` の PROG（「シェルの代わりに PROG を実行」）へ透過する。PROG 無しは既定シェル split で **完全後方互換**（出力・exit code 不変）。
+- **shell-send 棄却（DJ-b・実機根拠）**: 当初 `wez pane split`（シェル）→ `wez pane send "<cmd>"`（タイプ送信）で起動する案を採ったが、実機（cockpit）で **新規ペインのシェル rc が tmux に自動アタッチ**し、send したコマンドが実行されず描画されないことを e2e で確認 → 棄却。新ペインでのプログラム起動は send-keys に依存させず PROG 直接起動に倒す。
+- **副次効果（DJ-c）**: PROG は argv 配列で渡るため受信シェルの再トークナイズが起きず、パスのシェル注入面が消える（`printf %q` クォート不要）。
+- **スコープ**: PROG パススルーは split の薄い透過拡張のみ。PROG の中身・ライフサイクル管理は呼び出し側責務（oe-view は replace モデルで viewer を kill→spawn）。

--- a/projects/wezterm-ai-mode/lib/pane.sh
+++ b/projects/wezterm-ai-mode/lib/pane.sh
@@ -166,9 +166,23 @@ _wez_pane_split() {
   local opt_wait_ready=false
   local opt_timeout=10
   local opt_cwd=""
+  # PROG passthrough (DJ-4 #210): everything after a literal `--` becomes the
+  # program the new pane runs instead of the default shell. Passed verbatim to
+  # `wezterm cli split-pane -- <PROG>...` (split-pane treats trailing args after
+  # `--` as PROG per wezterm's official spec). Empty when no `--` is given, in
+  # which case the behavior is fully backward-compatible (default shell split).
+  local -a prog=()
+  local have_prog=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      --)
+        # Consume the rest as PROG (do not re-parse as options).
+        shift
+        have_prog=true
+        prog=("$@")
+        break
+        ;;
       --right)       opt_direction="--right" ;;
       --bottom)      opt_direction="--bottom" ;;
       --left)        opt_direction="--left" ;;
@@ -227,7 +241,7 @@ _wez_pane_split() {
         ;;
       --help|-h)
         cat <<'EOF'
-Usage: wez pane split [options]
+Usage: wez pane split [options] [-- PROG [ARGS...]]
 
 Split the current (or specified) pane and create a new one.
 Default direction: --right.
@@ -255,6 +269,12 @@ Options:
   --wait-ready     Wait until the new pane is ready for input
   --timeout <SEC>  Timeout for --wait-ready in seconds (default: 10)
   -h, --help       Show this help
+
+Trailing arguments after a literal `--` are forwarded verbatim as the
+program (PROG) for the new pane, run instead of the default shell
+(wezterm cli split-pane -- PROG ...). Without `--`, the new pane runs
+the default shell (backward-compatible). Example:
+  wez pane split --right --percent 40 --cwd "$dir" -- glow -p -- "$file"
 EOF
         return 0
         ;;
@@ -319,6 +339,13 @@ EOF
   [[ -n "$opt_percent" ]] && split_args+=(--percent "$opt_percent")
   [[ -n "$resolved_pane_id" ]] && split_args+=(--pane-id "$resolved_pane_id")
   [[ -n "$opt_cwd" ]] && split_args+=(--cwd "$opt_cwd")
+  # PROG passthrough (DJ-4 #210): append `-- <PROG>...` last so the new pane
+  # runs PROG instead of the default shell. `have_prog` (not array length)
+  # gates this so a bare trailing `--` still forwards an (empty) PROG marker if
+  # ever given; in practice PROG is non-empty (e.g. glow -p -- <path>).
+  if [[ "$have_prog" == true ]]; then
+    split_args+=(-- "${prog[@]+"${prog[@]}"}")
+  fi
 
   local new_pane_id
   if ! new_pane_id=$(wezterm cli split-pane "${split_args[@]}" 2>/dev/null); then

--- a/projects/wezterm-ai-mode/tests/test_pane_split_targeting.sh
+++ b/projects/wezterm-ai-mode/tests/test_pane_split_targeting.sh
@@ -265,5 +265,60 @@ run_case "priority: --pane-id wins over WEZTERM_PANE/self" 99 0 4 -- --pane-id 4
 run_case "compat: engine spawn-style omitted call" UNSET 0 "" -- --bottom --percent 30 --wait-ready --timeout 10
 
 # ============================================================
+# 6) PROG パススルー (DJ-4 #210): trailing `-- <PROG>...` を wezterm cli split-pane の
+#    PROG にそのまま渡す。PROG 無しは後方互換 (default shell split・既存挙動不変)。
+# ============================================================
+
+# SPLIT_LOG (1 引数 1 行) に PROG マーカー `--` 以降が記録されているか検証するヘルパ。
+# wezterm cli split-pane の最後が `-- <PROG>...` となっていること、PROG 要素が argv で
+# 渡る (リテラル・shell 非経由) ことを確認する。
+split_log_has_line() {  # <literal arg> — SPLIT_LOG に完全一致する 1 行があるか
+  [[ -f "$SPLIT_LOG" ]] || { echo no; return; }
+  if grep -qxF -- "$1" "$SPLIT_LOG"; then echo yes; else echo no; fi
+}
+# split-pane 引数列の `--` 以降 (PROG) を 1 行 1 要素で返す。
+split_log_prog() {
+  [[ -f "$SPLIT_LOG" ]] || return 0
+  awk 'found{print} /^--$/{found=1}' "$SPLIT_LOG"
+}
+
+# PROG 付き: trailing `-- glow -p -- <path>` が split-pane にそのまま渡る (exit 0)。
+reset_log
+export WEZTERM_PANE="1"
+# shellcheck disable=SC2016  # 単一引用は意図的: メタ文字を展開させずリテラルとして渡す検証。
+prog_out=$(_wez_pane_split --right --percent 40 --cwd "$_TMP_DIR" -- glow -p -- '/x/a$(whoami).md' 2>&1 >/dev/null)
+prog_rc=$?
+unset WEZTERM_PANE
+prog_dump="$(split_log_prog)"
+# 期待 PROG 列 (順序通り・メタ文字はリテラル): glow / -p / -- / /x/a$(whoami).md
+if [[ "$prog_rc" -eq 0 ]] \
+  && [[ "$(split_log_has_line 'glow')" == yes ]] \
+  && [[ "$(split_log_has_line '-p')" == yes ]] \
+  && [[ "$prog_dump" == $'glow\n-p\n--\n/x/a$(whoami).md' ]]; then
+  ok "prog: trailing -- forwards PROG verbatim (argv, metachar literal)"
+else
+  fail "prog: expected PROG 'glow -p -- /x/a\$(whoami).md' (rc=$prog_rc prog=[$prog_dump] out=$prog_out)"
+fi
+
+# PROG 列に direction/percent/cwd フラグが混ざらない (PROG は split オプションの後ろに単独で並ぶ)。
+if [[ "$(printf '%s\n' "$prog_dump" | grep -c -- '--right\|--percent\|--cwd' || true)" -eq 0 ]]; then
+  ok "prog: split options are not mixed into PROG"
+else
+  fail "prog: split options leaked into PROG (prog=[$prog_dump])"
+fi
+
+# PROG 無し (後方互換): trailing `--` を付けない従来呼び出しに `--` が現れない (default shell split)。
+reset_log
+export WEZTERM_PANE="1"
+noprog_out=$(_wez_pane_split --right --percent 40 2>&1 >/dev/null)
+noprog_rc=$?
+unset WEZTERM_PANE
+if [[ "$noprog_rc" -eq 0 ]] && ! grep -qxF -- '--' "$SPLIT_LOG"; then
+  ok "prog: omitting -- keeps default shell split (no PROG marker, backward-compatible)"
+else
+  fail "prog: expected no '--' marker without trailing -- (rc=$noprog_rc out=$noprog_out log=$(tr '\n' ' ' < "$SPLIT_LOG" 2>/dev/null))"
+fi
+
+# ============================================================
 printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 目的 / 背景

cockpit で plan/kickoff/episode 等の md を生成すると出力にパスは出るが、見るたびに Finder/手動ペイン操作が要る。これを「パスから Finder/手動操作なしで即ビュー（md=端末内 glow / 非md=open）」にする。本 PR は **PR1（hub CLI `oe-view`）**。クリック層（`.wezterm.lua` の `hyperlink_rules`+`open-uri`）は companion の dotfiles PR で実装する。

設計は 3者SO（Codex+Claude+Cursor）reconcile 済（計画書同梱）。

## 変更内容

- `projects/orchestration-engine/bin/oe-view`（新規・実行可能）
  - `oe-view [--here] [--from-link] [--json] [--] <path>`
  - md → viewer ペインを解決して `glow` 描画 / 非md → `open -- <path>`
  - `--here`: 分割せず `glow -p`（無ければ `bat`）。tmux 非 wez / Cursor 統合ターミナル / dotfiles 未反映時の degrade 本線
  - exit code 統一: `0` / `1`（不在・allowlist 外・サニタイズ・from-link 非md・glow/open 失敗）/ `2`（usage・環境=wez/glow 不在）
- `projects/orchestration-engine/lib/oe-viewer.sh`（新規・source 専用）: viewer ペイン解決（state file 追跡・生存確認・再利用/新規split・#111 focus 復帰・送信文字列の `%q` クォート）
- `projects/orchestration-engine/tests/test_oe_view.sh`（新規）: mock shim テスト 51 assertions / 17 cases
- `projects/orchestration-engine/bin/README.md`: `oe-view` 節 + 3段 degrade 表 + env 行
- 計画書 `docs/plans/2026-06-21-plan-210-oe-view-clickable-md.md`

## セキュリティ（設計SO で固めた P0）

- **送信層のシェル注入対策**: viewer 表示は `wez pane send` で受信シェルに行入力され再トークナイズされる。`a$(whoami).md` 等を防ぐため送信文字列のパスを `printf %q` でクォート
- **allowlist**: `--from-link`（クリック経由）は `realpath` 正規化後に `OE_VIEW_ROOTS` 配下 prefix を境界判定（`..`/symlink トラバーサル対策）。範囲外は拒否
- **非md拒否**: `--from-link` は md 限定（クリック経由の任意アプリ/スクリプト起動を防ぐ）
- **サニタイズ**: 改行/CR/制御文字を拒否、存在＋通常ファイル確認
- Lua 側（companion PR）は parse と argv 起動のみ、実行判断は oe-view に集約

## テスト

- `shellcheck bin/oe-view lib/oe-viewer.sh tests/test_oe_view.sh` → clean（rc 0）
- `bash tests/test_oe_view.sh` / `/bin/bash`(3.2) → **51 pass / 0 fail（両方）**
- 注入（`%q`）・allowlist 外/symlink/`..`・サニタイズ・from-link 非md拒否・viewer 再利用(alive→send / stale→split+state / 新規→source activate)・各 exit code・`--here`・`--json` schema を網羅

## 未解決 / integration pending（実機・別途）

- end-to-end（実 wezterm での `oe-view x.md` → ペイン split + glow 描画）は **`glow` 導入後**に実機確認（現環境は glow 未導入。dotfiles で provisioning）
- `wez pane split` の出力（bare pane id 前提）を実機で確認
- Cmd+Click → oe-view 発火は companion dotfiles PR とセットで実機確認

## 関連

- Refs #210
- 親: #169（CLI cockpit）
- companion（クリック層・dotfiles）: stlwolf/dotfiles#21
