### PR TITLE
feat(oe): add oe-activity --timeline read-time view (#206)

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -45,7 +45,7 @@ projects/orchestration-engine/
 │   ├── oe-select              # oe-list + fzf の対話ペインセレクタ（cockpit 最小 UI・#176）
 │   ├── oe-report              # 親へ申し送り/レビュー依頼（legacy・戻しは oe-send に一本化）
 │   ├── oe-status              # cockpit 観測UI: read-only 俯瞰（ENGINE=audit-terminal state / DELEGATE=liveness）+ 監査ログ閲覧（#177）
-│   └── oe-activity            # 親子活動ログ（oe-events.jsonl）の read 時投影ビュー: 往復/配送/preview/子生存・report inbox（#206）
+│   └── oe-activity            # 親子活動ログ（oe-events.jsonl）の read 時投影ビュー: 往復/配送/preview/子生存・report inbox / timeline（#206）
 ├── lib/                       # Bash 関数ライブラリ（source 専用）
 │   ├── constants.sh           # OE_POLL_INTERVAL, OE_CB_*, OE_DATA_DIR, OE_TARGET_AI_*, OE_VERIFY_AI_* 等
 │   ├── event-bus.sh           # 親子活動ログ emit プリミティブ（child_spawned / message_sent・best-effort・#206）

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -6,7 +6,7 @@ scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
 - **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report` / `oe-jump`（通知→ペインへ focus）
-- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox・#206）
+- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox / timeline・#206）
 
 ---
 
@@ -257,13 +257,14 @@ set -g pane-border-format '#[align=left] #(/path/to/repo/projects/orchestration-
 
 ---
 
-## oe-activity — 親子活動ログの read 時投影ビュー（#206 増分1）
+## oe-activity — 親子活動ログの read 時投影ビュー（#206 増分1+2）
 
 `lib/event-bus.sh` が best-effort 追記する永続 append-only 活動ログ（`oe-events.jsonl`）を **read 時に投影**する read-only ビュー。各イベントは `from`/`to` の `{pane,role,label}` を emit 時に焼き込む自己完結レコードで、`session_id` を主キーにせず registry の生存にも依存しない（GC 後・子が消えた後も残る＝departed children も可視）。新規 write path は持たない（#188 read 時相関の思想に整合）。
 
 ```bash
 oe-activity            # 俯瞰: 親子関係ごとに 往復 / 配送 / 直近 preview / 子(送信元)生存
 oe-activity --inbox    # report inbox: 自分(=$TMUX_PANE)宛の報告を送信元(子)ごとに
+oe-activity --timeline # 時系列: 関係内の各送信を turn 順に 1 行ずつ（kick も出る・turn は read 時導出）
 ```
 
 - 出す情報は 4 つだけ（**lifecycle-end / stall は推論しない** ＝ DJ-188-2 尊重）:
@@ -271,6 +272,7 @@ oe-activity --inbox    # report inbox: 自分(=$TMUX_PANE)宛の報告を送信�
   - `DELIVERY` … 直近 message の `delivery_signal`（`suspected_miss`|`none`・`delivered` は名乗らない・`(×N)` は suspected_miss 件数）
   - `PREVIEW` … 直近 message 先頭 ~100 字
   - `LIVE` … 子(worker)ペインの mux 存在 query（`alive`|`gone`|`?`）。report の送信元＝子なので「報告者がまだ居るか」を honest に示す。ended/stalled の分類はしない（在る=alive / 無い=gone / tmux 不在=?）
+- モード: 既定の俯瞰と `--inbox` は **1 関係 = 1 行のサマリ**（直近 message + 往復数）。`--timeline`（#206 増分2）は **1 送信 = 1 行の時系列**で、関係内の各 `message_sent` を `TURN`（関係内の read 時導出位置）/ `TS` / `DIR`（`report`=子→親 / `kick`=親→子）/ `DELIVERY` / `RELATION` / `PREVIEW` で並べる（kick も含む・全体は古→新）。turn はスキーマに焼かず read 時に `ts` 順で導出する（**スキーマ不変** ＝ event-bus は無改変）。lifecycle-end / stall は推論しない点は俯瞰と同じ（生の `ts` / `dir` のみ）
 - read-only / 非検出: 触れるのは `oe-events.jsonl` と tmux ペイン存在（mux query）のみ。ペイン出力は読まない（capture / polling しない）・書込なし
 - degrade: `jq` 不在は件数のみ表示・`tmux` 不在は `LIVE=?`・ログ空は明示メッセージ（いずれも exit 0）
 - 既知の制約（増分1）: liveness は現サーバの `tmux list-panes -a` 突合で別サーバのペイン ID は `gone` と出る。イベントは server pid を持たず **pane を関係キー**にするため、同一サーバで `%N` が再利用（pane 破棄後の再割当）されると別関係が同一 `%N` に混線し得る（TRIPS 過大・親/inbox 取り違え）。server-pid キー化は後続増分（DJ-188-4 拡張）へ defer。壊れた JSONL 行は read 時に黙ってスキップ（degrade）

--- a/projects/orchestration-engine/bin/oe-activity
+++ b/projects/orchestration-engine/bin/oe-activity
@@ -4,6 +4,7 @@
 # usage:
 #   oe-activity            俯瞰: 親子関係ごとに 往復 / 配送 / 直近 preview / 子(送信元)生存
 #   oe-activity --inbox    report inbox: 自分(=$TMUX_PANE)宛の報告を送信元(子)ごとに表示
+#   oe-activity --timeline 時系列: 関係内の各送信を turn 順に 1 行ずつ（turn は read 時導出）
 #   oe-activity -h | --help
 #
 # lib/event-bus.sh が best-effort 追記する自己完結レコード（from/to の {pane,role,label} を
@@ -39,6 +40,7 @@ usage() {
 usage:
   oe-activity            俯瞰（親子関係ごとに 往復 / 配送 / preview / 子生存）
   oe-activity --inbox    report inbox（自分宛の報告を送信元ごとに）
+  oe-activity --timeline 時系列（関係内の各送信を turn 順に 1 行ずつ）
   oe-activity -h|--help
 
 read-only: oe-events.jsonl と tmux ペイン存在のみを読む（検出・送信はしない）。
@@ -49,6 +51,7 @@ MODE="overview"
 case "${1:-}" in
   -h|--help) usage; exit 0 ;;
   --inbox) MODE="inbox"; shift ;;
+  --timeline) MODE="timeline"; shift ;;
   "" ) ;;
   -*) err "unknown option: $1"; usage; exit 2 ;;
   *)  err "unexpected argument: $1"; usage; exit 2 ;;
@@ -89,8 +92,9 @@ liveness_of() {
   if printf '%s\n' "$LIVE_SET" | grep -qxF "$pane"; then printf 'alive'; else printf 'gone'; fi
 }
 
-# --- 投影（jq・slurp）: 1 関係 = 1 行の TSV を新しい順に返す ---
-# 出力フィールド: child_pane \t parent_pane \t child_label \t parent_label \t trips \t deliv \t miss \t preview
+# --- 投影（jq・slurp）: overview/inbox=1 関係 1 行（新しい順）/ timeline=1 送信 1 行（時系列）---
+# overview/inbox フィールド: child_pane \t parent_pane \t child_label \t parent_label \t trips \t deliv \t miss \t preview
+# timeline フィールド:       turn \t ts \t dir \t deliv \t child_pane \t parent_pane \t child_label \t parent_label \t preview
 # 前段の `jq -R 'fromjson? // empty'` で壊れた JSONL 行を黙ってスキップ（1 行破損で全体 exit 1 を回避）。
 project() {
   jq -R 'fromjson? // empty' "$OE_EVENT_FILE" \
@@ -108,27 +112,37 @@ project() {
               elif ($m.from.role=="parent") and ($m.to.role=="child")  then {p:$m.from.pane, c:$m.to.pane}
               else {p:$m.from.pane, c:$m.to.pane} end ) as $r
           | { c:$r.c, p:$r.p, ts:$m.ts, recipient:$m.to.pane,
+              dir:   (if $m.to.pane==$r.p then "report" elif $m.to.pane==$r.c then "kick" else "→" end),
               clab_m: (if $r.c==$m.from.pane then $m.from.label else $m.to.label end),
               plab_m: (if $r.p==$m.from.pane then $m.from.label else $m.to.label end),
               deliv: ($m.delivery_signal // "none"),
               prev:  (($m.preview // "") | gsub("[\t\r\n]"; " ")) } ] ) as $msgs
     # inbox は自分宛の報告だけに絞る
     | ( if $mode=="inbox" then [ $msgs[] | select(.recipient==$self) ] else $msgs end ) as $fmsgs
-    # 関係キー = (俯瞰のみ) spawn 子 ∪ message 子
-    | ( ( (if $mode=="inbox" then [] else [ $spawns[].to.pane ] end) + [ $fmsgs[].c ] ) | unique ) as $children
-    | [ $children[] | . as $c
-        | ( [ $fmsgs[] | select(.c==$c) ] | sort_by(.ts) ) as $g
-        | ( ($parent_of[$c]) // (if ($g|length)>0 then $g[-1].p else "" end) ) as $p
-        | { c:$c, p:$p,
-            clab: ( ($clabel[$c]) // (if ($g|length)>0 then $g[-1].clab_m else "" end) // "" ),
-            plab: ( ($plabel[$p]) // (if ($g|length)>0 then $g[-1].plab_m else "" end) // "" ),
-            trips: ($g|length),
-            deliv: (if ($g|length)>0 then $g[-1].deliv else "-" end),
-            miss:  ([ $g[] | select(.deliv=="suspected_miss") ] | length),
-            prev:  (if ($g|length)>0 then ($g[-1].prev // "") else "" end),
-            lts:   (if ($g|length)>0 then $g[-1].ts else "" end) } ]
-    | sort_by(.lts) | reverse
-    | .[] | [ .c, .p, .clab, .plab, .trips, .deliv, .miss, .prev ] | @tsv
+    | if $mode=="timeline"
+      then
+        # timeline: 関係(子)ごとに ts 昇順で turn を振り（read 時導出）、全体を時系列に 1 送信 1 行で展開
+        ( $fmsgs | group_by(.c)
+          | map( sort_by(.ts) | to_entries | map(.value + {turn:(.key+1)}) ) | add // [] )
+        | sort_by(.ts)
+        | .[] | [ (.turn|tostring), .ts, (.dir // "→"), (.deliv // "none"), .c, .p, (.clab_m // ""), (.plab_m // ""), (.prev // "") ] | @tsv
+      else
+        # 関係キー = (俯瞰のみ) spawn 子 ∪ message 子
+        ( ( (if $mode=="inbox" then [] else [ $spawns[].to.pane ] end) + [ $fmsgs[].c ] ) | unique ) as $children
+        | [ $children[] | . as $c
+            | ( [ $fmsgs[] | select(.c==$c) ] | sort_by(.ts) ) as $g
+            | ( ($parent_of[$c]) // (if ($g|length)>0 then $g[-1].p else "" end) ) as $p
+            | { c:$c, p:$p,
+                clab: ( ($clabel[$c]) // (if ($g|length)>0 then $g[-1].clab_m else "" end) // "" ),
+                plab: ( ($plabel[$p]) // (if ($g|length)>0 then $g[-1].plab_m else "" end) // "" ),
+                trips: ($g|length),
+                deliv: (if ($g|length)>0 then $g[-1].deliv else "-" end),
+                miss:  ([ $g[] | select(.deliv=="suspected_miss") ] | length),
+                prev:  (if ($g|length)>0 then ($g[-1].prev // "") else "" end),
+                lts:   (if ($g|length)>0 then $g[-1].ts else "" end) } ]
+        | sort_by(.lts) | reverse
+        | .[] | [ .c, .p, .clab, .plab, .trips, .deliv, .miss, .prev ] | @tsv
+      end
   '
 }
 
@@ -141,7 +155,23 @@ disp() {
 rows="$(project 2>/dev/null)" || { err "failed to project ${OE_EVENT_FILE} (corrupt jsonl?)"; exit 1; }
 
 if [[ -z "$rows" ]]; then
-  if [[ "$MODE" == "inbox" ]]; then echo "(no reports addressed to ${SELF})"; else echo "(no relationships in ${OE_EVENT_FILE})"; fi
+  case "$MODE" in
+    inbox)    echo "(no reports addressed to ${SELF})" ;;
+    timeline) echo "(no messages in ${OE_EVENT_FILE})" ;;
+    *)        echo "(no relationships in ${OE_EVENT_FILE})" ;;
+  esac
+  exit 0
+fi
+
+# timeline: 1 送信 1 行を時系列で（turn は関係内の read 時導出位置）。LIVE 列は出さない（時系列に専念）。
+if [[ "$MODE" == "timeline" ]]; then
+  printf '=== activity timeline (parent/child · tmux · read-only) ===\n'
+  printf '%-4s  %-26s  %-7s  %-16s  %-30s  %s\n' "TURN" "TS" "DIR" "DELIVERY" "RELATION" "PREVIEW"
+  while IFS=$'\t' read -r turn ts dir deliv c p clab plab prev; do
+    [[ -n "$ts" ]] || continue
+    relation="$(disp "$p" "$plab") → $(disp "$c" "$clab")"
+    printf '%-4s  %-26s  %-7s  %-16s  %-30s  %s\n' "$turn" "$ts" "$dir" "$deliv" "$relation" "$prev"
+  done <<< "$rows"
   exit 0
 fi
 

--- a/projects/orchestration-engine/bin/oe-activity
+++ b/projects/orchestration-engine/bin/oe-activity
@@ -93,8 +93,10 @@ liveness_of() {
 }
 
 # --- 投影（jq・slurp）: overview/inbox=1 関係 1 行（新しい順）/ timeline=1 送信 1 行（時系列）---
-# overview/inbox フィールド: child_pane \t parent_pane \t child_label \t parent_label \t trips \t deliv \t miss \t preview
-# timeline フィールド:       turn \t ts \t dir \t deliv \t child_pane \t parent_pane \t child_label \t parent_label \t preview
+# フィールド区切りは US (\u001f)。tab だと IFS 空白扱いで連続 tab が折り畳まれ空フィールド（空 label 等）が
+# 消えて列ズレする（実装SO cursor 指摘）。US は非空白なので read -r が空フィールドを保持する。
+# overview/inbox 列順: child_pane, parent_pane, child_label, parent_label, trips, deliv, miss, preview
+# timeline 列順:       turn, ts, dir, deliv, child_pane, parent_pane, child_label, parent_label, preview
 # 前段の `jq -R 'fromjson? // empty'` で壊れた JSONL 行を黙ってスキップ（1 行破損で全体 exit 1 を回避）。
 project() {
   jq -R 'fromjson? // empty' "$OE_EVENT_FILE" \
@@ -104,33 +106,35 @@ project() {
     | ( reduce $spawns[] as $s ({}; .[$s.to.pane] = $s.from.pane) )            as $parent_of
     | ( reduce $spawns[] as $s ({}; .[$s.to.pane] = ($s.to.label // "")) )     as $clabel
     | ( reduce $spawns[] as $s ({}; .[$s.from.pane] = ($s.from.label // "")) ) as $plabel
-    # 各 message を親/子へ向き付け（直接 parent リンク優先 → role → fallback）
-    | ( [ .[] | select(.type=="message_sent") | . as $m
+    # 各 message を親/子へ向き付け（直接 parent リンク優先 → role → fallback）。
+    # idx = message_sent の append 順位置。秒精度 ts の同秒タイ時に turn/表示順を決定的にする（実装SO codex 指摘）。
+    | ( [ .[] | select(.type=="message_sent") ] | to_entries
+        | map( .key as $idx | .value as $m
           | ( if   (($parent_of[$m.from.pane]) // "") == $m.to.pane   then {p:$m.to.pane,   c:$m.from.pane}
               elif (($parent_of[$m.to.pane])   // "") == $m.from.pane then {p:$m.from.pane, c:$m.to.pane}
               elif ($m.from.role=="child")  and ($m.to.role=="parent") then {p:$m.to.pane,   c:$m.from.pane}
               elif ($m.from.role=="parent") and ($m.to.role=="child")  then {p:$m.from.pane, c:$m.to.pane}
               else {p:$m.from.pane, c:$m.to.pane} end ) as $r
-          | { c:$r.c, p:$r.p, ts:$m.ts, recipient:$m.to.pane,
+          | { idx:$idx, c:$r.c, p:$r.p, ts:$m.ts, recipient:$m.to.pane,
               dir:   (if $m.to.pane==$r.p then "report" elif $m.to.pane==$r.c then "kick" else "→" end),
               clab_m: (if $r.c==$m.from.pane then $m.from.label else $m.to.label end),
               plab_m: (if $r.p==$m.from.pane then $m.from.label else $m.to.label end),
               deliv: ($m.delivery_signal // "none"),
-              prev:  (($m.preview // "") | gsub("[\t\r\n]"; " ")) } ] ) as $msgs
+              prev:  (($m.preview // "") | gsub("[[:cntrl:]]"; " ")) } ) ) as $msgs
     # inbox は自分宛の報告だけに絞る
     | ( if $mode=="inbox" then [ $msgs[] | select(.recipient==$self) ] else $msgs end ) as $fmsgs
     | if $mode=="timeline"
       then
-        # timeline: 関係(子)ごとに ts 昇順で turn を振り（read 時導出）、全体を時系列に 1 送信 1 行で展開
+        # timeline: 関係(子)ごとに (ts,idx) 昇順で turn を read 時導出、全体も (ts,idx) で時系列に 1 送信 1 行
         ( $fmsgs | group_by(.c)
-          | map( sort_by(.ts) | to_entries | map(.value + {turn:(.key+1)}) ) | add // [] )
-        | sort_by(.ts)
-        | .[] | [ (.turn|tostring), .ts, (.dir // "→"), (.deliv // "none"), .c, .p, (.clab_m // ""), (.plab_m // ""), (.prev // "") ] | @tsv
+          | map( sort_by(.ts, .idx) | to_entries | map(.value + {turn:(.key+1)}) ) | add // [] )
+        | sort_by(.ts, .idx)
+        | .[] | [ (.turn|tostring), .ts, (.dir // "→"), (.deliv // "none"), .c, .p, (.clab_m // ""), (.plab_m // ""), (.prev // "") ] | join("\u001f")
       else
         # 関係キー = (俯瞰のみ) spawn 子 ∪ message 子
         ( ( (if $mode=="inbox" then [] else [ $spawns[].to.pane ] end) + [ $fmsgs[].c ] ) | unique ) as $children
         | [ $children[] | . as $c
-            | ( [ $fmsgs[] | select(.c==$c) ] | sort_by(.ts) ) as $g
+            | ( [ $fmsgs[] | select(.c==$c) ] | sort_by(.ts, .idx) ) as $g
             | ( ($parent_of[$c]) // (if ($g|length)>0 then $g[-1].p else "" end) ) as $p
             | { c:$c, p:$p,
                 clab: ( ($clabel[$c]) // (if ($g|length)>0 then $g[-1].clab_m else "" end) // "" ),
@@ -139,9 +143,10 @@ project() {
                 deliv: (if ($g|length)>0 then $g[-1].deliv else "-" end),
                 miss:  ([ $g[] | select(.deliv=="suspected_miss") ] | length),
                 prev:  (if ($g|length)>0 then ($g[-1].prev // "") else "" end),
-                lts:   (if ($g|length)>0 then $g[-1].ts else "" end) } ]
-        | sort_by(.lts) | reverse
-        | .[] | [ .c, .p, .clab, .plab, .trips, .deliv, .miss, .prev ] | @tsv
+                lts:   (if ($g|length)>0 then $g[-1].ts else "" end),
+                lidx:  (if ($g|length)>0 then $g[-1].idx else -1 end) } ]
+        | sort_by(.lts, .lidx) | reverse
+        | .[] | [ .c, .p, .clab, .plab, (.trips|tostring), .deliv, (.miss|tostring), .prev ] | join("\u001f")
       end
   '
 }
@@ -167,7 +172,7 @@ fi
 if [[ "$MODE" == "timeline" ]]; then
   printf '=== activity timeline (parent/child · tmux · read-only) ===\n'
   printf '%-4s  %-26s  %-7s  %-16s  %-30s  %s\n' "TURN" "TS" "DIR" "DELIVERY" "RELATION" "PREVIEW"
-  while IFS=$'\t' read -r turn ts dir deliv c p clab plab prev; do
+  while IFS=$'\037' read -r turn ts dir deliv c p clab plab prev; do
     [[ -n "$ts" ]] || continue
     relation="$(disp "$p" "$plab") → $(disp "$c" "$clab")"
     printf '%-4s  %-26s  %-7s  %-16s  %-30s  %s\n' "$turn" "$ts" "$dir" "$deliv" "$relation" "$prev"
@@ -183,7 +188,7 @@ else
   printf '%-6s  %-5s  %-20s  %-30s  %s\n' "LIVE" "TRIPS" "DELIVERY" "RELATION" "PREVIEW"
 fi
 
-while IFS=$'\t' read -r c p clab plab trips deliv miss prev; do
+while IFS=$'\037' read -r c p clab plab trips deliv miss prev; do
   [[ -n "$c" || -n "$p" ]] || continue
   live="$(liveness_of "$c")"     # 送信元 ＝ 子(worker)の生存
   deliv_disp="$deliv"

--- a/projects/orchestration-engine/docs/discussions/2026-06-29-discussion-206-increment2-timeline.md
+++ b/projects/orchestration-engine/docs/discussions/2026-06-29-discussion-206-increment2-timeline.md
@@ -1,0 +1,92 @@
+---
+id: "01KW94DF3TDNADEF2E0BTXF6ZP"
+title: "#206 増分2 = 親子活動 timeline（B）の設計探索 — turn は read 時導出 / report_received(A) は defer"
+date: 2026-06-29
+type: discussion
+status: stable
+related:
+  - type: implements
+    ref: "#206"
+  - type: depends_on
+    ref: "#188"
+  - type: design_context
+    ref: ../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md
+    reason: "増分1 の決定境界（DJ-206-1/2/3）。本増分はこれを additive 拡張する前提"
+  - type: parent
+    ref: "#169"
+---
+
+# #206 増分2 = 親子活動 timeline（B）の設計探索
+
+## 文脈
+
+`#206`（HITL クロスセッション活動フロー観測 + 報告可視化）は 2 軸ある:
+
+- **(A) 報告の確実な可視化** — 子→親報告の可視 inbox（pending / 未読）。
+- **(B) クロスセッション活動フロー観測** — セッション × ターン × 往復の時系列 timeline（read-only）。
+
+増分1（PR #213・merged 2026-06-23）で event-bus（`lib/event-bus.sh`）+ 自己完結ログ（`oe-events.jsonl`）+ read-only viewer（`bin/oe-activity` の overview / `--inbox`）が landed した。本増分（増分2）は **(B) の turn 粒度 timeline** を、増分1 の event-bus を **additive 拡張**する形で実装する範囲を確定する。
+
+## 増分1 が引いた決定境界（本増分の制約）
+
+増分1 ADR（`../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md`）の確定事項。本増分はこれを**再オープンしない**:
+
+- **DJ-206-1 — 自己完結イベント（write 時 snapshot）**: 各イベントが `from`/`to` の `{pane,role,label}` を emit 時に焼き込む。read 時は live registry に依存しない。[verified] ADR:46
+- **DJ-206-2 — lifecycle-end / stall は推論しない**: viewer が出すのは 往復 / 配送 / preview / 送信元生存（`alive`|`gone`|`?`）の 4 つのみ。「終了 vs stall」分類はしない（DJ-188-2 の category error 回避を観測側へ徹底）。[verified] ADR:47
+- **DJ-206-3 — vocab は additive**: `report_received` / turn 粒度は非破壊追加できる設計。engine 側（`audit-log.schema.json`）とは別系統に保つ。[verified] ADR:48
+
+加えて event-bus の不変条件（`lib/event-bus.sh:11-16`）: **emit は過去ログを read しない / 1 行 = atomic append（O_APPEND, < PIPE_BUF） / best-effort（常に return 0）**。[verified]
+
+## 探索した選択肢（増分2 項目のトリアージ）
+
+ADR の defer リストには増分2 候補が複数ある。それを「クリーン additive か / 決定境界をまたぐか」で仕分けた:
+
+- **turn 粒度 timeline（B）** → クリーン additive。下記 DJ-i2-1 で read 時導出に確定。**本増分の核**。
+- **report_received（A）** → スキーマ enum 追加自体は additive だが、emit に **actor 側の新しい write path とトリガ設計**が要る（viewer は read-only 維持のため書かせない）。→ **本増分では defer**。
+- **engine session_id 統合** → #188 の D-vs-F（pane 層 vs session 層統一）と 2-world topology（engine=wez-split は tmux 外・delegate=tmux-split は wez 外で相互不可視・DJ-188-1）を再オープンする。**対象外**。
+- **stall / lifecycle 推論** → DJ-206-2 を覆す（category error 回避を意図的に選んだ箇所）。**対象外**。
+- **server-pid キー化 / log rotation** → 増分1 の既知制約。本増分のスコープ外（別 follow-up）。
+
+### turn の表現: read 時導出 vs スキーマ焼込
+
+- **案 turn-stored（棄却）**: `message_sent` に turn 連番を焼き込む。→ 連番を振るには emit 時に「その関係の既存件数」を read する必要があり、**emit は過去ログを read しない**不変条件（`lib/event-bus.sh:14-16`）と同時 emit のレース耐性を壊す。
+- **案 turn-readtime（採用 = DJ-i2-1）**: イベントは既に `ts` を持つ。viewer が関係内で `ts` ソートした**位置がそのまま turn 順**。現に `bin/oe-activity` の `project()` は関係ごとに `sort_by(.ts)`（`bin/oe-activity:120`）して直近 1 件へ畳んでいる。timeline は同じ `$g` を畳まず各メッセージを行にするだけ。**スキーマ変更ゼロ・増分1 の既存 jsonl と後方互換・#188 DJ-188-3「read 時投影」と整合**。[verified] `bin/oe-activity:95-133`
+
+## 未収束 SO の文脈（session_id / stall を外す根拠）
+
+「増分前に SO が収束しなかった」案件 = **#188（2基盤 identity 統一）**。設計SO（`tmp/so-188-design/`・codex+cursor）は構造的な答え（query-side fusion）には収束したが、**「そもそも #188 を解くべきか / F(session 層統一) を入れるか / #114 を先にすべきか」という framing で割れた**（cursor は F 保留・#114 先行を主張）。[verified] `tmp/so-188-design/cursor-stdout.txt`・ADR `2026-06-19-decision-188-identity-unification.md:78`
+
+increment-1 の自己完結イベントは、この F-vs-session の対立を **「永続化の鍵」でなく「write 時の投影」で満たす**ことで orthogonal にした（`../episodes/2026-06-22-episode-206-activity-log.md:31`）。よって増分2 で **engine session_id 統合 / stall 推論を入れると、その未収束領域に戻る**。本増分はそこへ踏み込まず、event-bus の additive 拡張に閉じる。
+
+（補足: #206 自身の設計SO も v1–v3 で 3 連続 refuted を経て v4 に確定した経緯がある — `../episodes/2026-06-22-episode-206-activity-log.md:25`。[verified]）
+
+## 決めたこと
+
+- **DJ-i2-1 — turn index は read 時導出**（スキーマに turn フィールドを足さない）。viewer に `--timeline` モードを追加し、関係内 `ts` ソート位置を turn 番号とする。
+- **スコープ = `oe-activity --timeline`（B）のみ・viewer-only・スキーマ不変**。
+- **report_received（A）は defer**（actor トリガ設計を含むため別増分）。
+- DJ-206-1/2/3・#188 を再オープンしない（stall 推論・engine session_id 統合は対象外）。
+
+## やらない / defer
+
+- **report_received（A）**: viewer read-only を保つため actor 側 emit が要る → トリガ設計（明示コマンド等）を伴うので別増分。
+- **engine session_id 統合**: #188 D-vs-F / 2-world topology の再オープン。
+- **stall / lifecycle 推論**: DJ-206-2 を覆す。
+- **server-pid キー化 / log rotation**: 増分1 の既知制約・別 follow-up。
+
+## doc flow（本増分・明示）
+
+- **discussion**（本ファイル）: 設計探索・スコープ確定。
+- **plan**: `../plans/2026-06-29-plan-206-increment2-timeline.md`（実行可能プラン）。
+- **設計SO**: timeline 単体は viewer-only・スキーマ変更ゼロで低リスク → heavy 設計SO は省略（report_received を defer したことで設計判断の重い部分が外れた）。判断は episode に残す。
+- **実装SO（`oe-review`）**: コード変更があるため **PR 前に必須**（codex+cursor・欠陥/到達可能性レンズ・verdict refuted なら PR 保留）。
+- **decision/ADR**: DJ-i2-1 は DJ-206 の小精緻化のため、原則 episode 記録に留める。昇格価値が出たら decision card 化を検討。
+- **episode**: 実装着手時に作成しリアルタイム追記。締めで `episode-retrospective`（消費者明示・routing・status・tier）。後追い執筆になる場合は冒頭 `reconstructed` を明示。
+
+## 参照
+
+- 増分1 ADR: `../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md`（DJ-206-1/2/3）
+- 増分1 episode: `../episodes/2026-06-22-episode-206-activity-log.md`
+- #188 ADR: `../decisions/2026-06-19-decision-188-identity-unification.md`（DJ-188-1/2/3・D vs F）
+- 設計SO 生出力（#188）: `tmp/so-188-design/`（worktree・gitignore）
+- Issue: [#206](https://github.com/stlwolf/ai-development-hub/issues/206) / [#188](https://github.com/stlwolf/ai-development-hub/issues/188) / [#169](https://github.com/stlwolf/ai-development-hub/issues/169)

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md
@@ -1,0 +1,44 @@
+---
+id: "01KW9ZS54TRJNCA8KMKQ8SFTS9"
+title: "#206 増分2 = oe-activity --timeline（B・viewer-only）実装エピソード"
+date: 2026-06-30
+type: episode
+status: draft
+related:
+  - type: implements
+    ref: "#206"
+  - type: derived_from
+    ref: ../plans/2026-06-29-plan-206-increment2-timeline.md
+    reason: "本エピソードの実行プラン（S1–S7・Gate）"
+  - type: design_context
+    ref: ../discussions/2026-06-29-discussion-206-increment2-timeline.md
+    reason: "スコープ確定・DJ-i2-1（turn=read 時導出）"
+  - type: depends_on
+    ref: "#188"
+---
+
+# #206 増分2 = oe-activity --timeline（B・viewer-only）実装エピソード
+
+> リアルタイム追記（作業中に逐次記録）。
+
+## コンテキスト / なぜ
+
+増分1（PR #213）で event-bus + 自己完結ログ + read-only viewer（overview / `--inbox`）が landed した。本増分は #206 (B) の **turn 粒度 timeline** を、event-bus を additive 拡張（実質 viewer のみ）で実装する。設計上 turn はスキーマに焼かず **read 時導出**（関係内 `ts` ソート位置）とした（DJ-i2-1）。`report_received`(A) / engine session_id 統合 / stall 推論は defer（未収束 SO 領域・DJ-206-2 を再オープンしないため）。
+
+## 進行ログ
+
+### 実装着手（S1–S3）
+
+- branch `feature/#206_increment2_timeline`・viewer-only。`lib/event-bus.sh` / `schemas/oe-events.schema.json` は触らない（スキーマ不変の担保）。
+- `bin/oe-activity` に変更を集約:
+  - 引数 `--timeline`（`MODE="timeline"`）+ usage / help 追記。
+  - `project()` jq: `$msgs` に `dir`（`report`=子→親 / `kick`=親→子・recipient で判定）を追加。末尾を `if $mode=="timeline" then … else <既存サマリ> end` で分岐。timeline は `group_by(.c)`（関係＝子）→ 各群 `sort_by(.ts)|to_entries` で **turn を read 時導出**（1-based 位置）→ `add` で平坦化 → 全体 `sort_by(.ts)`（古→新）→ 1 送信 1 行の TSV。
+  - レンダリング: timeline 専用 header / 行（`TURN / TS / DIR / DELIVERY / RELATION / PREVIEW`・LIVE 列は出さない）。空入力は `case "$MODE"` で `(no messages …)` を出す。
+- **DJ-i2-1 の実装的帰結**: turn は emit 時に振らない（event-bus の「過去ログを read しない / atomic append」不変条件を壊さない）。viewer が `ts` 順位置として read 時に算出するだけ ＝ スキーマ変更ゼロ・増分1 既存 jsonl と後方互換。
+
+### 検証（G1 / G2）
+
+- **G1**: `shellcheck bin/oe-activity` rc=0。ダミー jsonl（2 関係・往復・kick・suspected_miss・壊れ行）で `--timeline` を目視 → 関係内 turn 連番（%66=1,2,3 / %70=1）・全体時系列・`dir`・`delivery`・壊れ行 skip を確認。overview / `--inbox` の既存出力は不変。TS 列が ISO 25 桁で `%-20s` を超えたため `%-26s` に微調整。
+- **S4**: `tests/test_oe_activity.sh` に [12]–[14] 追加（turn 連番 / dir / 時系列順 / kick 可視 / spawn-only→no messages / 壊れ行 skip）。bash 3.2 footgun（`declare -A`・空配列）は新規追加で踏まない。多バイト grep 回避のため kick マーカは ASCII `increment1`。
+- **G2**: `test_oe_activity.sh` を **bash 5.2.37 / 3.2.57 両系で 39/39 green・rc=0**。`shellcheck` test ファイル rc=0。`git diff` は `bin/oe-activity`（+66/-19）と test（+34）のみ ＝ **event-bus / schema 無変更**（viewer-only 担保）。無回帰: `test_event_bus.sh` 36/36（bash 3.2.57）。
+- **S5**: `bin/README.md`（oe-activity 節に `--timeline` + モード対比 + スキーマ不変を明記）/ `projects/orchestration-engine/README.md`（ツリー行）に追記。

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md
@@ -3,7 +3,7 @@ id: "01KW9ZS54TRJNCA8KMKQ8SFTS9"
 title: "#206 増分2 = oe-activity --timeline（B・viewer-only）実装エピソード"
 date: 2026-06-30
 type: episode
-status: draft
+status: stable
 related:
   - type: implements
     ref: "#206"
@@ -42,3 +42,32 @@ related:
 - **S4**: `tests/test_oe_activity.sh` に [12]–[14] 追加（turn 連番 / dir / 時系列順 / kick 可視 / spawn-only→no messages / 壊れ行 skip）。bash 3.2 footgun（`declare -A`・空配列）は新規追加で踏まない。多バイト grep 回避のため kick マーカは ASCII `increment1`。
 - **G2**: `test_oe_activity.sh` を **bash 5.2.37 / 3.2.57 両系で 39/39 green・rc=0**。`shellcheck` test ファイル rc=0。`git diff` は `bin/oe-activity`（+66/-19）と test（+34）のみ ＝ **event-bus / schema 無変更**（viewer-only 担保）。無回帰: `test_event_bus.sh` 36/36（bash 3.2.57）。
 - **S5**: `bin/README.md`（oe-activity 節に `--timeline` + モード対比 + スキーマ不変を明記）/ `projects/orchestration-engine/README.md`（ツリー行）に追記。
+
+### 実装SO（Gate G3・`oe-review` codex+cursor）
+
+- 初回 `oe-review --lanes 2 --base master`（reviewed_sha `f60db94`・audit `202606291538449ZSP19KCNCAN`・出力 `tmp/oe-review-202606291538449ZSP19KCNCAN/`）= **refuted 2/2**。3 指摘いずれも一次照合で **real**（前回のような false positive は無し）。1 ラウンド自律対応:
+  - **[cursor・real・採用]** `--timeline` の TSV パースが `IFS=$'\t' read` の連続タブ折り畳みで**スキーマ正当な空 label 時に列ズレ**（RELATION/PREVIEW 誤表示）。cursor が adversarial 実行で再現。→ 区切りを **tab→US(`0x1f`)** に変更（jq `join("\u001f")` + `IFS=$'\037' read`。US は非空白 IFS なので空フィールドを保持）。
+  - **[codex・real・採用]** preview の制御文字畳み込みが `\t\r\n` だけで **ESC/OSC が `--timeline` 表示へ素通り**（端末注入が到達可能）。→ `gsub("[\t\r\n]")` → `gsub("[[:cntrl:]]")`（C0+DEL を空白化）。
+  - **[codex・real・採用]** **秒精度 ts** の同秒複数送信で turn 導出が `sort_by(.ts)` のみ＝順序不定（jq sort 安定性依存・cursor も「実装依存」と追認）。→ `message_sent` の append 順 `idx` を付与し `sort_by(.ts, .idx)`（turn 導出・全体時系列・summary の最新判定すべて）で**決定的化**。
+- 回帰テスト [15]（空 label 列ズレ）[16]（ESC 畳み込み）[17]（同一秒 turn 決定性）を追加し各指摘を locking。**修正後 50/50 green（bash 5.2.37 / 3.2.57）・shellcheck rc=0**。
+- **スコープ判断（back-prop）**: US 区切りへの変更は **既存 overview/inbox の同型潜在バグ（空 label 列ズレ）も同時に解消**した（根本原因が共有の `IFS=$'\t'` 折り畳みのため。timeline だけ直すのは hacky な部分修正）。rendered 出力は不変ゆえ既存テストは透過。これは増分2 スコープの軽微な拡大だが、既知バグを残さない判断（implementation-principles・最小スコープは silent 拡大を禁ずるのみ＝本記録で明示）。
+
+## closure
+
+- **tier: heavy**（意図的 SO 起動 + SO refuted で方針修正 + 非自明な設計判断 DJ-i2-1）。
+- **status: stable** / **達成度: 達成**（増分2 = `--timeline`（B）viewer-only・スキーマ不変・実装SO 1 ラウンド対応まで）。
+- **次の消費者**: (1) cockpit を見る人間（`oe-activity --timeline` で「見ていない間の往復」を時系列把握）/ (2) **report_received(A) 増分の着手者**（本増分は (B) のみ・(A) は actor トリガ設計を伴うため defer）/ (3) #185 lifecycle 機械制御の検討者（turn は read 時導出で持つ＝engine 結合や stall 推論は依然未着手の地点を確認できる）。
+- **決定と根拠（コア・diff から復元しにくい所）**:
+  - **DJ-i2-1（turn = read 時導出）**: emit 時に turn を振らない。event-bus の「過去ログを read しない / atomic append / best-effort」不変条件とレース耐性を壊さないため。viewer が関係内 `ts`（+ append `idx`）順の位置として算出 → スキーマ変更ゼロ・増分1 既存 jsonl 後方互換。
+  - **US(`0x1f`) 区切り採用**: `@tsv` + `IFS=$'\t'` は tab が IFS 空白で連続折り畳み＝空フィールド消失。非空白の US なら `read` が空フィールドを保持。`[[:cntrl:]]` 畳み込みで preview に US も混入しない。
+- **原則（negative knowledge・#62 候補）**:
+  - Anti: `IFS=$'\t' read` で TSV を分解（tab は IFS 空白 → 連続 tab が 1 区切りに畳まれ空列消失で列ズレ）/ OK: 非空白区切り（US 0x1f）+ `IFS=$'\037'`、または列数検証。
+  - Anti: 秒精度 ts だけで時系列順・連番を導出（同秒タイで順序不定・sort 安定性依存）/ OK: append-order index を tiebreaker に。
+  - Anti: 端末出力の制御文字畳み込みを `\t\r\n` 限定（ESC/OSC 素通り＝注入）/ OK: `[[:cntrl:]]` で C0+DEL を畳む。
+- **follow-up routing**:
+  - `report_received`(A) / engine session_id 統合 / stall・lifecycle 推論 → **defer**（#206 ADR defer リスト・DJ-206-2 / #188 未収束領域。discussion に根拠）。別増分。
+  - server-pid キー化（`%N` 再利用混線）/ log rotation → **defer**（増分1 既知制約のまま・本増分で悪化させていない）。
+  - 既存 overview/inbox の空 label 列ズレ → **本 PR で解消済**（back-prop・上記）。追加 follow-up なし。
+- **evidence anchor**: SO audit `202606291538449ZSP19KCNCAN`・reviewed_sha `f60db94`・出力 `tmp/oe-review-202606291538449ZSP19KCNCAN/`（worktree・gitignore＝揮発のため要点を本文へ転記済）。テスト 50/50（bash 5.2.37 / 3.2.57）・shellcheck rc=0・event-bus/schema diff ゼロ。
+- **蒸留シグナル**: Decision 昇格は **保留**（DJ-i2-1 は #206 ADR の小精緻化＝本 episode 記録で足りる。新規 ADR は作らない）。negative knowledge 3 件は **#62 注入候補**（今回は本 episode 記録に留める）。
+- **Step4 辞退（heavy 外部チェック・advisory）**: closure 4 観点を自己点検し低リスクと判断して辞退。覆った観点= 失敗の選択的省略なし（SO refuted 3 件・fix・back-prop をすべて明記）／ routing 網羅（defer 群すべて行き先付与・overview バグは解消済）／ evidence anchor（SO audit id・出力パス・テスト数を本文転記）／ back-propagation（overview/inbox への波及を明記）。未実施観点と判断= so-compare 再チェックは指定フロー外（実装SO は別レンズ＝コード欠陥で closure 品質を代替しない点は理解の上、上記 4 観点を本文で自己点検済のため不実施）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md
@@ -19,11 +19,11 @@ related:
 
 # #206 増分2 = oe-activity --timeline（B・viewer-only）実装エピソード
 
-> リアルタイム追記（作業中に逐次記録）。
+> 作業中に追記（skeleton → S1–S5 → G3+closure の 3 チャンクで記録。厳密な逐次ではない）。
 
 ## コンテキスト / なぜ
 
-増分1（PR #213）で event-bus + 自己完結ログ + read-only viewer（overview / `--inbox`）が landed した。本増分は #206 (B) の **turn 粒度 timeline** を、event-bus を additive 拡張（実質 viewer のみ）で実装する。設計上 turn はスキーマに焼かず **read 時導出**（関係内 `ts` ソート位置）とした（DJ-i2-1）。`report_received`(A) / engine session_id 統合 / stall 推論は defer（未収束 SO 領域・DJ-206-2 を再オープンしないため）。
+増分1（PR #213）で event-bus + 自己完結ログ + read-only viewer（overview / `--inbox`）が landed した。本増分は #206 (B) の **turn 粒度 timeline** を、event-bus を additive 拡張（実質 viewer のみ）で実装する。設計上 turn はスキーマに焼かず **read 時導出**（関係内 `ts` + append `idx` 順の位置）とした（DJ-i2-1）。`report_received`(A) / engine session_id 統合 / stall 推論は defer（未収束 SO 領域・DJ-206-2 を再オープンしないため）。
 
 ## 進行ログ
 
@@ -32,7 +32,7 @@ related:
 - branch `feature/#206_increment2_timeline`・viewer-only。`lib/event-bus.sh` / `schemas/oe-events.schema.json` は触らない（スキーマ不変の担保）。
 - `bin/oe-activity` に変更を集約:
   - 引数 `--timeline`（`MODE="timeline"`）+ usage / help 追記。
-  - `project()` jq: `$msgs` に `dir`（`report`=子→親 / `kick`=親→子・recipient で判定）を追加。末尾を `if $mode=="timeline" then … else <既存サマリ> end` で分岐。timeline は `group_by(.c)`（関係＝子）→ 各群 `sort_by(.ts)|to_entries` で **turn を read 時導出**（1-based 位置）→ `add` で平坦化 → 全体 `sort_by(.ts)`（古→新）→ 1 送信 1 行の TSV。
+  - `project()` jq: `$msgs` に `dir`（`report`=子→親 / `kick`=親→子・recipient で判定）を追加。末尾を `if $mode=="timeline" then … else <既存サマリ> end` で分岐。timeline は `group_by(.c)`（関係＝子）→ 各群 `sort_by(.ts)|to_entries` で **turn を read 時導出**（1-based 位置）→ `add` で平坦化 → 全体 `sort_by(.ts)`（古→新）→ 1 送信 1 行の TSV。**※この時点の実装。G3 で区切りを US 化＋ `sort_by(.ts, .idx)` に差し替え（下記）。**
   - レンダリング: timeline 専用 header / 行（`TURN / TS / DIR / DELIVERY / RELATION / PREVIEW`・LIVE 列は出さない）。空入力は `case "$MODE"` で `(no messages …)` を出す。
 - **DJ-i2-1 の実装的帰結**: turn は emit 時に振らない（event-bus の「過去ログを read しない / atomic append」不変条件を壊さない）。viewer が `ts` 順位置として read 時に算出するだけ ＝ スキーマ変更ゼロ・増分1 既存 jsonl と後方互換。
 
@@ -45,10 +45,10 @@ related:
 
 ### 実装SO（Gate G3・`oe-review` codex+cursor）
 
-- 初回 `oe-review --lanes 2 --base master`（reviewed_sha `f60db94`・audit `202606291538449ZSP19KCNCAN`・出力 `tmp/oe-review-202606291538449ZSP19KCNCAN/`）= **refuted 2/2**。3 指摘いずれも一次照合で **real**（前回のような false positive は無し）。1 ラウンド自律対応:
+- 初回 `oe-review --lanes 2 --base master`（reviewed_sha `f60db94`・audit `202606291538449ZSP19KCNCAN`・出力 `tmp/oe-review-202606291538449ZSP19KCNCAN/`）= **refuted 2/2**（3 指摘）。finding B/C は real。**finding A は当時 real と判断したが、後日の jq 実測で「過大」と判明**（下記で訂正）。1 ラウンド自律対応:
   - **[cursor・real・採用]** `--timeline` の TSV パースが `IFS=$'\t' read` の連続タブ折り畳みで**スキーマ正当な空 label 時に列ズレ**（RELATION/PREVIEW 誤表示）。cursor が adversarial 実行で再現。→ 区切りを **tab→US(`0x1f`)** に変更（jq `join("\u001f")` + `IFS=$'\037' read`。US は非空白 IFS なので空フィールドを保持）。
   - **[codex・real・採用]** preview の制御文字畳み込みが `\t\r\n` だけで **ESC/OSC が `--timeline` 表示へ素通り**（端末注入が到達可能）。→ `gsub("[\t\r\n]")` → `gsub("[[:cntrl:]]")`（C0+DEL を空白化）。
-  - **[codex・real・採用]** **秒精度 ts** の同秒複数送信で turn 導出が `sort_by(.ts)` のみ＝順序不定（jq sort 安定性依存・cursor も「実装依存」と追認）。→ `message_sent` の append 順 `idx` を付与し `sort_by(.ts, .idx)`（turn 導出・全体時系列・summary の最新判定すべて）で**決定的化**。
+  - **[codex・過大 → 堅牢化として採用]** codex は「秒精度 `ts` の同秒送信で turn 導出が**順序不定**」と指摘。だが**後日実測（jq 1.8.0）では `sort_by`/`group_by` は安定（append 順保持）で、関係内 turn は現行 jq では実際には決定的に正しかった**（cursor の「実装依存」が正確・codex / 初稿の「順序不定」は過大。SO を一次照合せず転記した evidence-verification の漏れ）。残る実問題は (a) jq sort 安定性は仕様保証された契約でない、(b) 全体 `sort_by(.ts)` は group 順を経るため同一秒の**異関係**行が append 順でなく group 順で並ぶ軽微な表示差、の 2 点。→ append 順 `idx` を付与し `sort_by(.ts, .idx)` で**安定性に依存せず決定化**（現行 jq のバグ修正ではなく堅牢化＋異関係表示順の是正）。
 - 回帰テスト [15]（空 label 列ズレ）[16]（ESC 畳み込み）[17]（同一秒 turn 決定性）を追加し各指摘を locking。**修正後 50/50 green（bash 5.2.37 / 3.2.57）・shellcheck rc=0**。
 - **スコープ判断（back-prop）**: US 区切りへの変更は **既存 overview/inbox の同型潜在バグ（空 label 列ズレ）も同時に解消**した（根本原因が共有の `IFS=$'\t'` 折り畳みのため。timeline だけ直すのは hacky な部分修正）。rendered 出力は不変ゆえ既存テストは透過。これは増分2 スコープの軽微な拡大だが、既知バグを残さない判断（implementation-principles・最小スコープは silent 拡大を禁ずるのみ＝本記録で明示）。
 
@@ -62,8 +62,9 @@ related:
   - **US(`0x1f`) 区切り採用**: `@tsv` + `IFS=$'\t'` は tab が IFS 空白で連続折り畳み＝空フィールド消失。非空白の US なら `read` が空フィールドを保持。`[[:cntrl:]]` 畳み込みで preview に US も混入しない。
 - **原則（negative knowledge・#62 候補）**:
   - Anti: `IFS=$'\t' read` で TSV を分解（tab は IFS 空白 → 連続 tab が 1 区切りに畳まれ空列消失で列ズレ）/ OK: 非空白区切り（US 0x1f）+ `IFS=$'\037'`、または列数検証。
-  - Anti: 秒精度 ts だけで時系列順・連番を導出（同秒タイで順序不定・sort 安定性依存）/ OK: append-order index を tiebreaker に。
+  - Anti: 秒精度 ts だけで時系列順・連番を導出し、同秒タイの順序を sort 安定性に委ねる（仕様非保証への依存。jq 1.8.0 は実測安定だが契約ではない）/ OK: append-order index を tiebreaker に明示。
   - Anti: 端末出力の制御文字畳み込みを `\t\r\n` 限定（ESC/OSC 素通り＝注入）/ OK: `[[:cntrl:]]` で C0+DEL を畳む。
+  - Anti: テスト fixture の preview に制御文字を「バックスラッシュ u + 16進」(JSON エスケープ) で直接書く → エディタ / heredoc がリテラル制御文字へ展開し jq が不正 JSON として行 skip → テスト空振り（実装SO 対応中に数回手戻り）/ OK: `jq -cn` でオブジェクトを組んで出力させる、または perl の hex 指定（`\x5c`=バックスラッシュ）で挿入。
 - **follow-up routing**:
   - `report_received`(A) / engine session_id 統合 / stall・lifecycle 推論 → **defer**（#206 ADR defer リスト・DJ-206-2 / #188 未収束領域。discussion に根拠）。別増分。
   - server-pid キー化（`%N` 再利用混線）/ log rotation → **defer**（増分1 既知制約のまま・本増分で悪化させていない）。
@@ -71,3 +72,4 @@ related:
 - **evidence anchor**: SO audit `202606291538449ZSP19KCNCAN`・reviewed_sha `f60db94`・出力 `tmp/oe-review-202606291538449ZSP19KCNCAN/`（worktree・gitignore＝揮発のため要点を本文へ転記済）。テスト 50/50（bash 5.2.37 / 3.2.57）・shellcheck rc=0・event-bus/schema diff ゼロ。
 - **蒸留シグナル**: Decision 昇格は **保留**（DJ-i2-1 は #206 ADR の小精緻化＝本 episode 記録で足りる。新規 ADR は作らない）。negative knowledge 3 件は **#62 注入候補**（今回は本 episode 記録に留める）。
 - **Step4 辞退（heavy 外部チェック・advisory）**: closure 4 観点を自己点検し低リスクと判断して辞退。覆った観点= 失敗の選択的省略なし（SO refuted 3 件・fix・back-prop をすべて明記）／ routing 網羅（defer 群すべて行き先付与・overview バグは解消済）／ evidence anchor（SO audit id・出力パス・テスト数を本文転記）／ back-propagation（overview/inbox への波及を明記）。未実施観点と判断= so-compare 再チェックは指定フロー外（実装SO は別レンズ＝コード欠陥で closure 品質を代替しない点は理解の上、上記 4 観点を本文で自己点検済のため不実施）。
+  - **※ 後日訂正（自己評価の甘さの実例）**: この辞退は borderline だった。finding A の「順序不定」過大表現（技術的事実誤認）が closure 時点で残存し、ユーザー指摘 → jq 実測ではじめて訂正できた。Step4 外部チェックを回していれば closure 前に拾えた公算が高い。heavy で 3 件の指摘が出た episode の Step4 辞退は今後より慎重に。

--- a/projects/orchestration-engine/docs/plans/2026-06-29-plan-206-increment2-timeline.md
+++ b/projects/orchestration-engine/docs/plans/2026-06-29-plan-206-increment2-timeline.md
@@ -1,0 +1,97 @@
+---
+id: "01KW94DF3TYQC7GR73NR4Z1BTN"
+title: "#206 増分2 plan — oe-activity --timeline（B・viewer-only・additive）"
+date: 2026-06-29
+type: plan
+status: draft
+related:
+  - type: derived_from
+    ref: ../discussions/2026-06-29-discussion-206-increment2-timeline.md
+    reason: "本プランのスコープ確定元（設計探索・DJ-i2-1）"
+  - type: implements
+    ref: "#206"
+  - type: design_context
+    ref: ../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md
+    reason: "増分1 の決定境界（DJ-206-1/2/3）。本増分はこれを additive 拡張する前提"
+tags: [orchestration, activity-log, timeline, cockpit, read-only, increment2]
+---
+
+# #206 増分2 plan — oe-activity --timeline（B・viewer-only・additive）
+
+## Context / 前提
+
+増分1（PR #213）で event-bus + 自己完結ログ（`oe-events.jsonl`）+ read-only viewer（`bin/oe-activity` の overview / `--inbox`）が landed 済み。本増分は **(B) turn 粒度 timeline** を、event-bus を additive 拡張する形で実装する。設計判断・スコープ根拠は discussion（`../discussions/2026-06-29-discussion-206-increment2-timeline.md`）に確定済み。
+
+核となる確定事項:
+
+- **DJ-i2-1**: turn index は **read 時導出**（関係内 `ts` ソート位置）。スキーマに turn フィールドを足さない。
+- viewer-only・**スキーマ変更ゼロ**・増分1 の既存 jsonl と後方互換。
+- DJ-206-1/2/3・#188 を再オープンしない（stall 推論・engine session_id 統合・report_received は対象外）。
+
+## スコープ
+
+### IN
+
+- `bin/oe-activity` に `--timeline` モードを追加（関係内の各 `message_sent` を時系列 1 行で表示）。
+- `tests/test_oe_activity.sh` に timeline 投影のテスト追加。
+- `bin/README.md` / `projects/orchestration-engine/README.md` に `--timeline` を追記。
+
+### OUT（discussion の defer に同じ）
+
+- `report_received`（A・actor トリガ設計を伴う）。
+- engine session_id 統合 / stall・lifecycle 推論 / server-pid キー化 / log rotation。
+- `lib/event-bus.sh` / `schemas/oe-events.schema.json` の変更（**触らない** = スキーマ不変の担保）。
+
+## 成果物
+
+- `bin/oe-activity`（`--timeline` モード追加・既存 overview / `--inbox` は不変）。
+- `tests/test_oe_activity.sh`（timeline テストケース追加）。
+- README 2 ファイルの追記。
+- episode（実装記録）。
+
+## ステップ（TODO + Gate interleaved）
+
+- [ ] **S1. `--timeline` 引数パース追加**: `bin/oe-activity:48-56` の case に `--timeline` を追加（`MODE="timeline"`）。help（`usage`）にも 1 行追記。
+- [ ] **S2. timeline 投影を `project()` に追加**: `bin/oe-activity:95-133` の jq で、timeline モードのとき関係ごとの `$g`（`sort_by(.ts)`・既存 line 120）を畳まず**各メッセージを 1 行**に展開する。行フィールド = `child_pane / parent_pane / child_label / parent_label / turn_index / ts / dir(report|kick|→) / delivery / miss / preview`。turn_index は `$g` 内 1-based 位置（read 時導出）。
+  - 全体の並びは既定で**時系列（古→新）**で読み下せる順とする（overview の `newest-first` とは別モード・実装時に最終確認）。
+- [ ] **S3. timeline レンダリング追加**: `bin/oe-activity:148-167` に timeline 用の header / 行整形を追加（列案: `TS / TURN / DIR / DELIVERY / RELATION / PREVIEW`）。既存 overview / inbox の出力は不変に保つ。
+- [ ] **Gate G1（自己検証）**: `shellcheck bin/oe-activity` rc=0。手動で `OE_EVENT_DIR=<tmp>` に複数往復のダミー jsonl を置き `--timeline` の出力（turn 連番・順序・空入力・壊れ行 skip）を目視確認。
+- [ ] **S4. テスト追加**: `tests/test_oe_activity.sh` に — (a) 単一関係で turn が 1..N に振られる、(b) 複数関係の時系列インターリーブ、(c) 空入力で `(no ...)`、(d) 壊れ JSONL 行の skip（既存 degrade と整合）、(e) `--inbox` / overview の既存挙動が不変（回帰）。
+- [ ] **Gate G2（テスト・bash 両系）**: `bash tests/test_oe_activity.sh`（既存 24 + 追加）を **bash 5.2.x と bash 3.2.57 の両方**で green。**#193 の bash 3.2 footgun（空配列の `set -u` 展開・`declare -A`）を新テストで踏まないこと**を明示確認。
+- [ ] **S5. README 追記**: `bin/README.md` と `projects/orchestration-engine/README.md` に `--timeline` の用途を 1〜数行で追記（overview=サマリ / timeline=往復の時系列、を対比）。
+- [ ] **Gate G3（実装SO・必須）**: `oe-review`（codex+cursor・欠陥/到達可能性レンズ）を reviewed diff にバインドして実行。**verdict=refuted なら PR を保留**し 1 ラウンド自律対応（real は採用・false positive は一次照合で却下）。
+- [ ] **S6. episode 締め**: `episode-retrospective`（消費者明示・routing・status・tier 判定）。リアルタイム追記が崩れた場合は冒頭 `reconstructed` を明示。
+- [ ] **S7. PR 作成**: `pr-conventions`・**squash**・本文に Refs #206。Copilot レビュー依頼は既存フローどおり。
+
+## 検証 / 完了条件
+
+- `shellcheck bin/oe-activity` rc=0。
+- `tests/test_oe_activity.sh` が bash 5.2.x / 3.2.57 の両方で green（既存 + 追加ケース）。
+- overview / `--inbox` の既存出力が不変（回帰テストで担保）。
+- `lib/event-bus.sh` / `schemas/oe-events.schema.json` に diff が無い（スキーマ不変の担保）。
+- 実装SO（`oe-review`）1 ラウンド対応完了（refuted の real 指摘を反映 or 反証）。
+
+## doc flow（4層パイプライン・明示）
+
+- **discussion**〔済〕: `../discussions/2026-06-29-discussion-206-increment2-timeline.md` — 設計探索・スコープ確定。
+- **plan**〔本ファイル〕: 実行可能プラン。
+- **設計SO**〔省略・理由記録〕: timeline 単体は viewer-only・スキーマ変更ゼロで低リスク。重い設計判断（report_received のトリガ）は defer したため heavy 設計SO は当てない。判断は episode に残す。
+- **実装SO（`oe-review`）**〔Gate G3・必須〕: コード変更があるため PR 前に実行。
+- **decision/ADR**〔状況次第・原則 episode 止まり〕: DJ-i2-1 は DJ-206 の小精緻化。昇格価値が出た場合のみ decision card 化。
+- **episode**〔実装着手時に作成・リアルタイム追記 / 締めで必須〕: closure で `episode-retrospective`。
+- **branch / PR**: `feature/#206_increment2_timeline`（作成済）・PR は squash・pr-conventions。
+
+## リスク・未確認事項
+
+- **timeline の並び順**（全体 古→新 vs 新→古）: 既定は時系列読み下し（古→新）。実装時に overview との一貫性も含め最終確認（軽微）。
+- **列幅・情報密度**: timeline は行数が増える。preview 切り詰め（既存 ~100 字）と列整形で可読性を保つ。新モードとして分離し overview は汚さない。
+- **%N 再利用の混線**: 増分1 の既知制約（server-pid 非保持）をそのまま継承。本増分で新たに悪化させない（解消は別 follow-up）。
+- **report_received を defer したことで (A) の「人間が見た」可視化は本増分では未達**: discussion に defer 理由を明記済み。別増分でトリガ設計から扱う。
+
+## 参照
+
+- discussion: `../discussions/2026-06-29-discussion-206-increment2-timeline.md`
+- 増分1 ADR: `../decisions/2026-06-22-decision-206-activity-log-self-contained-events.md`
+- 増分1 episode: `../episodes/2026-06-22-episode-206-activity-log.md`
+- 実装対象: `bin/oe-activity` / `tests/test_oe_activity.sh`
+- Issue: [#206](https://github.com/stlwolf/ai-development-hub/issues/206)

--- a/projects/orchestration-engine/tests/test_oe_activity.sh
+++ b/projects/orchestration-engine/tests/test_oe_activity.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # liveness は PATH-stub tmux で固定（%59/%66 を alive・%77 は出さない＝gone）。jq は実体。
 # fixture の oe-events.jsonl を直に置いて投影（往復カウント / liveness / report/kick 向き /
-# inbox フィルタ / degrade / 空）を検証する。
+# inbox フィルタ / timeline(turn 連番・全体時系列・kick 可視) / degrade / 空）を検証する。
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -130,6 +130,38 @@ mkdir -p "$_TMP_DIR/corrupt"
 rc=0; OUT5="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/corrupt" bash "$OE_ACTIVITY" 2>&1)" || rc=$?
 ck "corrupt exit 0" "0" "$rc"
 ckc "valid row survives corrupt line" "$OUT5" "VALID-AFTER-CORRUPT"
+
+echo "[12] timeline: 1 送信 1 行・関係内 turn 連番・全体時系列（古→新）・kick も出る"
+TL="$(run --timeline)"
+ckc "timeline header" "$TL" "activity timeline"
+ckc "timeline shows kick (inbox では出ない送信)" "$TL" "increment1"
+ckc "timeline has %66 report" "$TL" "DONE-IMPL-REPORT"
+ckc "timeline has %77 report" "$TL" "PARTIAL-OLD-REPORT"
+# 行抽出（preview マーカで一意）。列: TURN TS DIR DELIVERY RELATION... PREVIEW → $1=turn
+tl_kick="$(row_of "$TL" "increment1")"
+tl_rep66="$(row_of "$TL" "DONE-IMPL-REPORT")"
+tl_rep77="$(row_of "$TL" "PARTIAL-OLD-REPORT")"
+ck "%66 kick turn=1"   "1" "$(printf '%s' "$tl_kick"  | awk '{print $1}')"
+ck "%66 report turn=2" "2" "$(printf '%s' "$tl_rep66" | awk '{print $1}')"
+ck "%77 report turn=1" "1" "$(printf '%s' "$tl_rep77" | awk '{print $1}')"
+ckc "%66 kick dir=kick"     "$tl_kick"  "kick"
+ckc "%66 report dir=report" "$tl_rep66" "report"
+ckc "%77 report suspected_miss" "$tl_rep77" "suspected_miss"
+# 全体は時系列（古→新）: 先頭データ行（title+header の次）= 最古 12:01 の kick
+tl_first="$(printf '%s\n' "$TL" | sed -n '3p')"
+ckc "timeline oldest-first (先頭=12:01 kick)" "$tl_first" "increment1"
+
+echo "[13] timeline: message_sent 無し（spawn のみ）→ (no messages) + exit 0"
+mkdir -p "$_TMP_DIR/spawnonly"
+printf '%s\n' '{"ts":"2026-06-22T14:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"p"},"to":{"pane":"%66","role":"child","label":"c"}}' > "$_TMP_DIR/spawnonly/oe-events.jsonl"
+rc=0; TL2="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/spawnonly" bash "$OE_ACTIVITY" --timeline 2>&1)" || rc=$?
+ck "timeline spawn-only exit 0" "0" "$rc"
+ckc "timeline spawn-only no-messages msg" "$TL2" "no messages"
+
+echo "[14] timeline: 壊れた JSONL 行は read 時にスキップ（exit 0・有効行は残る）"
+rc=0; TL3="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/corrupt" bash "$OE_ACTIVITY" --timeline 2>&1)" || rc=$?
+ck "timeline corrupt exit 0" "0" "$rc"
+ckc "timeline valid row survives corrupt" "$TL3" "VALID-AFTER-CORRUPT"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_activity.sh
+++ b/projects/orchestration-engine/tests/test_oe_activity.sh
@@ -163,5 +163,45 @@ rc=0; TL3="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/
 ck "timeline corrupt exit 0" "0" "$rc"
 ckc "timeline valid row survives corrupt" "$TL3" "VALID-AFTER-CORRUPT"
 
