### PR TITLE
feat(oe): orchestrate 対象のクリーン取得チャネルを file-redirect に統一

### DIFF
--- a/projects/orchestration-engine/docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md
+++ b/projects/orchestration-engine/docs/decisions/2026-05-18-decision-reviewer-output-file-redirect.md
@@ -64,6 +64,8 @@ cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | te
 wez pane send "$reviewer_pane_id" "$cli_command"
 ```
 
+> **後続是正（#114 / 2026-06-30）**: 上記 `tee` は共有 `/tmp` 上で既定 umask（0644・world-readable）でログを作るため、transcript（秘密情報を含み得る）の露出面がある。[#114 ADR](./2026-06-30-decision-114-clean-output-channel.md) で target/reviewer 両経路を `( umask 077 ; … | tee … )`（0600）に是正済み。本節の現行コードはその形。
+
 - サブシェル `( ... )` 内で `$?` を読むので claude/cursor の exit code が確定 → printf に渡る
 - printf も tee を経由 → log file と pane TTY の両方に書かれる
 - bash の PIPESTATUS 依存が消え、zsh / busybox tee でも動作 (pane 内 shell の柔軟性確保)

--- a/projects/orchestration-engine/docs/decisions/2026-06-30-decision-114-clean-output-channel.md
+++ b/projects/orchestration-engine/docs/decisions/2026-06-30-decision-114-clean-output-channel.md
@@ -61,7 +61,8 @@ orchestration-engine は orchestrate 対象（target）と検証者（reviewer�
 ## 実装（#98 = 案A の target 脚）
 
 - `lib/capture.sh`: `_oe_scan_log_file <path> [lines]`（log 走査の共通コア＝reviewer/target 共有 primitive）と `_oe_target_log_path <session_id> <pane_id>`（target log の単一情報源 → `/tmp/oe-{sid}-{pane}-target.log`）を新設。
-- `lib/spawn.sh:oe_spawn_send`: target 送信を `( cmd 2>&1 ; printf @@OE_EXIT ) | tee "$(_oe_target_log_path …)"` に統一。tee は pane TTY にも書くため**人間は引き続き pane で観察**できる。
+- `lib/spawn.sh:oe_spawn_send`: target 送信を `( umask 077 ; ( cmd 2>&1 ; printf @@OE_EXIT ) | tee "$(_oe_target_log_path …)" )` に統一。tee は pane TTY にも書くため**人間は引き続き pane で観察**できる。
+- **ログ権限 0600**（実装SO 反映）: transcript は task 本文/stderr/パス/秘密情報を含み得るため、共有 `/tmp` 上で world-readable（既定 umask 022 → 0644）にしない。`tee` はパイプライン側プロセスなので umask はパイプライン全体を囲う外側 subshell（`( umask 077 ; … | tee … )`）で設定する（左 subshell 内だけでは tee に効かない）。target/reviewer 両経路に適用し、統一チャネルを secure-by-construction にする（verify.sh も同形）。
 - `lib/monitor.sh`: scan を `oe_capture_scan`（wez pane capture）→ `_oe_scan_log_file "$(_oe_target_log_path …)"` に切替。`OE_SCAN_MARKER_TYPE=EXIT` 消費部は不変（source が pane→file に変わるだけ）。
 - `lib/verify.sh:_oe_verify_scan_log_file`: 共通コアへ委譲する薄いラッパに変更（reviewer 経路は不変）。
 - `lib/cleanup.sh`: 変更不要（glob `/tmp/oe-{session_id}-*`〔cleanup.sh:55〕が target log を捕捉）。
@@ -94,4 +95,6 @@ orchestration-engine は orchestrate 対象（target）と検証者（reviewer�
 - target/reviewer の取得チャネルが file-redirect に統一され、#98 の「経路の非対称＝将来 hazard」が解消。
 - 完了 acquisition の正準が明文化され、scrape の正当な残存用途（readiness / 対話 attach）と区別された。
 - 取得×配送×制御分離×(acquisition vs recording) の軸により、案C/案D/push 配送への将来拡張が記述上 open に保たれた。
-- 全テスト 23 ファイル green / shellcheck clean。実装SO（`oe-review`）を PR 前に実施。
+- 実装SO（`oe-review`・audit_id `202606301215340G0VFGFZW3R5`）が refuted（target transcript を 0644 で /tmp へ露出）。修正として両経路に `umask 077`（0600）を適用し再検証で survived。設計SO とは別レンズが実際に material 欠陥を捕捉した（#192 の false-pass 回避＝設計SO 通過≠実装SO 代替の実例）。
+- 全テスト 23 ファイル green / shellcheck clean。
+- 残ハードニング候補（defer・本 ADR スコープ外）: ログ保存先を共有 `/tmp` から専用ディレクトリ（`OE_DATA_DIR` 下 0700 等）へ移す案。reviewer 経路も含む大きめ変更のため別 issue 候補。

--- a/projects/orchestration-engine/docs/decisions/2026-06-30-decision-114-clean-output-channel.md
+++ b/projects/orchestration-engine/docs/decisions/2026-06-30-decision-114-clean-output-channel.md
@@ -1,0 +1,97 @@
+---
+id: "01KWC6K034H9NP0ENZB4S1WTT9"
+title: "#114 orchestrate 対象のクリーン取得チャネルは非対話 one-shot の協調 file-redirect を正準とし、scrape を完了 acquisition から降格する"
+date: 2026-06-30
+type: decision
+status: accepted
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
+    reason: "本 ADR の主スコープ（クリーン取得チャネルの正準化・方針/ADR レベル）"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/98"
+    reason: "本方針の target 経路における具体実装（同 PR で実装）"
+  - type: refines
+    ref: ./2026-05-18-decision-reviewer-output-file-redirect.md
+    reason: "reviewer を file-redirect 化した先行 ADR。本 ADR は target を同経路へ統一し『target 側は現状維持』を解消する"
+  - type: source_material
+    ref: ../../lib/capture.sh
+    reason: "本決定の実装（_oe_scan_log_file / _oe_target_log_path）"
+  - type: source_material
+    ref: ../../lib/spawn.sh
+    reason: "target 送信を file-redirect 形に統一（oe_spawn_send）"
+  - type: source_material
+    ref: ../../lib/monitor.sh
+    reason: "target 監視を pane scrape から log 走査に切替"
+  - type: episode
+    ref: ../episodes/2026-06-30-episode-114-clean-output-channel.md
+    reason: "本 ADR を生んだ実装エピソード（設計探索・設計SO・grounding・実装SO）"
+  - type: prior_art
+    ref: ../../../../docs/research/2026-05-31-agmsg-agent-messaging-patterns.md
+    reason: "scrape 脱却→構造化バス／配送セマンティクス分離の同型先行事例（取得×配送軸の出典）"
+tags: [orchestration, capture-channel, scrape, file-redirect, acquisition, delivery-semantics, decision, adr]
+---
+
+# #114 クリーン取得チャネルの正準化（scrape 脱却）
+
+## コンテキスト
+
+orchestration-engine は orchestrate 対象（target）と検証者（reviewer）の出力からマーカー（`@@OE_EXIT:N` / `@@OE_VERIFY:pass|fail|warn`）を読み取り、完了・結果を判定する。両者とも**非対話 one-shot** で起動済み（`cursor-agent --print` / `claude -p --output-format text`〔lib/spawn.sh:203,208〕）。しかし取得チャネルが非対称だった:
+
+- reviewer: `( cmd 2>&1 ; printf @@OE_EXIT ) | tee /tmp/oe-{rsid}-reviewer.log` → `tail` で log 走査（[2026-05-18 ADR](./2026-05-18-decision-reviewer-output-file-redirect.md) で file-redirect 化済み）。
+- target: `wez pane send` に生コマンド → `wez pane capture --lines 50`（WezTerm の **2D 描画グリッド**）を scrape〔lib/capture.sh:48〕。
+
+`wez pane capture` は WezTerm が解釈・描画済みのグリッドを返すため本質的に脆い: ボックス装飾 `│ @@OE_EXIT:0 │`、行折返し、TUI 再描画、viewport-only。#112 で字下げ marker への regex 緩和（Part 1）を入れたが、上記は緩和ではカバーできない。「マーカーはどんな形であれ取れる」というオーケストレーションの前提を満たすには、scrape でなくクリーンな取得チャネルが要る。
+
+非所有プロセスの stdout 直読は OS 的に原則不可で、クリーンに取る道は **(a) 所有（子を PTY 付きで起動）** か **(b) 協調（出力を file redirect させて読む）** の 2 つ。対話 TUI 出力は生ストリームを取れても制御コード列でクリーンでなく、クリーンテキストは print/構造化モード（`claude -p` 等）でのみ得られる。
+
+## 決定
+
+1. **正準取得チャネル**: orchestrate 対象の**完了/出力 acquisition** は「非対話 one-shot の `2>&1` transcript（stdout+stderr）を**協調 file-redirect**（per-session ログ）し、engine が `tail` で走査する」を正準ベースラインとする。target も reviewer と同じ経路へ統一する（#98）。
+2. **scrape の降格スコープ**: `wez pane capture`（2D グリッド scrape）は**非対話 target の完了 acquisition から降格**する。ただし次は scrape を機械的に継続する（降格は acquisition 限定）:
+   - spawn 前 readiness 判定（`oe_board_wait_ready` / `_wez_wait_pane_ready`〔lib/spawn.sh:102-106〕。出力の非空・安定のみを見る用途）。
+   - 対話ペインへの attach（`bin/oe-capture`、#109。対話中ペインを壊さず viewport を読む独立入口）。
+3. **記述軸**: 本チャネル選択を以下の軸で位置づけ、将来の進化余地を明示する（agmsg prior-art の軸）:
+   - **取得 (how)**: scrape / file-redirect / 所有 subprocess / 構造化イベント。本決定は file-redirect。
+   - **配送 (when)**: poll（現行・`tail` ポーリング）/ push（割込・将来）。本決定は poll 相当。
+   - **制御/本文の分離**: 現行は制御信号（marker）が本文 transcript と**同居**。将来の分離（サイドカー/イベント化）の余地を残す。
+   - **acquisition と recording の分離**: 本 ADR は acquisition（子→engine の結果取得）の正準化。engine の event-bus/audit JSONL〔lib/event-bus.sh / lib/audit.sh〕は engine が検知後に emit する **recording（downstream）** であり acquisition チャネルではない。両者を混同しない。
+4. **対話 TUI orchestrate** は別チャネル課題（セッションログ / フック等）として **defer**（本サイクル対象外）。
+
+## 実装（#98 = 案A の target 脚）
+
+- `lib/capture.sh`: `_oe_scan_log_file <path> [lines]`（log 走査の共通コア＝reviewer/target 共有 primitive）と `_oe_target_log_path <session_id> <pane_id>`（target log の単一情報源 → `/tmp/oe-{sid}-{pane}-target.log`）を新設。
+- `lib/spawn.sh:oe_spawn_send`: target 送信を `( cmd 2>&1 ; printf @@OE_EXIT ) | tee "$(_oe_target_log_path …)"` に統一。tee は pane TTY にも書くため**人間は引き続き pane で観察**できる。
+- `lib/monitor.sh`: scan を `oe_capture_scan`（wez pane capture）→ `_oe_scan_log_file "$(_oe_target_log_path …)"` に切替。`OE_SCAN_MARKER_TYPE=EXIT` 消費部は不変（source が pane→file に変わるだけ）。
+- `lib/verify.sh:_oe_verify_scan_log_file`: 共通コアへ委譲する薄いラッパに変更（reviewer 経路は不変）。
+- `lib/cleanup.sh`: 変更不要（glob `/tmp/oe-{session_id}-*`〔cleanup.sh:55〕が target log を捕捉）。
+- target log を `(session_id, pane_id)` で鍵付け（reviewer は単一で session 鍵で足りるが、target は #98 が動機に挙げた multi-pane 並走でログ衝突を避けるため）。spawn（tee 構築）と monitor（走査）が同関数を使い**パス書式の drift = #98 が警戒する非対称ハザードを構造的に排除**。
+
+## 根拠
+
+- reviewer で file-redirect が実証済み（[2026-05-18 ADR](./2026-05-18-decision-reviewer-output-file-redirect.md)）。target はその水平展開でデルタ最小・回帰リスク低。
+- file 経路は OS ファイルシステム上で全ストリームを保証し、WezTerm の viewport-only / グリッド描画に非依存（長文・行折返し・装飾でも marker を取りこぼさない）。
+- per-session ログ（`/tmp/oe-{sid}-{pane}-target.log`）は agmsg が踏んだ**共有テキストファイルの並行破損**とは無縁（セッション/ペイン別で衝突しない）。
+- 「ランタイムは借りる・engine は協調プロトコルを提供する」という Phase 3 選択肢B と整合（所有 subprocess 化＝案B は逸脱）。
+
+## 棄却・defer 案（確定前のゼロベース探索＋設計SO で外部化）
+
+確定前に `oe-refute --claim … --rubric exploration`（設計SO・lanes=codex/cursor）を実行。verdict=**refuted**（audit_id `20260630094501F1333D1JNE4W`）で確定を保留し、指摘された第4カテゴリ群を一次情報で grounding した上で各案を以下に位置づけた。
+
+| 案 | 差分軸 | 判定 | 理由 |
+|---|---|---|---|
+| **案A** file-redirect（採用） | 取得=file・marker 本文同居・poll | ✅ 採用 | reviewer 経路の水平展開。実証済み・デルタ最小・人間 pane 観察を保持 |
+| **案B** engine 所有 subprocess + 構造化 JSON（pane なし） | 責務=所有・pane 無 | ❌ 棄却 | `cursor-agent`/`claude` とも `--output-format json` 対応は**一次確認済**（棄却根拠は「json 不明」ではない）。pane 喪失（人間観察不可）+ Phase 3「ランタイムは借りる」逸脱 + blast radius 大 |
+| **案C** 構造化 status サイドカー（制御/本文分離・将来 push） | 制御信号を本文から分離 | ⏸ defer（進化経路） | #112 偽陽性を構造的に根絶しうるが、クラッシュ耐性ある atomic 書込ラッパ + 二重メンテが必要。現時点は YAGNI |
+| **案D** producer-side typed event bus（既存 event-bus/audit） | 構造化イベント発行 | ⏸ defer（#188 と連結） | 既存 event-bus/audit は engine が検知後に emit する **recording・downstream であり acquisition でない**（[#206 ADR](./2026-06-22-decision-206-activity-log-self-contained-events.md)）。子が bus へ emit する「真の案D」は案C と #188 DJ-188-4 の合流＝将来 |
+| get-text/scrollback（`wez pane capture --start-line` / `wezterm cli get-text --start-line`） | scrape の延命 | ❌ 棄却 | [2026-05-18 ADR](./2026-05-18-decision-reviewer-output-file-redirect.md) が Step4-4 スコープ外で棄却済を本決定で再分類。描画グリッド依存は残り scrape の本質的脆さを解消しない |
+| #20 `wez agent` リッチ API 中間層 | プロトコル中間層 | ⏸ future | #20 Phase 3 で着手予定。pane scrape でも file-redirect でもない別カテゴリ |
+| agmsg 型 SQLite-WAL バス | 構造化バス | ⏸ defer（Track-B） | research note の experiment/defer 対象。常駐購読プロセスのライフサイクル管理（agmsg #66-68）が同型の落とし穴 |
+| 対話 TUI 用 別チャネル（セッション JSONL / フック） | 対話 orchestrate | ⏸ defer | #114 が明示的に切り出した別課題。本サイクル対象外 |
+
+## 結果
+
+- target/reviewer の取得チャネルが file-redirect に統一され、#98 の「経路の非対称＝将来 hazard」が解消。
+- 完了 acquisition の正準が明文化され、scrape の正当な残存用途（readiness / 対話 attach）と区別された。
+- 取得×配送×制御分離×(acquisition vs recording) の軸により、案C/案D/push 配送への将来拡張が記述上 open に保たれた。
+- 全テスト 23 ファイル green / shellcheck clean。実装SO（`oe-review`）を PR 前に実施。

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
@@ -139,3 +139,23 @@ closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / b
 - follow-up routing は網羅と確認（漏れなし）。
 - 揮発 scratchpad の要点は ADR 棄却案節へ転記済と確認。Step4 結果リンク未記入 → **本記述で充足**。
 - **back-propagation 漏れ（valid）**: 先行 ADR `2026-05-18-decision-reviewer-output-file-redirect.md` が reviewer の旧 `tee` を accepted のまま載せ、umask 是正への前方参照が無い → 同 ADR に #114 ADR への補足参照を **1 行追記して是正**。
+
+## Follow-up（2026-07-01・PR #216 受け入れレビュー対応・追記）
+
+closure 後の追記（リアルタイム追記の延長・上記本体は overwrite しない）。親の受け入れレビューからの 2 件を 1 ラウンドで対応。
+
+### Copilot レビュー対応（PR #216・1 ラウンド）
+
+未返信 Copilot スレッド 2 件（spawn.sh:257 / verify.sh:281）。**同一の妥当な指摘**: `umask 077` は **新規作成時のみ** mode を決めるため、ログが既存（前回 run 残り等）だと `tee` が既存 mode を保持し 0600 保証が崩れる。
+
+- 対応（valid・修正）: `tee` 直前に `rm -f "$log_path"` を追加し、必ず restrictive umask 下で作り直す。spawn.sh(target) + verify.sh(reviewer) 両方。/tmp で実証（stale 0644 + umask のみ→0644 / +rm -f→0600・exit code 捕捉維持）。e2e に rm -f 回帰アサーション 2 件追加。両スレッドへ返信済。
+- 残（defer・既記載）: /tmp symlink 攻撃の完全対処は保存先を 0700 専用 dir へ移す別 issue 候補（rm -f は TOCTOU 残あり・現実的な stale 0644 ケースは解消）。
+- 1 ラウンドで完結。再レビュー再依頼（`--add-reviewer @copilot`）はしない（ユーザー明示時のみ）。
+
+### episode 訂正（親ファクトチェック反映）
+
+本体の数値を残したまま訂正を追記（additive）:
+
+- **e2e テスト数**: テスト節「`test_e2e_smoke` … 46 PASS」は誤り。umask アサーション追加で **48**、本 follow-up の rm -f アサーション追加で現在 **50 PASS**（`bash tests/test_e2e_smoke.sh` で確認）。
+- **bash 3.2 失敗の明記（選択的省略の補完）**: 「全 23 テストファイル green」は **bash 5.2.37 での結果**。macOS 標準 `/bin/bash`（**3.2.57**）では `tests/test_*.sh` 23 件中 **21 green / 2 fail**（`test_monitor` 本 PR 変更・`test_cleanup` 未変更）。原因は **#193 の既存債務**（`declare -A` 連想配列＝bash 4+ 必須、`test_monitor.sh:37 line 37: declare: -A: invalid option`）。**master の同テストも 3.2 で同様に fail＝本変更の回帰ではない**（master 版を 3.2 で実行し確認）。bash 5.2 では 23 件全 green。
+- **行番号ドリフト**: 上記「設計フェーズ」の `oe_audit_emit "session_end"` 参照 `monitor.sh:123` は master 時点の値。本変更でコメント追加により現在 **:128**（attach.sh:45 は不変）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
@@ -76,4 +76,11 @@ acquisition チャネルの正準ベースライン = 非対話 one-shot の `2>
 
 ### 検証ゲート
 
