### PR TITLE
docs(specs): SO 強/弱モードを定義し kickoff/plan frontmatter で選択

### DIFF
--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -34,7 +34,7 @@
 | predecision-exploration | 設計判断を確定する前にゼロベースで代替案を最低1回引き出し、探索木を確定前 artifact に残してから確定する（so-compare 選択肢拡張・確定前証跡・暫定停止条件）。exhaustion-before-conclusion-rule の設計ドメイン層2（soft forcing。hard 版は defer） | `skills/predecision-exploration/SKILL.md` | skill: so-compare, skill: kickoff-to-plan, skill: episode-retrospective, command: peer-ai-review |
 | question-driven-design | 実装前に設計ツリーを質問で網羅的に掘り下げ、暗黙の前提を明示化する | `skills/question-driven-design/SKILL.md` | — |
 | sentry-investigation | Sentry APIからエラー情報・スタックトレースを取得するパターン集 | `skills/sentry-investigation/SKILL.md` | — |
-| so-compare | so-compare.shでセカンドオピニオン（Codex/Claude）を取得し、結果を比較する | `skills/so-compare/SKILL.md` | cli: so-compare |
+| so-compare | so-compare.shでセカンドオピニオン（Codex/Claude/Cursor）を取得し比較する。**弱SO**（1周可・partial=disclose・0はなし）。強SOは peer-ai-review | `skills/so-compare/SKILL.md` | cli: so-compare |
 | spec-card | 蒸留パイプラインのドキュメントフォーマット適用ガイド（frontmatter・ULID・status） | `skills/spec-card/SKILL.md` | — |
 | worktrunk-worktrees | Worktrunk (wt) ベースの worktree 運用 | `skills/worktrunk-worktrees/SKILL.md` | skill: branch-naming, cli: wt |
 
@@ -51,7 +51,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 
 | 名前 | 説明 | パス | depends |
 |------|------|------|---------|
-| peer-ai-review | 修正タスクや設計判断に対して、Codex CLIとClaude Codeにピアレビューを依頼し、3者合意に至るまでイテレーションを繰り返す | `commands/verification/peer-ai-review.md` | skill: so-compare, skill: persistent-exploration, skill: adversarial-review, skill: implementer-contract, cli: so-compare, command: pr-review-checklist |
+| peer-ai-review | 修正タスクや設計判断に対して、Codex CLIとClaude Codeにピアレビューを依頼し、3者合意に至るまでイテレーションを繰り返す。**強SO**（全レーン合意まで iterate・0=不可） | `commands/verification/peer-ai-review.md` | skill: so-compare, skill: persistent-exploration, skill: adversarial-review, skill: implementer-contract, cli: so-compare, command: pr-review-checklist |
 | arena-perspectives | 同一プロンプトを複数モデルに並列投入し、モデルごとの回答を並べて表示する | `commands/verification/arena-perspectives.md` | skill: arena-compare, skill: persistent-exploration, cli: arena-compare |
 | issue-debug | Issue / Sentryエラーの調査・分析・修正を行う | `commands/investigation/issue-debug.md` | skill: sentry-investigation, skill: persistent-exploration, skill: branch-naming, skill: conventional-commits, skill: pr-conventions, command: arena-perspectives, command: peer-ai-review |
 | research-intake | 外部記事/論文のURL起点で、本質抽出→既存資産マッピング→統合判断→Issue化/ドキュメント化を行う | `commands/investigation/research-intake.md` | skill: oss-research-session, skill: issue-conventions, skill: markdown-conventions |

--- a/canonical/CATALOG.md
+++ b/canonical/CATALOG.md
@@ -34,7 +34,7 @@
 | predecision-exploration | 設計判断を確定する前にゼロベースで代替案を最低1回引き出し、探索木を確定前 artifact に残してから確定する（so-compare 選択肢拡張・確定前証跡・暫定停止条件）。exhaustion-before-conclusion-rule の設計ドメイン層2（soft forcing。hard 版は defer） | `skills/predecision-exploration/SKILL.md` | skill: so-compare, skill: kickoff-to-plan, skill: episode-retrospective, command: peer-ai-review |
 | question-driven-design | 実装前に設計ツリーを質問で網羅的に掘り下げ、暗黙の前提を明示化する | `skills/question-driven-design/SKILL.md` | — |
 | sentry-investigation | Sentry APIからエラー情報・スタックトレースを取得するパターン集 | `skills/sentry-investigation/SKILL.md` | — |