+echo "[15] 空 label でも列ズレしない（US 区切り・実装SO cursor 指摘・overview + timeline）"
+mkdir -p "$_TMP_DIR/emptylabel"
+{
+  printf '%s\n' '{"ts":"2026-06-22T15:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":""},"to":{"pane":"%66","role":"child","label":""}}'
+  printf '%s\n' '{"ts":"2026-06-22T15:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":""},"to":{"pane":"%59","role":"parent","label":""},"preview":"EMPTYLABEL-PREVIEW","delivery_signal":"none"}'
+} > "$_TMP_DIR/emptylabel/oe-events.jsonl"
+EL_OV="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/emptylabel" bash "$OE_ACTIVITY")"
+ckc "overview 空label: preview が正しく出る" "$EL_OV" "EMPTYLABEL-PREVIEW"
+ckc "overview 空label: RELATION=%59 → %66" "$(row_of "$EL_OV" "EMPTYLABEL-PREVIEW")" "%59 → %66"
+EL_TL="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/emptylabel" bash "$OE_ACTIVITY" --timeline)"
+ckc "timeline 空label: preview が正しく出る" "$EL_TL" "EMPTYLABEL-PREVIEW"
+el_tl="$(row_of "$EL_TL" "EMPTYLABEL-PREVIEW")"
+ckc "timeline 空label: RELATION=%59 → %66" "$el_tl" "%59 → %66"
+ck "timeline 空label: turn=1" "1" "$(printf '%s' "$el_tl" | awk '{print $1}')"
+
+echo "[16] preview の制御文字（ESC 等）は空白へ畳む（端末注入防止・実装SO codex 指摘）"
+mkdir -p "$_TMP_DIR/ctrl"
+{
+  printf '%s\n' '{"ts":"2026-06-22T16:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"p"},"to":{"pane":"%66","role":"child","label":"c"}}'
+  printf '%s\n' '{"ts":"2026-06-22T16:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"c"},"to":{"pane":"%59","role":"parent","label":"p"},"preview":"CTRL\u001b[31mINJECT","delivery_signal":"none"}'
+} > "$_TMP_DIR/ctrl/oe-events.jsonl"
+CT="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/ctrl" bash "$OE_ACTIVITY" --timeline)"
+ESC="$(printf '\033')"
+if printf '%s' "$CT" | LC_ALL=C grep -q "$ESC"; then echo "  FAIL: ESC 未畳み込み"; FAIL=$((FAIL+1)); else echo "  PASS: ESC folded to space"; PASS=$((PASS+1)); fi
+ckc "ctrl: 周辺テキスト CTRL 残存" "$CT" "CTRL"
+ckc "ctrl: 周辺テキスト INJECT 残存" "$CT" "INJECT"
+
+echo "[17] 同一秒の複数送信でも turn は append 順で決定的（実装SO codex 指摘・idx tiebreak）"
+mkdir -p "$_TMP_DIR/samesec"
+{
+  printf '%s\n' '{"ts":"2026-06-22T17:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"p"},"to":{"pane":"%66","role":"child","label":"c"}}'
+  printf '%s\n' '{"ts":"2026-06-22T17:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"c"},"to":{"pane":"%59","role":"parent","label":"p"},"preview":"SS-FIRST","delivery_signal":"none"}'
+  printf '%s\n' '{"ts":"2026-06-22T17:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"c"},"to":{"pane":"%59","role":"parent","label":"p"},"preview":"SS-SECOND","delivery_signal":"none"}'
+  printf '%s\n' '{"ts":"2026-06-22T17:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"c"},"to":{"pane":"%59","role":"parent","label":"p"},"preview":"SS-THIRD","delivery_signal":"none"}'
+} > "$_TMP_DIR/samesec/oe-events.jsonl"
+SS="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/samesec" bash "$OE_ACTIVITY" --timeline)"
+ck "same-sec FIRST turn=1"  "1" "$(printf '%s' "$(row_of "$SS" "SS-FIRST")"  | awk '{print $1}')"
+ck "same-sec SECOND turn=2" "2" "$(printf '%s' "$(row_of "$SS" "SS-SECOND")" | awk '{print $1}')"
+ck "same-sec THIRD turn=3"  "3" "$(printf '%s' "$(row_of "$SS" "SS-THIRD")"  | awk '{print $1}')"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 概要