-- 実装SO（`oe-review`・reviewed diff バインド・設計SO と別レンズ）: （結果を追記）
+- 実装SO（`oe-review`・reviewed diff バインド・設計SO と別レンズ）: **refuted**（1/2 material・audit_id `202606301215340G0VFGFZW3R5`）。
+  - codex(refuted): target transcript を権限制限なしの `tee /tmp/oe-{sid}-{pane}-target.log`（既定 umask 022 → 0644 world-readable）へ永続化。pane 表示のみ（ephemeral）だった target が共有 /tmp 上の読み取り可能ファイルに露出。秘密情報を含み得る。cleanup は best-effort で実行中/異常終了時を防げない。
+  - cursor(survived): correctness/堅牢性に material 欠陥なし。
+  - 注: reviewer 経路（verify.sh:277 の `tee …-reviewer.log`）も同じ露出を持つ**先行 issue**。本変更は同パターンを target へ水平展開した結果、target にも露出が及んだ。
+  - 規律どおり PR を保留。修正方針（log 作成時に `umask 077` で 0600）と reviewer 同時是正の要否を人間と確認 → **target+reviewer 両方**を選択。
+  - 修正: `( umask 077 ; ( cmd 2>&1 ; printf @@OE_EXIT ) | tee log )` に。tee はパイプライン側なので umask はパイプライン全体を囲う外側 subshell で設定（左 subshell 内では効かない＝/tmp で実証: 左のみ 0644 / 全体囲い 0600、exit code 捕捉も維持）。spawn.sh(target) + verify.sh(reviewer) 両方。e2e に umask 077 回帰アサーション追加。
+  - 再 oe-review（同 diff）: （結果を追記）
+  - 学び: 設計SO（oe-refute・breadth）を通過しても実装SO（oe-review・コード欠陥/到達可能性）が別レンズで material 欠陥を捕捉した。両 SO は代替不可（#192 の false-pass 回避の実例）。

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
@@ -1,0 +1,79 @@
+---
+id: "01KWC6K04BKRM56PJZ6MCZ34K9"
+title: "#114 クリーン出力チャネル統一(scrape脱却)ADR + #98 target file-redirect 実装"
+date: 2026-06-30
+type: episode
+status: in-development
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
+    reason: "方針/ADR レベル（クリーン取得チャネルの正準化）"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/98"
+    reason: "target 経路の具体実装（file-redirect 統一）"
+  - type: decision
+    ref: ../decisions/2026-06-30-decision-114-clean-output-channel.md
+    reason: "本 episode が生んだ ADR"
+  - type: refines
+    ref: ../decisions/2026-05-18-decision-reviewer-output-file-redirect.md
+    reason: "reviewer を file-redirect 化した先行 ADR。target 側を同経路へ統一して非対称を解消"
+tags: [orchestration, capture-channel, scrape, file-redirect, adr, episode]
+---
+
+# #114 クリーン出力チャネル統一 + #98 target file-redirect 実装
+
+委譲子セッション（親＝統括）。設計・実装は人間とこのペインで直接、完了確認のみ親へ。
+
+## 設計フェーズ（discussion → predecision → 設計確定）
+
+### 現状コードマップ（検証済み）
+
+両系統とも**非対話 one-shot** で起動済み。差は取得チャネルのみ:
+
+- target (cursor-agent/composer-2): `cursor-agent --print --force`〔lib/spawn.sh:203〕→ `wez pane send` 生コマンド〔spawn.sh:244-246〕→ `wez pane capture --lines 50`(2D グリッド scrape)〔capture.sh:48〕。
+- reviewer (claude/sonnet-4-6): `claude -p --output-format text`〔spawn.sh:208〕→ `( cmd 2>&1; printf @@OE_EXIT ) | tee /tmp/oe-{rsid}-reviewer.log`〔verify.sh:274-279〕→ `tail -n 5000` でログ走査〔verify.sh:491〕。
+
+→ 「非対話 claude -p」は既に両系統で成立。残ギャップは **target の取得チャネルが pane-scrape のまま**という非対称（#98 = その target 脚の実装）。
+
+### predecision-exploration（ゼロベース代替＋設計SO）
+
+初期案 A/B/C を外部化し、確定前に `oe-refute --rubric exploration`（設計SO）を実行。
+
+- 設計SO: `oe-refute --claim claim-114.md --rubric exploration`、lanes=2(codex,cursor)
+- verdict: **refuted**（2/2 material）/ audit_id `20260630094501F1333D1JNE4W`
+- codex: 「既存 typed event/audit JSONL の producer-side channel と get-text/scrollback 代替が未評価。grounding 不足」
+- cursor: 「event-bus/audit/wez-agent/oe-capture/readiness-scrape の第4カテゴリ未評価。2>&1 tee・二重マーカー・機械scrape残存」
+
+規律どおり**確定を保留**し、指摘を一次情報で grounding:
+
+- 案B 棄却根拠の修正: `cursor-agent --output-format json|stream-json`・`claude -p --output-format json` とも**サポートを一次確認**。棄却は「json不明」でなく pane喪失 + Phase3「ランタイムは借りる」逸脱 + blast radius に拠る。
+- 案D(既存 event-bus/audit)は **acquisition 層でない**: `oe_audit_emit "session_end" … "$OE_CLASSIFY_STATE"`〔monitor.sh:123, attach.sh:45〕は engine が検知後に記録＝recording・downstream。→ ADR に **acquisition(子→engine) vs recording(engine→JSONL)** 軸を新設。
+- 「scrape を人間補助に降格」は過大: scrape は readiness 判定〔spawn.sh:102-106〕と対話 attach `bin/oe-capture`(#109)で機械必須。降格スコープは「非対話 target の完了 acquisition」に限定。
+- チャネルは "stdout" でなく `2>&1` transcript。per-session ログ `/tmp/oe-{sid}-*.log` で agmsg 共有ファイル破損とは無縁。
+
+確定前証跡（探索木＋verdict/reason）: 別途記録し ADR 「棄却・defer 案」節へ蒸留。人間に再提示 → **これで確定** の承認を得た（収束 cutoff = 人間）。
+
+### 確定した設計（= ADR）
+
+acquisition チャネルの正準ベースライン = 非対話 one-shot の `2>&1` transcript を協調 file-redirect(per-session)。scrape は acquisition から降格（readiness/対話 attach では機械継続）。案A を #98 実装ベースラインに採用。詳細は ADR 参照。
+
+## 実装フェーズ（#98 = 案A target 脚）
+
+- ブランチ `feature/#114_clean_output_channel`（master 最新・issue起点）作成。
+- `lib/capture.sh`: `_oe_target_log_path`（`/tmp/oe-{sid}-{pane}-target.log` の単一情報源）+ `_oe_scan_log_file`（log 走査の共通コア）を新設。
+- `lib/verify.sh:_oe_verify_scan_log_file` を共通コアへ委譲する薄いラッパに（reviewer 呼び出し側不変）。
+- `lib/spawn.sh:oe_spawn_send`: target 送信を `( cmd 2>&1 ; printf @@OE_EXIT ) | tee target.log` に統一。tee で pane TTY にも出るため人間の pane 観察を保持。
+- `lib/monitor.sh`: scan を `oe_capture_scan`（pane scrape）→ `_oe_scan_log_file "$(_oe_target_log_path …)"` に切替。EXIT 消費部は不変。
+- `lib/cleanup.sh`: 変更不要（glob が target log を捕捉）。
+- 設計上の判断: target log は `(session_id, pane_id)` 鍵（#98 の multi-pane 動機でログ衝突回避）。spawn と monitor が同関数を使いパス書式 drift を排除。
+
+### テスト
+
+- `tests/test_monitor.sh`: monitor のループ制御を対象にするため scan 層（`_oe_scan_log_file`/`_oe_target_log_path`）をモック化（pane capture 廃止）。31 PASS。
+- `tests/test_capture.sh`: `_oe_target_log_path`/`_oe_scan_log_file` の実ファイル単体テスト追加（不在 file 安全 / EXIT 検出 / 長文 tail / 字下げ正規化 / プロンプトエコー非検知）。112 PASS。
+- `tests/test_e2e_smoke.sh`: wez mock の send に target tee 検知ブロック追加、capture-count assertion → tee-path assertion に更新。46 PASS。
+- 全 23 テストファイル green / shellcheck clean（lib 4 + tests 3）。
+
+### 検証ゲート
+
+- 実装SO（`oe-review`・reviewed diff バインド・設計SO と別レンズ）: （結果を追記）

--- a/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
+++ b/projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md
@@ -3,7 +3,7 @@ id: "01KWC6K04BKRM56PJZ6MCZ34K9"
 title: "#114 クリーン出力チャネル統一(scrape脱却)ADR + #98 target file-redirect 実装"
 date: 2026-06-30
 type: episode
-status: in-development
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/114"
@@ -82,5 +82,60 @@ acquisition チャネルの正準ベースライン = 非対話 one-shot の `2>
   - 注: reviewer 経路（verify.sh:277 の `tee …-reviewer.log`）も同じ露出を持つ**先行 issue**。本変更は同パターンを target へ水平展開した結果、target にも露出が及んだ。
   - 規律どおり PR を保留。修正方針（log 作成時に `umask 077` で 0600）と reviewer 同時是正の要否を人間と確認 → **target+reviewer 両方**を選択。
   - 修正: `( umask 077 ; ( cmd 2>&1 ; printf @@OE_EXIT ) | tee log )` に。tee はパイプライン側なので umask はパイプライン全体を囲う外側 subshell で設定（左 subshell 内では効かない＝/tmp で実証: 左のみ 0644 / 全体囲い 0600、exit code 捕捉も維持）。spawn.sh(target) + verify.sh(reviewer) 両方。e2e に umask 077 回帰アサーション追加。
-  - 再 oe-review（同 diff）: （結果を追記）
+  - 再 oe-review（同 diff・audit_id `20260630122954FD9EF151FGHT`）: **survived**（2/2・codex が umask 077 の transcript 権限制限を実コードで確認、cursor も umask 0600・共通 scan primitive の一貫性を確認）。
   - 学び: 設計SO（oe-refute・breadth）を通過しても実装SO（oe-review・コード欠陥/到達可能性）が別レンズで material 欠陥を捕捉した。両 SO は代替不可（#192 の false-pass 回避の実例）。
+
+## Closure（episode-retrospective・heavy tier）
+
+tier: **heavy**（実行中に SO 2回 refuted→修正の方針反映 / 意図的外部レビュー2レーン[oe-refute, oe-review×2] / 非自明設計判断[A-D・acquisition vs recording 軸] / Decision 昇格あり）。
+
+### closure gate checklist
+
+- **Context / なぜ**: 冒頭に記載済（両系統とも非対話 one-shot 化済で残ギャップは target の取得チャネルが pane-scrape のまま＝非対称。#114 が方針、#98 が target 実装）。
+- **次の消費者**: #98（target file-redirect 実装の親 issue・本 PR で close）/ 将来 push 配送・案C/案D を検討する engine 拡張（#188 typed event bus・#105 Phase5）/ scrape の正当残存用途（readiness・oe-capture #109）を触る作業。
+- **follow-up routing**:
+  - reviewer 経路の同露出 → **本 PR で同時是正済**（umask 077）。
+  - ログ保存先を共有 `/tmp` → 専用ディレクトリ（`OE_DATA_DIR` 下 0700 等）へ移すハードニング → **defer・別 issue 候補**（reviewer 含む大きめ変更）。ADR 結果節に明記。
+  - 案C（構造化 sidecar）/ 案D（子が typed event を emit）/ push 配送 → **defer・進化経路**として ADR に外部化（#188 / #105 と連結）。
+  - 対話 TUI orchestrate の別チャネル → **defer**（#114 が明示的に切り出した別課題）。
+- **status 確定**: draft → **stable**（達成: #114 ADR 確定 + #98 target 実装完了・全テスト green・両 SO クリア）。
+- **evidence anchor**: 設計SO audit_id `20260630094501F1333D1JNE4W`、実装SO refuted `202606301215340G0VFGFZW3R5` / survived `20260630122954FD9EF151FGHT`。設計SO の探索木 trace は揮発 scratchpad（dj-114-tree.md）だったが**内容を ADR 棄却案節へ転記済**（パス依存を排除）。
+
+### 事実・失敗
+
+- 設計SO（oe-refute）が **refuted**（2/2）。第4カテゴリ（既存 event-bus/audit の producer-side channel・get-text/scrollback）未評価と grounding 不足を指摘 → 一次情報で grounding し ADR の幅・精度を是正（本文「設計フェーズ」§predecision 参照）。
+- 実装SO（oe-review）が **refuted**（1/2 material）。transcript を /tmp に 0644 で露出するセキュリティ欠陥 → `umask 077`（0600）で是正、再 oe-review survived（本文「検証ゲート」参照）。
+- いずれも選択的省略なし（両 refuted の audit_id・修正・再検証を上記に明記）。
+
+### 決定と根拠（→ Decision 昇格済）
+
+本 episode の設計判断は ADR `2026-06-30-decision-114-clean-output-channel.md` に蒸留（取得チャネル正準化・scrape 降格スコープ・取得×配送×制御分離×acquisition/recording 軸・棄却/defer 案）。
+
+### わかったこと（W）
+
+- target/reviewer は**既に両方とも非対話 one-shot**（`cursor-agent --print` / `claude -p`）。#114 の初期案「非対話 claude -p + file-redirect」のうち非対話部分は実現済で、残ギャップは取得チャネルのみだった（設計の最大の単純化点）。
+- 既存 event-bus/audit JSONL は engine が**検知後に emit する recording・downstream** であり、acquisition チャネルではない（混同しやすい・設計SO が指摘）。
+- `cursor-agent`/`claude` とも `--output-format json` を一次確認（案B 棄却根拠は「json 不明」でなく pane 喪失・Phase3 逸脱）。
+- パイプライン `( cmd ) | tee` の umask は**外側 subshell で囲わないと tee に効かない**（/tmp で実証）。
+
+### 原則（Pattern / Anti-pattern）
+
+- Pattern: 取得経路を統一するとき**パス書式の単一情報源**（`_oe_target_log_path`）を spawn/monitor で共有 → 経路非対称ハザード（#98 が警戒）を構造的に排除。
+- Anti-pattern: 取得チャネルを file-redirect 化する際、transcript を**共有 /tmp に既定 umask（0644）で**落とす → world-readable 露出。`( umask 077; … | tee )` で 0600 にする。チャネル統一は「機能」だけでなく**権限**も統一せよ。
+- Pattern: 設計SO（breadth）と実装SO（コード欠陥）は**別レンズ・別ステップ**。設計SO 通過は実装SO の代替にならない（本 episode で実装SO のみが material セキュリティ欠陥を捕捉）。
+
+### 蒸留シグナル
+
+- Decision: **昇格済**（本 ADR）。
+- skill/rule: なし（既存 episode-flow / predecision / SO 群で覆われる）。
+- negative knowledge（#62）: 「file-redirect 化で /tmp 既定 umask 露出」は anti-pattern 候補として上記に記録。
+
+### Step4 外部チェック
+
+closure 品質（失敗の選択的省略 / routing 網羅 / evidence anchor / back-propagation）の focused check を `so-compare`（codex）で実施。出力: `tmp/so-20260630-213846/codex-stdout.txt`。
+
+結果=部分合格。指摘と対応:
+- 選択的省略なし（両 refuted は記録済）と確認。ただし機械確認用に `事実・失敗` 見出しが無い → **本 closure に追加**（上記）。
+- follow-up routing は網羅と確認（漏れなし）。
+- 揮発 scratchpad の要点は ADR 棄却案節へ転記済と確認。Step4 結果リンク未記入 → **本記述で充足**。
+- **back-propagation 漏れ（valid）**: 先行 ADR `2026-05-18-decision-reviewer-output-file-redirect.md` が reviewer の旧 `tee` を accepted のまま載せ、umask 是正への前方参照が無い → 同 ADR に #114 ADR への補足参照を **1 行追記して是正**。

--- a/projects/orchestration-engine/lib/capture.sh
+++ b/projects/orchestration-engine/lib/capture.sh
@@ -53,6 +53,53 @@ oe_capture_scan() {
   _oe_capture_scan_parse "$normalized"
 }
 
+# _oe_target_log_path — orchestrate 対象 (target) の file-redirect ログパスを 1 箇所で生成する。
+#
+# spawn 側 (tee 構築) と monitor 側 (scan) の両方がこの関数を使い、パス書式の drift を防ぐ
+# (#98: 経路の非対称そのものが将来の hazard 要因)。reviewer は単一なので session 単独鍵
+# (/tmp/oe-{rsid}-reviewer.log) で足りるが、target は monitor が複数ペインを並走しうる
+# (#98 動機: multi-pane) ため pane_id も鍵に含め、同一 session の複数ペインが同じログへ tee して
+# marker が混ざるのを防ぐ。共通 glob /tmp/oe-{session_id}-* (cleanup.sh:55) で掃除されるよう
+# session_id 前置を維持する (target log の cleanup 追加変更は不要)。
+_oe_target_log_path() {
+  local session_id="$1"
+  local pane_id="$2"
+  printf '/tmp/oe-%s-%s-target.log' "$session_id" "$pane_id"
+}
+
+# _oe_scan_log_file — file-redirect ログから marker をスキャンする共通コア。
+#
+# tail で末尾 N 行を取り、capture 経路と同じ正規化 (_oe_normalize_capture_output) + parse
+# (_oe_capture_scan_parse) を適用する。pane scrape (oe_capture_scan) と違い WezTerm の
+# viewport-only / 2D グリッド描画に依存しないため、長文・行折返し・装飾でも marker を取りこぼさない
+# (#114: クリーン取得チャネル / #98: target を本経路へ統一)。
+# verify 経路 (verify.sh:_oe_verify_scan_log_file) と monitor 経路 (target) の双方から呼ぶ
+# 単一の primitive。正規化を含め経路間差異 (=ロケール依存の取り残し) を 1 箇所に集約する。
+#
+# 引数: log_path, [lines] (既定 5000 — 長文 markdown でも marker が tail 内に収まる量)
+# 戻り値: OE_SCAN_* 変数群 (_oe_capture_scan_parse と同じインターフェース)。
+#         file 不在時は OE_SCAN_* を空のまま return 0 (cleanup と race しても無害に継続)。
+_oe_scan_log_file() {
+  local log_path="$1"
+  local lines="${2:-5000}"
+
+  OE_SCAN_MARKER_TYPE=""
+  OE_SCAN_VALUE=""
+  OE_SCAN_BLOCKED="false"
+  OE_SCAN_EXIT_CODE=""
+  OE_SCAN_VERIFY_RESULT=""
+
+  [[ -f "$log_path" ]] || return 0
+
+  local captured
+  captured="$(tail -n "$lines" "$log_path" 2>/dev/null)" || return 0
+
+  local normalized
+  normalized="$(_oe_normalize_capture_output "$captured")"
+
+  _oe_capture_scan_parse "$normalized"
+}
+
 # _oe_capture_scan_parse — capture 出力文字列をパースする内部関数
 # テスト容易性のために wez 呼び出しと分離
 #

--- a/projects/orchestration-engine/lib/monitor.sh
+++ b/projects/orchestration-engine/lib/monitor.sh
@@ -105,8 +105,13 @@ oe_monitor_loop() {
     fi
 
     # 各ペインスキャン + マーカー処理
+    #
+    # #114/#98: pane scrape (oe_capture_scan = wez pane capture, viewport-only/2D グリッド) でなく
+    #   target が tee した per-session ログファイルを走査する (spawn.sh:oe_spawn_send が同じ
+    #   _oe_target_log_path で tee 先を組む = パス書式の単一情報源)。OE_SCAN_MARKER_TYPE=EXIT の
+    #   消費部 (下記 case) は不変で、marker の source が pane→file に変わるだけ。
     for pane_id in "${pending[@]}"; do
-      oe_capture_scan "$pane_id"
+      _oe_scan_log_file "$(_oe_target_log_path "$session_id" "$pane_id")"
 
       case "$OE_SCAN_MARKER_TYPE" in
         EXIT)

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -244,12 +244,17 @@ oe_spawn_send() {
   #   `( cmd 2>&1 ; printf @@OE_EXIT ) | tee log_path` 形で stdout+stderr+marker を per-session
   #   ログへ落とし、monitor は wez pane capture (2D グリッド scrape・viewport-only) でなく
   #   ログファイルを走査する。tee は pane TTY にも書くため人間は引き続き pane で観察できる。
-  #   exit code は subshell 末尾の $? で AI CLI のものを捕捉 (printf 自身の rc に汚染されない)。
+  #   exit code は内側 subshell 末尾の $? で AI CLI のものを捕捉 (printf 自身の rc に汚染されない)。
+  #
+  #   umask 077: transcript には task 本文/stderr/パス/秘密情報が含まれ得るため、共有 /tmp 上で
+  #   world-readable (既定 umask 022 → 0644) にしない。tee はパイプライン側プロセスなので umask は
+  #   パイプライン全体を囲う外側 subshell で設定する (左 subshell 内だけでは tee に効かない)。
+  #   → ログは 0600。umask 変更は subshell scope でペインの対話シェルに波及しない (実装SO #114 反映)。
   local log_path
   log_path="$(_oe_target_log_path "$session_id" "$pane_id")"
 
   local cli_command
-  cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
+  cli_command="( umask 077 ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
 
   wez pane send "$pane_id" "$cli_command"
 

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -250,11 +250,15 @@ oe_spawn_send() {
   #   world-readable (既定 umask 022 → 0644) にしない。tee はパイプライン側プロセスなので umask は
   #   パイプライン全体を囲う外側 subshell で設定する (左 subshell 内だけでは tee に効かない)。
   #   → ログは 0600。umask 変更は subshell scope でペインの対話シェルに波及しない (実装SO #114 反映)。
+  #   rm -f: umask は **新規作成時のみ** mode を決める。同パスが既存 (前回 run の残り等) だと tee は
+  #   既存 mode を保持して 0600 保証が崩れるため、tee 直前に削除して必ず restrictive umask 下で
+  #   作り直す (Copilot PR #216 指摘反映)。/tmp symlink 攻撃の完全対処は保存先を 0700 専用 dir へ
+  #   移す別 issue 候補 (ADR 残ハードニング候補) で扱う。
   local log_path
   log_path="$(_oe_target_log_path "$session_id" "$pane_id")"
 
   local cli_command
-  cli_command="( umask 077 ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
+  cli_command="( umask 077 ; rm -f \"${log_path}\" ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
 
   wez pane send "$pane_id" "$cli_command"
 

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -240,8 +240,16 @@ oe_spawn_send() {
   local base_cli_command
   base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$envelope_path" "$workspace")"
 
+  # #114/#98: target も reviewer (verify.sh) と同じ file-redirect 経路に統一する。
+  #   `( cmd 2>&1 ; printf @@OE_EXIT ) | tee log_path` 形で stdout+stderr+marker を per-session
+  #   ログへ落とし、monitor は wez pane capture (2D グリッド scrape・viewport-only) でなく
+  #   ログファイルを走査する。tee は pane TTY にも書くため人間は引き続き pane で観察できる。
+  #   exit code は subshell 末尾の $? で AI CLI のものを捕捉 (printf 自身の rc に汚染されない)。
+  local log_path
+  log_path="$(_oe_target_log_path "$session_id" "$pane_id")"
+
   local cli_command
-  cli_command="${base_cli_command} ; printf '\\n@@OE_EXIT:%d\\n' \$?"
+  cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
 
   wez pane send "$pane_id" "$cli_command"
 

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -268,13 +268,17 @@ oe_verify_spawn() {
   # `( cmd 2>&1 ; printf @@OE_EXIT ) | tee log_path` の形にすることで:
   #   - claude/cursor の stdout/stderr と @@OE_EXIT の両方を 1 つの log file に同順序で記録
   #   - pane (TTY) には引き続き出力されるので人間可視性は維持
-  #   - bash の PIPESTATUS 依存を回避 (sub-shell 内の $? で claude exit code を反映)
-  # scan は file 経路 (_oe_verify_scan_log_file) に切替済み。
+  #   - bash の PIPESTATUS 依存を回避 (内側 sub-shell 内の $? で claude exit code を反映)
+  # scan は file 経路 (_oe_verify_scan_log_file → capture.sh:_oe_scan_log_file) に切替済み。
+  #
+  # umask 077: reviewer transcript も秘密情報を含み得るため共有 /tmp 上で world-readable に
+  #   しない (target と統一・実装SO #114 反映)。tee はパイプライン側なので umask はパイプライン
+  #   全体を囲う外側 subshell で設定する。→ ログは 0600。
   local log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
   local base_cli_command
   base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$OE_VERIFY_ENVELOPE_PATH" "$PROJECT_DIR")"
   local cli_command
-  cli_command="( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\""
+  cli_command="( umask 077 ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
 
   wez pane send "$reviewer_pane_id" "$cli_command"
 

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -274,11 +274,13 @@ oe_verify_spawn() {
   # umask 077: reviewer transcript も秘密情報を含み得るため共有 /tmp 上で world-readable に
   #   しない (target と統一・実装SO #114 反映)。tee はパイプライン側なので umask はパイプライン
   #   全体を囲う外側 subshell で設定する。→ ログは 0600。
+  #   rm -f: umask は新規作成時のみ mode を決めるため、既存ログ (前回 run 残り等) があると tee が
+  #   既存 mode を保持して 0600 保証が崩れる。tee 直前に削除して必ず作り直す (Copilot PR #216 指摘・target と対称)。
   local log_path="/tmp/oe-${reviewer_session_id}-reviewer.log"
   local base_cli_command
   base_cli_command="$(_oe_spawn_build_cli_command "$ai_cli" "$ai_model" "$OE_VERIFY_ENVELOPE_PATH" "$PROJECT_DIR")"
   local cli_command
-  cli_command="( umask 077 ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
+  cli_command="( umask 077 ; rm -f \"${log_path}\" ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
 
   wez pane send "$reviewer_pane_id" "$cli_command"
 

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -475,27 +475,12 @@ oe_verify_emit_completed() {
 #   適用する実装 (wezterm-ai-mode ADR-004:65)。長文 markdown では @@OE_VERIFY が viewport 外に
 #   押し出されて拾えない。reviewer 送信側で `( cmd ; printf @@OE_EXIT ) | tee log_path` に
 #   切替えており、本関数は log file 経路で同じ parse を行う。
+#
+# #114/#98: log-file 走査の実体は capture.sh:_oe_scan_log_file に集約済み (target 経路と共有する
+#   単一 primitive)。本関数は reviewer 呼び出し側の名前を維持する薄いラッパ。正規化 (#112) も
+#   共通コア側で適用される。
 _oe_verify_scan_log_file() {
-  local log_path="$1"
-  local lines="${2:-5000}"
-
-  OE_SCAN_MARKER_TYPE=""
-  OE_SCAN_VALUE=""
-  OE_SCAN_BLOCKED="false"
-  OE_SCAN_EXIT_CODE=""
-  OE_SCAN_VERIFY_RESULT=""
-
-  [[ -f "$log_path" ]] || return 0
-
-  local captured
-  captured="$(tail -n "$lines" "$log_path" 2>/dev/null)" || return 0
-
-  # #112: capture 経路と同じ正規化（U+3000/NBSP 畳み込み含む）を共通ヘルパーで適用し、
-  # log-file 経路だけ字下げ marker がロケール依存で残る取りこぼしを防ぐ（Copilot 指摘）。
-  local normalized
-  normalized="$(_oe_normalize_capture_output "$captured")"
-
-  _oe_capture_scan_parse "$normalized"
+  _oe_scan_log_file "$1" "${2:-5000}"
 }
 
 # _oe_verify_generate_session_id — 検証 agent 用の ULID 形式セッション ID を生成

--- a/projects/orchestration-engine/tests/test_capture.sh
+++ b/projects/orchestration-engine/tests/test_capture.sh
@@ -356,6 +356,48 @@ echo "-- exit_code=42 → protocol_error --"
 oe_capture_classify 42
 assert_eq "state" "protocol_error" "$OE_CLASSIFY_STATE"
 
+# --- #114/#98: _oe_target_log_path（target log の単一情報源） ---
+echo ""
+echo "=== #114/#98: _oe_target_log_path ==="
+assert_eq "session+pane 鍵で /tmp/oe-{sid}-{pane}-target.log" \
+  "/tmp/oe-SESS01-777-target.log" "$(_oe_target_log_path "SESS01" "777")"
+assert_eq "別 pane は別パス（同一 session でも衝突しない）" \
+  "/tmp/oe-SESS01-888-target.log" "$(_oe_target_log_path "SESS01" "888")"
+
+# --- #114/#98: _oe_scan_log_file（file-redirect ログ走査の共通コア） ---
+echo ""
+echo "=== #114/#98: _oe_scan_log_file ==="
+_SCAN_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$_SCAN_TMPDIR"' EXIT
+
+echo "-- ファイル不在 → OE_SCAN_* 空・return 0（cleanup と race しても無害） --"
+_rc=0
+_oe_scan_log_file "${_SCAN_TMPDIR}/nonexistent.log" || _rc=$?
+assert_eq "return 0" "0" "$_rc"
+assert_eq "MARKER_TYPE 空" "" "$OE_SCAN_MARKER_TYPE"
+
+echo "-- @@OE_EXIT:0 を含むログ → EXIT 検出 --"
+printf 'target output line 1\ntarget output line 2\n\n@@OE_EXIT:0\n' > "${_SCAN_TMPDIR}/exit0.log"
+_oe_scan_log_file "${_SCAN_TMPDIR}/exit0.log"
+assert_eq "MARKER_TYPE=EXIT" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "EXIT_CODE=0" "0" "$OE_SCAN_EXIT_CODE"
+
+echo "-- 多数行の末尾に marker（tail で確実に拾う＝viewport-only 非依存） --"
+{ for i in $(seq 1 300); do echo "verbose line $i"; done; printf '@@OE_EXIT:1\n'; } > "${_SCAN_TMPDIR}/long.log"
+_oe_scan_log_file "${_SCAN_TMPDIR}/long.log"
+assert_eq "MARKER_TYPE=EXIT（長文でも検出）" "EXIT" "$OE_SCAN_MARKER_TYPE"
+assert_eq "EXIT_CODE=1" "1" "$OE_SCAN_EXIT_CODE"
+
+echo "-- TUI 字下げ marker（先頭空白）→ 正規化で検出（#112 と同経路） --"
+printf '  @@OE_EXIT:0\n' > "${_SCAN_TMPDIR}/indent.log"
+_oe_scan_log_file "${_SCAN_TMPDIR}/indent.log"
+assert_eq "字下げ marker 検出" "0" "$OE_SCAN_EXIT_CODE"
+
+echo "-- プロンプトエコー行（marker 後にテキスト）→ 誤検知しない（行末アンカー維持） --"
+printf '正確に @@OE_EXIT:0 とだけ出力してください\n' > "${_SCAN_TMPDIR}/echo.log"
+_oe_scan_log_file "${_SCAN_TMPDIR}/echo.log"
+assert_eq "エコー行は EXIT 非検出" "" "$OE_SCAN_EXIT_CODE"
+
 # --- サマリ ---
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -144,6 +144,11 @@ assert_eq "state.state" "success" "$(jq -r '.state' "$state_file")"
 # ことで確認する（reviewer の tee assertion と対称）。
 assert_eq "target payload に tee target.log (#114/#98)" "true" \
   "$(awk -F'|' '$1=="777" && match($0, /tee[[:space:]]+"[^"]+-target\.log"/){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
+# #114 実装SO 反映: transcript ログを world-readable にしないため payload は umask 077 で囲う。
+assert_eq "target payload に umask 077 (#114 secure log)" "true" \
+  "$(awk -F'|' '$1=="777" && index($0, "umask 077"){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
+assert_eq "reviewer payload に umask 077 (#114 secure log)" "true" \
+  "$(awk -F'|' '$1=="888" && index($0, "umask 077"){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
 
 assert_eq "session_start emitted" "1" \
   "$(jq -r 'select(.event_type=="session_start") | 1' "$audit_file" | wc -l | tr -d ' ')"

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -149,6 +149,11 @@ assert_eq "target payload に umask 077 (#114 secure log)" "true" \
   "$(awk -F'|' '$1=="777" && index($0, "umask 077"){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
 assert_eq "reviewer payload に umask 077 (#114 secure log)" "true" \
   "$(awk -F'|' '$1=="888" && index($0, "umask 077"){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
+# Copilot PR #216 反映: 既存ログの mode 保持で 0600 が崩れるのを防ぐため tee 前に rm -f。
+assert_eq "target payload に rm -f target.log (#216 pre-existing fix)" "true" \
+  "$(awk -F'|' '$1=="777" && match($0, /rm -f[[:space:]]+"[^"]+-target\.log"/){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
+assert_eq "reviewer payload に rm -f reviewer.log (#216 pre-existing fix)" "true" \
+  "$(awk -F'|' '$1=="888" && match($0, /rm -f[[:space:]]+"[^"]+-reviewer\.log"/){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
 
 assert_eq "session_start emitted" "1" \
   "$(jq -r 'select(.event_type=="session_start") | 1' "$audit_file" | wc -l | tr -d ' ')"

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -79,6 +79,12 @@ if [[ "${1:-}" == "pane" && "${2:-}" == "send" ]]; then
     reviewer_log="${BASH_REMATCH[1]}"
     printf 'review output\n@@OE_VERIFY:pass\n\n@@OE_EXIT:0\n' > "$reviewer_log"
   fi
+  # #114/#98: target pane (777) も file-redirect 経路に統一。payload の tee "...-target.log" を
+  # 検知し、@@OE_EXIT:0 を log file へ書く（monitor は wez pane capture でなく本 file を走査する）。
+  if [[ "$pane_id" == "777" ]] && [[ "$payload" =~ tee[[:space:]]+\"([^\"]+-target\.log)\" ]]; then
+    target_log="${BASH_REMATCH[1]}"
+    printf 'mock target output\n@@OE_EXIT:0\n' > "$target_log"
+  fi
   exit 0
 fi
 
@@ -132,8 +138,12 @@ assert_eq "audit file exists" "true" "$( [[ -f "$audit_file" ]] && echo true || 
 assert_eq "state.session_id" "$session_id" "$(jq -r '.session_id' "$state_file")"
 assert_eq "session_id matches ULID alphabet pattern" "true" "$( [[ "$session_id" =~ ^[0-9A-HJKMNP-TV-Z]{26}$ ]] && echo true || echo false )"
 assert_eq "state.state" "success" "$(jq -r '.state' "$state_file")"
-assert_eq "capture target pane (777) called at least once" "true" \
-  "$( [[ -f "${OE_MOCK_LOG_DIR}/capture_count_777" && "$(cat "${OE_MOCK_LOG_DIR}/capture_count_777")" -ge 1 ]] && echo true || echo false )"
+# #114/#98: target は file-redirect 経路で監視される（旧 capture_count_777 ≥1 assertion は廃止）。
+# monitor が wez pane capture でなく tee した log を走査することは、target payload (pane=777) に
+# tee /tmp/oe-{sid}-{pane}-target.log が含まれ、かつ state.state==success で 1 サイクル完走した
+# ことで確認する（reviewer の tee assertion と対称）。
+assert_eq "target payload に tee target.log (#114/#98)" "true" \
+  "$(awk -F'|' '$1=="777" && match($0, /tee[[:space:]]+"[^"]+-target\.log"/){found=1} END{print (found+0==1) ? "true" : "false"}' "${OE_MOCK_LOG_DIR}/send.log")"
 
 assert_eq "session_start emitted" "1" \
   "$(jq -r 'select(.event_type=="session_start") | 1' "$audit_file" | wc -l | tr -d ' ')"

--- a/projects/orchestration-engine/tests/test_monitor.sh
+++ b/projects/orchestration-engine/tests/test_monitor.sh
@@ -34,20 +34,12 @@ _MOCK_TMPDIR="${SCRIPT_DIR}/.tmp_test_monitor_$$"
 mkdir -p "$_MOCK_TMPDIR"
 trap 'rm -rf "$_MOCK_TMPDIR"' EXIT
 
-declare -A _MOCK_CAPTURE_OUTPUT
+declare -A _MOCK_SCAN_OUTPUT
 _MOCK_KILL_CALLS=()
 
-# wez モック（capture count はサブシェル対応のためファイルベース）
+# wez モック（CB の kill 経路用。#114/#98 以降 monitor は target を pane capture せず
+# log ファイルを走査するため capture 分岐は廃止）
 wez() {
-  if [[ "${1:-}" == "pane" && "${2:-}" == "capture" ]]; then
-    local pane_id="${3:-}"
-    local count_file="${_MOCK_TMPDIR}/capture_${pane_id}"
-    local current=0
-    [[ -f "$count_file" ]] && current=$(<"$count_file")
-    echo $(( current + 1 )) > "$count_file"
-    echo "${_MOCK_CAPTURE_OUTPUT[$pane_id]:-}"
-    return 0
-  fi
   if [[ "${1:-}" == "pane" && "${2:-}" == "kill" ]]; then
     _MOCK_KILL_CALLS+=("${3:-}")
     return 0
@@ -55,9 +47,37 @@ wez() {
   return 1
 }
 
-mock_capture_count() {
+# _oe_target_log_path / _oe_scan_log_file のモック（#114/#98）
+#
+# monitor は `_oe_scan_log_file "$(_oe_target_log_path "$session_id" "$pane_id")"` を呼ぶ。
+# 本テストは monitor の **ループ制御**（完了検知 / ポーリング継続 / CB）を対象にするため、
+# scan 層をモックして pane 単位の入力と呼び出し回数を制御する（log ファイル走査の実体
+# = capture.sh:_oe_scan_log_file / _oe_target_log_path は test_capture.sh で実ファイルで検証）。
+# _oe_target_log_path を「pane_id をそのまま返す」よう上書きし、mock の scan へ pane_id を渡す。
+_oe_target_log_path() {
+  printf '%s' "$2"
+}
+
+# scan モック: 渡された path(=pane_id) で呼び出し回数を記録し、_MOCK_SCAN_OUTPUT[pane] を
+# 実 parse (_oe_capture_scan_parse) に流して OE_SCAN_* を本物どおり設定する（parse 忠実性を保つ）。
+_oe_scan_log_file() {
   local pane_id="$1"
-  local count_file="${_MOCK_TMPDIR}/capture_${pane_id}"
+  local count_file="${_MOCK_TMPDIR}/scan_${pane_id}"
+  local current=0
+  [[ -f "$count_file" ]] && current=$(<"$count_file")
+  echo $(( current + 1 )) > "$count_file"
+
+  OE_SCAN_MARKER_TYPE=""
+  OE_SCAN_VALUE=""
+  OE_SCAN_BLOCKED="false"
+  OE_SCAN_EXIT_CODE=""
+  OE_SCAN_VERIFY_RESULT=""
+  _oe_capture_scan_parse "${_MOCK_SCAN_OUTPUT[$pane_id]:-}"
+}
+
+mock_scan_count() {
+  local pane_id="$1"
+  local count_file="${_MOCK_TMPDIR}/scan_${pane_id}"
   if [[ -f "$count_file" ]]; then
     cat "$count_file"
   else
@@ -91,7 +111,7 @@ oe_capture_write_kvs() {
 # --- モックリセット ---
 
 reset_mocks() {
-  _MOCK_CAPTURE_OUTPUT=()
+  _MOCK_SCAN_OUTPUT=()
   _MOCK_KILL_CALLS=()
   _MOCK_AUDIT_CALLS=()
   _MOCK_CLEANUP_CALLED=0
@@ -103,7 +123,7 @@ reset_mocks() {
   OE_CB_MAX_TURNS=10
   OE_CB_MAX_PANES=5
   OE_POLL_INTERVAL=2
-  rm -f "${_MOCK_TMPDIR}"/capture_* 2>/dev/null || true
+  rm -f "${_MOCK_TMPDIR}"/scan_* 2>/dev/null || true
 }
 
 # --- アサーション ---
@@ -145,7 +165,7 @@ assert_contains() {
 
 echo "=== Test a: 単一ペイン EXIT:0 → ループ終了 ==="
 reset_mocks
-_MOCK_CAPTURE_OUTPUT[p1]="task output
+_MOCK_SCAN_OUTPUT[p1]="task output
 @@OE_EXIT:0
 done"
 
@@ -154,7 +174,7 @@ oe_monitor_loop "sess-a" "p1"
 assert_eq "OE_DONE_PANES count" "1" "${#OE_DONE_PANES[@]}"
 assert_eq "OE_DONE_PANES[0]" "p1" "${OE_DONE_PANES[0]}"
 assert_eq "OE_LAST_STATE[p1]" "success" "$(_oe_monitor_last_state_get p1 || true)"
-assert_eq "capture count for p1" "1" "$(mock_capture_count p1)"
+assert_eq "scan count for p1" "1" "$(mock_scan_count p1)"
 assert_eq "KVS write count" "1" "$_MOCK_KVS_WRITE_COUNT"
 assert_eq "KVS args include session/pane/state" "sess-a|p1|success" "$_MOCK_KVS_LAST_ARGS"
 assert_contains "state_change emitted" "state_change|sess-a|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
@@ -168,7 +188,7 @@ echo ""
 echo "=== Test b: CB タイムアウト発動 ==="
 reset_mocks
 OE_CB_TIMEOUT=0
-_MOCK_CAPTURE_OUTPUT[p1]="no markers here"
+_MOCK_SCAN_OUTPUT[p1]="no markers here"
 
 oe_monitor_loop "sess-b" "p1" || true
 
@@ -185,15 +205,15 @@ echo ""
 echo "=== Test c: 複数ペイン — 1 完了 + 1 未完了 ==="
 reset_mocks
 OE_CB_MAX_TURNS=3
-_MOCK_CAPTURE_OUTPUT[p1]="@@OE_EXIT:0"
-_MOCK_CAPTURE_OUTPUT[p2]="still running"
+_MOCK_SCAN_OUTPUT[p1]="@@OE_EXIT:0"
+_MOCK_SCAN_OUTPUT[p2]="still running"
 
 oe_monitor_loop "sess-c" "p1" "p2" || true
 
 assert_eq "OE_DONE_PANES count" "1" "${#OE_DONE_PANES[@]}"
 assert_eq "OE_DONE_PANES[0]" "p1" "${OE_DONE_PANES[0]}"
-assert_eq "p1 capture count" "1" "$(mock_capture_count p1)"
-assert_eq "p2 capture count" "3" "$(mock_capture_count p2)"
+assert_eq "p1 scan count" "1" "$(mock_scan_count p1)"
+assert_eq "p2 scan count" "3" "$(mock_scan_count p2)"
 assert_contains "state_change for p1" "state_change|sess-c|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
 assert_contains "session_end for p1" "session_end|sess-c|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
 assert_contains "CB max_turns" \
@@ -207,12 +227,12 @@ echo ""
 echo "=== Test d: マーカーなし → ループ継続 ==="
 reset_mocks
 OE_CB_MAX_TURNS=3
-_MOCK_CAPTURE_OUTPUT[p1]="just normal output"
+_MOCK_SCAN_OUTPUT[p1]="just normal output"
 
 oe_monitor_loop "sess-d" "p1" || true
 
 assert_eq "OE_DONE_PANES count" "0" "${#OE_DONE_PANES[@]}"
-assert_eq "p1 capture count" "3" "$(mock_capture_count p1)"
+assert_eq "p1 scan count" "3" "$(mock_scan_count p1)"
 assert_contains "CB max_turns" \
   'circuit_breaker_triggered|sess-d|0||{"reason":"max_turns"}' \
   "${_MOCK_AUDIT_CALLS[@]}"
@@ -235,7 +255,7 @@ assert_eq "kill count" "3" "${#_MOCK_KILL_CALLS[@]}"
 echo ""
 echo "=== Test g: interrupt (SIGINT) ==="
 reset_mocks
-_MOCK_CAPTURE_OUTPUT[p1]="running without marker"
+_MOCK_SCAN_OUTPUT[p1]="running without marker"
 OE_CB_MAX_TURNS=100
 _OE_MONITOR_SLEEP_INT_PHASE=0
 sleep() {
@@ -262,7 +282,7 @@ sleep() { :; }
 echo ""
 echo "=== Test f: trap 復元 ==="
 reset_mocks
-_MOCK_CAPTURE_OUTPUT[p1]="@@OE_EXIT:0"
+_MOCK_SCAN_OUTPUT[p1]="@@OE_EXIT:0"
 
 oe_monitor_loop "sess-f" "p1"
 


### PR DESCRIPTION
## 概要

orchestrate 対象（target）の出力取得を、reviewer と同じ **file-redirect 経路**に統一し、screen-scrape（`wez pane capture`）への依存を完了 acquisition から外す。`#114` を方針 ADR として記録し、その target 脚の具体実装 `#98` を同サイクルで実装する。

着手前の調査で判明した重要事実: target/reviewer は**すでに両方とも非対話 one-shot**（`cursor-agent --print` / `claude -p`）。残っていた非対称は**取得チャネルのみ**（target=pane scrape / reviewer=file-redirect）だった。

## 決定（ADR・#114）

`projects/orchestration-engine/docs/decisions/2026-06-30-decision-114-clean-output-channel.md`

- 正準取得チャネル = 非対話 one-shot の `2>&1` transcript を**協調 file-redirect**（per-session）し `tail` 走査。
- scrape は**非対話 target の完了 acquisition から降格**。ただし readiness 判定（`oe_board_wait_ready`）と対話 attach（`bin/oe-capture` #109）では機械的に継続。
- 記述軸: **取得(how) × 配送(when: push/poll) × 制御/本文の分離 × acquisition vs recording**。案C（構造化 sidecar）/ 案D（子が typed event を emit）/ push 配送を進化経路として open に。
- 対話 TUI orchestrate は別チャネル課題として defer。

## 実装（#98）

- `lib/capture.sh`: `_oe_scan_log_file`（log 走査の共通コア・reviewer/target 共有）+ `_oe_target_log_path`（`/tmp/oe-{sid}-{pane}-target.log` の単一情報源）を新設。
- `lib/spawn.sh`: target 送信を `( umask 077 ; ( cmd 2>&1 ; printf @@OE_EXIT ) | tee target.log )` に統一。tee で pane TTY にも出力 → 人間の pane 観察を保持。
- `lib/monitor.sh`: scan を `oe_capture_scan`（pane scrape）→ `_oe_scan_log_file` に切替（`OE_SCAN_MARKER_TYPE=EXIT` 消費部は不変）。
- `lib/verify.sh`: `_oe_verify_scan_log_file` を共通コアへ委譲する薄いラッパに（reviewer 経路不変）。
- `lib/cleanup.sh`: 変更不要（glob `/tmp/oe-{sid}-*` が target log を捕捉）。
- target log は `(session_id, pane_id)` 鍵で `#98` が動機に挙げた **multi-pane 並走のログ衝突を回避**。spawn/monitor が同関数を使い**パス書式の drift（= #98 が警戒する非対称ハザード）を構造的に排除**。

## 検証ゲート（SO）

- **設計SO**（`oe-refute --rubric exploration`）: 確定前に実行 → **refuted**。既存 event-bus/audit の producer-side channel・get-text/scrollback 等の第4カテゴリ未評価を指摘。一次情報で grounding し ADR の幅・精度・正直さを是正（acquisition vs recording 軸の新設、案B 棄却根拠の再 grounding 等）。trace は ADR 棄却・defer 案節へ蒸留。
- **実装SO**（`oe-review`）: PR 前に実行 → 初回 **refuted**（target transcript を /tmp に 0644 で露出するセキュリティ欠陥）。`umask 077`（0600）で是正、**再実行 survived**（2/2）。reviewer 経路の同露出も同時是正。
  - 設計SO 通過 ≠ 実装SO 代替（別レンズが material 欠陥を捕捉）の実例。
- **episode closure** Step4（`so-compare` closure 品質チェック）で back-propagation 漏れを検出 → 先行 ADR（2026-05-18）に umask 是正への前方参照を追記。

## テスト

- 全 **23 テストファイル green** / **shellcheck clean**（lib 4 + tests 3）。
- `tests/test_capture.sh`: 新 primitive の実ファイル単体テスト（不在 file 安全 / EXIT 検出 / 長文 tail / 字下げ正規化 / プロンプトエコー非検知）。
- `tests/test_monitor.sh`: scan 層をモック化しループ制御を検証。
- `tests/test_e2e_smoke.sh`: target tee 検知 + tee-path / umask 077 回帰アサーション。1 サイクル `state==success` 完走。

## 残ハードニング候補（defer・本 PR スコープ外）

- ログ保存先を共有 `/tmp` → 専用ディレクトリ（`OE_DATA_DIR` 下 0700 等）へ移す案。reviewer 経路も含む大きめ変更のため別 issue 候補。

## ドキュメント

- ADR: `projects/orchestration-engine/docs/decisions/2026-06-30-decision-114-clean-output-channel.md`
- Episode: `projects/orchestration-engine/docs/episodes/2026-06-30-episode-114-clean-output-channel.md`

Refs #114 #98