-| so-compare | so-compare.shでセカンドオピニオン（Codex/Claude/Cursor）を取得し比較する。**弱SO**（1周可・partial=disclose・0はなし）。強SOは peer-ai-review | `skills/so-compare/SKILL.md` | cli: so-compare |
+| so-compare | so-compare.shでセカンドオピニオン（Codex/Claude/Cursor）を取得し比較する。**弱 SO**（1周可・partial=disclose・0はなし）。強 SO は `peer-ai-review` | `skills/so-compare/SKILL.md` | cli: so-compare |
 | spec-card | 蒸留パイプラインのドキュメントフォーマット適用ガイド（frontmatter・ULID・status） | `skills/spec-card/SKILL.md` | — |
 | worktrunk-worktrees | Worktrunk (wt) ベースの worktree 運用 | `skills/worktrunk-worktrees/SKILL.md` | skill: branch-naming, cli: wt |
 
@@ -51,7 +51,7 @@ Skills テーブルの `depends` は技術的参照（このスキルが使用�
 
 | 名前 | 説明 | パス | depends |
 |------|------|------|---------|
-| peer-ai-review | 修正タスクや設計判断に対して、Codex CLIとClaude Codeにピアレビューを依頼し、3者合意に至るまでイテレーションを繰り返す。**強SO**（全レーン合意まで iterate・0=不可） | `commands/verification/peer-ai-review.md` | skill: so-compare, skill: persistent-exploration, skill: adversarial-review, skill: implementer-contract, cli: so-compare, command: pr-review-checklist |
+| peer-ai-review | 修正タスクや設計判断に対して、Codex CLIとClaude Codeにピアレビューを依頼し、3者合意に至るまでイテレーションを繰り返す。**強 SO**（全レーン合意まで iterate・0=不可） | `commands/verification/peer-ai-review.md` | skill: so-compare, skill: persistent-exploration, skill: adversarial-review, skill: implementer-contract, cli: so-compare, command: pr-review-checklist |
 | arena-perspectives | 同一プロンプトを複数モデルに並列投入し、モデルごとの回答を並べて表示する | `commands/verification/arena-perspectives.md` | skill: arena-compare, skill: persistent-exploration, cli: arena-compare |
 | issue-debug | Issue / Sentryエラーの調査・分析・修正を行う | `commands/investigation/issue-debug.md` | skill: sentry-investigation, skill: persistent-exploration, skill: branch-naming, skill: conventional-commits, skill: pr-conventions, command: arena-perspectives, command: peer-ai-review |
 | research-intake | 外部記事/論文のURL起点で、本質抽出→既存資産マッピング→統合判断→Issue化/ドキュメント化を行う | `commands/investigation/research-intake.md` | skill: oss-research-session, skill: issue-conventions, skill: markdown-conventions |

--- a/canonical/commands/verification/peer-ai-review.md
+++ b/canonical/commands/verification/peer-ai-review.md
@@ -1,6 +1,6 @@
 ---
 name: peer-ai-review
-description: 修正タスクや設計判断に対して、Codex CLIとClaude Codeにピアレビューを依頼し、3者合意に至るまでイテレーションを繰り返す。SOプロンプト構成、カバレッジギャップ分析、レビューログ運用を含む。
+description: 修正タスクや設計判断に対して、Codex CLIとClaude Codeにピアレビューを依頼し、3者合意に至るまでイテレーションを繰り返す。**強 SO**（全レーン返却＋合意まで iterate・partial=再試行・0=不可）。SOプロンプト構成、カバレッジギャップ分析、レビューログ運用を含む。
 depends:
   - skill: so-compare
   - skill: persistent-exploration
@@ -14,6 +14,8 @@ depends:
 
 修正タスクや設計判断に対して、Codex CLI と Claude Code にピアレビューを依頼し、自分の判断と比較する。
 **3者（自分 / Codex / Claude）が合意に至るまでイテレーションを繰り返す。1回で終わらせる必要はない。**
+
+> **SO モード: 強 SO**（強/弱の定義は `docs/specs/document-format.md` §3.1）。**終了条件**: 指定全レーン返却＋全レーン合意（material 残ゼロ）まで iterate（partial=再試行で埋める・**0=不可＝全返却が条件**）。高難易度/高リスク/不可逆に。低〜中で可逆・1 周で足りるなら **弱 SO**（`so-compare` / `oe-refute` / `oe-review`）を使う。
 
 ## 入力形式
 