`#206`（HITL クロスセッション活動フロー観測）の **増分2 = (B) turn 粒度 timeline**。増分1（PR #213）の event-bus を **viewer-only で additive 拡張**し、`oe-activity` に `--timeline` モードを追加する。スキーマ（`oe-events.schema.json`）と `lib/event-bus.sh` は無変更。

`report_received`(A) / engine session_id 統合 / stall・lifecycle 推論は **defer**（#206 ADR の defer リスト・DJ-206-2 / #188 の未収束領域を再オープンしないため。判断根拠は discussion に記録）。

## 変更内容

- `bin/oe-activity`: `--timeline` モード追加。関係内の各 `message_sent` を 1 送信 1 行で時系列表示（`TURN / TS / DIR / DELIVERY / RELATION / PREVIEW`）。`overview` / `--inbox` は不変。
- `tests/test_oe_activity.sh`: timeline + 回帰テスト追加（24 → 50 ケース）。
- `bin/README.md` / `README.md`: `--timeline` を追記。

## 設計判断

- **DJ-i2-1（turn = read 時導出）**: turn をスキーマに焼かず、viewer が関係内 `ts`（+ append `idx`）順の位置として read 時に算出する。emit は過去ログを read しない／atomic append という event-bus の不変条件を壊さないため。結果 **スキーマ変更ゼロ・増分1 既存ログと後方互換**。

