### PR TITLE
feat(oe): add oe-activity read-time view + parent/child activity log (#206)

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -44,9 +44,11 @@ projects/orchestration-engine/
 │   ├── oe-list                # 委譲の宛先候補を一覧（spawn registry + pane-issue）
 │   ├── oe-select              # oe-list + fzf の対話ペインセレクタ（cockpit 最小 UI・#176）
 │   ├── oe-report              # 親へ申し送り/レビュー依頼（legacy・戻しは oe-send に一本化）
-│   └── oe-status              # cockpit 観測UI: read-only 俯瞰（ENGINE=audit-terminal state / DELEGATE=liveness）+ 監査ログ閲覧（#177）
+│   ├── oe-status              # cockpit 観測UI: read-only 俯瞰（ENGINE=audit-terminal state / DELEGATE=liveness）+ 監査ログ閲覧（#177）
+│   └── oe-activity            # 親子活動ログ（oe-events.jsonl）の read 時投影ビュー: 往復/配送/preview/子生存・report inbox（#206）
 ├── lib/                       # Bash 関数ライブラリ（source 専用）
 │   ├── constants.sh           # OE_POLL_INTERVAL, OE_CB_*, OE_DATA_DIR, OE_TARGET_AI_*, OE_VERIFY_AI_* 等
+│   ├── event-bus.sh           # 親子活動ログ emit プリミティブ（child_spawned / message_sent・best-effort・#206）
 │   ├── envelope.sh            # JSON エンベロープ生成
 │   ├── spawn.sh               # wez pane split + send + CLI ディスパッチャ（cursor-agent / claude / codex）
 │   ├── capture.sh             # マーカー検出・6 値分類・KVS 書き込み（target pane 監視）

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -6,7 +6,7 @@ scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
 - **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report` / `oe-jump`（通知→ペインへ focus）
-- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影）
+- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox・#206）
 
 ---
 
@@ -257,6 +257,28 @@ set -g pane-border-format '#[align=left] #(/path/to/repo/projects/orchestration-
 
 ---
 
+## oe-activity — 親子活動ログの read 時投影ビュー（#206 増分1）
+
+`lib/event-bus.sh` が best-effort 追記する永続 append-only 活動ログ（`oe-events.jsonl`）を **read 時に投影**する read-only ビュー。各イベントは `from`/`to` の `{pane,role,label}` を emit 時に焼き込む自己完結レコードで、`session_id` を主キーにせず registry の生存にも依存しない（GC 後・子が消えた後も残る＝departed children も可視）。新規 write path は持たない（#188 read 時相関の思想に整合）。
+
+```bash
+oe-activity            # 俯瞰: 親子関係ごとに 往復 / 配送 / 直近 preview / 子(送信元)生存
+oe-activity --inbox    # report inbox: 自分(=$TMUX_PANE)宛の報告を送信元(子)ごとに
+```
+
+- 出す情報は 4 つだけ（**lifecycle-end / stall は推論しない** ＝ DJ-188-2 尊重）:
+  - `TRIPS` … 関係内の `message_sent` 数（往復回数）
+  - `DELIVERY` … 直近 message の `delivery_signal`（`suspected_miss`|`none`・`delivered` は名乗らない・`(×N)` は suspected_miss 件数）
+  - `PREVIEW` … 直近 message 先頭 ~100 字
+  - `LIVE` … 子(worker)ペインの mux 存在 query（`alive`|`gone`|`?`）。report の送信元＝子なので「報告者がまだ居るか」を honest に示す。ended/stalled の分類はしない（在る=alive / 無い=gone / tmux 不在=?）
+- read-only / 非検出: 触れるのは `oe-events.jsonl` と tmux ペイン存在（mux query）のみ。ペイン出力は読まない（capture / polling しない）・書込なし
+- degrade: `jq` 不在は件数のみ表示・`tmux` 不在は `LIVE=?`・ログ空は明示メッセージ（いずれも exit 0）
+- 既知の制約: liveness は現サーバの `tmux list-panes -a` 突合。別サーバのペイン ID は `gone` と出る（イベントは server pid を持たないため cross-server scope は増分1 対象外）
+
+関連: `lib/event-bus.sh`（emit プリミティブ・`oe-delegate` が `child_spawned` / `oe_send_line` が `message_sent` を発火）、`schemas/oe-events.schema.json`（レコードスキーマ・audit-log とは別系統）。設計判断は #188 DJ-188-4 を delegate 現実（session_id 不在）へ精緻化したもの。
+
+---
+
 ## 主要な環境変数
 
 | 変数 | 用途 | 既定 |
@@ -270,5 +292,8 @@ set -g pane-border-format '#[align=left] #(/path/to/repo/projects/orchestration-
 | `OE_JUMP_STATE_DIR` | oe-jump: `--record`/replay の state 置き場 | `~/.claude/state/oe-jump` |
 | `OE_VIEW_ROOTS` | oe-view: allowlist 許可ルート（コロン区切り。`--from-link` 時に強制） | 各プロジェクトの `projects/*/docs` のみ（クリック境界を doc に限定。該当無しなら空＝fail-closed） |
 | `OE_VIEW_STATE_DIR` | oe-view: viewer pane id の state 置き場 | `~/.claude/state/oe-view` |
+| `OE_EVENT_DIR` | 活動ログ（#206）の置き場（`oe-events.jsonl`）。emit / oe-activity 共通 | `~/.claude/state` |
+| `OE_EVENT_LOG` | 活動ログ emit の有効/無効（`0` で kill-switch） | 有効 |
+| `OE_EVENT_PREVIEW_MAX` | message_sent の preview 切り詰め codepoint 数 | `100` |
 
 本体エンジン側（`OE_POLL_INTERVAL` / `OE_CB_*` / `OE_TARGET_AI_*` / `OE_VERIFY_AI_*` 等）は [`../lib/constants.sh`](../lib/constants.sh) を参照。

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -273,7 +273,7 @@ oe-activity --inbox    # report inbox: 自分(=$TMUX_PANE)宛の報告を送信�
   - `LIVE` … 子(worker)ペインの mux 存在 query（`alive`|`gone`|`?`）。report の送信元＝子なので「報告者がまだ居るか」を honest に示す。ended/stalled の分類はしない（在る=alive / 無い=gone / tmux 不在=?）
 - read-only / 非検出: 触れるのは `oe-events.jsonl` と tmux ペイン存在（mux query）のみ。ペイン出力は読まない（capture / polling しない）・書込なし
 - degrade: `jq` 不在は件数のみ表示・`tmux` 不在は `LIVE=?`・ログ空は明示メッセージ（いずれも exit 0）
-- 既知の制約: liveness は現サーバの `tmux list-panes -a` 突合。別サーバのペイン ID は `gone` と出る（イベントは server pid を持たないため cross-server scope は増分1 対象外）
+- 既知の制約（増分1）: liveness は現サーバの `tmux list-panes -a` 突合で別サーバのペイン ID は `gone` と出る。イベントは server pid を持たず **pane を関係キー**にするため、同一サーバで `%N` が再利用（pane 破棄後の再割当）されると別関係が同一 `%N` に混線し得る（TRIPS 過大・親/inbox 取り違え）。server-pid キー化は後続増分（DJ-188-4 拡張）へ defer。壊れた JSONL 行は read 時に黙ってスキップ（degrade）
 
 関連: `lib/event-bus.sh`（emit プリミティブ・`oe-delegate` が `child_spawned` / `oe_send_line` が `message_sent` を発火）、`schemas/oe-events.schema.json`（レコードスキーマ・audit-log とは別系統）。設計判断は #188 DJ-188-4 を delegate 現実（session_id 不在）へ精緻化したもの。
 

--- a/projects/orchestration-engine/bin/oe-activity
+++ b/projects/orchestration-engine/bin/oe-activity
@@ -19,15 +19,20 @@
 #
 # read-only / 非検出: 触れるのは (1) oe-events.jsonl (2) tmux ペイン存在（mux query）のみ。
 #   ペイン出力は一切読まない（capture / polling はしない）。書込なし。
-# 既知の制約: liveness は現サーバの `tmux list-panes -a` 突合。別サーバのペイン ID は gone と出る
-#   （イベントは server pid を持たないため cross-server の厳密 scope は増分1 対象外）。
+# 既知の制約（増分1・実装SO 指摘を反映）:
+#   - liveness は現サーバの `tmux list-panes -a` 突合。別サーバのペイン ID は gone と出る。
+#   - イベントは server pid を持たない＝pane を関係キーにする。同一サーバで %N が再利用される
+#     （pane 破棄後の再割当）と、別関係が同一 %N に混線し TRIPS 過大・親/inbox の取り違えが起き得る。
+#     server-pid キー化は後続増分（DJ-188-4 の event bus 拡張）へ defer。
+#   - 壊れた JSONL 行（外部編集等）は read 時に黙ってスキップする（degrade・下記 project）。
 
 set -euo pipefail
 
 err() { echo "oe-activity: $*" >&2; }
 
+# 単一ノブ OE_EVENT_DIR（writer=event-bus.sh と一致）。reader 専用の別ノブは footgun なので持たない。
 OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
-OE_EVENT_FILE="${OE_EVENT_FILE:-${OE_EVENT_DIR}/oe-events.jsonl}"
+OE_EVENT_FILE="${OE_EVENT_DIR}/oe-events.jsonl"
 
 usage() {
   cat >&2 <<'EOF'
@@ -86,8 +91,10 @@ liveness_of() {
 
 # --- 投影（jq・slurp）: 1 関係 = 1 行の TSV を新しい順に返す ---
 # 出力フィールド: child_pane \t parent_pane \t child_label \t parent_label \t trips \t deliv \t miss \t preview
+# 前段の `jq -R 'fromjson? // empty'` で壊れた JSONL 行を黙ってスキップ（1 行破損で全体 exit 1 を回避）。
 project() {
-  jq -rs \
+  jq -R 'fromjson? // empty' "$OE_EVENT_FILE" \
+  | jq -rs \
     --arg mode "$MODE" --arg self "$SELF" '
     ( [ .[] | select(.type=="child_spawned") ] ) as $spawns
     | ( reduce $spawns[] as $s ({}; .[$s.to.pane] = $s.from.pane) )            as $parent_of
@@ -122,7 +129,7 @@ project() {
             lts:   (if ($g|length)>0 then $g[-1].ts else "" end) } ]
     | sort_by(.lts) | reverse
     | .[] | [ .c, .p, .clab, .plab, .trips, .deliv, .miss, .prev ] | @tsv
-  ' "$OE_EVENT_FILE"
+  '
 }
 
 # pane を「label (pane)」or「pane」で表示

--- a/projects/orchestration-engine/bin/oe-activity
+++ b/projects/orchestration-engine/bin/oe-activity
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# oe-activity — 親子相互作用の活動ログ（oe-events.jsonl）の read-only 投影ビュー（#206 増分1）
+#
+# usage:
+#   oe-activity            俯瞰: 親子関係ごとに 往復 / 配送 / 直近 preview / 子(送信元)生存
+#   oe-activity --inbox    report inbox: 自分(=$TMUX_PANE)宛の報告を送信元(子)ごとに表示
+#   oe-activity -h | --help
+#
+# lib/event-bus.sh が best-effort 追記する自己完結レコード（from/to の {pane,role,label} を
+# emit 時に焼込）を read 時に投影する。新規 write path は持たない（#188 read 時相関の思想に整合）。
+#
+# 出す情報は 4 つだけ（lifecycle-end / stall は推論しない ＝ DJ-188-2 尊重）:
+#   - 往復回数（TRIPS）  : 関係内の message_sent 数
+#   - 配送（DELIVERY）   : 直近 message の delivery_signal（suspected_miss|none、delivered は名乗らない）
+#   - preview            : 直近 message の先頭 ~100 字
+#   - 送信元生存（LIVE） : 子(worker)ペインの mux 存在 query 結果（alive|gone|?）。
+#                          report の送信元 ＝ 子なので「報告者がまだ居るか」を honest に示す。
+#                          ended/stalled の分類はしない（pane が在る=alive / 無い=gone / tmux 不在=?）。
+#
+# read-only / 非検出: 触れるのは (1) oe-events.jsonl (2) tmux ペイン存在（mux query）のみ。
+#   ペイン出力は一切読まない（capture / polling はしない）。書込なし。
+# 既知の制約: liveness は現サーバの `tmux list-panes -a` 突合。別サーバのペイン ID は gone と出る
+#   （イベントは server pid を持たないため cross-server の厳密 scope は増分1 対象外）。
+
+set -euo pipefail
+
+err() { echo "oe-activity: $*" >&2; }
+
+OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
+OE_EVENT_FILE="${OE_EVENT_FILE:-${OE_EVENT_DIR}/oe-events.jsonl}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  oe-activity            俯瞰（親子関係ごとに 往復 / 配送 / preview / 子生存）
+  oe-activity --inbox    report inbox（自分宛の報告を送信元ごとに）
+  oe-activity -h|--help
+
+read-only: oe-events.jsonl と tmux ペイン存在のみを読む（検出・送信はしない）。
+EOF
+}
+
+MODE="overview"
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --inbox) MODE="inbox"; shift ;;
+  "" ) ;;
+  -*) err "unknown option: $1"; usage; exit 2 ;;
+  *)  err "unexpected argument: $1"; usage; exit 2 ;;
+esac
+[[ $# -eq 0 ]] || { err "unexpected extra argument: $1"; usage; exit 2; }
+
+# --- 入力が無い場合 ---
+if [[ ! -s "$OE_EVENT_FILE" ]]; then
+  echo "(no activity recorded yet in ${OE_EVENT_FILE})"
+  exit 0
+fi
+
+# --- jq 不在は degrade（投影せず件数のみ）---
+if ! command -v jq >/dev/null 2>&1; then
+  err "jq not found — showing raw event count only (install jq for the projected view)"
+  printf 'events: %s  (%s)\n' "$(grep -c '' "$OE_EVENT_FILE" 2>/dev/null || echo '?')" "$OE_EVENT_FILE"
+  exit 0
+fi
+
+SELF="${TMUX_PANE:-}"
+if [[ "$MODE" == "inbox" && -z "$SELF" ]]; then
+  err "inbox mode needs \$TMUX_PANE (run inside a tmux pane) — nothing to filter"
+  exit 0
+fi
+
+# --- liveness（mux 存在 query。tmux 不在は ? で degrade）---
+TMUX_AVAIL=0
+LIVE_SET=""
+if command -v tmux >/dev/null 2>&1; then
+  if LIVE_SET="$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null)"; then
+    TMUX_AVAIL=1
+  fi
+fi
+liveness_of() {
+  local pane="$1"
+  [[ -n "$pane" ]] || { printf '?'; return; }
+  if [[ "$TMUX_AVAIL" != "1" ]]; then printf '?'; return; fi
+  if printf '%s\n' "$LIVE_SET" | grep -qxF "$pane"; then printf 'alive'; else printf 'gone'; fi
+}
+
+# --- 投影（jq・slurp）: 1 関係 = 1 行の TSV を新しい順に返す ---
+# 出力フィールド: child_pane \t parent_pane \t child_label \t parent_label \t trips \t deliv \t miss \t preview
+project() {
+  jq -rs \
+    --arg mode "$MODE" --arg self "$SELF" '
+    ( [ .[] | select(.type=="child_spawned") ] ) as $spawns
+    | ( reduce $spawns[] as $s ({}; .[$s.to.pane] = $s.from.pane) )            as $parent_of
+    | ( reduce $spawns[] as $s ({}; .[$s.to.pane] = ($s.to.label // "")) )     as $clabel
+    | ( reduce $spawns[] as $s ({}; .[$s.from.pane] = ($s.from.label // "")) ) as $plabel
+    # 各 message を親/子へ向き付け（直接 parent リンク優先 → role → fallback）
+    | ( [ .[] | select(.type=="message_sent") | . as $m
+          | ( if   (($parent_of[$m.from.pane]) // "") == $m.to.pane   then {p:$m.to.pane,   c:$m.from.pane}
+              elif (($parent_of[$m.to.pane])   // "") == $m.from.pane then {p:$m.from.pane, c:$m.to.pane}
+              elif ($m.from.role=="child")  and ($m.to.role=="parent") then {p:$m.to.pane,   c:$m.from.pane}
+              elif ($m.from.role=="parent") and ($m.to.role=="child")  then {p:$m.from.pane, c:$m.to.pane}
+              else {p:$m.from.pane, c:$m.to.pane} end ) as $r
+          | { c:$r.c, p:$r.p, ts:$m.ts, recipient:$m.to.pane,
+              clab_m: (if $r.c==$m.from.pane then $m.from.label else $m.to.label end),
+              plab_m: (if $r.p==$m.from.pane then $m.from.label else $m.to.label end),
+              deliv: ($m.delivery_signal // "none"),
+              prev:  (($m.preview // "") | gsub("[\t\r\n]"; " ")) } ] ) as $msgs
+    # inbox は自分宛の報告だけに絞る
+    | ( if $mode=="inbox" then [ $msgs[] | select(.recipient==$self) ] else $msgs end ) as $fmsgs
+    # 関係キー = (俯瞰のみ) spawn 子 ∪ message 子
+    | ( ( (if $mode=="inbox" then [] else [ $spawns[].to.pane ] end) + [ $fmsgs[].c ] ) | unique ) as $children
+    | [ $children[] | . as $c
+        | ( [ $fmsgs[] | select(.c==$c) ] | sort_by(.ts) ) as $g
+        | ( ($parent_of[$c]) // (if ($g|length)>0 then $g[-1].p else "" end) ) as $p
+        | { c:$c, p:$p,
+            clab: ( ($clabel[$c]) // (if ($g|length)>0 then $g[-1].clab_m else "" end) // "" ),
+            plab: ( ($plabel[$p]) // (if ($g|length)>0 then $g[-1].plab_m else "" end) // "" ),
+            trips: ($g|length),
+            deliv: (if ($g|length)>0 then $g[-1].deliv else "-" end),
+            miss:  ([ $g[] | select(.deliv=="suspected_miss") ] | length),
+            prev:  (if ($g|length)>0 then ($g[-1].prev // "") else "" end),
+            lts:   (if ($g|length)>0 then $g[-1].ts else "" end) } ]
+    | sort_by(.lts) | reverse
+    | .[] | [ .c, .p, .clab, .plab, .trips, .deliv, .miss, .prev ] | @tsv
+  ' "$OE_EVENT_FILE"
+}
+
+# pane を「label (pane)」or「pane」で表示
+disp() {
+  local pane="$1" label="$2"
+  if [[ -n "$label" ]]; then printf '%s (%s)' "$label" "$pane"; else printf '%s' "$pane"; fi
+}
+
+rows="$(project 2>/dev/null)" || { err "failed to project ${OE_EVENT_FILE} (corrupt jsonl?)"; exit 1; }
+
+if [[ -z "$rows" ]]; then
+  if [[ "$MODE" == "inbox" ]]; then echo "(no reports addressed to ${SELF})"; else echo "(no relationships in ${OE_EVENT_FILE})"; fi
+  exit 0
+fi
+
+if [[ "$MODE" == "inbox" ]]; then
+  printf '=== report inbox (to %s · tmux · read-only) ===\n' "$SELF"
+  printf '%-6s  %-5s  %-20s  %-30s  %s\n' "LIVE" "TRIPS" "DELIVERY" "FROM" "PREVIEW"
+else
+  printf '=== activity (parent/child · tmux · read-only) ===\n'
+  printf '%-6s  %-5s  %-20s  %-30s  %s\n' "LIVE" "TRIPS" "DELIVERY" "RELATION" "PREVIEW"
+fi
+
+while IFS=$'\t' read -r c p clab plab trips deliv miss prev; do
+  [[ -n "$c" || -n "$p" ]] || continue
+  live="$(liveness_of "$c")"     # 送信元 ＝ 子(worker)の生存
+  deliv_disp="$deliv"
+  [[ "${miss:-0}" -gt 0 ]] 2>/dev/null && deliv_disp="${deliv} (×${miss})"
+  if [[ "$MODE" == "inbox" ]]; then
+    relation="$(disp "$c" "$clab")"
+  else
+    relation="$(disp "$p" "$plab") → $(disp "$c" "$clab")"
+  fi
+  printf '%-6s  %-5s  %-20s  %-30s  %s\n' "$live" "$trips" "$deliv_disp" "$relation" "$prev"
+done <<< "$rows"

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -14,6 +14,9 @@ set -euo pipefail
 BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../lib/delegate-registry.sh
 source "${BIN_DIR}/../lib/delegate-registry.sh"
+# 活動ログ emit（best-effort・#206）。source 失敗や関数不在でも委譲本体は壊さない。
+# shellcheck source=../lib/event-bus.sh
+source "${BIN_DIR}/../lib/event-bus.sh" 2>/dev/null || true
 
 usage() {
   cat >&2 <<'EOF'
@@ -149,6 +152,11 @@ tmux list-panes -a -F "#{pane_id}" | grep -qxF "$CHILD_PANE" || {
 
 # spawn レジストリに登録（親スコープ + ゼロベース期の仮ラベル保持）。best-effort。
 oe_reg_record "$CHILD_PANE" "$LABEL" "$WORKSPACE" "$PARENT_PANE" || true
+
+# 活動ログに child_spawned を best-effort emit（registry 登録後 ＝ 親 label 解決可）。本体は壊さない。
+if declare -F oe_event_child_spawned >/dev/null 2>&1; then
+  oe_event_child_spawned "$PARENT_PANE" "$CHILD_PANE" "$LABEL" || true
+fi
 
 # キックを oe-send で注入する。delegate は report を内包しない（戻しは子が oe-send で行う）。
 SEND_ARGS=()

--- a/projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md
+++ b/projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md
@@ -4,6 +4,7 @@ title: "#188 オーケストレーション2基盤の identity は pane 層で�
 date: 2026-06-19
 type: decision
 status: accepted
+superseded_by: "Partially superseded by 2026-06-22-decision-206-activity-log-self-contained-events.md — DJ-188-4（Stage-B event bus の鍵戦略）の範囲のみ精緻化（session_id 主キー → 自己完結イベントの write 時 snapshot）。DJ-188-1/2/3/5 は不変。"
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/188"

--- a/projects/orchestration-engine/docs/decisions/2026-06-22-decision-206-activity-log-self-contained-events.md
+++ b/projects/orchestration-engine/docs/decisions/2026-06-22-decision-206-activity-log-self-contained-events.md
@@ -1,0 +1,75 @@
+---
+id: "01KVQPVHWZTRGV46B94JVRQ7SR"
+title: "#206 親子活動ログは session_id 主キーでなく自己完結イベント（write 時 snapshot）の append-only ログにする — #188 DJ-188-4 の精緻化"
+date: 2026-06-22
+type: decision
+status: accepted
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/206"
+    reason: "本 ADR の主スコープ（report inbox / 親子活動ログ 増分1 の鍵戦略）"
+  - type: refines
+    ref: "projects/orchestration-engine/docs/decisions/2026-06-19-decision-188-identity-unification.md"
+    reason: "DJ-188-4（Stage-B の event bus は session_id 主キー）を、delegate に session_id が無い現実へ精緻化（部分 supersede・DJ-188-4 の範囲のみ）"
+  - type: source_material
+    ref: "projects/orchestration-engine/lib/event-bus.sh"
+    reason: "本決定の実装（emit プリミティブ・自己完結レコード）"
+  - type: source_material
+    ref: "projects/orchestration-engine/schemas/oe-events.schema.json"
+    reason: "レコードスキーマ（audit-log とは別系統・additive）"
+  - type: episode
+    ref: ../episodes/2026-06-22-episode-206-activity-log.md
+    reason: "本 ADR を生んだ実装エピソード（探索・実装SO・経緯）"
+tags: [orchestration, activity-log, event-bus, identity, cockpit, report-inbox, decision, read-only]
+---
+
+# #206 親子活動ログは session_id 主キーでなく自己完結イベント（write 時 snapshot）の append-only ログにする — #188 DJ-188-4 の精緻化
+
+## コンテキスト
+
+`#206`（report inbox）の増分1 として、親子委譲の相互作用（spawn・送信）を永続記録し read 時に投影する活動ログを実装する。動機は親子委譲の「中身を回収できない／配送が見えない／子が消えると追えない」問題（departed children も後から見たい）。
+
+[#188 ADR](2026-06-19-decision-188-identity-unification.md) は、永続横断観測が必要になった場合の本線を **DJ-188-4 = `session_id` 主キーの typed append-only event/activity bus** と申し送っていた（deferred）。本 ADR はその deferred 方針を増分1 として実装するにあたり、**鍵戦略を 1 点だけ精緻化**する。DJ-188-1/2/3/5 は不変・本 ADR の対象外。
+
+## 確定した事実（決定の前提）
+
+| 項目 | 内容 | 根拠 | status |
+|---|---|---|---|
+| delegate 子は session_id を持たない | registry は `{pane,label,workspace,parent_pane,role}` のみ。session_id/state/audit を持たない | `lib/delegate-registry.sh:56`・[#188 ADR 前提表](2026-06-19-decision-188-identity-unification.md) | verified |
+| pane は寿命が短く再利用される | tmux `%N` は pane 破棄後に再割当。registry は GC される（`oe_reg_gc`） | `lib/delegate-registry.sh:168` | verified |
+| #188 の read-only/read 時相関 | observer は両ソースを read 時投影・永続マップを作らない（DJ-188-3）。read-only は観測者拘束（DJ-188-5） | [#188 ADR](2026-06-19-decision-188-identity-unification.md) | verified |
+
+→ DJ-188-4 の素朴な「`session_id` 主キー」は **delegate の相互作用を 1 件も載せられない**（session_id が無い）。pane 主キーは GC/再利用で read 時に identity が失われる（寿命ミスマッチ）。
+
+## 決定
+
+- **DJ-206-1 — 鍵は session_id でも pane でもなく「自己完結イベント」。** 各イベントが `from`/`to` の `{pane, role, label}` を **emit 時に焼き込む**（write 時 snapshot）。role/label は emit 時に registry/pane-issue を read 時投影して決める。read 時は live registry に一切依存しない＝registry が GC されても・pane が消えても・再利用されてもレコードの意味は保たれる（departed children も可視）。
+- **DJ-206-2 — lifecycle-end/stall は推論しない。** viewer（`oe-activity`）が出すのは 往復回数 / 配送（`suspected_miss`|`none`）/ preview / 送信元(子)生存（mux 存在 query = `alive`|`gone`|`?`）の 4 つのみ。「終了 vs stall」の分類はしない。これは **DJ-188-2**（対話 delegate 子の非対称 lifecycle を engine の完了 enum に押し込む category error を避ける）の帰結を観測側へ徹底したもの。
+- **DJ-206-3 — vocab は additive。** 増分1 は `child_spawned` / `message_sent` の 2 種。`report_received` / turn 粒度などは非破壊追加できる設計にし、engine session_id 側（audit-log.schema.json）とは**別系統**に保つ（混ぜない）。
+
+これにより [#188 ADR](2026-06-19-decision-188-identity-unification.md) の **DJ-188-4 を部分的に supersede** する（「永続横断観測が要れば event bus」という方針は維持、鍵戦略のみ session_id 主キー → 自己完結 write 時 snapshot へ差し替え）。
+
+## 検討した選択肢と評価
+
+| 案 | 概要 | 評価 |
+|---|---|---|
+| **session_id 主キー bus**（DJ-188-4 原案） | engine と同じ session_id を主キーに | ❌ delegate 子は session_id を持たない → 親子相互作用を 1 件も載せられない |
+| **pane 主キー bus** | tmux `%N` を主キーに | ❌ pane は GC/再利用される → read 時に kind/role 導出が破綻（v1–v3 設計SO が反復指摘した寿命ミスマッチ） |
+| **自己完結イベント（write 時 snapshot・採用）** | 各レコードが from/to の identity を emit 時に焼込 | ◎ session_id 不要・寿命ミスマッチ解消・read-only/read 時相関（#188 思想）と整合・departed children 可視 |
+| **lifecycle 状態機械（ended/stalled 分類）** | 最終イベント＋無音時間で推論 | △ 増分1 では不採用（DJ-188-2 の category error を観測側へ持ち込む）。liveness の生 fact（alive/gone）のみに留める |
+
+## 帰結（本決定の影響範囲）
+
+- **実装（増分1）**: `lib/event-bus.sh`（best-effort emit）/ `schemas/oe-events.schema.json`（別系統・additive）/ `bin/oe-activity`（read-only 投影・report inbox）。emit は `oe-delegate`（`child_spawned`）と `oe_send_line`（`message_sent`）に best-effort 結線（本体を壊さない）。
+- **#188 への back-prop**: [#188 ADR](2026-06-19-decision-188-identity-unification.md) に「DJ-188-4 は本 ADR で部分 supersede」のステータス行を 1 行追記（本文は不可触）。
+- **残課題（後続増分へ defer）**:
+  - server-pid をレコードに含めない現状では、同一サーバの `%N` 再利用で別関係が混線し得る（viewer の既知制約として明記済）。server-pid キー化は後続で。
+  - log rotation / retention（永続＝増加）。`#185` raw-log retention と同様に defer（viewer の既定窓で緩和）。
+  - engine session_id 側との統合・turn 粒度 timeline（B）。
+- **#144 reliability は再実装しない**（境界）。delivery_signal は #144 の finalize 信号を読むのみ。
+
+## 関連
+
+- 精緻化元: [#188 identity unification ADR](2026-06-19-decision-188-identity-unification.md)（DJ-188-4）
+- 実装エピソード（探索・実装SO・経緯）: [#206 activity-log episode](../episodes/2026-06-22-episode-206-activity-log.md)
+- Issue: [#206](https://github.com/stlwolf/ai-development-hub/issues/206) / [#188](https://github.com/stlwolf/ai-development-hub/issues/188) / [#177](https://github.com/stlwolf/ai-development-hub/issues/177)

--- a/projects/orchestration-engine/docs/episodes/2026-06-22-episode-206-activity-log.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-22-episode-206-activity-log.md
@@ -1,0 +1,55 @@
+---
+id: "01KVQPVHZKTC5PGX3JF39GCSZ0"
+title: "#206 親子活動ログ + oe-activity（report inbox 増分1）実装エピソード"
+date: 2026-06-22
+type: episode
+status: stable
+related:
+  - type: implements
+    ref: "#206"
+  - type: decision
+    ref: ../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md
+  - type: depends_on
+    ref: "#188"
+---
+
+# #206 親子活動ログ + oe-activity（report inbox 増分1）実装エピソード
+
+> `reconstructed`（締めで一括執筆＝後追い再構成・リアルタイム追記ではない＝証拠価値はその分低い）。
+> 委譲子セッション（`%66`）が WORKTREE `feature/#206_report_inbox` で実装（親 `%59` から委譲）。
+
+## コンテキスト / なぜ
+
+親子委譲は「投げて忘れる」運用になりがちで、(1) 子が何を返したか中身を回収できない、(2) 送信が届いたか見えない、(3) 子ペインが消えると相互作用を追えない（departed children も後から見たい）という観測欠落があった。`#206`（report inbox）の増分1 として、親子相互作用を永続記録し read 時に投影する活動ログを最小実装する。
+
+入口は v4 claim（`.oe/claim-206-increment1-v4.md`・question-driven-design で仕様確定・設計SO v1–v3 の 3 連続 refuted を経て確定）。本セッションでは親の指示でさらにスコープを縮小した（下記）。
+
+## 決定と根拠（diff / ADR から復元しにくいコアのみ）
+
+設計判断の正本は [#206 ADR](../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md)。ここでは ADR に落ちない「なぜこの形に縮んだか」を残す:
+
+- **session_id 主キー（#188 DJ-188-4 原案）→ 自己完結イベント（write 時 snapshot）へ精緻化**。きっかけは「delegate 子に session_id が無い」という #188 の確定事実。v1–v3 設計SO が反復で潰した「pane 主キー bus は GC/再利用で寿命ミスマッチ」も、emit 時に from/to の identity を焼き込めば read 時に live registry へ依存せず解消する。**識別の単一ソース（#188 の思想）を“永続化の鍵”でなく“write 時の投影”で満たした**のが非自明な接続。→ ADR で DJ-188-4 を部分 supersede、#188 にはステータス行のみ back-prop（本文不可触）。
+- **親指示でのスコープ縮小（v4 claim からさらに削った）**: claim では viewer が lifecycle-end/stall を read 時推論（最終イベント + mux 生存 query で「終了 vs stall」分類）する設計だった。本セッションで **lifecycle/stall 推論を落とし**、viewer は 往復 / 配送 / preview / 送信元(子)生存 の 4 つだけに縮めた。理由＝**DJ-188-2 の category error（対話子の非対称 lifecycle を engine 完了 enum に押し込む）を観測側に持ち込まない**。liveness は「終了/stall」の解釈でなく `alive`|`gone`|`?` の生 fact に留める。これは「観測は honest な生データまで・解釈はしない」という #177/#188 の read-only 規律の延長。
+
+## 検証（要点・SO 証跡）
+
+- shellcheck rc=0 / **bash 3.2.57・5.2.37 で test_event_bus 31/31・test_oe_activity 24/24**（既存 test_delegate_send 36・test_oe_delegate 20 も green・emit は `OE_EVENT_LOG=0` で隔離）。
+- **実装中に自己検出した bug**: `extra="${8:-{}}"` の default `{}` の `}` が展開閉じ括弧と衝突して `{}}`（不正 JSON）になり、jq が空を返して **emit が黙って no-op**。best-effort（常に return 0）ゆえテストで初めて「ファイルが出来ない」として顕在化。別代入 `extra="${8:-}"; [[ -n "$extra" ]] || extra='{}'` で修正。→ **負の知見**: best-effort で握り潰す経路は、パラメータ展開の罠を silent に飲み込む。emit 系は最小の happy-path テストを先に通すべき。
+- **実装SO** `oe-review` 2 レーン（codex+cursor）: **refuted 2/2**（audit `20260622124724DX9W4KPGCM2Z` / diff_base master / reviewed_sha `36accbf`・SO 出力 `tmp/oe-review-20260622124724DX9W4KPGCM2Z/`）。1 ラウンド自律対応:
+  - **[cursor・real・採用]** label 内 TAB が `_oe_event_ident` の `role<TAB>label<TAB>parent` 内部プロトコルを壊し parent/role の焼き込みを誤る（改行は畳むが TAB 未処理）。→ label の TAB も空白へ畳む + 回帰テスト [8b]。実機 repro で確認（`foo\tbar` → parent が `bar` に誤シフト）。
+  - **[codex・false positive・不採用]** 「`jq -rs … @tsv` が raw でなく主要表示がパース不能」→ **直接検証で反証**（`jq -rs '…@tsv'` は raw TSV を出力。codex の repro は `jq '.|@tsv'` で `-r` 抜きの別 invocation。viewer テスト 22 件も実データで通過）。SO 指摘でも oracle 照合で却下した一次確認の例。
+  - **[cursor・doc/degrade・採用]** 同一サーバ `%N` 再利用の混線 → 既知制約に明記（server-pid キー化は後続 defer）。壊れた JSONL 行で exit 1 → `jq -R 'fromjson? // empty'` 前段でスキップ + 回帰テスト [11]。reader 専用 `OE_EVENT_FILE` footgun は撤去し `OE_EVENT_DIR` 単一ノブに統一。
+- **Copilot**: PR レビュー依頼済み（本 episode 締め時点で未返信／対応は別途）。
+
+## closure
+
+- status: `stable` / **達成度: 達成**（増分1 = emit 結線 + 自己完結ログ + read-only viewer + report inbox を実装・テスト・実装SO 1 ラウンド対応まで）。
+- tier: **heavy**（意図的な実装SO 起動・非自明な設計判断＝DJ-188-4 精緻化と棄却理由・Decision 昇格あり）。
+- 次の消費者: cockpit を見る人間（`oe-activity` / `--inbox`）+ **増分2**（B の turn 粒度 timeline・`report_received` 追加。additive schema が前提）+ #114/Stage-B 着手者（永続横断観測の鍵戦略を本 ADR が確定）。
+- 蒸留シグナル: **Decision 昇格あり** → [#206 ADR](../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md)（#188 DJ-188-4 を部分 supersede）。負の知見（best-effort emit の silent no-op）は #62 注入候補だが今回は本 episode 記録に留める。
+- follow-up routing:
+  - server-pid をレコードに含めず `%N` を関係キーにする → 同一サーバ再利用の混線。**後続増分**（ADR 残課題・viewer の既知制約に明記済）。
+  - log rotation / retention → **defer**（`#185` raw-log retention と同様・viewer 既定窓で緩和）。
+  - engine session_id 側との統合 / turn 粒度 timeline（B）→ **増分2**。
+  - #144 reliability 再実装は **追わない**（境界・delivery_signal は #144 信号を読むのみ）。
+- **Step4 辞退（heavy 外部チェック・advisory）**: 親指示の本タスクのフローは 実装→実装SO→episode→PR→Copilot で、episode の追加外部SO は指定プロセス外。closure 品質 4 観点を自己点検し低リスクと判断して辞退。覆った観点= 失敗の選択的省略なし（`${8:-{}}` bug / SO refuted / codex false positive を明記）／ routing 網羅（defer 4 件すべて行き先付与）／ evidence anchor（SO audit id・出力パスを本文転記）／ back-propagation（#188 にステータス行追記済・矛盾なし）。未実施観点と判断= so-compare 再チェックは指定フロー外 + 上記 4 観点を本文で自己点検済のため不実施。

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -14,6 +14,12 @@
 # 後段で走らせ、入力欄に payload が staged のまま残る吸収を after-the-fact で1回だけ回復する。
 # finalize は Claude TUI の screen scrape ベースの best-effort・保守的判定で、transport の
 # rc を一切変えない。設計経緯は docs/plans/2026-06-09-plan-oe-send-ingestion-rootfix.md。
+#
+# 活動ログ（#206）: 送信成功時に message_sent を best-effort emit する（永続 append-only・
+# read 時 viewer 用）。event-bus.sh は delegate-registry.sh を必要に応じ自前で source する。
+# 失敗しても oe_send_line の rc は変えない（emit は常に return 0）。
+# shellcheck source=event-bus.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/event-bus.sh" 2>/dev/null || true
 
 # --- finalize 内部ヘルパー（source 専用・oe_ 接頭辞でネームスペース汚染を最小化） ---
 
@@ -204,12 +210,23 @@ oe_send_line() {
     # それを rc=4（suspected non-delivery / stage miss）へ昇格し、呼び出し側のフォールバック/
     # リトライを可能にする（既定は従来どおり rc を変えない・#154）。「confirmed」ではなく「suspected」
     # なのは fast-submit を未着と誤判定し得るため（SO 指摘）。
+    local delivery_signal="none"
     if [[ "$fin_on" == "1" ]]; then
       local fin_rc=0
       _oe_send_finalize "$pane" "$text" "$base_proc" "$base_staged" || fin_rc=$?
+      [[ "$fin_rc" == "3" ]] && delivery_signal="suspected_miss"
+      # 活動ログ（#206）: 送信を message_sent として best-effort emit（rc は不変・常に成功扱い）。
+      if declare -F oe_event_message_sent >/dev/null 2>&1; then
+        oe_event_message_sent "${TMUX_PANE:-}" "$pane" "$text" "$delivery_signal" || true
+      fi
       if [[ "$fin_rc" == "3" && "${OE_SEND_SIGNAL_MISS:-0}" == "1" ]]; then
         echo "oe_send_line: signaling suspected non-delivery (stage miss) on ${pane} (rc=4; OE_SEND_SIGNAL_MISS=1)" >&2
         return 4
+      fi
+    else
+      # finalize 無効時は配送を観測しないため none（未着シグナル無し ＝ delivered の確証ではない）。
+      if declare -F oe_event_message_sent >/dev/null 2>&1; then
+        oe_event_message_sent "${TMUX_PANE:-}" "$pane" "$text" "$delivery_signal" || true
       fi
     fi
   fi

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -1,0 +1,129 @@
+# shellcheck shell=bash
+# event-bus.sh — 親子相互作用の永続 append-only 活動ログ（source 専用・#206 増分1）
+#
+# 各イベントは from/to の {pane, role, label} を emit 時に焼き込む「自己完結レコード」。
+# session_id を主キーにせず（delegate 子は session_id を持たない）、registry の生存にも
+# read 時依存しない（GC されても残る ＝ departed children も後から可視）。これは #188
+# DJ-188-4 の「session_id 主キー event bus」を、delegate に session_id が無い現実へ精緻化した形
+# （decision で昇格判断）。lifecycle/stall は推論しない（DJ-188-2 尊重 ＝ 非対称 lifecycle を
+# engine の完了 enum に押し込まない）。viewer 側は read 時に liveness（mux 存在 query）のみ見る。
+#
+# 設計上の不変条件:
+#   - best-effort: emit 失敗（jq 不在・dir 作成不可・encode 失敗）は本体（oe-delegate /
+#     oe_send_line）を一切壊さない。全 public 関数は常に return 0。
+#   - atomic append: 1 イベント = 1 行 JSON を `>>` で追記。preview を ~100 codepoint に切り詰め
+#     行を PIPE_BUF（>=4KB）未満に保つことで、親子同時追記でも write が atomic（O_APPEND）。
+#   - read-time projection: role/label は emit 時の registry/pane-issue 焼込（live registry 非依存）。
+#
+# 識別子解決は oe-ident（#202）と同じ read 時投影だが、emit を self-contained・best-effort に
+# 保つため本 lib 内に独立実装する（oe-ident の表示契約と疎結合）。
+
+# delegate-registry.sh の _oe_reg_key / _oe_reg_server_pid / OE_*_DIR を使う。
+# 呼び出し側が未 source なら自前で取り込む（多重 source は冪等）。
+if ! declare -F _oe_reg_key >/dev/null 2>&1; then
+  # shellcheck source=delegate-registry.sh
+  source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/delegate-registry.sh" 2>/dev/null || true
+fi
+
+# ログの保存先（cross-session。registry / pane-issue と同じ ~/.claude/state 規約）。
+# テストは OE_EVENT_DIR で隔離する。
+OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
+
+# _oe_event_ident <pane> — pane の識別子を read 時投影し "role<TAB>label<TAB>parent_pane" を返す。
+#   role  : parent（この pane を parent_pane に持つ子 entry が在る） > child（自身の spawn entry が在る） > ""
+#   label : pane-issue(.name) 優先 → spawn-registry(.label)
+#   parent_pane : 自身の spawn entry の parent_pane（無ければ空）。message の report/kick 方向判定に使う。
+#   file 読みのみ・tmux 不要・best-effort（jq 不在は全空）。
+_oe_event_ident() {
+  local pane="${1:-}" pid key label="" own parent="" is_child=0 is_parent=0 role=""
+  if ! command -v jq >/dev/null 2>&1; then printf '\t\t\n'; return 0; fi
+  pid="$(_oe_reg_server_pid 2>/dev/null)" || pid=""
+  key="$(_oe_reg_key "$pane" 2>/dev/null)" || key=""
+  [[ -n "$key" ]] || { printf '\t\t\n'; return 0; }
+  if [[ -f "${OE_PANE_ISSUE_DIR}/${key}" ]]; then
+    label="$(jq -r '.name // empty' "${OE_PANE_ISSUE_DIR}/${key}" 2>/dev/null)" || label=""
+  fi
+  own="${OE_DELEGATE_STATE_DIR}/${key}.json"
+  if [[ -f "$own" ]]; then
+    is_child=1
+    parent="$(jq -r '.parent_pane // empty' "$own" 2>/dev/null)" || parent=""
+    [[ -z "$label" ]] && label="$(jq -r '.label // empty' "$own" 2>/dev/null)"
+  fi
+  # 現サーバ pid の子 entry を走査して parent 判定（別サーバの stale で pane-id 衝突しても誤検知しない）。
+  # grep -F で per-file jq を避ける（oe-ident と同イディオム）。
+  if [[ -n "$pid" ]] && grep -lF "\"parent_pane\":\"${pane}\"" "${OE_DELEGATE_STATE_DIR}/${pid}"_*.json >/dev/null 2>&1; then
+    is_parent=1
+  fi
+  if [[ "$is_parent" -eq 1 ]]; then role="parent"; elif [[ "$is_child" -eq 1 ]]; then role="child"; fi
+  # label の改行（LF/CR）は 1 行 JSON に焼く前に畳む（行境界の偽造防止・oe_reg_list と同方針）。
+  label="${label//$'\n'/ }"; label="${label//$'\r'/ }"
+  printf '%s\t%s\t%s\n' "$role" "$label" "$parent"
+}
+
+# oe_event_emit <type> <from_pane> <from_role> <from_label> <to_pane> <to_role> <to_label> [extra_json]
+#   1 イベントを oe-events.jsonl に best-effort 追記。常に return 0。
+oe_event_emit() {
+  [[ "${OE_EVENT_LOG:-1}" != "0" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local type="${1:-}" fp="${2:-}" frole="${3:-}" flabel="${4:-}" tp="${5:-}" trole="${6:-}" tlabel="${7:-}" extra="${8:-}"
+  # `${8:-{}}` は default の `}` が展開閉じ括弧と衝突して壊れるため別代入で `{}` を補う。
+  [[ -n "$extra" ]] || extra='{}'
+  [[ -n "$type" ]] || return 0
+  local dir="$OE_EVENT_DIR" file ts line
+  mkdir -p "$dir" 2>/dev/null || return 0
+  file="${dir}/oe-events.jsonl"
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" || return 0
+  line="$(jq -cn \
+    --arg ts "$ts" --arg type "$type" \
+    --arg fp "$fp" --arg frole "$frole" --arg flabel "$flabel" \
+    --arg tp "$tp" --arg trole "$trole" --arg tlabel "$tlabel" \
+    --argjson extra "$extra" \
+    '{ts:$ts, type:$type,
+      from:{pane:$fp, role:$frole, label:$flabel},
+      to:{pane:$tp, role:$trole, label:$tlabel}} + $extra' 2>/dev/null)" || return 0
+  [[ -n "$line" ]] || return 0
+  # 1 行 printf（< PIPE_BUF）を O_APPEND で追記 ＝ 同時追記でも atomic。
+  printf '%s\n' "$line" >> "$file" 2>/dev/null || return 0
+  return 0
+}
+
+# oe_event_child_spawned <parent_pane> <child_pane> [child_label]
+#   oe-delegate が子 spawn + registry 登録の直後に呼ぶ。role は構築上 parent/child で確定。
+oe_event_child_spawned() {
+  [[ "${OE_EVENT_LOG:-1}" != "0" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local pp="${1:-}" cp="${2:-}" clabel="${3:-}"
+  local plabel clabel_r
+  # role/parent は構築上 parent/child で確定するため捨てる（label だけ使う）。
+  IFS=$'\t' read -r _ plabel _ < <(_oe_event_ident "$pp") || true
+  if [[ -z "$clabel" ]]; then
+    IFS=$'\t' read -r _ clabel_r _ < <(_oe_event_ident "$cp") || true
+    clabel="$clabel_r"
+  fi
+  oe_event_emit "child_spawned" "$pp" "parent" "$plabel" "$cp" "child" "$clabel" "{}"
+}
+
+# oe_event_message_sent <from_pane> <to_pane> <preview-text> [delivery_signal]
+#   oe_send_line が送信成功後に呼ぶ。delivery_signal は suspected_miss|none（delivered は名乗らない）。
+#   preview は先頭 ~100 codepoint に jq で切り詰め（マルチバイトを壊さず行を小さく保つ）。
+oe_event_message_sent() {
+  [[ "${OE_EVENT_LOG:-1}" != "0" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local fp="${1:-}" tp="${2:-}" preview="${3:-}" delivery="${4:-none}"
+  local frole flabel fparent trole tlabel tparent
+  IFS=$'\t' read -r frole flabel fparent < <(_oe_event_ident "$fp") || true
+  IFS=$'\t' read -r trole tlabel tparent < <(_oe_event_ident "$tp") || true
+  # 直接の親子リンク（spawn entry の parent_pane）で report/kick の方向を honest に確定する。
+  # 多段ツリーで pane が parent かつ child のとき per-pane role は曖昧なので、関係で上書きする。
+  if [[ -n "$fparent" && "$fparent" == "$tp" ]]; then
+    frole="child"; trole="parent"      # report: 子 → 親
+  elif [[ -n "$tparent" && "$tparent" == "$fp" ]]; then
+    frole="parent"; trole="child"      # kick: 親 → 子
+  fi
+  local maxc="${OE_EVENT_PREVIEW_MAX:-100}" extra
+  # delivery_signal を suspected_miss|none に正規化（未知値は none）。
+  case "$delivery" in suspected_miss|none) ;; *) delivery="none" ;; esac
+  extra="$(jq -cn --arg p "$preview" --arg d "$delivery" --argjson n "$maxc" \
+    '{preview: (if ($p|length) > $n then ($p[0:$n] + "…") else $p end), delivery_signal: $d}' 2>/dev/null)" || return 0
+  oe_event_emit "message_sent" "$fp" "$frole" "$flabel" "$tp" "$trole" "$tlabel" "$extra"
+}

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -55,8 +55,10 @@ _oe_event_ident() {
     is_parent=1
   fi
   if [[ "$is_parent" -eq 1 ]]; then role="parent"; elif [[ "$is_child" -eq 1 ]]; then role="child"; fi
-  # label の改行（LF/CR）は 1 行 JSON に焼く前に畳む（行境界の偽造防止・oe_reg_list と同方針）。
-  label="${label//$'\n'/ }"; label="${label//$'\r'/ }"
+  # label の制御文字を畳む: TAB は本関数の内部プロトコル（role<TAB>label<TAB>parent）の区切りを
+  # 壊し parent/role の焼き込みを誤らせる（実装SO cursor 指摘）。LF/CR は 1 行 JSON の行境界を壊す
+  # （oe_reg_list / oe-ident と同方針）。いずれも空白へ畳んでから返す。
+  label="${label//$'\t'/ }"; label="${label//$'\n'/ }"; label="${label//$'\r'/ }"
   printf '%s\t%s\t%s\n' "$role" "$label" "$parent"
 }
 

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -25,6 +25,12 @@ if ! declare -F _oe_reg_key >/dev/null 2>&1; then
   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/delegate-registry.sh" 2>/dev/null || true
 fi
 
+# delegate-registry.sh が source されない（_oe_reg_key を他所が定義済 等）/ 環境で未設定でも、
+# 未定義の state dir で `/${pid}_*.json` のように root 配下を誤って glob しないよう、registry と
+# 同じ既定値をここでもフォールバック設定する（best-effort・Copilot 指摘）。
+OE_DELEGATE_STATE_DIR="${OE_DELEGATE_STATE_DIR:-${HOME}/.claude/state/oe-delegate}"
+OE_PANE_ISSUE_DIR="${OE_PANE_ISSUE_DIR:-${HOME}/.claude/state/pane-issue}"
+
 # ログの保存先（cross-session。registry / pane-issue と同じ ~/.claude/state 規約）。
 # テストは OE_EVENT_DIR で隔離する。
 OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
@@ -123,6 +129,9 @@ oe_event_message_sent() {
     frole="parent"; trole="child"      # kick: 親 → 子
   fi
   local maxc="${OE_EVENT_PREVIEW_MAX:-100}" extra
+  # 非数値の OE_EVENT_PREVIEW_MAX だと `jq --argjson n` が失敗し emit 丸ごと no-op になる
+  # （best-effort のはずがサイレント no-op になる・Copilot 指摘）。非数値は 100 へ落として warn を出す。
+  case "$maxc" in ''|*[!0-9]*) echo "oe_event_message_sent: OE_EVENT_PREVIEW_MAX='${maxc}' は非数値 → 100 を使用" >&2; maxc=100 ;; esac
   # delivery_signal を suspected_miss|none に正規化（未知値は none）。
   case "$delivery" in suspected_miss|none) ;; *) delivery="none" ;; esac
   extra="$(jq -cn --arg p "$preview" --arg d "$delivery" --argjson n "$maxc" \

--- a/projects/orchestration-engine/schemas/oe-events.schema.json
+++ b/projects/orchestration-engine/schemas/oe-events.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/stlwolf/ai-development-hub/schemas/oe-events.schema.json",
+  "title": "OE Activity Event",
+  "description": "親子相互作用の永続 append-only 活動ログ（oe-events.jsonl）の 1 行分のスキーマ（#206 増分1）。audit-log.schema.json（engine の session_id 主キー監査）とは別系統。各イベントは from/to の {pane,role,label} を emit 時に焼き込む自己完結レコードで、session_id を主キーにせず registry の生存にも read 時依存しない（#188 DJ-188-4 を delegate 現実へ精緻化）。1 行 1 イベント。vocab は additive 設計（増分2 で report_received / turn を非破壊追加可能）。",
+  "type": "object",
+  "required": ["ts", "type", "from", "to"],
+  "properties": {
+    "ts": {
+      "type": "string",
+      "description": "イベント発生時刻（ISO 8601 with timezone）",
+      "format": "date-time",
+      "examples": ["2026-06-22T15:30:00+00:00"]
+    },
+    "type": {
+      "type": "string",
+      "description": "イベント種別。増分1 は child_spawned / message_sent の 2 種。追加種別は additive に拡張する。",
+      "enum": ["child_spawned", "message_sent"]
+    },
+    "from": {
+      "$ref": "#/definitions/endpoint",
+      "description": "発生元（child_spawned=親 / message_sent=送信元）。pane/role/label を emit 時に焼き込む。"
+    },
+    "to": {
+      "$ref": "#/definitions/endpoint",
+      "description": "宛先（child_spawned=子 / message_sent=宛先）。pane/role/label を emit 時に焼き込む。"
+    },
+    "preview": {
+      "type": "string",
+      "description": "message_sent のみ: payload 先頭 ~100 codepoint の切り詰め（情報過多回避・行を PIPE_BUF 内に保つ）。spawn の起動コマンドは出さない。"
+    },
+    "delivery_signal": {
+      "type": "string",
+      "description": "message_sent のみ: 配送シグナル。suspected_miss=finalize が未着候補を観測 / none=未着シグナル無し（delivered の確証ではない）。#144 信号を読むのみで reliability の再実装はしない。",
+      "enum": ["suspected_miss", "none"]
+    }
+  },
+  "definitions": {
+    "endpoint": {
+      "type": "object",
+      "required": ["pane", "role", "label"],
+      "properties": {
+        "pane": {
+          "type": "string",
+          "description": "tmux ペイン ID（%N）。emit 時の TMUX_PANE / spawn 結果。空文字は不明（honest）。",
+          "examples": ["%59", "%66"]
+        },
+        "role": {
+          "type": "string",
+          "description": "emit 時に焼き込んだ spawn 関係上の役割。parent=子を spawn した側 / child=spawn された側 / 空=関係不明。read 時に report(child→parent)/kick(parent→child) を live registry 非依存で分類するのに使う。",
+          "enum": ["parent", "child", ""]
+        },
+        "label": {
+          "type": "string",
+          "description": "emit 時に焼き込んだ識別ラベル（pane-issue の #N slug 優先 → spawn registry の label）。空は識別情報なし（honest）。"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "type": { "const": "message_sent" } } },
+      "then": {
+        "required": ["preview", "delivery_signal"],
+        "description": "message_sent は preview と delivery_signal を必須とする。"
+      }
+    }
+  ]
+}

--- a/projects/orchestration-engine/tests/test_delegate_send.sh
+++ b/projects/orchestration-engine/tests/test_delegate_send.sh
@@ -16,6 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="${SCRIPT_DIR}/../lib/delegate-send.sh"
 
 export OE_SEND_ENTER_DELAY=0   # テスト高速化（Enter 前の小休止を 0 に）
+export OE_EVENT_LOG=0          # 活動ログ（#206）emit を無効化（本テストは transport が対象）
 
 # --- サブシェル越しに持つ状態（capture の連続返却とコール数） ---
 CAP_IDXFILE="$(mktemp)";   echo 0 > "$CAP_IDXFILE"

--- a/projects/orchestration-engine/tests/test_event_bus.sh
+++ b/projects/orchestration-engine/tests/test_event_bus.sh
@@ -102,6 +102,15 @@ printf '%s' '{"name":"#206\ninbox"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %59)"  # JSO
 oe_event_child_spawned "%59" "%66" "#206 impl"
 ck "1 physical line" "1" "$(nlines)"
 ck "label folded"    "#206 inbox" "$(last | jq -r .from.label)"
+
+echo "[8b] label 内 TAB も畳む（_oe_event_ident の TAB 区切り内部プロトコルを守る・実装SO cursor 指摘）"
+printf '%s' '{"name":"foo\tbar"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %59)"  # JSON 文字列内の TAB
+IFS=$'\t' read -r _ _l _p < <(_oe_event_ident "%59") || true
+ck "tab folded in label"       "foo bar" "$_l"
+ck "parent not shifted by tab" ""        "$_p"   # %59 は own entry 無し ＝ parent 空のはず
+reset_events
+oe_event_message_sent "%66" "%59" "x" "none"      # %66→%59（report）。to=%59 の label が焼かれる
+ck "burned label tab-folded"   "foo bar" "$(last | jq -r .to.label)"
 printf '%s' '{"name":"#206 inbox"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %59)"  # 復元
 
 echo "[9] 関係不明（spawn 関係の無い 2 ペイン）: role は空・fallback で type は出る"

--- a/projects/orchestration-engine/tests/test_event_bus.sh
+++ b/projects/orchestration-engine/tests/test_event_bus.sh
@@ -143,5 +143,25 @@ env PATH="$STUB_BIN:$PATH" TMUX="oe,${PID},0" TMUX_PANE="%1" \
 ck "child_spawned emitted" "1" "$(jq -rs '[.[]|select(.type=="child_spawned" and .to.pane=="%9")]|length' "$EVENTS" 2>/dev/null || echo 0)"
 ck "child label burned-in" "#child" "$(jq -rs 'map(select(.type=="child_spawned"))[-1].to.label' "$EVENTS" 2>/dev/null || echo MISSING)"
 
+echo "[11] 非数値 OE_EVENT_PREVIEW_MAX でも emit は no-op にならない（100 fallback・Copilot 指摘）"
+reset_events
+OE_EVENT_PREVIEW_MAX="abc" oe_event_message_sent "%66" "%59" "$(printf 'A%.0s' {1..150})" "none" 2>/dev/null
+ck "still emitted (not silent no-op)" "1" "$(nlines)"
+ck "preview fell back to 100+…"       "101" "$(last | jq -r '.preview|length')"
+warn="$(OE_EVENT_PREVIEW_MAX="abc" oe_event_message_sent "%66" "%59" "x" "none" 2>&1 >/dev/null)"
+case "$warn" in *非数値*) ck "warn emitted" "1" "1" ;; *) ck "warn emitted" "1" "0" ;; esac
+
+echo "[12] state dir 未設定でも event-bus.sh が既定を入れる（root glob 防止・Copilot 指摘）"
+# _oe_reg_key を他所が定義済 ＝ delegate-registry.sh は source されない経路を再現し、
+# event-bus.sh 自身の fallback 既定が効くことを確認する。PROJECT_DIR は env で渡し inner bash で展開する。
+# shellcheck disable=SC2016  # bash -c 本文の $ は inner shell で展開させる意図
+defs="$(env -u OE_DELEGATE_STATE_DIR -u OE_PANE_ISSUE_DIR PROJECT_DIR="$PROJECT_DIR" bash -c '
+  _oe_reg_key() { printf "k_%s" "$1"; }
+  _oe_reg_server_pid() { printf "9999"; }
+  source "$PROJECT_DIR/lib/event-bus.sh"
+  printf "%s|%s" "${OE_DELEGATE_STATE_DIR:-EMPTY}" "${OE_PANE_ISSUE_DIR:-EMPTY}"')"
+ck "state dir defaulted (not empty)"  "1" "$([[ -n "${defs%|*}" && "${defs%|*}" != "EMPTY" ]] && echo 1 || echo 0)"
+ck "pane-issue dir defaulted (not empty)" "1" "$([[ -n "${defs#*|}" && "${defs#*|}" != "EMPTY" ]] && echo 1 || echo 0)"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_event_bus.sh
+++ b/projects/orchestration-engine/tests/test_event_bus.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_event_bus.sh — lib/event-bus.sh（#206 増分1 活動ログ emit）の検証。
+#
+# 実 tmux 不要（emit は file 読みのみ・liveness は viewer 側）。registry/pane-issue は mock し、
+# 固定 server pid（TMUX 経由）でキー名前空間を固定する（test_oe_ident と同イディオム）。jq は実体。
+# 末尾に oe-delegate を PATH-stub tmux で 1 回起動し、child_spawned が実 bin から emit される
+# 結線も検証する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+export OE_EVENT_DIR="$_TMP_DIR/events"
+export OE_DELEGATE_STATE_DIR="$_TMP_DIR/oe-delegate"
+export OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
+mkdir -p "$OE_EVENT_DIR" "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+EVENTS="$OE_EVENT_DIR/oe-events.jsonl"
+
+# shellcheck source=../lib/delegate-registry.sh
+source "$PROJECT_DIR/lib/delegate-registry.sh"
+# shellcheck source=../lib/event-bus.sh
+source "$PROJECT_DIR/lib/event-bus.sh"
+
+PID=9999
+export TMUX="oe,${PID},0"
+keyfor() { TMUX="oe,${PID},0" _oe_reg_key "$1"; }
+
+PASS=0; FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then echo "  PASS: $label"; PASS=$((PASS+1));
+  else echo "  FAIL: $label (want=[$expected] got=[$actual])"; FAIL=$((FAIL+1)); fi
+}
+reset_events() { : > "$EVENTS"; }
+last() { tail -n 1 "$EVENTS"; }
+nlines() { [[ -s "$EVENTS" ]] && wc -l < "$EVENTS" | tr -d '[:space:]' || echo 0; }
+
+# --- mock 状態: parent %59（pane-issue ラベル）、child %66（spawn entry・parent=%59）---
+printf '{"name":"#206 inbox"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %59)"
+jq -cn '{pane:"%66",label:"#206 impl",workspace:"/w",parent_pane:"%59",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %66).json"
+
+echo "[1] child_spawned: from=parent(label 解決) / to=child(label 引数) / role 固定"
+reset_events
+oe_event_child_spawned "%59" "%66" "#206 impl"
+ck "type"        "child_spawned"  "$(last | jq -r .type)"
+ck "from.pane"   "%59"            "$(last | jq -r .from.pane)"
+ck "from.role"   "parent"         "$(last | jq -r .from.role)"
+ck "from.label"  "#206 inbox"     "$(last | jq -r .from.label)"
+ck "to.pane"     "%66"            "$(last | jq -r .to.pane)"
+ck "to.role"     "child"          "$(last | jq -r .to.role)"
+ck "to.label"    "#206 impl"      "$(last | jq -r .to.label)"
+ck "ts present"  "true"           "$(last | jq -r '(.ts|type=="string") and (.ts|length>0)')"
+
+echo "[2] message_sent report（子→親）: 直接 parent リンクで from=child/to=parent に確定"
+reset_events
+oe_event_message_sent "%66" "%59" "実装完了しました" "none"
+ck "type"           "message_sent" "$(last | jq -r .type)"
+ck "from.role=child" "child"       "$(last | jq -r .from.role)"
+ck "to.role=parent"  "parent"      "$(last | jq -r .to.role)"
+ck "preview"         "実装完了しました" "$(last | jq -r .preview)"
+ck "delivery none"   "none"        "$(last | jq -r .delivery_signal)"
+
+echo "[3] message_sent kick（親→子）: from=parent/to=child・delivery=suspected_miss"
+reset_events
+oe_event_message_sent "%59" "%66" "増分1を進めて" "suspected_miss"
+ck "from.role=parent" "parent"        "$(last | jq -r .from.role)"
+ck "to.role=child"    "child"         "$(last | jq -r .to.role)"
+ck "delivery miss"    "suspected_miss" "$(last | jq -r .delivery_signal)"
+
+echo "[4] preview 切り詰め: >100 codepoint → 100 + … (length 101)・末尾 …"
+reset_events
+LONG="$(printf 'あ%.0s' {1..150})"
+oe_event_message_sent "%66" "%59" "$LONG" "none"
+ck "preview length 101" "101" "$(last | jq -r '.preview|length')"
+ck "preview ends …"     "true" "$(last | jq -r '.preview|endswith("…")')"
+
+echo "[5] preview ≤100 はそのまま（… を付けない）"
+reset_events
+oe_event_message_sent "%66" "%59" "短い報告" "none"
+ck "short unchanged" "短い報告" "$(last | jq -r .preview)"
+
+echo "[6] delivery_signal 未知値は none に正規化"
+reset_events
+oe_event_message_sent "%66" "%59" "x" "garbage-value"
+ck "unknown→none" "none" "$(last | jq -r .delivery_signal)"
+
+echo "[7] OE_EVENT_LOG=0 で kill-switch（書き込まない）"
+reset_events
+OE_EVENT_LOG=0 oe_event_child_spawned "%59" "%66" "#206 impl"
+OE_EVENT_LOG=0 oe_event_message_sent "%59" "%66" "x" "none"
+ck "no write when off" "0" "$(nlines)"
+
+echo "[8] label 内の改行（JSON 文字列内エスケープ）は焼く前に畳む（行境界の偽造防止）"
+reset_events
+printf '%s' '{"name":"#206\ninbox"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %59)"  # JSON 内 escape \n
+oe_event_child_spawned "%59" "%66" "#206 impl"
+ck "1 physical line" "1" "$(nlines)"
+ck "label folded"    "#206 inbox" "$(last | jq -r .from.label)"
+printf '%s' '{"name":"#206 inbox"}' > "$OE_PANE_ISSUE_DIR/$(keyfor %59)"  # 復元
+
+echo "[9] 関係不明（spawn 関係の無い 2 ペイン）: role は空・fallback で type は出る"
+reset_events
+oe_event_message_sent "%80" "%81" "side chat" "none"
+ck "from.role empty" "" "$(last | jq -r .from.role)"
+ck "to.role empty"   "" "$(last | jq -r .to.role)"
+ck "type"            "message_sent" "$(last | jq -r .type)"
+
+echo "[10] 結線: oe-delegate を PATH-stub tmux で起動 → child_spawned が実 bin から emit"
+reset_events
+STUB_BIN="$_TMP_DIR/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  split-window) printf '%%9\n' ;;
+  list-panes)   printf '%%1\n%%9\n' ;;
+  send-keys)    : ;;
+  display-message) printf '0\n' ;;
+  *) : ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB_BIN/tmux"
+# claude を no-op に（子コマンドは split-window が無視するので不要だが PATH は隔離）。
+env PATH="$STUB_BIN:$PATH" TMUX="oe,${PID},0" TMUX_PANE="%1" \
+    OE_DELEGATE_WAIT_SEC=0 OE_SEND_FINALIZE=0 OE_SEND_ENTER_DELAY=0 \
+    OE_EVENT_DIR="$OE_EVENT_DIR" OE_DELEGATE_STATE_DIR="$OE_DELEGATE_STATE_DIR" OE_PANE_ISSUE_DIR="$OE_PANE_ISSUE_DIR" \
+    bash "$PROJECT_DIR/bin/oe-delegate" --label "#child" -- "やること" >/dev/null 2>&1 || true
+ck "child_spawned emitted" "1" "$(jq -rs '[.[]|select(.type=="child_spawned" and .to.pane=="%9")]|length' "$EVENTS" 2>/dev/null || echo 0)"
+ck "child label burned-in" "#child" "$(jq -rs 'map(select(.type=="child_spawned"))[-1].to.label' "$EVENTS" 2>/dev/null || echo MISSING)"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_activity.sh
+++ b/projects/orchestration-engine/tests/test_oe_activity.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_activity.sh — bin/oe-activity（#206 増分1 read-only 投影ビュー）の検証。
+#
+# liveness は PATH-stub tmux で固定（%59/%66 を alive・%77 は出さない＝gone）。jq は実体。
+# fixture の oe-events.jsonl を直に置いて投影（往復カウント / liveness / report/kick 向き /
+# inbox フィルタ / degrade / 空）を検証する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OE_ACTIVITY="$PROJECT_DIR/bin/oe-activity"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+export OE_EVENT_DIR="$_TMP_DIR/events"; mkdir -p "$OE_EVENT_DIR"
+EVENTS="$OE_EVENT_DIR/oe-events.jsonl"
+
+# --- stub tmux: list-panes は %59 %66 を返す（%77 は不在＝gone）---
+STUB_BIN="$_TMP_DIR/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list-panes" ]]; then printf '%%59\n%%66\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$STUB_BIN/tmux"
+
+# fixture: %66 = 生存子（kick + report の 2 往復）、%77 = departed 子（report 1・suspected_miss）
+cat > "$EVENTS" <<'EOF'
+{"ts":"2026-06-22T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"#206 inbox"},"to":{"pane":"%66","role":"child","label":"#206 impl"}}
+{"ts":"2026-06-22T12:01:00+00:00","type":"message_sent","from":{"pane":"%59","role":"parent","label":"#206 inbox"},"to":{"pane":"%66","role":"child","label":"#206 impl"},"preview":"increment1 を進めて","delivery_signal":"none"}
+{"ts":"2026-06-22T12:02:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206 impl"},"to":{"pane":"%59","role":"parent","label":"#206 inbox"},"preview":"DONE-IMPL-REPORT","delivery_signal":"none"}
+{"ts":"2026-06-22T12:03:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"#206 inbox"},"to":{"pane":"%77","role":"child","label":"#199 old"}}
+{"ts":"2026-06-22T12:04:00+00:00","type":"message_sent","from":{"pane":"%77","role":"child","label":"#199 old"},"to":{"pane":"%59","role":"parent","label":"#206 inbox"},"preview":"PARTIAL-OLD-REPORT","delivery_signal":"suspected_miss"}
+EOF
+
+PASS=0; FAIL=0
+ck() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
+ckc() { # contains: <desc> <haystack> <needle>
+  if printf '%s' "$2" | grep -qF -- "$3"; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (missing [$3])"; FAIL=$((FAIL+1)); fi; }
+run() { env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" bash "$OE_ACTIVITY" "$@"; }
+# %66 row / %77 row を取り出す（preview マーカで一意特定）
+row_of() { printf '%s\n' "$1" | grep -F "$2"; }
+
+echo "[1] overview: 2 関係・新しい順（%77 の最終 12:04 が先頭）"
+OUT="$(run)"
+ckc "has %66 child label" "$OUT" "#206 impl"
+ckc "has %77 child label" "$OUT" "#199 old"
+first_data="$(printf '%s\n' "$OUT" | sed -n '3p')"   # 1=title 2=header 3=first row
+ckc "newest first = %77 row" "$first_data" "#199 old"
+
+echo "[2] liveness: 生存子=alive / departed 子=gone"
+ckc "%66 alive" "$(row_of "$OUT" "DONE-IMPL-REPORT")" "alive"
+ckc "%77 gone"  "$(row_of "$OUT" "PARTIAL-OLD-REPORT")" "gone"
+
+echo "[3] 往復回数: %66=2（kick+report）/ %77=1"
+r66="$(row_of "$OUT" "DONE-IMPL-REPORT")"; r77="$(row_of "$OUT" "PARTIAL-OLD-REPORT")"
+ck "%66 trips=2" "2" "$(printf '%s' "$r66" | awk '{print $2}')"
+ck "%77 trips=1" "1" "$(printf '%s' "$r77" | awk '{print $2}')"
+
+echo "[4] delivery: %77 は suspected_miss（miss 表示）/ %66 は none"
+ckc "%77 suspected_miss" "$r77" "suspected_miss"
+ckc "%66 none"           "$r66" "none"
+
+echo "[5] preview: 直近 message が出る"
+ckc "%66 latest preview" "$r66" "DONE-IMPL-REPORT"
+
+echo "[6] inbox: 自分(%59)宛の報告を送信元ごとに（kick は出ない）"
+IN="$(run --inbox)"
+ckc "inbox header" "$IN" "report inbox (to %59"
+ckc "inbox has %66 report" "$IN" "DONE-IMPL-REPORT"
+ckc "inbox has %77 report" "$IN" "PARTIAL-OLD-REPORT"
+in66="$(row_of "$IN" "DONE-IMPL-REPORT")"
+ck "inbox %66 trips=1 (report のみ)" "1" "$(printf '%s' "$in66" | awk '{print $2}')"
+ckc "inbox %66 alive" "$in66" "alive"
+
+echo "[7] liveness ?: tmux 失敗時は ? に degrade"
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$STUB_BIN/tmux"
+OUT2="$(run)"
+ckc "live=? on tmux fail" "$(row_of "$OUT2" "DONE-IMPL-REPORT")" "?"
+# stub 復元
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list-panes" ]]; then printf '%%59\n%%66\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$STUB_BIN/tmux"
+
+echo "[8] 空ログ: メッセージ + exit 0"
+rc=0; OUT3="$(OE_EVENT_DIR="$_TMP_DIR/empty" bash "$OE_ACTIVITY" 2>&1)" || rc=$?
+ck "empty exit 0" "0" "$rc"
+ckc "empty message" "$OUT3" "no activity recorded yet"
+
+echo "[9] jq 不在: degrade（件数のみ・exit 0）"
+NOJQ="$_TMP_DIR/nojq"; mkdir -p "$NOJQ"
+# 「jq だけ不在」の PATH を作る: 現 PATH の全実行可能ファイルを jq 以外 symlink する
+# （bash や profile 依存も残るので startup を壊さない）。
+IFS=':' read -ra _pdirs <<< "$PATH"
+for d in "${_pdirs[@]}"; do
+  [[ -d "$d" ]] || continue
+  for f in "$d"/*; do
+    [[ -x "$f" && ! -d "$f" ]] || continue
+    b="$(basename "$f")"
+    [[ "$b" == "jq" ]] && continue
+    [[ -e "$NOJQ/$b" ]] || ln -s "$f" "$NOJQ/$b" 2>/dev/null || true
+  done
+done
+rc=0; OUT4="$(PATH="$NOJQ" TMUX_PANE="%59" bash "$OE_ACTIVITY" 2>&1)" || rc=$?
+ck "nojq exit 0" "0" "$rc"
+ckc "nojq notice" "$OUT4" "jq not found"
+ckc "nojq count" "$OUT4" "events: 5"
+
+echo "[10] 不正オプション → usage・exit 2"
+rc=0; env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" bash "$OE_ACTIVITY" --bogus >/dev/null 2>&1 || rc=$?
+ck "bad opt exit 2" "2" "$rc"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_activity.sh
+++ b/projects/orchestration-engine/tests/test_oe_activity.sh
@@ -120,5 +120,16 @@ echo "[10] 不正オプション → usage・exit 2"
 rc=0; env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" bash "$OE_ACTIVITY" --bogus >/dev/null 2>&1 || rc=$?
 ck "bad opt exit 2" "2" "$rc"
 
+echo "[11] 壊れた JSONL 行は read 時にスキップ（degrade・exit 0・実装SO cursor 指摘）"
+mkdir -p "$_TMP_DIR/corrupt"
+{
+  printf '%s\n' 'this is not json {{{'
+  printf '%s\n' '{"ts":"2026-06-22T13:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"#206 inbox"},"to":{"pane":"%66","role":"child","label":"#206 impl"}}'
+  printf '%s\n' '{"ts":"2026-06-22T13:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206 impl"},"to":{"pane":"%59","role":"parent","label":"#206 inbox"},"preview":"VALID-AFTER-CORRUPT","delivery_signal":"none"}'
+} > "$_TMP_DIR/corrupt/oe-events.jsonl"
+rc=0; OUT5="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/corrupt" bash "$OE_ACTIVITY" 2>&1)" || rc=$?
+ck "corrupt exit 0" "0" "$rc"
+ckc "valid row survives corrupt line" "$OUT5" "VALID-AFTER-CORRUPT"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -61,6 +61,7 @@ export OE_PANE_ISSUE_DIR="${_TMP_DIR}/pane-issue"
 export OE_DELEGATE_WAIT_SEC=0
 export OE_SEND_FINALIZE=0
 export OE_SEND_ENTER_DELAY=0
+export OE_EVENT_LOG=0          # 活動ログ（#206）emit を無効化（本テストは spawn/kick が対象）
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## 目的

親子委譲の観測欠落（子の返答の中身を回収できない / 配送が見えない / 子ペインが消えると追えない）に対し、親子相互作用を永続記録し read 時に投影する活動ログを最小実装する。`#206`（report inbox）の **増分1**。

## 変更内容

- **`lib/event-bus.sh`（新）** — `child_spawned` / `message_sent` を best-effort emit する append-only ログ（`oe-events.jsonl`）。各イベントが `from`/`to` の `{pane,role,label}` を **emit 時に焼き込む自己完結レコード**（session_id 主キーにせず・registry の生存に read 時依存しない＝departed children も後から可視）。preview ~100 codepoint・`OE_EVENT_LOG` kill-switch・行 < PIPE_BUF で atomic append・**常に return 0（本体を壊さない）**。
- **`schemas/oe-events.schema.json`（新）** — audit-log とは別系統・additive 設計（増分2 で `report_received` / turn 追加可）。
- **emit 結線** — `oe-delegate`（`child_spawned`）/ `oe_send_line`（`message_sent`・finalize の suspected-miss を `delivery_signal` に反映）。
- **`bin/oe-activity`（新・read-only）** — 親子関係ごとに **往復 / 配送(`suspected_miss`|`none`) / preview / 送信元(子)生存** のみ表示。`--inbox` で自分宛 report ビュー。`jq`/`tmux` 不在は degrade・壊れた JSONL 行はスキップ。
- **docs** — `README.md` / `bin/README.md` に項目追記。
- **closure** — episode（heavy tier）+ ADR（`#188` DJ-188-4 を delegate 現実へ精緻化＝部分 supersede）+ `#188` にステータス行のみ back-prop。

## スコープ（増分1 ＝ 最小）

- **lifecycle-end / stall は推論しない**（DJ-188-2 尊重）。viewer の liveness は `alive`|`gone`|`?` の生 fact のみ（「終了 vs stall」分類はしない）。
- server-pid キー化（同一サーバ `%N` 再利用の混線解消）/ log rotation / engine session_id 側統合・turn timeline(B) は **後続増分へ defer**（ADR 残課題）。

## 実装SO（`oe-review` 2 レーン・audit `20260622124724DX9W4KPGCM2Z`）

refuted 2/2 → 1 ラウンド自律対応:
- **[cursor・real]** label 内 TAB が識別子解決の TAB 内部プロトコルを壊す → label の TAB も畳む + 回帰テスト。
- **[codex・false positive]** 「`jq @tsv` が raw でない」→ 直接検証で反証（`jq -rs '…@tsv'` は raw TSV・viewer テストも実データ通過）。変更なし。
- **[cursor・doc/degrade]** 同一サーバ `%N` 再利用を既知制約に明記 / 壊れた JSONL 行を `fromjson?` でスキップ / reader 専用 `OE_EVENT_FILE` footgun を撤去。

## テスト

- 新規 `test_event_bus.sh`（31）+ `test_oe_activity.sh`（24）。既存 `test_delegate_send` / `test_oe_delegate` は `OE_EVENT_LOG=0` で隔離。
- **bash 3.2.57 / 5.2.37 で全 green・shellcheck clean**。

## 設計判断

- ADR: `projects/orchestration-engine/docs/decisions/2026-06-22-decision-206-activity-log-self-contained-events.md`
- episode: `projects/orchestration-engine/docs/episodes/2026-06-22-episode-206-activity-log.md`

Refs #206, #188, #177