--- a/canonical/skills/code-path-exhaustion/SKILL.md
+++ b/canonical/skills/code-path-exhaustion/SKILL.md
@@ -35,7 +35,7 @@ depends:
 3. `persistent-exploration` の突破口チェックリスト（API 直接・DB 状態・マイグレーション履歴等）でコード側の代替アプローチを尽くす。
 4. 入出力のコードパスに未読が無くなって初めて外部要因の仮説に進む。
    - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階）: 外部要因へ進む確定の前に、「コードパスは読了し原因は外部要因である」を `claim` とした claim doc（frontmatter ＋ body に `hypothesis-*.md` 群＋read-state を集約）を `oe-refute --claim <doc> --rubric exploration` で**同期反証**する。生成と物理分離した独立レーンが breadth(軸5＝未読パス/未試行が残らないか)/grounding(軸3＝根拠) レンズで反証し、`{verdict, reason, output_dir}` が `refuted` なら外部要因ジャンプを**保留**する。`output_dir` は揮発するので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。
-   - **弱 SO の終了条件**（`docs/specs/document-format.md` §3.1）: `oe-refute` / `so-compare` が使えない、または `timeout_empty` の1回リトライ後も**全レーン 0**（＝"0 はなし"抵触）なら、外部要因ジャンプの確定を止めて人間承認を取る（黙って skip しない）。partial（一部 timeout）は disclose して進んでよい（advisory）。
+   - **弱 SO の終了条件**（`docs/specs/document-format.md` §3.1）: `oe-refute` / `so-compare` が使えない、または**全レーンが実返却なし**（`timeout_empty` の1回リトライ後も空、あるいは `success_empty`〔exit0 だが空〕で全レーン空。後者は機構上 partial＝exit1 計上だが、実返却ゼロなので "0 はなし" 抵触）なら、外部要因ジャンプの確定を止めて人間承認を取る（黙って skip しない）。partial は**実返却が 1 レーン以上あるとき**に限り disclose して進んでよい（advisory）。
 
 ## hypothesis ファイルフォーマット
 

--- a/canonical/skills/code-path-exhaustion/SKILL.md
+++ b/canonical/skills/code-path-exhaustion/SKILL.md
@@ -35,7 +35,7 @@ depends:
 3. `persistent-exploration` の突破口チェックリスト（API 直接・DB 状態・マイグレーション履歴等）でコード側の代替アプローチを尽くす。
 4. 入出力のコードパスに未読が無くなって初めて外部要因の仮説に進む。
    - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階）: 外部要因へ進む確定の前に、「コードパスは読了し原因は外部要因である」を `claim` とした claim doc（frontmatter ＋ body に `hypothesis-*.md` 群＋read-state を集約）を `oe-refute --claim <doc> --rubric exploration` で**同期反証**する。生成と物理分離した独立レーンが breadth(軸5＝未読パス/未試行が残らないか)/grounding(軸3＝根拠) レンズで反証し、`{verdict, reason, output_dir}` が `refuted` なら外部要因ジャンプを**保留**する。`output_dir` は揮発するので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。
-   - `oe-refute` / `so-compare` が使えない / timeout する場合は、外部要因ジャンプの確定を止めて人間承認を取る（黙って skip しない）。
+   - **弱 SO の終了条件**（`docs/specs/document-format.md` §3.1）: `oe-refute` / `so-compare` が使えない、または `timeout_empty` の1回リトライ後も**全レーン 0**（＝"0 はなし"抵触）なら、外部要因ジャンプの確定を止めて人間承認を取る（黙って skip しない）。partial（一部 timeout）は disclose して進んでよい（advisory）。
 
 ## hypothesis ファイルフォーマット
 

--- a/canonical/skills/orchestration-toolkit/SKILL.md
+++ b/canonical/skills/orchestration-toolkit/SKILL.md
@@ -16,9 +16,10 @@ oe-* ツール群を **1 つのパッケージとして一貫理解する**た�
 
 ## 駆動層規律（engine 作業の 1 サイクル）
 
-discussion/DJ → **設計SO（`oe-refute`）** → 実装 → **実装SO（`oe-review`）** → Episode → PR →（Copilot）→ closure。
+discussion/DJ → **設計SO** → 実装 → **実装SO** → Episode → PR →（Copilot）→ closure。設計SO/実装SO のツールは **`so` モード次第**（弱〔既定〕=`oe-refute`/`oe-review`・強=`peer-ai-review`。下記モード行参照）。
 
 - **SO レーンポリシー（運用方針。verb 既定は `--lanes 2`）**: 設計SO=**`oe-refute --lanes 3` を明示**（3社=codex+cursor+claude。Claude/Opus を設計＝選択肢拡張に活かす）／実装SO=既定の **`oe-review`（2社=codex+cursor・実装者 Claude を抜き model 多様性で欠陥検出）**。観点が違うので**両方**実施（設計だけで実装SO を省略しない）。重い対象は都度 3社+3社 もありだが、なるべく分割して重くしない。※レーンの model（cursor=composer / claude=opus 等）は **so-compare 側の指定**で oe-* は固定しない。