## 実装SO（`oe-review` codex+cursor）

初回 refuted 2/2（3 指摘）。B/C は real、**A は当時 real と判断したが後日 jq 実測で過大と判明**（下記）→ 1 ラウンド自律対応:

- **空 label 列ズレ（cursor 再現・real）**: TSV 区切りを tab → US(0x1f) に変更。tab は IFS 空白で連続タブが折り畳まれ空フィールドが消える。US は非空白なので `read` が空フィールドを保持。**既存 `overview`/`--inbox` の同型潜在バグも同時解消**（根本原因が共有・rendered 出力は不変）。
- **preview の端末注入（codex・real）**: 制御文字畳み込みを `[\t\r\n]` → `[[:cntrl:]]`（ESC/OSC を空白化）。
- **同一秒 turn（codex・過大→堅牢化）**: codex は「順序不定」と指摘したが、jq 1.8.0 の `sort_by`/`group_by` は実測安定で現行は決定的だった（cursor の「実装依存」が正確）。append 順 `idx` の tiebreak（`sort_by(.ts, .idx)`）は jq sort 安定性（仕様非保証）に依存しない堅牢化＋同一秒の異関係表示順の是正であり、現行 jq のバグ修正ではない。

各指摘は回帰テスト [15]（空 label）/ [16]（ESC 畳み込み）/ [17]（同一秒 turn）で locking。SO 証跡: audit `202606291538449ZSP19KCNCAN`。

## テスト

- `shellcheck bin/oe-activity tests/test_oe_activity.sh` rc=0
- `test_oe_activity.sh` **50/50 green（bash 5.2.37 / 3.2.57 両系）**
- `test_event_bus.sh` 36/36 無回帰
- `git diff` に `lib/event-bus.sh` / `schemas/oe-events.schema.json` の変更なし（viewer-only 担保）

## ドキュメント（蒸留パイプライン）

- discussion: `projects/orchestration-engine/docs/discussions/2026-06-29-discussion-206-increment2-timeline.md`
- plan: `projects/orchestration-engine/docs/plans/2026-06-29-plan-206-increment2-timeline.md`
- episode（closure・heavy tier）: `projects/orchestration-engine/docs/episodes/2026-06-30-episode-206-increment2-timeline.md`

Refs #206
