### PR TITLE
feat(oe): 検証入力を commit 範囲評価に変更

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -193,7 +193,7 @@ MVP（`bin/oe` 本体）完了後、運用ドッグフードから派生した�
 
 | Issue | 内容 |
 |---|---|
-| [#92](https://github.com/stlwolf/ai-development-hub/issues/92) | 検証ゲート v2 検討候補: 変更ファイル検出 per-pane 化 + 完了報告内容の充実 |
+| [#92](https://github.com/stlwolf/ai-development-hub/issues/92) | 検証ゲート v2: 検証入力を **commit 範囲 (baseline..end)** 評価に変更 (単一 UC 分 landed)。変更ファイル=`git diff baseline..end`・完了報告=`git log baseline..end`・worker commit 契約 + baseline/end materialize。設計SO 3 ラウンドで working-tree diff の pane-blind/dirty 混入を構造的欠陥と確定 (→ commit 評価に reframe)。残: multi-pane 帰属 (branch/worktree)・reviewer verdict チャネルの marker 注入 ([#101](https://github.com/stlwolf/ai-development-hub/issues/101)) は別 follow-up |
 | [#93](https://github.com/stlwolf/ai-development-hub/issues/93) | reviewer 一時ファイル掃除 (前半完了) + nonce marker (後半 = MVP 後拡張) |
 | [#98](https://github.com/stlwolf/ai-development-hub/issues/98) | target ペイン出力を file redirect 経路に統一 |
 | [#99](https://github.com/stlwolf/ai-development-hub/issues/99) | bin/oe --task-file の異常系 (空 / 不在 / 不正パス) の仕様明示 |

--- a/projects/orchestration-engine/docs/decisions/2026-07-01-decision-92-commit-range-verify-inputs.md
+++ b/projects/orchestration-engine/docs/decisions/2026-07-01-decision-92-commit-range-verify-inputs.md
@@ -1,0 +1,92 @@
+---
+id: "01KWERZMJ4FPJN2EHTCNE21GQX"
+title: "#92 検証ゲートの評価入力は working-tree diff 推定でなく commit 範囲（baseline..end）を正本とする — worker-commit 契約"
+date: 2026-07-01
+type: decision
+status: accepted
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/92"
+    reason: "本 ADR の主スコープ（検証ゲート v2 の評価入力＝変更ファイル/完了報告の正本化）"
+  - type: sibling
+    ref: ./2026-06-30-decision-114-clean-output-channel.md
+    reason: "取得/検証チャネル系の対。#114 は子出力の取得側、本 ADR は検証入力（評価単位）側"
+  - type: refines
+    ref: ./2026-05-16-decision-verification-gate-design.md
+    reason: "検証ゲート v1（Compliance Review / pane-keyed KVS）。本 ADR は v1 の評価入力を commit 範囲へ差し替える"
+  - type: source_material
+    ref: ../../lib/verify.sh
+    reason: "本決定の主実装（oe_verify_prompt_build の commit 範囲評価・_oe_verify_annotate_files）"
+  - type: source_material
+    ref: ../../lib/spawn.sh
+    reason: "baseline（git_head / baseline_dirty）を worker 起動前に session_start payload へ materialize"
+  - type: source_material
+    ref: ../../lib/monitor.sh
+    reason: "end を worker 終了（EXIT）時の HEAD に固定"
+  - type: source_material
+    ref: ../../lib/constants.sh
+    reason: "worker-commit 完了プロトコル（target task 契約）"
+  - type: episode
+    ref: ../episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
+    reason: "本 ADR を生んだ実装エピソード（設計SO 3R → reframe → 実装SO 2R）"
+  - type: future_hook
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/101"
+    reason: "reviewer verdict チャネルの marker 注入（本 ADR と直交・別 follow-up）"
+tags: [orchestration, verification-gate, commit-range, worker-commit, reframe, decision, adr]
+---
+
+# #92 検証ゲートの評価入力は commit 範囲（baseline..end）を正本とする
+
+## コンテキスト
+
+検証ゲート v1（[2026-05-16 ADR](./2026-05-16-decision-verification-gate-design.md)）は、検証 agent（Compliance Review）へ「変更ファイル一覧」と「完了報告」を渡して実装の妥当性を評価させる。v1 はこれを **working-tree diff の推定**で得ていた（`oe_verify_prompt_build` が KVS `outputs[]`、空なら `git diff --name-only` フォールバック）。#92 はこの入力の質不足（F-SO-8: 変更ファイル per-pane 化 / F-SO-9: 完了報告の充実）を扱う。
+
+working-tree diff 推定は共有 workspace で構造的に破綻する: repo-wide `git diff` は検証対象外の dirty を拾い、commit 済みなら空になり、複数 pane 並走ではどの pane の変更か区別できない。#92 の当初 framing は「commit すると `git diff` が空になる（＝"バグ"）」だったが、これは**フレーム自体の誤り**だった（後述）。
+
+## 決定
+
+- **評価単位 = commit 範囲 `baseline..end`。** working-tree diff の推定を廃し、VCS の論理単位（commit）を評価する。
+- **変更ファイル = `git diff --name-only <baseline>` + untracked**（＝baseline からの全 footprint。committed + 未コミット残余の両方を捕捉）。baseline 時点で既に dirty だったパスには `pre-existing at baseline` 注記を付け、worker の `git add -A` 巻き込みを可視化する。
+- **完了報告 = `git log baseline..end`**（skill 契約の「コミットログ」に合致）。旧 state enum 1 個の受け渡しを置換。
+- **worker-commit 契約を engine の target task に付与**（`lib/constants.sh` の完了プロトコル: 「作業完了後に自分の変更のみを git commit してから終了。1行目に何を・なぜ」）。検証はその commit 範囲を評価する。
+- **baseline は worker 起動前**（`lib/spawn.sh`・session_start payload の `git_head` / `baseline_dirty`）、**end は worker 終了（EXIT）時の HEAD に固定**（`lib/monitor.sh`。verify 遅延や後続 commit で範囲がずれるのを防ぐ）。
+- **degraded フォールバック**: 非 git / baseline 未解決（`attach.sh` 経路等）では working-tree diff へ明示的に縮退する（安全側）。
+
+## 実装
+
+- `lib/verify.sh`: `oe_verify_prompt_build` を commit 範囲評価へ変更 + `_oe_verify_annotate_files`（baseline-dirty 注記）。
+- `lib/spawn.sh`: baseline を send **前**に確定（send 後だと worker 変更が baseline に混入する競合窓が残る）。
+- `lib/monitor.sh`: end_head を worker 終了時に固定。
+- `lib/envelope.sh` / `lib/constants.sh`: 完了プロトコルを target の `task.description` 末尾へ付与。
+- 単一 UC（1 worker）スコープ。テスト 23 ファイル green（bash 5.2）・shellcheck clean。
+
+## 根拠
+
+- **なぜ commit が効くか**: commit は論理単位で、baseline からの diff が worker の footprint を過不足なく与える。単一 writer 前提なら帰属が構造的に決まる（推定でなく事実）。「commit で `git diff` が空＝問題」を「**commit を評価するのが設計**」へ反転した。
+- **reframe の経緯**: 設計SO を 3 ラウンド回した。v1（raw transcript embed）/ v2（F-SO-8-lite + F-SO-9-pull）はいずれも **2/2 refuted**——working-tree diff で推定する限り pane-blind / dirty 混入 / marker 注入（#101 既知弱点）が構造的に残る、と判明。**2 回の structural refuted を「フレームを疑え」の信号**（`reframe-on-stall-rule`）と捉え、3 回目で patch を重ねず、ユーザーの zero-base reframe（評価単位を commit にする）に乗ったことで root が溶けた（設計 D）。設計SO v3 は「有望・ただし worker commit 遵守が未検証」と structural kill から grounding-gap へ収束。
+- **実装SO が別レンズで material 欠陥を捕捉**: 実装後 `oe-review` v1 が refuted（部分コミット時に未コミット残余が漏れる / commit あるのに diff 空だと degraded へ誤フォールバックし事実矛盾）。変更ファイルを `baseline..end`[committed のみ] → `git diff <baseline>` + untracked[全 footprint] に修正し v2 で survived。設計SO 通過 ≠ 実装SO 代替（[#114](./2026-06-30-decision-114-clean-output-channel.md) と同じ再確認・#192 の false-pass 回避）。
+
+## 棄却・defer 案
+
+確定前に `oe-refute --rubric exploration`（設計SO 3R・lanes=codex/cursor）で外部化。
+
+| 案 | 判定 | 理由 |
+|---|---|---|
+| working-tree diff 推定（v1 現状） | ❌ 破棄 | 共有 workspace で pane-blind / dirty 混入 / commit 後 空。フレーム自体が誤り |
+| Alt A: raw transcript を verify-inputs.md に embed | ❌ 棄却 | 未信頼入力の注入面・skill 契約（叙述報告）不一致・tail サイズ無根拠 |
+| Alt B/E: pull だが working-tree 前提 | ❌ 棄却 | pull は妥当だが working-tree 推定を残す限り pane-blind/dirty が解けない |
+| output_dir スコープ | ❌ 棄却 | 契約が緩く（絶対パス / repo 外 /tmp で git 破綻）Compliance が見たい範囲外変更も落とす |
+| **commit 範囲 `baseline..end`（採用）** | ✅ 採用 | 論理単位・単一 writer で帰属が構造的に決まる・skill 契約と合致 |
+| multi-pane 帰属（per-pane branch/worktree） | ⏸ defer | 同一ブランチで commit 交錯。commit-range 基盤 + worktree 合流 path として別 follow-up（着手条件＝multi-pane を実際に行使する時） |
+
+## 結果
+
+- 検証入力（変更ファイル・完了報告）が単一 UC で **commit 範囲から構造的に決まる**（推定でなく事実）。検証ゲート v1 の working-tree フォールバックを置換。
+- **未検証 residual の上に立つ**: 「worker が実際に commit するか」は実装前に証明不可。人間ゲートで「文書化 residual を前提に作る」と承認の上で構築（exploration rubric の SO は empirical 仮定が残れば refute し続けるため、承認は人間の役）。degraded フォールバックで未コミット時も安全側へ縮退。
+- **follow-up**（routing 済み）:
+  - multi-pane 帰属（per-pane branch/worktree）→ #92 本文 + README に明記。
+  - reviewer verdict チャネルの marker 注入 → [#101](https://github.com/stlwolf/ai-development-hub/issues/101)（直交・別 issue）。
+  - worker commit 遵守率 → e2e / dogfood で fallback 率として実測。
+  - `git status --porcelain` の quoted-path パース（baseline_dirty 注記が外れ得る）→ 追わない（低頻度・注記のみの劣化）。
+  - `attach.sh` 経路の baseline 欠落 → 追わない（degraded で安全）。
+- SO 証跡: 設計SO 3R（audit `…4P78T7A6GM7H` / `…NMG0P7ZVB598` / `…1Q8NVTKJ0W2Z`）・実装SO 2R（`…7EMCG63SGW7P` refuted → `…KD1590C5MCT3` survived）。生出力は揮発（`tmp/oe-refute-*` / `tmp/oe-review-*`）だが verdict/要点は本文と episode に転記済み。

--- a/projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
@@ -1,0 +1,82 @@
+---
+id: "01KWEGNDJ4W0ZCYCFCJ0NDG5S5"
+title: "#92 検証入力を commit 範囲評価へ — working-tree 前提の破棄と commit reframe"
+date: 2026-07-01
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/92"
+    reason: "本 episode の対象 issue（検証ゲート v2）"
+  - type: refines
+    ref: ../decisions/2026-06-30-decision-114-clean-output-channel.md
+    reason: "#114 のクリーン取得チャネル上で検証入力を構築。#92 は acquisition の上の『何を検証入力にするか』"
+  - type: source_material
+    ref: ../../lib/verify.sh
+    reason: "oe_verify_prompt_build を commit 範囲評価へ変更（主実装）"
+  - type: follow_up
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/101"
+    reason: "reviewer verdict チャネルの marker 注入（本 episode スコープ外・直交）"
+tags: [orchestration, verification-gate, commit-range, design-so, impl-so, reframe, episode]
+---
+
+# #92 検証入力を commit 範囲評価へ
+
+> **reconstructed**: 本 episode はリアルタイム追記でなく、作業完了時に会話ログから再構成した。締めの構造化のみ episode-retrospective 準拠。証拠価値はリアルタイム追記ログと同列に扱わない。
+
+## Context（なぜ）
+
+検証ゲート（target を検証 agent が採点する）で、検証 agent への入力（変更ファイル一覧・完了報告）が貧弱だった（変更ファイル=repo-wide `git diff`、完了報告=state enum 1 個）。#114/#98 で per-pane のクリーン取得チャネルが landed した後、#92 の必要性を再評価し、必要分を実装するのが本作業。
+
+## 経緯（失敗と撤回を含む）
+
+蒸留パイプラインの gate（設計SO → 実装ゲート → 実装 → 実装SO）を全て踏んだ。**設計SO は 3 ラウンド refuted、実装SO は 1 ラウンド refuted**。各 refuted が設計/実装を実際に変えた。
+
+1. **再スコープ**: #114/#98 が subsume した範囲を一次確認。当初「F-SO-9（完了報告充実）のみ、F-SO-8（変更ファイル per-pane 化）は defer」で確定しかけた（ユーザー選択）。
+2. **設計SO v1（Alt A: raw transcript を verify-inputs.md に embed）→ refuted (2/2)**。前提 P1〜P3 が崩れた: `read_docs` は既に絶対パスを渡し validator も未検証（pull 型棄却根拠が無効）／skill は変更ファイル一覧を要求（F-SO-8 の defer は非対称）／raw transcript は未信頼入力。audit `202607010256044P78T7A6GM7H`。
+3. **方向再確定 → 設計SO v2（F-SO-8-lite + F-SO-9-pull）→ refuted (2/2)**。改訂も構造的に不足: output_dir スコープは per-pane でなく output_dir-wide 止まり（pre-existing dirty / 並行 writer が混入）、pull も marker 注入（#101 既知弱点）を構造的に解かない。audit `20260701041800NMG0P7ZVB598`。
+4. **フレーム破棄（ユーザー reframe）**: 2 ラウンド refuted で「minimal な working-tree diff 推定」というフレーム自体が誤りと判明。ユーザーが「**評価単位を commit にする**（WIP コミット可、commit された論理単位を評価）」を提案。これが working-tree 推定の構造的欠陥を root で溶かした（設計 D）。
+5. **設計SO v3（設計 D）→ refuted (2/2) だが質が変化**: 「commit 評価は**有望**、ただし engine が境界を強制せず worker 頼み／end 未固定／worker commit 遵守が未検証」。structural kill から grounding-gap へ収束。audit `202607010853001Q8NVTKJ0W2Z`。
+6. **SO ループ停止（reframe-on-stall）+ 人間ゲート**: exploration rubric は empirical 仮定が残る限り refute し続ける設計。3 ラウンドで「フレーム収束・残 residual は empirical/scope」と判断し、**「文書化 residual + テスト実測を前提に D' を作るか」をユーザー（人間ゲート）が承認**。D' = clean 境界強制（baseline + dirty 集合記録 / end materialize / pre-existing 注記）。
+7. **実装 → 実装SO v1（oe-review）→ refuted (2/2)**。設計SO とは別レンズがコード欠陥を捕捉: 部分コミット時に未コミット残余が漏れる（codex）／commit あるのに diff 空だと degraded へ誤フォールバックし事実矛盾（cursor）。audit `202607010937017EMCG63SGW7P`。
+8. **修正 → 実装SO v2 → survived (2/2)**。変更ファイルを `git diff <baseline>`（committed + 未コミット残余）+ untracked に変更。audit `20260701094830KD1590C5MCT3`。
+
+## 決定と根拠（棄却案つき）
+
+- **採用**: 評価単位 = commit 範囲。変更ファイル = `git diff --name-only <baseline>` + untracked（＝baseline からの全 footprint）、完了報告 = `git log baseline..end`、worker commit 契約を engine task に付与、baseline は spawn 前 / end は EXIT 時に materialize。
+- **棄却 Alt A（raw transcript embed）**: 未信頼入力の注入面・skill 契約（叙述報告）不一致・tail サイズ無根拠。
+- **棄却 Alt B/E（pull だが working-tree 前提）**: pull 自体は妥当だが、変更ファイルを working-tree diff で推定する限り pane-blind/dirty 混入が残る。
+- **棄却 output_dir スコープ**: 契約が緩く（絶対パス / repo 外 /tmp で git 破綻）、Compliance が見たい範囲外変更も落とす。
+- **なぜ commit が効くか**: commit は論理単位で、baseline からの diff が worker footprint を過不足なく与える。「commit すると git diff が空（#92 が"バグ"と記述）」を「commit を評価するのが設計」に反転した。
+
+## わかったこと（W）
+
+- **exploration rubric の SO は empirical 仮定が 1 つでも残れば refute する**。実装前に「worker が実際にコミットするか」等は証明不可 → survived を待つと loop する。SO は gap を surface する役で承認する役ではなく、**「文書化 residual を前提に作るか」は人間ゲートの判断**。
+- **設計SO 通過 ≠ 実装SO 代替**（#114 と同じ再確認）。設計 D は設計SO を通っていないが、実装SO が別レンズ（部分コミット・空 diff）で material 欠陥を捕捉した。逆も真で、設計SO が捉えた構造欠陥は実装SO のレンズでは出ない。
+- **2 回の structural refuted は「フレームを疑え」の信号**（reframe-on-stall）。3 回目で patch を重ねず、ユーザーの zero-base reframe に乗ったことで root が溶けた。
+
+## 原則（転用可能）
+
+- NG: 「汚れた作業ツリーの diff を推定して『誰が何を変えたか』を得る」→ 共有 workspace では原理的に pane-blind。
+- OK: 「評価単位を VCS の論理単位（commit）に置き、baseline からの footprint を取る」→ 帰属が構造的に決まる（単一 writer 前提）。
+
+## 残課題（routing 済み）
+
+- **multi-pane 帰属**: 同一ブランチで commit 交錯 → per-pane branch/worktree が必要。→ #92 本文 + README に「別 follow-up」と明記。着手条件 = multi-pane を実際に行使する時。
+- **reviewer verdict チャネルの marker 注入**: worker→reviewer 入力とは直交。→ [#101](https://github.com/stlwolf/ai-development-hub/issues/101)（既存 issue）に routing。
+- **worker commit 遵守率（empirical residual）**: pre-implementation では証明不可。→ e2e/dogfood で fallback 率として実測。未コミット時は degraded 明示で安全側に縮退する実装で暫定対処。
+- **`git status --porcelain` の quoted-path パース**: baseline_dirty 注記がクォート付きパスで外れ得る（ファイル自体は footprint に出る）。実装SO で「軽微・単独 refuted にせず」判定。→ 追わない（低頻度・注記のみの劣化）。
+- **`attach.sh` 経路の baseline 欠落**: session_start なし → baseline 未解決 → degraded フォールバック（既知・#92 スコープ外）。→ 追わない（degraded で安全）。
+
+## 蒸留シグナル
+
+- **昇格候補あり**: 「exploration rubric SO は empirical 仮定を残す設計を承認しない → 人間ゲートで『文書化 residual を前提に作る』を決める」は複数セッションで再現しうる運用知。`reframe-on-stall-rule` / `exhaustion-before-conclusion-rule` の「SO ループの停止条件」節、または so-compare skill への追記候補。ただし本 episode 1 事例では時期尚早 → 非昇格、次に同型が出たら Decision 化を検討。
+- 「commit-as-eval-unit」パターンは engine の multi-pane 設計（worktree-per-pane）着手時に再利用。
+
+## Closure
+
+- **次の消費者**: (1) #92 の multi-pane follow-up 着手者（本 episode の commit-range 基盤 + worktree 合流 path を読む）。(2) engine 検証ゲートを触る実装者（verify-inputs の構造）。
+- **status**: stable / 達成度 = **部分達成**（単一 UC 分の変更ファイル・完了報告は達成、multi-pane と verdict 注入は明示 defer）。
+- **evidence anchor**: 設計SO 3 ラウンド（audit `…4P78` / `…NMG0` / `…1Q8N`）・実装SO 2 ラウンド（`…MCG6` refuted → `…KD15` survived）。生出力は `tmp/oe-refute-*` / `tmp/oe-review-*`（揮発）だが verdict と要点は本文に転記済み。
+- **back-propagation**: #92 の issue framing（working-tree diff 前提・「commit で diff 空=問題」）が今回の設計で覆った → README 派生 issue 表の #92 行を landed スコープに更新。
+- **PR レビュー後の追記**: Copilot review の実質指摘があれば本 closure に追記（マージ前）。

--- a/projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
@@ -8,6 +8,9 @@ related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/92"
     reason: "本 episode の対象 issue（検証ゲート v2）"
+  - type: decision
+    ref: ../decisions/2026-07-01-decision-92-commit-range-verify-inputs.md
+    reason: "本 episode の設計判断を蒸留した ADR（commit 範囲評価・worker-commit 契約）"
   - type: refines
     ref: ../decisions/2026-06-30-decision-114-clean-output-channel.md
     reason: "#114 のクリーン取得チャネル上で検証入力を構築。#92 は acquisition の上の『何を検証入力にするか』"

--- a/projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md
@@ -79,4 +79,7 @@ tags: [orchestration, verification-gate, commit-range, design-so, impl-so, refra
 - **status**: stable / 達成度 = **部分達成**（単一 UC 分の変更ファイル・完了報告は達成、multi-pane と verdict 注入は明示 defer）。
 - **evidence anchor**: 設計SO 3 ラウンド（audit `…4P78` / `…NMG0` / `…1Q8N`）・実装SO 2 ラウンド（`…MCG6` refuted → `…KD15` survived）。生出力は `tmp/oe-refute-*` / `tmp/oe-review-*`（揮発）だが verdict と要点は本文に転記済み。
 - **back-propagation**: #92 の issue framing（working-tree diff 前提・「commit で diff 空=問題」）が今回の設計で覆った → README 派生 issue 表の #92 行を landed スコープに更新。
+- **PR**: [#219](https://github.com/stlwolf/ai-development-hub/pull/219)。マージ・worktree 掃除は人間/親（本 session はしない）。
 - **PR レビュー後の追記**: Copilot review の実質指摘があれば本 closure に追記（マージ前）。
+
+Step4 辞退: heavy tier の closure 外部チェック（`so-compare`）を起動したが SO lanes が空出力（env: codex は 240s 内に stdout を emit せず / claude-safe 空）で usable な結果を得られず。closure の 4 観点は本 episode で機械検証可能なため辞退。 / 既存チェックで覆った観点: 省略チェック（失敗＝本文の主内容・設計SO 3R + 実装SO refuted→survived を audit_id つきで全記載）/ routing（全 5 follow-up に行き先付与）/ evidence anchor（audit_id 5 件を本文転記・`tmp/oe-refute-*` / `tmp/oe-review-*` の verdict JSON と突合可）/ back-propagation（#92 issue framing の欠陥 → README #92 行を更新）。 / 未実施観点と判断: なし（4 観点すべて covered・低リスク）。

--- a/projects/orchestration-engine/lib/constants.sh
+++ b/projects/orchestration-engine/lib/constants.sh
@@ -75,6 +75,18 @@ OE_TARGET_AI_MODEL="${OE_TARGET_AI_MODEL:-composer-2}"
 OE_VERIFY_AI_CLI="${OE_VERIFY_AI_CLI:-claude}"
 OE_VERIFY_AI_MODEL="${OE_VERIFY_AI_MODEL:-claude-sonnet-4-6}"
 
+# #92: target 完了プロトコル — worker は作業を commit してから完了する。
+# 検証ゲートは「commit 範囲 (baseline..end)」を変更ファイル一覧・完了報告の正本にするため
+# (作業ツリーの推定をやめる。設計SO 3ラウンドで working-tree diff の pane-blind/dirty 混入が
+#  構造的欠陥と確定)。これは engine 側の target 契約であり、検証 skill (adversarial-review) の
+# プロンプト規約ではない。oe_envelope_create が target の task.description 末尾に付与する
+# (reviewer envelope = oe_verify_envelope_create には付与しない)。
+# 未コミット時は verify 側が working-tree diff に degraded フォールバックする (縮退を隠さない)。
+OE_TARGET_COMPLETION_PROTOCOL="
+
+---
+完了プロトコル (必須): 作業が完了したら、変更したファイルを git commit してください (WIP コミットで構いません)。自分が変更したファイルのみを git add し、コミットメッセージの1行目に「何を・なぜ」を要約してください (必要なら本文に詳細)。コミット後にタスクを終了してください (シェルが完了マーカーを自動付与します)。検証者はあなたのコミット範囲を評価します。"
+
 # Step 4-4 Phase C: reviewer 一時ファイル掃除用配列 (派生 Issue #93 前半)
 # oe_verify_run_phase で reviewer ULID 生成時に append、oe_cleanup で対応する /tmp/oe-{rsid}-verify-* を削除
 OE_VERIFY_REVIEWER_SESSION_IDS=()

--- a/projects/orchestration-engine/lib/envelope.sh
+++ b/projects/orchestration-engine/lib/envelope.sh
@@ -21,10 +21,15 @@ oe_envelope_create() {
 
   local envelope_path="/tmp/oe-${session_id}-envelope.json"
 
+  # #92: target には完了プロトコル (commit してから終了) を task.description 末尾に付与する。
+  # これは engine 側の target 契約 (検証ゲートが commit 範囲を評価入力にするため)。
+  # constants.sh 未 source 環境 (envelope.sh 単体テスト等) では :- で空フォールバックし従来挙動。
+  local full_desc="${task_description}${OE_TARGET_COMPLETION_PROTOCOL:-}"
+
   jq -n \
     --arg sid "$session_id" \
     --argjson pid "$pane_id" \
-    --arg desc "$task_description" \
+    --arg desc "$full_desc" \
     --arg odir "$output_dir" \
     --argjson timeout "$timeout_seconds" \
     --argjson max_panes "$OE_CB_MAX_PANES" \

--- a/projects/orchestration-engine/lib/monitor.sh
+++ b/projects/orchestration-engine/lib/monitor.sh
@@ -125,7 +125,13 @@ oe_monitor_loop() {
             oe_audit_emit "state_change" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
           fi
 
-          oe_audit_emit "session_end" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
+          # #92: worker 終了時点 (EXIT 検出時) の HEAD を materialize して session_end payload に記録。
+          #   検証ゲートは `baseline..end` を評価するため、end を verify 実行時の HEAD に依存させず
+          #   worker 終了時刻に固定する (verify 遅延・後続 commit で範囲がずれるのを防ぐ・設計SO round3 反映)。
+          local end_head end_payload
+          end_head="$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null || true)"
+          end_payload="$(jq -cn --arg gh "$end_head" '{git_head: $gh}')"
+          oe_audit_emit "session_end" "$session_id" "$pane_id" "$OE_CLASSIFY_STATE" "$end_payload"
           oe_capture_write_kvs "$session_id" "$pane_id" "$OE_CLASSIFY_STATE"
           OE_DONE_PANES+=("$pane_id")
           ;;

--- a/projects/orchestration-engine/lib/spawn.sh
+++ b/projects/orchestration-engine/lib/spawn.sh
@@ -260,10 +260,28 @@ oe_spawn_send() {
   local cli_command
   cli_command="( umask 077 ; rm -f \"${log_path}\" ; ( ${base_cli_command} 2>&1 ; printf '\\n@@OE_EXIT:%d\\n' \$? ) | tee \"${log_path}\" )"
 
+  # #92: worker 起動 **前** に baseline を確定する (send 後だと worker の変更が baseline に入る競合窓が残る)。
+  #   - git_head: worker 開始時点の HEAD。検証ゲートが `baseline..end` の commit 範囲を評価入力にする起点。
+  #   - baseline_dirty: 開始時点で既に dirty/untracked だったパス集合。worker が `git add -A` で
+  #     これらを巻き込んでも、verify 側が「pre-existing」と注記して silent な混入を防ぐ (設計SO round3 反映)。
+  #   git 不能 (非 git workspace 等) では空で記録し、verify 側は working-tree diff に degraded フォールバックする。
+  local baseline_head baseline_dirty_json
+  baseline_head="$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null || true)"
+  baseline_dirty_json="$(git -C "$PROJECT_DIR" status --porcelain 2>/dev/null \
+    | sed -E 's/^.{3}//; s/^.* -> //' \
+    | jq -R -s 'split("\n") | map(select(length>0))' 2>/dev/null || true)"
+  [[ -n "$baseline_dirty_json" ]] || baseline_dirty_json='[]'
+
   wez pane send "$pane_id" "$cli_command"
 
-  # session_start の state は audit schema（failure-taxonomy）と整合するため null
-  oe_audit_emit "session_start" "$session_id" "$pane_id" "" "{}"
+  # session_start: state は audit schema（failure-taxonomy）と整合するため null。
+  # payload に #92 baseline (git_head / baseline_dirty) を載せる。
+  local start_payload
+  start_payload="$(jq -cn \
+    --arg gh "$baseline_head" \
+    --argjson dirty "$baseline_dirty_json" \
+    '{git_head: $gh, baseline_dirty: $dirty}')"
+  oe_audit_emit "session_start" "$session_id" "$pane_id" "" "$start_payload"
 }
 
 # oe_spawn — 後方互換ラッパー（prepare → send）

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -139,11 +139,12 @@ The marker must be on its own line, no surrounding spaces, exact case. The shell
 #   設計SO 3 ラウンドで working-tree diff は pane-blind / pre-existing dirty 混入 / output_dir 契約破綻が
 #   構造的欠陥と確定。baseline は spawn 時 (session_start payload.git_head)、end は worker 終了時
 #   (session_end payload.git_head) を audit から解決する。
-#   - 変更ファイル = git diff --name-only baseline..end (per-pane・output_dir 非依存・範囲外の余計変更も可視)。
+#   - 変更ファイル = git diff --name-only <baseline> + untracked (= baseline からの全 footprint。
+#     committed + 未コミット残余の両方を捕捉。実装SO 反映で baseline..end [committed のみ] から変更)。
 #     baseline 時点で既に dirty だったファイルは「pre-existing」注記 (worker の git add -A 巻き込みを可視化)。
 #   - 完了報告 = git log baseline..end (skill 契約(2)「コミットログ」に合致)。旧 state_change enum は
 #     engine 分類状態 (補助) に relabel。
-#   - worker 未コミット (範囲空) / baseline 未解決時は working-tree diff に degraded フォールバック (縮退を明示)。
+#   - baseline 未解決時 (非 git / audit 欠落) は working-tree diff に degraded フォールバック (縮退を明示)。
 #   残 (別 follow-up): multi-pane 帰属 (branch/worktree) / reviewer verdict チャネルの marker 注入 (#101)。
 
 # _oe_verify_annotate_files — 変更ファイル行を組み立て、baseline 時点で既に dirty だったパスに注記を付ける。
@@ -229,7 +230,15 @@ oe_verify_prompt_build() {
     last_state_change="(audit log not found: $audit_path)"
   fi
 
-  # 変更ファイル: KVS outputs[] 優先 → commit 範囲 diff → degraded working-tree diff → placeholder。
+  # 変更ファイル: KVS outputs[] 優先 → baseline からの全 footprint → degraded working-tree → placeholder。
+  #
+  # 実装SO (oe-review, audit 202607010937017EMCG63SGW7P) 反映:
+  #   変更ファイルは `git diff --name-only <baseline>` (baseline commit と作業ツリーの差分) + untracked で
+  #   取る。これは committed (baseline..end) と **未コミット残余** の両方を1つの diff で捕捉するため:
+  #     - 部分コミット (一部だけ commit し残りを未コミットで終了) の残余が漏れない (codex 指摘)。
+  #     - 空/revert コミット (log 非空だが diff 空) を「footprint なし」と正確に表現し、
+  #       degraded working-tree へ誤フォールバックして「worker 未コミット」と矛盾する注記を出さない (cursor 指摘)。
+  #   完了報告 (git log baseline..end) が commit 構造を、本セクションが実ファイル footprint を示す。
   local changed_files_block="" changed_files_note=""
   local outputs_count=0
   if [[ -f "$kvs_path" ]]; then
@@ -239,24 +248,27 @@ oe_verify_prompt_build() {
   if [[ "$outputs_count" -gt 0 ]]; then
     changed_files_block="$(jq -r '.outputs[] | "- " + .' "$kvs_path")"
     changed_files_note="(source: KVS outputs[])"
-  else
-    local range_files=""
-    if [[ -n "$range" ]]; then
-      range_files="$(git -C "$PROJECT_DIR" diff --name-only "$range" 2>/dev/null || true)"
-    fi
-    if [[ -n "$range_files" ]]; then
-      changed_files_block="$(_oe_verify_annotate_files "$range_files" "$baseline_dirty")"
-      changed_files_note="(source: git diff --name-only ${range})"
+  elif [[ -n "$baseline_head" ]]; then
+    # 主経路: baseline からの全 footprint (committed + uncommitted + untracked)
+    local diff_files untracked_files all_files
+    diff_files="$(git -C "$PROJECT_DIR" diff --name-only "$baseline_head" 2>/dev/null || true)"
+    untracked_files="$(git -C "$PROJECT_DIR" ls-files --others --exclude-standard 2>/dev/null || true)"
+    all_files="$(printf '%s\n%s\n' "$diff_files" "$untracked_files" | awk 'NF' | sort -u)"
+    if [[ -n "$all_files" ]]; then
+      changed_files_block="$(_oe_verify_annotate_files "$all_files" "$baseline_dirty")"
+      changed_files_note="(source: git diff --name-only ${baseline_head} + untracked = baseline からの全 footprint。committed + 未コミット残余を含むため、完了報告の commit 列と突合し未コミット変更の有無を確認せよ)"
     else
-      # degraded: commit 範囲が空/未解決 → working-tree diff (無関係な変更を含み得る)
-      local wt_files
-      wt_files="$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null || true)"
-      if [[ -n "$wt_files" ]]; then
-        changed_files_block="$(printf '%s\n' "$wt_files" | awk 'NF { print "- " $0 }')"
-        changed_files_note="(degraded: working-tree diff — worker が未コミットのため commit 範囲を取れず。無関係な変更を含み得る。実コードで裏取りせよ)"
-      else
-        changed_files_block="(no changes detected: commit 範囲空 + working-tree diff 空)"
-      fi
+      changed_files_block="(no file changes since baseline ${baseline_head}. 完了報告の commit 列を確認せよ — 空コミット / revert 等で net 変更なしの可能性)"
+    fi
+  else
+    # baseline 未解決 (非 git / audit 欠落) → degraded working-tree diff (帰属不能・無関係変更を含み得る)
+    local wt_files
+    wt_files="$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null || true)"
+    if [[ -n "$wt_files" ]]; then
+      changed_files_block="$(printf '%s\n' "$wt_files" | awk 'NF { print "- " $0 }')"
+      changed_files_note="(degraded: baseline 未解決のため working-tree diff。無関係な変更を含み得る。実コードで裏取りせよ)"
+    else
+      changed_files_block="(no changes detected: baseline 未解決 + working-tree diff 空)"
     fi
   fi
 

--- a/projects/orchestration-engine/lib/verify.sh
+++ b/projects/orchestration-engine/lib/verify.sh
@@ -134,11 +134,36 @@ The marker must be on its own line, no surrounding spaces, exact case. The shell
 #
 # F4: engine は skill prompt 本文を組み立てない。3 入力の構造化抽出のみ。
 #     検証 agent が use_skills + read_docs で skill を読んで自分でプロンプトを組み立てる。
-# F7: outputs[] は MVP では常に空配列のため、git diff --name-only パスが常時選択される。
-#     outputs[] の書き込み拡張は本 Step スコープ外。
+#
+# #92 (設計 D): 評価単位を「作業ツリー diff の推定」から「commit 範囲 baseline..end」に変える。
+#   設計SO 3 ラウンドで working-tree diff は pane-blind / pre-existing dirty 混入 / output_dir 契約破綻が
+#   構造的欠陥と確定。baseline は spawn 時 (session_start payload.git_head)、end は worker 終了時
+#   (session_end payload.git_head) を audit から解決する。
+#   - 変更ファイル = git diff --name-only baseline..end (per-pane・output_dir 非依存・範囲外の余計変更も可視)。
+#     baseline 時点で既に dirty だったファイルは「pre-existing」注記 (worker の git add -A 巻き込みを可視化)。
+#   - 完了報告 = git log baseline..end (skill 契約(2)「コミットログ」に合致)。旧 state_change enum は
+#     engine 分類状態 (補助) に relabel。
+#   - worker 未コミット (範囲空) / baseline 未解決時は working-tree diff に degraded フォールバック (縮退を明示)。
+#   残 (別 follow-up): multi-pane 帰属 (branch/worktree) / reviewer verdict チャネルの marker 注入 (#101)。
+
+# _oe_verify_annotate_files — 変更ファイル行を組み立て、baseline 時点で既に dirty だったパスに注記を付ける。
+# 引数: files (改行区切りのパス), baseline_dirty (改行区切りの baseline dirty パス集合)
+_oe_verify_annotate_files() {
+  local files="$1"
+  local baseline_dirty="$2"
+  local f
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    if [[ -n "$baseline_dirty" ]] && printf '%s\n' "$baseline_dirty" | grep -qxF -- "$f"; then
+      printf -- '- %s  ⚠ pre-existing at baseline (worker が既存 dirty を巻き込んだ可能性・独立検証せよ)\n' "$f"
+    else
+      printf -- '- %s\n' "$f"
+    fi
+  done <<< "$files"
+}
+
 oe_verify_prompt_build() {
   local reviewer_session_id="$1"
-  # shellcheck disable=SC2034  # API 安定化のため引数として保持 (将来 per-pane 拡張で使用予定)
   local target_pane_id="$2"
   local target_session_id="$3"
   local target_envelope_path="$4"
@@ -157,9 +182,41 @@ oe_verify_prompt_build() {
     task_description="(target envelope not found: $target_envelope_path)"
   fi
 
-  # 完了報告: audit JSONL から target_pane_id の最後の state_change イベントを抽出
-  # Copilot #3 反映: 全セッションの最後の state_change ではなく、target_pane_id でフィルタする
-  # (oe_verify_run_phase は複数 target pane を順次扱うため、混線を避ける)
+  # #92: baseline / end / baseline_dirty を audit の session_start / session_end payload から
+  #   target_pane_id で解決する (複数 target pane を順次扱うため pane フィルタで混線回避)。
+  local baseline_head="" end_head="" baseline_dirty=""
+  if [[ -f "$audit_path" ]]; then
+    # audit は JSONL のため -s (slurp) で配列化してから map する。
+    baseline_head="$(jq -r -s --argjson pid "$target_pane_id" \
+      'map(select(.event_type == "session_start" and .pane_id == $pid)) | last | .payload.git_head // ""' \
+      "$audit_path")"
+    baseline_dirty="$(jq -r -s --argjson pid "$target_pane_id" \
+      'map(select(.event_type == "session_start" and .pane_id == $pid)) | last | (.payload.baseline_dirty // []) | .[]' \
+      "$audit_path")"
+    end_head="$(jq -r -s --argjson pid "$target_pane_id" \
+      'map(select(.event_type == "session_end" and .pane_id == $pid)) | last | .payload.git_head // ""' \
+      "$audit_path")"
+  fi
+  # end が materialize されていなければ現在 HEAD にフォールバック
+  # (単一 UC synchronous では verify は monitor 完了直後に走るため worker 終了時と一致)。
+  if [[ -z "$end_head" ]]; then
+    end_head="$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null || true)"
+  fi
+
+  local range=""
+  [[ -n "$baseline_head" && -n "$end_head" ]] && range="${baseline_head}..${end_head}"
+
+  # 完了報告: commit 範囲 baseline..end の git log を正本にする。
+  local commit_log_block=""
+  if [[ -n "$range" ]]; then
+    commit_log_block="$(git -C "$PROJECT_DIR" log --no-color --format='- %h %s' "$range" 2>/dev/null || true)"
+  fi
+  if [[ -z "$commit_log_block" ]]; then
+    commit_log_block="(commit 範囲 ${range:-<未解決>} にコミットなし。worker が未コミットの可能性。engine 分類状態と変更ファイルで判断せよ)"
+  fi
+
+  # engine 分類状態 (補助): audit の最後の state_change。engine の failure-taxonomy 分類であり、
+  # 実装者の完了報告ではない (旧「完了報告」ラベルは誤りだったため relabel)。
   local last_state_change
   if [[ -f "$audit_path" ]]; then
     last_state_change="$(jq -s --argjson pid "$target_pane_id" \
@@ -172,8 +229,8 @@ oe_verify_prompt_build() {
     last_state_change="(audit log not found: $audit_path)"
   fi
 
-  # 変更ファイル: KVS の outputs[] を優先、空なら git diff --name-only にフォールバック (F7)
-  local changed_files_block
+  # 変更ファイル: KVS outputs[] 優先 → commit 範囲 diff → degraded working-tree diff → placeholder。
+  local changed_files_block="" changed_files_note=""
   local outputs_count=0
   if [[ -f "$kvs_path" ]]; then
     outputs_count="$(jq '(.outputs // []) | length' "$kvs_path")"
@@ -181,15 +238,25 @@ oe_verify_prompt_build() {
 
   if [[ "$outputs_count" -gt 0 ]]; then
     changed_files_block="$(jq -r '.outputs[] | "- " + .' "$kvs_path")"
+    changed_files_note="(source: KVS outputs[])"
   else
-    # フォールバック: git diff --name-only (MVP では常にこちらが選択される)
-    # iter2 #3252519559 反映: PROJECT_DIR で git を実行することで、caller の CWD に依存しない安定した
-    # 結果を得る。target task の実際の output_dir に紐づけるのは派生 Issue #92 のスコープ。
-    local git_output
-    if git_output="$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null)" && [[ -n "$git_output" ]]; then
-      changed_files_block="$(printf '%s\n' "$git_output" | awk 'NF { print "- " $0 }')"
+    local range_files=""
+    if [[ -n "$range" ]]; then
+      range_files="$(git -C "$PROJECT_DIR" diff --name-only "$range" 2>/dev/null || true)"
+    fi
+    if [[ -n "$range_files" ]]; then
+      changed_files_block="$(_oe_verify_annotate_files "$range_files" "$baseline_dirty")"
+      changed_files_note="(source: git diff --name-only ${range})"
     else
-      changed_files_block="(no changes detected from KVS outputs[] or git diff)"
+      # degraded: commit 範囲が空/未解決 → working-tree diff (無関係な変更を含み得る)
+      local wt_files
+      wt_files="$(git -C "$PROJECT_DIR" diff --name-only 2>/dev/null || true)"
+      if [[ -n "$wt_files" ]]; then
+        changed_files_block="$(printf '%s\n' "$wt_files" | awk 'NF { print "- " $0 }')"
+        changed_files_note="(degraded: working-tree diff — worker が未コミットのため commit 範囲を取れず。無関係な変更を含み得る。実コードで裏取りせよ)"
+      else
+        changed_files_block="(no changes detected: commit 範囲空 + working-tree diff 空)"
+      fi
     fi
   fi
 
@@ -198,13 +265,18 @@ oe_verify_prompt_build() {
     printf '# Compliance Review Inputs\n\n'
     printf 'reviewer_session_id: %s\n' "$reviewer_session_id"
     printf 'target_session_id: %s\n' "$target_session_id"
-    printf 'target_pane_id: %s\n\n' "$target_pane_id"
+    printf 'target_pane_id: %s\n' "$target_pane_id"
+    printf 'commit_range: %s\n\n' "${range:-<未解決>}"
     printf '## 要件 (Task description)\n\n'
     printf '%s\n\n' "$task_description"
-    printf '## 完了報告 (Latest state_change event)\n\n'
+    printf '## 完了報告 (Commit log: %s)\n\n' "${range:-<未解決>}"
+    printf '**注**: これは被検証者 (worker) の自己申告です。adversarial-review の原則どおり報告を信用せず、必ず実コード (下記変更ファイル) を確認してください。\n\n'
+    # shellcheck disable=SC2016  # backticks in single quotes are literal Markdown fences here
+    printf '```\n%s\n```\n\n' "$commit_log_block"
+    printf '## engine 分類状態 (Latest state_change・補助シグナル)\n\n'
     # shellcheck disable=SC2016  # backticks in single quotes are literal Markdown fences here
     printf '```json\n%s\n```\n\n' "$last_state_change"
-    printf '## 変更ファイル (Changed files)\n\n'
+    printf '## 変更ファイル (Changed files) %s\n\n' "$changed_files_note"
     printf '%s\n' "$changed_files_block"
   } > "$prompt_path"
 

--- a/projects/orchestration-engine/tests/test_e2e_smoke.sh
+++ b/projects/orchestration-engine/tests/test_e2e_smoke.sh
@@ -158,8 +158,15 @@ assert_eq "reviewer payload に rm -f reviewer.log (#216 pre-existing fix)" "tru
 assert_eq "session_start emitted" "1" \
   "$(jq -r 'select(.event_type=="session_start") | 1' "$audit_file" | wc -l | tr -d ' ')"
 assert_eq "session_start state null" "null" "$(jq -r 'select(.event_type=="session_start") | .state' "$audit_file")"
+# #92: session_start は baseline (git_head) を、session_end は end (git_head) を payload に持つ。
+assert_eq "session_start payload に git_head キー (#92 baseline)" "true" \
+  "$(jq -r 'select(.event_type=="session_start") | (.payload | has("git_head"))' "$audit_file")"
+assert_eq "session_start payload に baseline_dirty キー (#92)" "true" \
+  "$(jq -r 'select(.event_type=="session_start") | (.payload | has("baseline_dirty"))' "$audit_file")"
 assert_eq "session_end emitted" "1" \
   "$(jq -r 'select(.event_type=="session_end") | 1' "$audit_file" | wc -l | tr -d ' ')"
+assert_eq "session_end payload に git_head キー (#92 end materialize)" "true" \
+  "$(jq -r 'select(.event_type=="session_end") | (.payload | has("git_head"))' "$audit_file")"
 assert_eq "state_change emitted" "1" \
   "$(jq -r 'select(.event_type=="state_change" and .state=="success") | 1' "$audit_file" | wc -l | tr -d ' ')"
 assert_eq "cleanup emitted" "1" \

--- a/projects/orchestration-engine/tests/test_envelope.sh
+++ b/projects/orchestration-engine/tests/test_envelope.sh
@@ -50,7 +50,11 @@ JSON="$OE_ENVELOPE_PATH"
 
 assert_eq "session_id" "TEST_SESSION_01" "$(jq -r '.session_id' "$JSON")"
 assert_eq "pane_id" "42" "$(jq -r '.pane_id' "$JSON")"
-assert_eq "task.description" "Test task description" "$(jq -r '.task.description' "$JSON")"
+# #92: task.description は元タスク + 完了プロトコル (commit してから終了) の付与形になる。
+assert_eq "task.description は元タスクで始まる" "true" \
+  "$(jq -r '.task.description' "$JSON" | head -1 | grep -qxF 'Test task description' && echo true || echo false)"
+assert_eq "task.description に完了プロトコル (commit 指示) を付与" "true" \
+  "$(jq -r '.task.description' "$JSON" | grep -q '完了プロトコル' && echo true || echo false)"
 assert_eq "task.output_dir" "./output" "$(jq -r '.task.output_dir' "$JSON")"
 assert_eq "task.exit_conditions.marker" "@@OE_EXIT" "$(jq -r '.task.exit_conditions.marker' "$JSON")"
 assert_eq "task.exit_conditions.timeout_seconds" "300" "$(jq -r '.task.exit_conditions.timeout_seconds' "$JSON")"

--- a/projects/orchestration-engine/tests/test_monitor.sh
+++ b/projects/orchestration-engine/tests/test_monitor.sh
@@ -161,6 +161,25 @@ assert_contains() {
   (( FAIL++ )) || true
 }
 
+# #92: session_end は end HEAD を materialize した payload ({"git_head":...}) を持つため、
+# 完全一致でなく prefix でアサートする (git_head 値は実行環境の HEAD で非決定的)。
+assert_contains_prefix() {
+  local label="$1"
+  local prefix="$2"
+  shift 2
+  local haystack=("$@")
+  local item
+  for item in "${haystack[@]}"; do
+    if [[ "$item" == "$prefix"* ]]; then
+      echo "  PASS: $label"
+      (( PASS++ )) || true
+      return 0
+    fi
+  done
+  echo "  FAIL: $label (prefix='$prefix' not found in [${haystack[*]}])"
+  (( FAIL++ )) || true
+}
+
 # --- テスト a: 単一ペイン EXIT:0 → ループ終了 ---
 
 echo "=== Test a: 単一ペイン EXIT:0 → ループ終了 ==="
@@ -178,7 +197,7 @@ assert_eq "scan count for p1" "1" "$(mock_scan_count p1)"
 assert_eq "KVS write count" "1" "$_MOCK_KVS_WRITE_COUNT"
 assert_eq "KVS args include session/pane/state" "sess-a|p1|success" "$_MOCK_KVS_LAST_ARGS"
 assert_contains "state_change emitted" "state_change|sess-a|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
-assert_contains "session_end emitted" "session_end|sess-a|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
+assert_contains_prefix "session_end emitted (#92: git_head payload)" 'session_end|sess-a|p1|success|{"git_head":' "${_MOCK_AUDIT_CALLS[@]}"
 assert_eq "no kill calls" "0" "${#_MOCK_KILL_CALLS[@]}"
 assert_eq "cleanup not called in monitor" "0" "$_MOCK_CLEANUP_CALLED"
 
@@ -215,7 +234,7 @@ assert_eq "OE_DONE_PANES[0]" "p1" "${OE_DONE_PANES[0]}"
 assert_eq "p1 scan count" "1" "$(mock_scan_count p1)"
 assert_eq "p2 scan count" "3" "$(mock_scan_count p2)"
 assert_contains "state_change for p1" "state_change|sess-c|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
-assert_contains "session_end for p1" "session_end|sess-c|p1|success|" "${_MOCK_AUDIT_CALLS[@]}"
+assert_contains_prefix "session_end for p1 (#92: git_head payload)" 'session_end|sess-c|p1|success|{"git_head":' "${_MOCK_AUDIT_CALLS[@]}"
 assert_contains "CB max_turns" \
   'circuit_breaker_triggered|sess-c|0||{"reason":"max_turns"}' \
   "${_MOCK_AUDIT_CALLS[@]}"

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -36,21 +36,37 @@ assert_eq() {
 # OE_MOCK_GIT_FILES が設定されていればそれを返し、未設定なら空文字列を返す
 cat > "${_TMP_DIR}/bin/git" <<'EOF'
 #!/usr/bin/env bash
-# iter2 #3252519559 反映: verify.sh は `git -C "$PROJECT_DIR" diff --name-only` 形式で呼ぶようになった。
-# 先頭の -C <dir> を skip して subcommand を判定する。
+# iter2 #3252519559 反映: verify.sh は `git -C "$PROJECT_DIR" ...` 形式で呼ぶ。先頭の -C <dir> を skip。
+# #92 (設計 D): commit 範囲評価のため diff <range> / log / rev-parse を追加でモックする。
 args=("$@")
 i=0
-# -C <path> を skip
 if [[ "${args[0]:-}" == "-C" && -n "${args[1]:-}" ]]; then
   i=2
 fi
-if [[ "${args[i]:-}" == "diff" && "${args[$((i+1))]:-}" == "--name-only" ]]; then
-  if [[ -n "${OE_MOCK_GIT_FILES:-}" ]]; then
-    printf '%s\n' "${OE_MOCK_GIT_FILES}"
+sub="${args[i]:-}"
+if [[ "$sub" == "diff" && "${args[$((i+1))]:-}" == "--name-only" ]]; then
+  # range 引数 (args[i+2]) の有無で range diff / working-tree diff を分岐:
+  #   range あり → OE_MOCK_GIT_RANGE_FILES (commit 範囲) / range なし → OE_MOCK_GIT_FILES (working-tree)
+  if [[ -n "${args[$((i+2))]:-}" ]]; then
+    [[ -n "${OE_MOCK_GIT_RANGE_FILES:-}" ]] && printf '%s\n' "${OE_MOCK_GIT_RANGE_FILES}"
+  else
+    [[ -n "${OE_MOCK_GIT_FILES:-}" ]] && printf '%s\n' "${OE_MOCK_GIT_FILES}"
   fi
   exit 0
 fi
-# git diff 以外の git は素通り (実 git を使う)
+if [[ "$sub" == "log" ]]; then
+  [[ -n "${OE_MOCK_GIT_LOG:-}" ]] && printf '%s\n' "${OE_MOCK_GIT_LOG}"
+  exit 0
+fi
+if [[ "$sub" == "rev-parse" ]]; then
+  printf '%s\n' "${OE_MOCK_GIT_HEAD:-0000000000000000000000000000000000000000}"
+  exit 0
+fi
+if [[ "$sub" == "status" ]]; then
+  [[ -n "${OE_MOCK_GIT_DIRTY:-}" ]] && printf '%s\n' "${OE_MOCK_GIT_DIRTY}"
+  exit 0
+fi
+# その他の git は素通り (実 git を使う)
 exec /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git "$@"
 EOF
 chmod +x "${_TMP_DIR}/bin/git"
@@ -242,16 +258,78 @@ assert_eq "payload.reviewer_pane_id" "888" \
 assert_eq "payload.reviewer_session_id" "$reviewer_session_id_for_spawn" \
   "$(jq -r 'select(.event_type=="verification_started") | .payload.reviewer_session_id' "$target_audit")"
 
-# ---- Phase C: oe_verify_prompt_build (3 入力の構造化抽出) ----
+# ---- Phase C: oe_verify_prompt_build (#92 設計 D: commit 範囲 baseline..end 評価) ----
 echo ""
-echo "=== oe_verify_prompt_build (Phase C) ==="
+echo "=== oe_verify_prompt_build (Phase C・#92 commit 範囲) ==="
 
-# 既に oe_verify_spawn 経由で target session の audit log に verification_started イベントが
-# 書かれている。Phase C 用に state_change イベントを追記:
+# 補助シグナルの state_change (engine 分類状態)
 oe_audit_emit "state_change" "$target_session_id" "$target_pane_id" "success" '{"from":"progress","to":"success"}'
 
-# Case 1: KVS に outputs[] が複数あるケース (git フォールバックは呼ばれない)
 target_kvs_file="${OE_STATE_DIR}/${target_session_id}.state.json"
+_empty_outputs_kvs() {
+  cat > "$target_kvs_file" <<'JSON'
+{
+  "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
+  "pane_id": 42,
+  "state": "success",
+  "last_updated": "2026-05-15T12:34:56Z",
+  "outputs": [],
+  "blockers": []
+}
+JSON
+}
+
+# -- Case A: commit 範囲 baseline..end からの変更ファイル + commit log + pre-existing 注記 --
+echo "-- Case A: commit 範囲 (session_start baseline + session_end end) --"
+oe_audit_emit "session_start" "$target_session_id" "$target_pane_id" "" '{"git_head":"BASE111","baseline_dirty":["docs/preexisting.md"]}'
+oe_audit_emit "session_end" "$target_session_id" "$target_pane_id" "success" '{"git_head":"END222"}'
+_empty_outputs_kvs
+export OE_MOCK_GIT_RANGE_FILES="lib/feature.sh
+docs/preexisting.md"
+export OE_MOCK_GIT_LOG="- abc123 feat: add feature
+- def456 wip: docs"
+oe_verify_prompt_build "RTEST_PROMPT_RANGE" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+unset OE_MOCK_GIT_RANGE_FILES OE_MOCK_GIT_LOG
+P="$OE_VERIFY_PROMPT_PATH"
+
+assert_eq "OE_VERIFY_PROMPT_PATH set" "/tmp/oe-RTEST_PROMPT_RANGE-verify-inputs.md" "$P"
+assert_eq "prompt file exists" "true" "$( [[ -f "$P" ]] && echo true || echo false )"
+assert_eq "section: 要件" "true" "$(grep -q '^## 要件' "$P" && echo true || echo false)"
+assert_eq "section: 完了報告 (commit log)" "true" "$(grep -q '^## 完了報告 (Commit log: BASE111..END222)' "$P" && echo true || echo false)"
+assert_eq "section: engine 分類状態" "true" "$(grep -q '^## engine 分類状態' "$P" && echo true || echo false)"
+assert_eq "section: 変更ファイル" "true" "$(grep -q '^## 変更ファイル' "$P" && echo true || echo false)"
+assert_eq "commit_range メタ = BASE111..END222" "true" "$(grep -q '^commit_range: BASE111..END222' "$P" && echo true || echo false)"
+assert_eq "要件 = target.task.description" "true" \
+  "$(grep -q 'Target task description' "$P" && echo true || echo false)"
+assert_eq "完了報告に commit log (abc123)" "true" \
+  "$(grep -q 'abc123 feat: add feature' "$P" && echo true || echo false)"
+assert_eq "engine 分類状態に state_change イベント" "true" \
+  "$(grep -qE '"event_type": ?"state_change"' "$P" && echo true || echo false)"
+assert_eq "変更ファイルに range file (lib/feature.sh)" "true" \
+  "$(grep -q '^- lib/feature.sh' "$P" && echo true || echo false)"
+assert_eq "pre-existing 注記 (docs/preexisting.md)" "true" \
+  "$(grep -qF -- '- docs/preexisting.md  ⚠ pre-existing' "$P" && echo true || echo false)"
+
+# -- Case B: worker 未コミット (commit 範囲空) → degraded working-tree diff --
+echo ""
+echo "-- Case B: 未コミット → degraded working-tree diff --"
+# session_start/end は Case A のものが残る (range=BASE111..END222)。range diff / log を空にして degraded 経路へ。
+_empty_outputs_kvs
+export OE_MOCK_GIT_FILES="lib/uncommitted.sh"
+oe_verify_prompt_build "RTEST_PROMPT_DEGRADED" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+unset OE_MOCK_GIT_FILES
+PD="$OE_VERIFY_PROMPT_PATH"
+
+assert_eq "degraded: working-tree diff file (lib/uncommitted.sh)" "true" \
+  "$(grep -q '^- lib/uncommitted.sh' "$PD" && echo true || echo false)"
+assert_eq "degraded: 変更ファイル note に degraded 明示" "true" \
+  "$(grep -q 'degraded' "$PD" && echo true || echo false)"
+assert_eq "degraded: 完了報告に未コミット注記" "true" \
+  "$(grep -q 'コミットなし' "$PD" && echo true || echo false)"
+
+# -- Case C: KVS outputs[] は commit 範囲より優先される --
+echo ""
+echo "-- Case C: KVS outputs[] 優先 --"
 cat > "$target_kvs_file" <<'JSON'
 {
   "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
@@ -262,77 +340,42 @@ cat > "$target_kvs_file" <<'JSON'
   "blockers": []
 }
 JSON
+export OE_MOCK_GIT_RANGE_FILES="lib/should_not_appear.sh"
+oe_verify_prompt_build "RTEST_PROMPT_OUTPUTS" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+unset OE_MOCK_GIT_RANGE_FILES
+PO="$OE_VERIFY_PROMPT_PATH"
 
-echo "-- Case 1: KVS の outputs[] を使用 --"
-oe_verify_prompt_build "RTEST_PROMPT_01" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+assert_eq "outputs[] 優先: src/foo.sh" "true" \
+  "$(grep -q '^- src/foo.sh' "$PO" && echo true || echo false)"
+assert_eq "outputs[] 優先: range file は出ない" "false" \
+  "$(grep -q 'should_not_appear' "$PO" && echo true || echo false)"
 
-assert_eq "OE_VERIFY_PROMPT_PATH set" "/tmp/oe-RTEST_PROMPT_01-verify-inputs.md" "$OE_VERIFY_PROMPT_PATH"
-assert_eq "prompt file exists" "true" "$( [[ -f "$OE_VERIFY_PROMPT_PATH" ]] && echo true || echo false )"
-
-assert_eq "section: 要件" "true" "$(grep -q '^## 要件' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "section: 完了報告" "true" "$(grep -q '^## 完了報告' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "section: 変更ファイル" "true" "$(grep -q '^## 変更ファイル' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-
-assert_eq "要件 = target.task.description" "true" \
-  "$(grep -q 'Target task description' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "完了報告に state_change イベント" "true" \
-  "$(grep -qE '"event_type": ?"state_change"' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "変更ファイルに outputs[0]" "true" \
-  "$(grep -q '^- src/foo.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "変更ファイルに outputs[1]" "true" \
-  "$(grep -q '^- tests/test_foo.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-
-# Case 2: KVS の outputs[] が空 → git diff フォールバック (git mock 経由)
+# -- Case D: baseline / state_change は target_pane_id でフィルタ (別 pane を混入させない) --
 echo ""
-echo "-- Case 2: outputs[] 空 → git diff --name-only フォールバック --"
-
-cat > "$target_kvs_file" <<'JSON'
-{
-  "session_id": "01KRMYHMET73WDE32JXD1TZ0A4",
-  "pane_id": 42,
-  "state": "success",
-  "last_updated": "2026-05-15T12:34:56Z",
-  "outputs": [],
-  "blockers": []
-}
-JSON
-
-export OE_MOCK_GIT_FILES="lib/changed.sh
-tests/test_changed.sh"
-oe_verify_prompt_build "RTEST_PROMPT_GIT" "$target_pane_id" "$target_session_id" "$target_envelope_path"
-unset OE_MOCK_GIT_FILES
-
-assert_eq "prompt path (git fallback)" "/tmp/oe-RTEST_PROMPT_GIT-verify-inputs.md" "$OE_VERIFY_PROMPT_PATH"
-assert_eq "git fallback: lib/changed.sh" "true" \
-  "$(grep -q '^- lib/changed.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "git fallback: tests/test_changed.sh" "true" \
-  "$(grep -q '^- tests/test_changed.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-assert_eq "git fallback: outputs[0] (src/foo.sh) は含まない" "false" \
-  "$(grep -q '^- src/foo.sh' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-
-# Case 3: outputs[] 空 + git 出力も空 → "(no changes detected ...)" プレースホルダ
-echo ""
-echo "-- Case 3: outputs[] 空 + git 空 → プレースホルダ --"
-
-unset OE_MOCK_GIT_FILES
-oe_verify_prompt_build "RTEST_PROMPT_02" "$target_pane_id" "$target_session_id" "$target_envelope_path"
-assert_eq "プレースホルダ表示" "true" \
-  "$(grep -q 'no changes detected' "$OE_VERIFY_PROMPT_PATH" && echo true || echo false)"
-
-# Copilot #3 反映: state_change は target_pane_id でフィルタされる
-# 別 pane (99) の state_change イベントを混入させても、target (pane 42) の方が選ばれることを確認
-echo ""
-echo "-- Copilot #3: oe_verify_prompt_build は state_change を target_pane_id でフィルタ --"
+echo "-- Case D: pane_id フィルタ (baseline + state_change) --"
+# 別 pane 99 の session_start / state_change を混入させても pane 42 の baseline / 分類が選ばれる。
+oe_audit_emit "session_start" "$target_session_id" 99 "" '{"git_head":"OTHERBASE","baseline_dirty":[]}'
 oe_audit_emit "state_change" "$target_session_id" 99 "partial" '{"from":"progress","to":"partial","note":"different pane"}'
+_empty_outputs_kvs
+export OE_MOCK_GIT_RANGE_FILES="lib/pane42.sh"
+export OE_MOCK_GIT_LOG="- aaa111 pane42 commit"
 oe_verify_prompt_build "RTEST_PROMPT_FILTER" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+unset OE_MOCK_GIT_RANGE_FILES OE_MOCK_GIT_LOG
 filter_prompt_path="$OE_VERIFY_PROMPT_PATH"
 
-assert_eq "Copilot #3: prompt に target pane_id=42 が含まれる" "true" \
+assert_eq "pane フィルタ: commit_range は pane 42 baseline (BASE111)" "true" \
+  "$(grep -q '^commit_range: BASE111..END222' "$filter_prompt_path" && echo true || echo false)"
+assert_eq "pane フィルタ: 別 pane baseline (OTHERBASE) は使わない" "false" \
+  "$(grep -q 'OTHERBASE' "$filter_prompt_path" && echo true || echo false)"
+assert_eq "pane フィルタ: prompt に target pane_id=42" "true" \
   "$(grep -q '"pane_id": 42' "$filter_prompt_path" && echo true || echo false)"
-assert_eq "Copilot #3: 別 pane 99 の state_change は混入しない" "false" \
+assert_eq "pane フィルタ: 別 pane 99 の state_change は混入しない" "false" \
   "$(grep -q '"pane_id": 99' "$filter_prompt_path" && echo true || echo false)"
 
-rm -f "/tmp/oe-RTEST_PROMPT_FILTER-verify-inputs.md"
+rm -f "/tmp/oe-RTEST_PROMPT_RANGE-verify-inputs.md" \
+  "/tmp/oe-RTEST_PROMPT_DEGRADED-verify-inputs.md" \
+  "/tmp/oe-RTEST_PROMPT_OUTPUTS-verify-inputs.md" \
+  "/tmp/oe-RTEST_PROMPT_FILTER-verify-inputs.md"
 
 # ---- Phase C: oe_verify_envelope_create に prompt path を渡すと read_docs に 5 件目が追加される ----
 echo ""

--- a/projects/orchestration-engine/tests/test_verify.sh
+++ b/projects/orchestration-engine/tests/test_verify.sh
@@ -58,6 +58,10 @@ if [[ "$sub" == "log" ]]; then
   [[ -n "${OE_MOCK_GIT_LOG:-}" ]] && printf '%s\n' "${OE_MOCK_GIT_LOG}"
   exit 0
 fi
+if [[ "$sub" == "ls-files" ]]; then
+  [[ -n "${OE_MOCK_GIT_UNTRACKED:-}" ]] && printf '%s\n' "${OE_MOCK_GIT_UNTRACKED}"
+  exit 0
+fi
 if [[ "$sub" == "rev-parse" ]]; then
   printf '%s\n' "${OE_MOCK_GIT_HEAD:-0000000000000000000000000000000000000000}"
   exit 0
@@ -279,17 +283,19 @@ _empty_outputs_kvs() {
 JSON
 }
 
-# -- Case A: commit 範囲 baseline..end からの変更ファイル + commit log + pre-existing 注記 --
-echo "-- Case A: commit 範囲 (session_start baseline + session_end end) --"
+# -- Case A: baseline からの全 footprint (committed + untracked) + commit log + pre-existing 注記 --
+echo "-- Case A: 全 footprint (committed + untracked/uncommitted) --"
 oe_audit_emit "session_start" "$target_session_id" "$target_pane_id" "" '{"git_head":"BASE111","baseline_dirty":["docs/preexisting.md"]}'
 oe_audit_emit "session_end" "$target_session_id" "$target_pane_id" "success" '{"git_head":"END222"}'
 _empty_outputs_kvs
+# git diff <baseline> (committed + 未コミット tracked) と ls-files (untracked) の両方を footprint に含む。
 export OE_MOCK_GIT_RANGE_FILES="lib/feature.sh
 docs/preexisting.md"
+export OE_MOCK_GIT_UNTRACKED="newfile.txt"
 export OE_MOCK_GIT_LOG="- abc123 feat: add feature
 - def456 wip: docs"
 oe_verify_prompt_build "RTEST_PROMPT_RANGE" "$target_pane_id" "$target_session_id" "$target_envelope_path"
-unset OE_MOCK_GIT_RANGE_FILES OE_MOCK_GIT_LOG
+unset OE_MOCK_GIT_RANGE_FILES OE_MOCK_GIT_UNTRACKED OE_MOCK_GIT_LOG
 P="$OE_VERIFY_PROMPT_PATH"
 
 assert_eq "OE_VERIFY_PROMPT_PATH set" "/tmp/oe-RTEST_PROMPT_RANGE-verify-inputs.md" "$P"
@@ -305,27 +311,32 @@ assert_eq "完了報告に commit log (abc123)" "true" \
   "$(grep -q 'abc123 feat: add feature' "$P" && echo true || echo false)"
 assert_eq "engine 分類状態に state_change イベント" "true" \
   "$(grep -qE '"event_type": ?"state_change"' "$P" && echo true || echo false)"
-assert_eq "変更ファイルに range file (lib/feature.sh)" "true" \
+assert_eq "footprint に committed file (lib/feature.sh)" "true" \
   "$(grep -q '^- lib/feature.sh' "$P" && echo true || echo false)"
+assert_eq "footprint に untracked/uncommitted file (newfile.txt) [codex 欠陥修正]" "true" \
+  "$(grep -q '^- newfile.txt' "$P" && echo true || echo false)"
+assert_eq "変更ファイル note に footprint 明示" "true" \
+  "$(grep -q 'footprint' "$P" && echo true || echo false)"
 assert_eq "pre-existing 注記 (docs/preexisting.md)" "true" \
   "$(grep -qF -- '- docs/preexisting.md  ⚠ pre-existing' "$P" && echo true || echo false)"
 
-# -- Case B: worker 未コミット (commit 範囲空) → degraded working-tree diff --
+# -- Case B: commits あり but footprint 空 (空/revert コミット) → placeholder (degraded に誤フォールバックしない) --
 echo ""
-echo "-- Case B: 未コミット → degraded working-tree diff --"
-# session_start/end は Case A のものが残る (range=BASE111..END222)。range diff / log を空にして degraded 経路へ。
+echo "-- Case B: commits あり + footprint 空 → 'no file changes since baseline' [cursor 欠陥修正] --"
+# session_start/end は Case A の pane42 baseline BASE111..END222 が残る。
+# git diff <baseline> / untracked を空に、commit log は非空 (空 or revert コミットの想定)。
 _empty_outputs_kvs
-export OE_MOCK_GIT_FILES="lib/uncommitted.sh"
-oe_verify_prompt_build "RTEST_PROMPT_DEGRADED" "$target_pane_id" "$target_session_id" "$target_envelope_path"
-unset OE_MOCK_GIT_FILES
-PD="$OE_VERIFY_PROMPT_PATH"
+export OE_MOCK_GIT_LOG="- ccc333 revert: undo previous"
+oe_verify_prompt_build "RTEST_PROMPT_EMPTY" "$target_pane_id" "$target_session_id" "$target_envelope_path"
+unset OE_MOCK_GIT_LOG
+PE="$OE_VERIFY_PROMPT_PATH"
 
-assert_eq "degraded: working-tree diff file (lib/uncommitted.sh)" "true" \
-  "$(grep -q '^- lib/uncommitted.sh' "$PD" && echo true || echo false)"
-assert_eq "degraded: 変更ファイル note に degraded 明示" "true" \
-  "$(grep -q 'degraded' "$PD" && echo true || echo false)"
-assert_eq "degraded: 完了報告に未コミット注記" "true" \
-  "$(grep -q 'コミットなし' "$PD" && echo true || echo false)"
+assert_eq "empty footprint: 完了報告に commit (ccc333)" "true" \
+  "$(grep -q 'ccc333 revert' "$PE" && echo true || echo false)"
+assert_eq "empty footprint: 変更ファイルは 'no file changes since baseline'" "true" \
+  "$(grep -q 'no file changes since baseline' "$PE" && echo true || echo false)"
+assert_eq "empty footprint: degraded/未コミット と誤表示しない" "false" \
+  "$(grep -qE 'degraded|worker が未コミット' "$PE" && echo true || echo false)"
 
 # -- Case C: KVS outputs[] は commit 範囲より優先される --
 echo ""
@@ -372,10 +383,28 @@ assert_eq "pane フィルタ: prompt に target pane_id=42" "true" \
 assert_eq "pane フィルタ: 別 pane 99 の state_change は混入しない" "false" \
   "$(grep -q '"pane_id": 99' "$filter_prompt_path" && echo true || echo false)"
 
+# -- Case E: baseline 未解決 (session_start なし) → degraded working-tree diff --
+echo ""
+echo "-- Case E: baseline 未解決 → degraded working-tree diff --"
+# 別 session (audit に session_start なし) を使い baseline を未解決にする。
+nobase_sid="RTEST_NOBASE_SID"
+export OE_MOCK_GIT_FILES="lib/degraded.sh"
+oe_verify_prompt_build "RTEST_PROMPT_NOBASE" "$target_pane_id" "$nobase_sid" "$target_envelope_path"
+unset OE_MOCK_GIT_FILES
+PN="$OE_VERIFY_PROMPT_PATH"
+
+assert_eq "degraded: commit_range 未解決" "true" \
+  "$(grep -q '^commit_range: <未解決>' "$PN" && echo true || echo false)"
+assert_eq "degraded: working-tree diff file (lib/degraded.sh)" "true" \
+  "$(grep -q '^- lib/degraded.sh' "$PN" && echo true || echo false)"
+assert_eq "degraded: 変更ファイル note に degraded + baseline 未解決 明示" "true" \
+  "$(grep -q 'degraded: baseline 未解決' "$PN" && echo true || echo false)"
+
 rm -f "/tmp/oe-RTEST_PROMPT_RANGE-verify-inputs.md" \
-  "/tmp/oe-RTEST_PROMPT_DEGRADED-verify-inputs.md" \
+  "/tmp/oe-RTEST_PROMPT_EMPTY-verify-inputs.md" \
   "/tmp/oe-RTEST_PROMPT_OUTPUTS-verify-inputs.md" \
-  "/tmp/oe-RTEST_PROMPT_FILTER-verify-inputs.md"
+  "/tmp/oe-RTEST_PROMPT_FILTER-verify-inputs.md" \
+  "/tmp/oe-RTEST_PROMPT_NOBASE-verify-inputs.md"
 
 # ---- Phase C: oe_verify_envelope_create に prompt path を渡すと read_docs に 5 件目が追加される ----
 echo ""


### PR DESCRIPTION
## 概要

検証ゲート（target を検証 agent が採点する）の**検証入力**を、`working-tree diff の推定`から**`commit 範囲 (baseline..end)` の評価**に変更する。#114/#98（クリーン取得チャネル）landed 後の #92 再スコープを経て、単一 UC 分を実装した。

- **変更ファイル**: repo-wide `git diff` → `git diff --name-only <baseline>` + untracked（= baseline からの全 footprint。committed + 未コミット残余を捕捉）
- **完了報告**: 最後の `state_change` enum 1 個 → `git log baseline..end`（skill 契約の「コミットログ」に合致）。旧 `state_change` は `engine 分類状態`（補助）に relabel
- **enabler**: worker 起動前に baseline HEAD + dirty 集合を `session_start` に記録／worker 終了時に end HEAD を `session_end` に materialize／target task に「commit してから完了」プロトコルを付与（engine 契約・検証 skill は不変）

## なぜ commit 範囲か（設計の経緯）

kickoff の gate（設計SO → 実装ゲート → 実装 → 実装SO）を全て踏んだ。**設計SO を 3 ラウンド、実装SO を 1 ラウンド** refuted で回し、各 refuted が設計/実装を実際に変えた。

- 当初案（raw transcript embed / output_dir スコープの working-tree diff）は設計SO で 2 回 structural refuted。`working-tree diff の推定`というフレーム自体が pane-blind / pre-existing dirty 混入 / output_dir 契約破綻で構造的に不健全と判明。
- **評価単位を commit にする reframe** で root が解消。「commit すると git diff が空（#92 が"バグ"と記述）」を「commit を評価するのが設計」に反転。
- 実装SO（`oe-review`）が別レンズでコード欠陥 2 件を捕捉（部分コミット時の未コミット残余漏れ／空・revert コミット時の degraded 誤フォールバック）→ 変更ファイルを `git diff <baseline>` + untracked に是正し **survived (2/2)**。

詳細な journey・棄却案・SO 証跡 anchor は episode 参照:
`projects/orchestration-engine/docs/episodes/2026-07-01-episode-92-commit-range-verify-inputs.md`

## スコープ（landed / defer）

- **landed（単一 UC）**: commit 範囲評価・pre-existing 注記・degraded フォールバック・baseline/end materialize・worker commit 契約
- **defer（別 follow-up）**:
  - multi-pane 帰属（同一ブランチで commit 交錯 → per-pane branch/worktree）。本実装に合流 path あり
  - reviewer verdict チャネルの marker 注入（worker→reviewer 入力とは直交・[#101](https://github.com/stlwolf/ai-development-hub/issues/101)）
  - worker commit 遵守率は empirical residual → e2e/dogfood で fallback 率として実測

## 変更ファイル

- `lib/constants.sh`: `OE_TARGET_COMPLETION_PROTOCOL`（target 完了プロトコル定数）
- `lib/envelope.sh`: target task.description に完了プロトコル付与
- `lib/spawn.sh`: 起動前 baseline HEAD + dirty 集合を `session_start` payload に記録
- `lib/monitor.sh`: EXIT 時 end HEAD を `session_end` payload に materialize
- `lib/verify.sh`: `oe_verify_prompt_build` を commit 範囲評価に（footprint + commit log + relabel + degraded）
- `tests/`: `test_verify.sh`（Case A–E 全書換）/ `test_monitor.sh` / `test_envelope.sh` / `test_e2e_smoke.sh`
- `README.md`: 派生 issue 表の #92 行を landed スコープに更新

## 検証

- 全 **23 テストファイル green（912 assertions）** / `shellcheck` clean
- 設計SO（`oe-refute --rubric exploration`）×3: audit `202607010256044P78T7A6GM7H` / `20260701041800NMG0P7ZVB598` / `202607010853001Q8NVTKJ0W2Z`
- 実装SO（`oe-review`）: `202607010937017EMCG63SGW7P`（refuted）→ `20260701094830KD1590C5MCT3`（**survived 2/2**）

## Open questions / risks

- worker が実際に commit するかは実装前検証不可（empirical）。未コミット時は degraded 明示で安全側に縮退
- `git status --porcelain` の quoted-path パースで baseline_dirty 注記が外れ得る（ファイル自体は footprint に出る・軽微）
- `attach.sh` 経路は `session_start` なし → baseline 未解決 → degraded（既知・スコープ外）

Refs #92 #114 #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