+- **SO モード（強/弱・レーン軸と直交）**: **強 SO**=`peer-ai-review`（全レーン合意まで iterate・partial=再試行・0=不可）／**弱 SO**=`so-compare`/`oe-refute`/`oe-review`（1 周可・partial=disclose・**0=SO 未実施で再試行/escalate="0 はなし"**）。**設計段階に kickoff/plan の `so` frontmatter で選択**（正本 `docs/specs/document-format.md` §3.1）。レーン数（上記ポリシー）とモードは**直交**（別々に選ぶ）。
 - 集約は **conservative**（1 レーンでも material な指摘 → 全体 refuted）。`refuted` は **exit 3（advisory・JSON が正本）**＝oe-* は機械的に PR/マージを止めない（確定保留は harness/運用判断）。
 - 蒸留パイプライン doc: discussion / kickoff / **episode（締めで必須・本文は随時追記・後追い再構成は `reconstructed` 明示）** / decision-ADR（任意・content 次第）。closure は `episode-retrospective`。
 - **完全移譲**: 自律委譲子は discussion/設計SO から 実装→実装SO→Episode→PR→Copilot→closure まで**一気通貫**（親は巻き取らない）。

--- a/canonical/skills/plan-to-kickoff/SKILL.md
+++ b/canonical/skills/plan-to-kickoff/SKILL.md
@@ -79,6 +79,10 @@ related:
     ref: "~/.cursor/plans/adversarial-review_skill_plan_981ae49b.plan.md"
     reason: "変換元プラン"
 tags: []  # 推測禁止。明示的なタグ情報がある場合のみ
+so:                       # SO モード（§3.1・kickoff 必須）。プランから推測不可＝要選択（既定 weak 提案）
+  design: weak | strong
+  impl: weak | strong
+  reason: "<要選択>"
 ```
 
 | 入力フィールド | 出力フィールド | 変換ルール |
@@ -93,6 +97,7 @@ tags: []  # 推測禁止。明示的なタグ情報がある場合のみ
 | _(新規)_ | `scope` | Context 内の記述から推測（例: `canonical` スキル関連なら `canonical`）。推測不可な場合は省略（フィールド自体を出力しない） |
 | _(新規)_ | `related[]` | Context セクションのURL・パスを構造化。不明な場合は `derived_from` のみ |
 | _(新規)_ | `tags` | 推測禁止。ソースに明示的なタグ情報がある場合のみ使用。不明な場合は空配列 `[]` |
+| _(新規)_ | `so` | SO モード（§3.1・kickoff 必須）。プランから推測不可＝**要選択**（既定 `weak` を提案し、高難易度/高リスク/不可逆なら `strong`）。省略しない |
 
 **リポジトリのプランMD → Kickoff:**
 
@@ -191,6 +196,7 @@ related:
 ```
 ## 必須チェック
 - [ ] frontmatter に title, date, type: kickoff が含まれている
+- [ ] frontmatter に `so`（`design`/`impl`/`reason`）が含まれている（§3.1・kickoff 必須。推測不可なら要選択プレースホルダで残す）
 - [ ] プランの全Stepが「## 実装計画」配下に含まれている
 - [ ] プランの全GATEが含まれている
 - [ ] プランの全STOP（Stage境界）が含まれている

--- a/canonical/skills/predecision-exploration/SKILL.md
+++ b/canonical/skills/predecision-exploration/SKILL.md
@@ -35,7 +35,7 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 1. 初期選択肢セットと暗黙の前提を明示的に列挙する。
 2. 最低1回、ゼロベース SO を**実際に回す**（インラインで「なぞる」だけにしない）。`so-compare` の「選択肢拡張（設計を確定する SO のとき）」テンプレを使い、初期案と異なるカテゴリ / 責務分界 / データフロー / 実行経路 / 運用前提の代替案を出させる。タイミングは「A/B 仮決定後・最終確定前」を含む（最終確定後ではない）。
    - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir`（`oe-refute` が返す反証レーンの生出力先・永続しない）なので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
-   - **弱 SO の終了条件**（`docs/specs/document-format.md` §3.1）: `so-compare` / `oe-refute` が使えない、または `timeout_empty` の1回リトライ後も**全レーン 0**（＝"0 はなし"抵触）なら、確定を止めて人間承認を取る（黙って skip しない）。partial（一部 timeout）は disclose して進んでよい（advisory）。
+   - **弱 SO の終了条件**（`docs/specs/document-format.md` §3.1）: `so-compare` / `oe-refute` が使えない、または**全レーンが実返却なし**（`timeout_empty` の1回リトライ後も空、あるいは `success_empty`〔exit0 だが空〕で全レーン空。後者は機構上 partial＝exit1 計上だが、実返却ゼロなので "0 はなし" 抵触）なら、確定を止めて人間承認を取る（黙って skip しない）。partial は**実返却が 1 レーン以上あるとき**に限り disclose して進んでよい（advisory）。
 3. 出た代替案は「良さそう」で止めず、検証可能な条件で即検証する（検証不能な環境では検証条件を残して保留）。
 4. **確定前に証跡をその場で残す**: 探索木＋反証の出力パス（`so-compare` なら `tmp/so-*/`、`oe-refute` なら `verdict`/`reason`＋`output_dir`）＋採否を、確定と同一セッションで**確定前 artifact** に書く。置き場は手近なもの: `tmp/dj-N-tree.md` / ADR 草稿の「棄却案」節 / kickoff の DJ 節 / PR 本文 / peer-review ログ（`tmp/peer-review-*/review-log.md`）。**episode closure まで先送りしない**（「後で追記」は監査で 100% 不履行＝L4）。
 5. 暫定停止条件を満たしたら確定に進む（下記）。

--- a/canonical/skills/predecision-exploration/SKILL.md
+++ b/canonical/skills/predecision-exploration/SKILL.md
@@ -35,7 +35,7 @@ wez notify の option C（TTY 直接書き込み）は、A/B 仮決定**後・�
 1. 初期選択肢セットと暗黙の前提を明示的に列挙する。
 2. 最低1回、ゼロベース SO を**実際に回す**（インラインで「なぞる」だけにしない）。`so-compare` の「選択肢拡張（設計を確定する SO のとき）」テンプレを使い、初期案と異なるカテゴリ / 責務分界 / データフロー / 実行経路 / 運用前提の代替案を出させる。タイミングは「A/B 仮決定後・最終確定前」を含む（最終確定後ではない）。
    - **engine 統合経路**（効果は未測定・#177 で観測予定＝so-compare 手動反証を engine 統合・再現可能にした段階。現状 so-compare と同列の選択肢）: 確定しようとする判断を claim doc 化し `oe-refute --claim <doc> --rubric exploration` を**同期で呼ぶ**（`so-compare` を wrap し、生成と物理分離した独立レーンが breadth(軸5)/grounding(軸3) レンズで反証）。返る `{verdict, reason, output_dir}` が `refuted` なら**確定を保留**する。`output_dir`（`oe-refute` が返す反証レーンの生出力先・永続しない）なので verdict/reason の**内容**を確定時証跡へ転記する（パスだけに頼らない）。claim doc は frontmatter（`claim` 必須・`rubric` 任意＝省略時は既定 exploration だが明示を推奨）＋ body（探索木をそのまま不透明に渡す）。
-   - `so-compare` / `oe-refute` が使えない / timeout する場合は、確定を止めて人間承認を取る（黙って skip しない）。
+   - **弱 SO の終了条件**（`docs/specs/document-format.md` §3.1）: `so-compare` / `oe-refute` が使えない、または `timeout_empty` の1回リトライ後も**全レーン 0**（＝"0 はなし"抵触）なら、確定を止めて人間承認を取る（黙って skip しない）。partial（一部 timeout）は disclose して進んでよい（advisory）。
 3. 出た代替案は「良さそう」で止めず、検証可能な条件で即検証する（検証不能な環境では検証条件を残して保留）。
 4. **確定前に証跡をその場で残す**: 探索木＋反証の出力パス（`so-compare` なら `tmp/so-*/`、`oe-refute` なら `verdict`/`reason`＋`output_dir`）＋採否を、確定と同一セッションで**確定前 artifact** に書く。置き場は手近なもの: `tmp/dj-N-tree.md` / ADR 草稿の「棄却案」節 / kickoff の DJ 節 / PR 本文 / peer-review ログ（`tmp/peer-review-*/review-log.md`）。**episode closure まで先送りしない**（「後で追記」は監査で 100% 不履行＝L4）。
 5. 暫定停止条件を満たしたら確定に進む（下記）。

--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: so-compare
-description: so-compare.shでセカンドオピニオン（Codex/Claude/Cursor）を取得し、結果を比較する。ピアレビュー、修正方針の検証、設計判断の反証に使用する。プロンプト設計原則、結果読み込み手順、合意判定基準を含む。
+description: so-compare.shでセカンドオピニオン（Codex/Claude/Cursor）を取得し、結果を比較する。ピアレビュー、修正方針の検証、設計判断の反証に使用する。**弱 SO**（1周可・partial=disclose・0はなし）。プロンプト設計原則、結果読み込み手順、合意判定基準を含む。
 depends:
   - cli: so-compare
 ---
 
 # SO Compare — セカンドオピニオン比較
+
+> **SO モード: 弱 SO**（強/弱の定義は `docs/specs/document-format.md` §3.1）。**1 周で終了可**（iteration は推奨だが任意）。**終了条件**: partial（一部 timeout）=**disclose して進む**（advisory）／**0（全 timeout/空）=SO 未実施扱いで再試行/escalate＝最低 1 レーン実返却必須（"0 はなし"）**。機構: `SO_TIMEOUT`（既定 240）は**初回試行の基準**・`timeout_empty` 時のみ `×1.5` に延長して**1回リトライ**（なお空なら "0" 扱い）。レーン数/モデルは mode と直交（都度指定・既定ポリシーは `orchestration-toolkit`）。全レーン合意まで詰める **強 SO** が要る局面は `peer-ai-review`。
 
 ## スクリプトの場所
 

--- a/canonical/skills/so-compare/SKILL.md
+++ b/canonical/skills/so-compare/SKILL.md
@@ -7,7 +7,7 @@ depends:
 
 # SO Compare — セカンドオピニオン比較
 
-> **SO モード: 弱 SO**（強/弱の定義は `docs/specs/document-format.md` §3.1）。**1 周で終了可**（iteration は推奨だが任意）。**終了条件**: partial（一部 timeout）=**disclose して進む**（advisory）／**0（全 timeout/空）=SO 未実施扱いで再試行/escalate＝最低 1 レーン実返却必須（"0 はなし"）**。機構: `SO_TIMEOUT`（既定 240）は**初回試行の基準**・`timeout_empty` 時のみ `×1.5` に延長して**1回リトライ**（なお空なら "0" 扱い）。レーン数/モデルは mode と直交（都度指定・既定ポリシーは `orchestration-toolkit`）。全レーン合意まで詰める **強 SO** が要る局面は `peer-ai-review`。
+> **SO モード: 弱 SO**（強/弱の定義は `docs/specs/document-format.md` §3.1）。**1 周で終了可**（iteration は推奨だが任意）。**終了条件**: partial（**実返却が 1 レーン以上**）=**disclose して進む**（advisory）／**"0"（全レーン実返却なし）=SO 未実施扱いで再試行/escalate＝最低 1 レーン実返却必須（"0 はなし"）**。※`success_empty`〔exit0 だが空〕は機構上 partial（exit1）計上だが、**全レーンがこれ＝実返却ゼロなら "0" 扱い**（consumer 判定・`so-compare.sh` は success_empty を PARTIAL 集計）。機構: `SO_TIMEOUT`（既定 240）は**初回試行の基準**・`timeout_empty` 時のみ `×1.5` に延長して**1回リトライ**（なお空なら "0" 扱い）。レーン数/モデルは mode と直交（都度指定・既定ポリシーは `orchestration-toolkit`）。全レーン合意まで詰める **強 SO** が要る局面は `peer-ai-review`。
 
 ## スクリプトの場所
 

--- a/canonical/skills/spec-card/SKILL.md
+++ b/canonical/skills/spec-card/SKILL.md
@@ -32,6 +32,21 @@ description: 蒸留パイプライン文書（kickoff/episode/decision/discussio
 | `type` | enum | `discussion` / `kickoff` / `plan` / `episode` / `decision` |
 | `status` | enum | `draft` / `in-development` / `stable` / `deprecated` |
 
+### kickoff / plan は `so` モードを必須で宣言する
+
+`kickoff` / `plan` を作成するときは、frontmatter に **`so` モードを必須**で入れる（SO を**設計段階で選択・記録**する）:
+
+```yaml
+so:
+  design: weak | strong   # 設計 SO のモード
+  impl: weak | strong     # 実装 SO のモード
+  reason: "<なぜそのモードか>"
+```
+
+- **強 SO** = `peer-ai-review`（全レーン返却＋合意まで iterate・partial=再試行・0=不可）。高難易度/高リスク/不可逆に。
+- **弱 SO** = `so-compare` / `oe-refute` / `oe-review`（1 周可・partial=disclose して進む・**0=SO 未実施扱いで再試行/escalate＝最低 1 レーン必須="0 はなし"**）。低〜中難易度/可逆に。
+- レーン数・モデルは mode に焼かず都度指定（直交・既定ポリシーは `orchestration-toolkit`）。定義の正本は `docs/specs/document-format.md` §3.1。
+
 ### 文書型の選び方
 
 | type | 用途 | フォーマット深度 |

--- a/docs/specs/document-format.md
+++ b/docs/specs/document-format.md
@@ -79,7 +79,24 @@ related:                                # 型付き参照配列（§6 参照）
     ref: "<パスまたは URL>"
     reason: "<関係の説明>"
 tags: [tag1, tag2]                      # 検索・フィルタ用タグ
+so:                                     # SO モード（kickoff/plan で必須・§3.1 参照）
+  design: weak | strong                 # 設計 SO のモード
+  impl: weak | strong                   # 実装 SO のモード
+  reason: "<なぜそのモードか>"
 ```
+
+### 3.1 SO モード（強/弱・kickoff/plan で選択）
+
+セカンドオピニオン（SO）を **強 SO / 弱 SO** の 2 モードとして定義し、kickoff/plan の frontmatter `so.design` / `so.impl`（＋ `reason`）で **設計段階に選択・記録**する。用途目安: 強＝高難易度・高リスク・不可逆／弱＝低〜中難易度・可逆。
+
+| | ツール | 終了条件 | partial（一部 timeout） | 0（全 timeout/空） |
+|---|---|---|---|---|
+| **強 SO** | `peer-ai-review` | 指定全レーン返却 ＋ 全レーン合意（material 残ゼロ）まで iterate | 不許容＝再試行で埋める | 不可（全返却が条件） |
+| **弱 SO** | `so-compare` / `oe-refute` / `oe-review` | 1 周で終了可（iteration は推奨だが任意） | 許容＝**disclose して進む**（advisory） | **不可＝SO 未実施扱い・再試行/escalate**（最低 1 レーン実返却必須＝"0 はなし"） |
+
+- **レーン数・モデル多様性は mode に焼かない**＝都度オプションで指定（直交）。既定のレーンポリシー（設計=3社 codex+cursor+claude / 実装=2社 codex+cursor 等）は `orchestration-toolkit` スキル参照。
+- 機構層（`SO_TIMEOUT`[既定 240]は**初回試行の基準**＝`timeout_empty` 時のみ `×1.5` に延長して**1回リトライ**・#22 の exit 0/1/2 分離・#196 の conservative 集約＝verdict 取れないレーンは `error` で survived を阻む）の上に乗る **consumer ルール**。「timeout で実質 SO をパスできる」を弱 SO の "0 はなし" フロアで塞ぐ。
+- 補足（機構境界）: exit0＋空（`success_empty`）は機構上 **partial に計上**されるため、「最低 1 レーン**実返却**」の担保は機構 exit code でなく **consumer ルール側**が負う。また `oe-refute`/`oe-review` の集約は #196 conservative＝**error レーンがあれば全体 `refuted`（保留）**で、弱 SO の generic partial=disclose より**厳しい側に倒す**（error は disclose せず保留）。
 
 ## 4. ULID 規約
 
@@ -202,6 +219,10 @@ related:
     ref: "<URL>"
     reason: "<説明>"
 tags: [tags]
+so:                          # SO モード（必須・§3.1）
+  design: weak | strong
+  impl: weak | strong
+  reason: "<なぜそのモードか>"
 ---
 
 # <タイトル>
@@ -212,7 +233,7 @@ tags: [tags]
 ## 完了条件
 ## ステップ
 ## リスク・未確認事項
-## セカンドオピニオン検証（任意）
+## セカンドオピニオン検証（frontmatter `so` のモードに従う・§3.1）
 ```
 
 ### Plan
@@ -231,6 +252,10 @@ related:
     ref: "<kickoff ファイルパス>"
     reason: "<説明>"
 tags: [tags]
+so:                          # SO モード（必須・§3.1）
+  design: weak | strong
+  impl: weak | strong
+  reason: "<なぜそのモードか>"
 ---
 ```
 


### PR DESCRIPTION
## 目的

SO（セカンドオピニオン）を **強 SO / 弱 SO** の 2 モードとして定義し、kickoff/plan の frontmatter で **設計段階に選択・記録**できるようにする（`docs/specs/document-format.md` を正本化）。

背景の 1 つに「実装 SO は timeout が出るまで回すのか？」という運用上の混乱があった。実際はレーンは終わり次第返り、timeout は上限・`timeout_empty` のみ 1 回リトライ（×1.5）という機構だが、**強度（どこまで詰めるか）が document format 上で選べない**のが根因だった。#215 はこれを format のフィールドに落として設計時決定にする。

## 変更内容

### 正本（`docs/specs/document-format.md` §3.1 を新設）

| | ツール | 終了条件 | partial（一部 timeout） | 0（全 timeout/空） |
|---|---|---|---|---|
| **強 SO** | `peer-ai-review` | 指定全レーン返却 ＋ 全レーン合意（material 残ゼロ）まで iterate | 不許容＝再試行で埋める | 不可（全返却が条件） |
| **弱 SO** | `so-compare` / `oe-refute` / `oe-review` | 1 周で終了可（iteration は推奨だが任意） | 許容＝**disclose して進む**（advisory） | **不可＝SO 未実施扱い・再試行/escalate**（"0 はなし"＝最低 1 レーン実返却必須） |

- `so.design` / `so.impl`（＋ `reason`）を frontmatter 任意フィールド＋ §7 KickOff/Plan テンプレに追加。
- **レーン数・モデル多様性は mode と直交**（都度指定・既定ポリシーは `orchestration-toolkit`）。強/弱は「どこまで詰めるか」、レーン数は「何社に投げるか」で別軸。
- 機構層（`SO_TIMEOUT`[既定 240]＝初回試行の基準・`timeout_empty` のみ ×1.5 で 1 回リトライ／#22 の exit 0/1/2 分離／#196 conservative 集約）の上に乗る **consumer ルール**として位置づけ。「timeout で実質 SO をパスできる」を弱 SO の "0 はなし" フロアで塞ぐ。
- 機構境界も明記: `success_empty`（exit0＋空）は機構上 partial 計上のため「最低 1 レーン**実返却**」担保は consumer 側／`oe-refute`・`oe-review` の #196 conservative は error→全体 refuted で generic partial=disclose より厳しい側。

### 関連への反映（帰属・終了条件）

- `spec-card`: kickoff/plan の `so` を**必須化**（yaml ＋ 強/弱サマリ）。
- `plan-to-kickoff`: 生成 frontmatter 例・変換表・必須チェックに `so` を**追随**（推測不可＝要選択プレースホルダで残す）。生成物が §3.1 とドリフトする穴を塞ぐ。
- `predecision-exploration` / `code-path-exhaustion`: 弱 SO の終了条件を精緻化（`timeout_empty` 1 回リトライ後も全レーン 0＝escalate／partial=disclose）。
- `so-compare`（=弱SO）/ `peer-ai-review`（=強SO）を description・本文 callout・`CATALOG.md` に明示。

## 検証（3社設計 SO＝policy B）

設計 SO を **policy B の 3 社（codex + cursor[composer] + claude[opus]）** で実施（本 PR がその初回実適用）。verdict は「修正推奨後マージ」。convergent に挙がった material 指摘を反映済み:

- §7 KickOff/Plan テンプレが §3.1 と自己不整合（`so` 未記載・「SO 検証（任意）」）→ 修正。
- `SO_TIMEOUT` の説明が「全体上限」に読める → 「初回試行の基準＋`timeout_empty` のみ ×1.5 リトライ」に是正。
- `success_empty`=partial の機構境界／`oe-refute` conservative の非対称を補足。
- **`plan-to-kickoff` が `so` 未追随（実際の kickoff 生成経路のドリフト源）** → 生成例・変換表・必須チェックに追加。

## 影響範囲

- ドキュメント（`.md`）のみ。shellcheck 対象なし。
- `canonical/` 配下（skills / commands / CATALOG）を変更 → **マージ後に sync が必要**（so-compare / spec-card / plan-to-kickoff / orchestration-toolkit / predecision-exploration / code-path-exhaustion の各 skill と peer-ai-review command は 3 者へコピー配布）。

## スコープ外（follow-up）

- 強 SO ステップの手順オペレーション化（`peer-ai-review` 側の運用詳細）。
- `so` の hard バリデーション（#19 4-3 系のスキーマ強制）。

Refs #215 #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
