### PR TITLE
feat(oe): spawn トポロジの read-only ツリー観測 verb oe-tree を追加

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -46,7 +46,8 @@ projects/orchestration-engine/
 │   ├── oe-report              # 親へ申し送り/レビュー依頼（legacy・戻しは oe-send に一本化。送信は oe_send_line 経由=活動ログに載る）
 │   ├── oe-ack                 # 自分宛て報告への受領印（report_received）を打つ actor verb（#206A・frontier snapshot）
 │   ├── oe-status              # cockpit 観測UI: read-only 俯瞰（ENGINE=audit-terminal state / DELEGATE=liveness）+ 監査ログ閲覧（#177）
-│   └── oe-activity            # 親子活動ログ（oe-events.jsonl）の read 時投影ビュー: 往復/配送/preview/子生存/受領（inbox PENDING・timeline ack 行）（#206）
+│   ├── oe-activity            # 親子活動ログ（oe-events.jsonl）の read 時投影ビュー: 往復/配送/preview/子生存/受領（inbox PENDING・timeline ack 行）（#206）
+│   └── oe-tree                # spawn トポロジ（親→子→孫）の read-only 罫線ツリー表示（registry 現 server スナップショット・#221）
 ├── lib/                       # Bash 関数ライブラリ（source 専用）
 │   ├── constants.sh           # OE_POLL_INTERVAL, OE_CB_*, OE_DATA_DIR, OE_TARGET_AI_*, OE_VERIFY_AI_* 等
 │   ├── event-bus.sh           # 親子活動ログ emit プリミティブ（child_spawned / message_sent / report_received・best-effort・#206）

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -326,6 +326,7 @@ oe-tree -h     # ヘルプ
 - **root 合成**: root 親は registry に entry を持たない（`parent_pane` 参照としてのみ現れる）ため合成する。ラベルは pane-issue > `pane_title`（alive のみ）> `?`（honest — 無い物を捏造しない。`oe-ident` と同方針）。子のラベルは pane-issue(.name) > registry(.label)（`oe_reg_list` と同優先順位）
 - **role 列は持たない**: ツリーは関係そのものを描くため parent/child は木の形が搬送する（`oe-ident` が role を前置するのは単一ペインの孤立表示だから）
 - **read-only / 非検出**: 触れるのは registry / pane-issue の state ファイルと tmux のペイン存在・pane_title（mux query）のみ。`oe_reg_gc` 等の write path は呼ばない（#177 / #188 の read-only 観測規律）
+- **出力 sanitize**: label / workspace の制御文字（C0 全域 + DEL + C1 = U+0000-001F / 007F / 0080-009F）を codepoint レベルで空白へ畳む。人間向け cockpit 表示のため ESC/CSI/OSC による偽行・画面消去・視覚偽装を遮断する（`oe_reg_list` の LF/CR 防御より広い — 表示ツールの脅威モデル）
 - degrade / exit: liveness query 失敗は `?` で継続。`$TMUX` 不在は scoping も liveness も成立しない（部分価値を残す degrade が構造的に無い）ため stderr note + exit 2（`oe_reg_list` / `oe_reg_resolve` の rc=2 規約と一致）。異 server の stale entry は非表示 + footer で件数開示。純粋 cycle（pane-id 再利用の理論ケース）は擬似 root で描画し `[cycle]` で打ち切り
 - follow-up（未実装・surface のみ）: `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化
 

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -327,7 +327,7 @@ oe-tree -h     # ヘルプ
 - **role 列は持たない**: ツリーは関係そのものを描くため parent/child は木の形が搬送する（`oe-ident` が role を前置するのは単一ペインの孤立表示だから）
 - **read-only / 非検出**: 触れるのは registry / pane-issue の state ファイルと tmux のペイン存在・pane_title（mux query）のみ。`oe_reg_gc` 等の write path は呼ばない（#177 / #188 の read-only 観測規律）
 - **出力 sanitize**: label / workspace の制御文字（C0 全域 + DEL + C1 = U+0000-001F / 007F / 0080-009F）を codepoint レベルで空白へ畳む。人間向け cockpit 表示のため ESC/CSI/OSC による偽行・画面消去・視覚偽装を遮断する（`oe_reg_list` の LF/CR 防御より広い — 表示ツールの脅威モデル）
-- degrade / exit: liveness query 失敗は `?` で継続。`$TMUX` 不在は scoping も liveness も成立しない（部分価値を残す degrade が構造的に無い）ため stderr note + exit 2（`oe_reg_list` / `oe_reg_resolve` の rc=2 規約と一致）。異 server の stale entry は非表示 + footer で件数開示。純粋 cycle（pane-id 再利用の理論ケース）は擬似 root で描画し `[cycle]` で打ち切り
+- degrade / exit: liveness query 失敗は `?` で継続。`$TMUX` 不在は scoping も liveness も成立しない（部分価値を残す degrade が構造的に無い）ため stderr note + exit 2（`oe_reg_list` / `oe_reg_resolve` の rc=2 規約と一致）。異 server の stale entry は非表示 + footer で件数開示。現 server の読めない/不正/重複 entry も無言で捨てず footer で skip 件数を開示（全滅時は `(no readable spawn entries ...)` — 「登記なし」と偽らない）。純粋 cycle（pane-id 再利用の理論ケース）は擬似 root で描画し `[cycle]` で打ち切り
 - follow-up（未実装・surface のみ）: `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化
 
 関連 lib: `delegate-registry.sh`（`_oe_reg_server_pid` / `_oe_reg_key`・read ヘルパのみ使用）。

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -302,6 +302,35 @@ oe-activity --timeline # 時系列: 関係内の各送信を turn 順に 1 行�
 
 関連: `lib/event-bus.sh`（emit プリミティブ・`oe-delegate` が `child_spawned` / `oe_send_line` が `message_sent` / `oe-ack` が `report_received` を発火）、`schemas/oe-events.schema.json`（レコードスキーマ・audit-log とは別系統）。設計判断は #188 DJ-188-4 を delegate 現実（session_id 不在）へ精緻化したもの。
 
+## oe-tree — spawn トポロジの read-only ツリー表示（#221）
+
+spawn registry（`~/.claude/state/oe-delegate/`）の現 tmux server 分を走査し、`parent_pane` 連鎖から森林を再構成して罫線ツリーで表示する。`oe-list` が flat な宛先候補（自分の直下の子に scoping）なのに対し、oe-tree は「何が何を立てたか」「どのペインが孫か」を**現 server 全域**で描く観測ビュー（`oe-status` / `oe-activity` と同クラス）。
+
+```bash
+oe-tree        # 現 server の spawn 森林を罫線ツリーで表示
+oe-tree -h     # ヘルプ
+```
+
+出力例（各ノード: `<pane> <liveness> <label> [~workspace] [(you)]`）:
+
+```text
+%49  gone   ?
+└─ %83  alive  fresh-orch-2 ~biz-infra
+   ├─ %85  alive  #5706 ~attelu.5706-orchestration
+   └─ %94  alive  #36 ~biz-infra.infra-#36_ecs-stack
+%73  alive  #206 increment2-timeline
+└─ %114  alive  #221 spawn-tree-view ~ai-development-hub (you)
+```
+
+- **スナップショット意味論**: 本ビューは「現在の登記」であり歴史ではない。gone entry は次の `oe_reg_record` 時の GC まで表示される（read-only ではデータ源の性質を変えられない）。spawn の**歴史**フローは `oe-activity`（event log・`child_spawned`）の領分（レイヤ分離）
+- **root 合成**: root 親は registry に entry を持たない（`parent_pane` 参照としてのみ現れる）ため合成する。ラベルは pane-issue > `pane_title`（alive のみ）> `?`（honest — 無い物を捏造しない。`oe-ident` と同方針）。子のラベルは pane-issue(.name) > registry(.label)（`oe_reg_list` と同優先順位）
+- **role 列は持たない**: ツリーは関係そのものを描くため parent/child は木の形が搬送する（`oe-ident` が role を前置するのは単一ペインの孤立表示だから）
+- **read-only / 非検出**: 触れるのは registry / pane-issue の state ファイルと tmux のペイン存在・pane_title（mux query）のみ。`oe_reg_gc` 等の write path は呼ばない（#177 / #188 の read-only 観測規律）
+- degrade / exit: liveness query 失敗は `?` で継続。`$TMUX` 不在は scoping も liveness も成立しない（部分価値を残す degrade が構造的に無い）ため stderr note + exit 2（`oe_reg_list` / `oe_reg_resolve` の rc=2 規約と一致）。異 server の stale entry は非表示 + footer で件数開示。純粋 cycle（pane-id 再利用の理論ケース）は擬似 root で描画し `[cycle]` で打ち切り
+- follow-up（未実装・surface のみ）: `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化
+
+関連 lib: `delegate-registry.sh`（`_oe_reg_server_pid` / `_oe_reg_key`・read ヘルパのみ使用）。
+
 ---
 
 ## 主要な環境変数

--- a/projects/orchestration-engine/bin/oe-tree
+++ b/projects/orchestration-engine/bin/oe-tree
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# oe-tree — spawn トポロジ（親→子→孫）を read-only でツリー表示する（#221）
+#
+# usage: oe-tree
+#
+# spawn registry（~/.claude/state/oe-delegate/）の現 tmux server 分を走査し、
+# parent_pane 連鎖から森林を再構成して罫線ツリーで表示する。oe-list が flat な
+# 宛先候補（自分の直下の子に scoping）なのに対し、oe-tree は「何が何を立てたか」
+# 「どのペインが孫か」を現 server 全域で描く観測ビュー（oe-activity / oe-status と
+# 同クラス）。
+#
+# 意味論（設計SO で明文化を要求された点・DJ-221-2/6）:
+#   - 本ビューは「現在の登記のスナップショット」であり歴史ではない。gone entry は
+#     次の oe_reg_record 時の GC まで表示される（read-only ではデータ源の性質を
+#     変えられない）。spawn の歴史フローは oe-activity（event log）の領分。
+#   - liveness は oe-activity と同じ mux 存在 query（tmux list-panes -a 突合）:
+#     pane が在る=alive / 無い=gone / query 失敗=?（degrade・観測は止めない）。
+#   - root 親は registry に entry を持たない（parent_pane 参照としてのみ現れる）
+#     ため合成し、ラベルは pane-issue > pane_title(alive のみ) > "?"（honest —
+#     無い物を捏造しない。oe-ident と同方針）。
+#   - role 列は持たない: ツリーは関係そのものを描くため parent/child は木の形が
+#     搬送する（oe-ident が role を前置するのは単一ペインの孤立表示だから）。
+#
+# read-only / 非検出: 読むのは (1) registry / pane-issue の state ファイル
+#   (2) tmux のペイン存在・pane_title（mux query）のみ。oe_reg_gc 等の write path は
+#   一切呼ばない（#177 / #188 の read-only 観測規律）。
+#
+# exit: 0=表示成功（登記 0 件の空表示を含む）/ 2=環境エラー（tmux scope 不能・jq 不在）。
+#   $TMUX 不在は server_pid が導出できず scoping も liveness も成立しない＝部分価値を
+#   残す degrade が構造的に無いため、lib 家族の規約（oe_reg_list / oe_reg_resolve）に
+#   合わせ exit 2（DJ-221-7）。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/delegate-registry.sh
+source "${BIN_DIR}/../lib/delegate-registry.sh"
+
+case "${1:-}" in
+  -h|--help)
+    cat >&2 <<'EOF'
+usage: oe-tree
+
+spawn registry の parent_pane 連鎖から親→子→孫のトポロジを罫線ツリーで表示する
+（read-only・現 tmux server の全森林）。各ノード: <pane> <liveness> <label> [~workspace] [(you)]
+
+注: 現在の登記のスナップショット（gone entry は次の spawn 登記時の GC まで表示）。
+歴史は oe-activity を参照。
+EOF
+    exit 0 ;;
+  "" ) : ;;
+  * ) echo "oe-tree: unexpected argument: $1" >&2; echo "usage: oe-tree" >&2; exit 2 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || { echo "oe-tree: jq is required" >&2; exit 2; }
+
+SERVER_PID="$(_oe_reg_server_pid)"
+if [[ -z "$SERVER_PID" ]]; then
+  echo "oe-tree: not inside tmux (\$TMUX is unset) — spawn registry is scoped by tmux server pid" >&2
+  exit 2
+fi
+SELF="${TMUX_PANE:-}"
+
+# --- liveness（mux 存在 query。query 失敗は ? で degrade — oe-activity と同方針）---
+HAVE_LIVE=0
+LIVE_SET=""
+if LIVE_SET="$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null)"; then
+  HAVE_LIVE=1
+fi
+liveness_of() {
+  local pane="$1"
+  if [[ "$HAVE_LIVE" -ne 1 ]]; then printf '?'; return; fi
+  if printf '%s\n' "$LIVE_SET" | grep -qxF "$pane"; then printf 'alive'; else printf 'gone'; fi
+}
+
+# --- 現 server の entry 収集（US 区切り: pane<US>parent<US>workspace<US>label）---
+# 制御文字は jq 側で空白へ畳む: US は行内プロトコルの区切りを壊し（event-bus と同根）、
+# LF/CR は行指向出力の偽行注入（oe_reg_list L155-162 と同じ防御）、TAB は表示崩れ防止
+# （oe-activity の畳み方針。oe_reg_list の注記どおりレコード境界偽造ではない — 別根拠）。
+ENTRIES=""
+FOREIGN=0
+for _f in "${OE_DELEGATE_STATE_DIR}"/*.json; do
+  [[ -e "$_f" ]] || continue
+  _base="$(basename "$_f" .json)"
+  if [[ "$_base" != "${SERVER_PID}_"* ]]; then
+    FOREIGN=$((FOREIGN + 1))
+    continue
+  fi
+  _line="$(jq -r '
+    def clean: tostring | gsub("[\u001f\t\r\n]"; " ");
+    [ (.pane // "" | clean), (.parent_pane // "" | clean),
+      (.workspace // "" | clean), (.label // "" | clean) ] | join("\u001f")
+  ' "$_f" 2>/dev/null)" || continue
+  [[ -n "$_line" ]] || continue
+  # pane が %N 形でない entry は辺として解釈できないためスキップ（壊れた JSON と同扱い）
+  [[ "${_line%%$'\037'*}" =~ ^%[0-9]+$ ]] || continue
+  ENTRIES+="${_line}"$'\n'
+done
+
+if [[ -z "$ENTRIES" ]]; then
+  echo "(no spawn entries for this tmux server)"
+  [[ "$FOREIGN" -gt 0 ]] && echo "note: ${FOREIGN} entries from other tmux servers not shown (stale)"
+  exit 0
+fi
+
+entry_field_of() { # <pane> <field-index> — ENTRIES から該当 pane の列を引く
+  printf '%s' "$ENTRIES" | awk -F $'\037' -v p="$1" -v i="$2" '$1==p {print $i; exit}'
+}
+
+children_of() { # <pane> — 直下の子を pane 番号の数値昇順で
+  printf '%s' "$ENTRIES" | awk -F $'\037' -v p="$1" '$2==p {print $1}' | sort -t% -k2 -n
+}
+
+label_of() { # <pane> — pane-issue(.name) > registry(.label) > pane_title(alive のみ) > "?"
+  local pane="$1" key label=""
+  key="$(_oe_reg_key "$pane")"
+  if [[ -f "${OE_PANE_ISSUE_DIR}/${key}" ]]; then
+    label="$(jq -r '.name // empty' "${OE_PANE_ISSUE_DIR}/${key}" 2>/dev/null)" || label=""
+  fi
+  [[ -n "$label" ]] || label="$(entry_field_of "$pane" 4)"
+  if [[ -z "$label" && "$HAVE_LIVE" -eq 1 ]] && printf '%s\n' "$LIVE_SET" | grep -qxF "$pane"; then
+    label="$(tmux display-message -p -t "$pane" '#{pane_title}' 2>/dev/null)" || label=""
+  fi
+  # 出力チョークポイントの sanitize（pane-issue / pane_title 由来を含む全ソース一括防御）
+  label="${label//$'\n'/ }"; label="${label//$'\r'/ }"; label="${label//$'\t'/ }"
+  printf '%s' "${label:-?}"
+}
+
+# --- 森林構築: root = parent 参照のうち entry 無し pane ∪ parent 空の entry ---
+ROOTS="$(
+  {
+    printf '%s' "$ENTRIES" | awk -F $'\037' '$2!="" {print $2}' | sort -u \
+    | while IFS= read -r _p; do
+        [[ -n "$_p" ]] || continue
+        if ! printf '%s' "$ENTRIES" | awk -F $'\037' -v p="$_p" '$1==p {found=1} END {exit found?0:1}'; then
+          printf '%s\n' "$_p"
+        fi
+      done
+    printf '%s' "$ENTRIES" | awk -F $'\037' '$2=="" {print $1}'
+  } | sort -t% -k2 -n -u
+)"
+
+VISITED=" "
+render() { # <pane> <prefix> <child-prefix>
+  local pane="$1" pfx="$2" cpfx="$3"
+  local live label ws suffix=""
+  if [[ "$VISITED" == *" ${pane} "* ]]; then
+    printf '%s%s  [cycle]\n' "$pfx" "$pane"
+    return 0
+  fi
+  VISITED+="${pane} "
+  live="$(liveness_of "$pane")"
+  label="$(label_of "$pane")"
+  ws="$(entry_field_of "$pane" 3)"
+  [[ -n "$ws" ]] && suffix+=" ~${ws##*/}"
+  [[ -n "$SELF" && "$pane" == "$SELF" ]] && suffix+=" (you)"
+  printf '%s%s  %-5s  %s%s\n' "$pfx" "$pane" "$live" "$label" "$suffix"
+  local kids n i=0 c
+  kids="$(children_of "$pane")"
+  n="$(printf '%s' "$kids" | grep -c . || true)"
+  while IFS= read -r c; do
+    [[ -n "$c" ]] || continue
+    i=$((i + 1))
+    if [[ "$i" -eq "$n" ]]; then
+      render "$c" "${cpfx}└─ " "${cpfx}   "
+    else
+      render "$c" "${cpfx}├─ " "${cpfx}│  "
+    fi
+  done <<< "$kids"
+}
+
+while IFS= read -r _r; do
+  [[ -n "$_r" ]] || continue
+  render "$_r" "" ""
+done <<< "$ROOTS"
+
+# 未到達 entry の sweep: 純粋 cycle（全ノードが entry 持ち parent を指す輪）は root を
+# 持たず上のループで描かれない。無言で消すと「登記に在るのに見えない」偽りになるため、
+# 最小 pane を擬似 root として描く（cycle guard が輪の閉じで [cycle] を打って止める）。
+while IFS= read -r _p; do
+  [[ -n "$_p" ]] || continue
+  [[ "$VISITED" == *" ${_p} "* ]] && continue
+  render "$_p" "" ""
+done < <(printf '%s' "$ENTRIES" | awk -F $'\037' '{print $1}' | sort -t% -k2 -n)
+
+[[ "$FOREIGN" -gt 0 ]] && echo "note: ${FOREIGN} entries from other tmux servers not shown (stale)"
+exit 0

--- a/projects/orchestration-engine/bin/oe-tree
+++ b/projects/orchestration-engine/bin/oe-tree
@@ -74,9 +74,13 @@ liveness_of() {
 }
 
 # --- 現 server の entry 収集（US 区切り: pane<US>parent<US>workspace<US>label）---
-# 制御文字は jq 側で空白へ畳む: US は行内プロトコルの区切りを壊し（event-bus と同根）、
-# LF/CR は行指向出力の偽行注入（oe_reg_list L155-162 と同じ防御）、TAB は表示崩れ防止
-# （oe-activity の畳み方針。oe_reg_list の注記どおりレコード境界偽造ではない — 別根拠）。
+# 制御文字は jq 側で C0 全域 + DEL + C1（U+0000-001F / 007F / 0080-009F）を空白へ畳む:
+#   - US は行内プロトコルの区切りを壊す（event-bus と同根）・LF/CR は行指向出力の偽行注入
+#     （oe_reg_list L155-162 と同じ防御）・TAB は表示崩れ（oe-activity の畳み方針）。
+#   - ESC/CSI/OSC 等はツリー行の視覚偽装・画面消去・端末制御に到達し得る（oe-delegate の
+#     --label は LF/CR しか拒否しない＝registry 経由で到達可能・実装SO codex 指摘）。
+#     oe_reg_list は ANSI を「別軸・scope 外」と注記するが、oe-tree は人間向け cockpit
+#     表示そのものなので視覚偽装が本ツールの脅威モデルに入る — codepoint レベルで畳む。
 ENTRIES=""
 FOREIGN=0
 SKIPPED=0
@@ -89,7 +93,7 @@ for _f in "${OE_DELEGATE_STATE_DIR}"/*.json; do
     continue
   fi
   _line="$(jq -r '
-    def clean: tostring | gsub("[\u001f\t\r\n]"; " ");
+    def clean: tostring | gsub("[\u0000-\u001f\u007f-\u009f]"; " ");
     [ (.pane // "" | clean), (.parent_pane // "" | clean),
       (.workspace // "" | clean), (.label // "" | clean) ] | join("\u001f")
   ' "$_f" 2>/dev/null)" || { SKIPPED=$((SKIPPED + 1)); continue; }
@@ -132,6 +136,14 @@ children_of() { # <pane> — 直下の子を pane 番号の数値昇順で
   printf '%s' "$ENTRIES" | awk -F $'\037' -v p="$1" '$2==p {print $1}' | sort -t% -k2 -n
 }
 
+# sanitize_out <text> — 出力チョークポイントの sanitize（収集ループの clean と同じ
+# codepoint クラス。pane-issue / pane_title 由来＝jq clean を通らない経路の一括防御）。
+# jq 失敗時は C0+DEL のみの byte-wise tr へ縮退（C0/DEL は UTF-8 多バイト列に現れない）。
+sanitize_out() {
+  printf '%s' "$1" | jq -Rrs 'gsub("[\u0000-\u001f\u007f-\u009f]"; " ")' 2>/dev/null \
+    || printf '%s' "$1" | LC_ALL=C tr '\000-\037\177' ' '
+}
+
 label_of() { # <pane> — pane-issue(.name) > registry(.label) > pane_title(alive のみ) > "?"
   local pane="$1" key label=""
   key="$(_oe_reg_key "$pane")"
@@ -142,8 +154,7 @@ label_of() { # <pane> — pane-issue(.name) > registry(.label) > pane_title(aliv
   if [[ -z "$label" && "$HAVE_LIVE" -eq 1 ]] && printf '%s\n' "$LIVE_SET" | grep -qxF "$pane"; then
     label="$(tmux display-message -p -t "$pane" '#{pane_title}' 2>/dev/null)" || label=""
   fi
-  # 出力チョークポイントの sanitize（pane-issue / pane_title 由来を含む全ソース一括防御）
-  label="${label//$'\n'/ }"; label="${label//$'\r'/ }"; label="${label//$'\t'/ }"; label="${label//$'\037'/ }"
+  label="$(sanitize_out "$label")"
   printf '%s' "${label:-?}"
 }
 

--- a/projects/orchestration-engine/bin/oe-tree
+++ b/projects/orchestration-engine/bin/oe-tree
@@ -79,6 +79,8 @@ liveness_of() {
 # （oe-activity の畳み方針。oe_reg_list の注記どおりレコード境界偽造ではない — 別根拠）。
 ENTRIES=""
 FOREIGN=0
+SKIPPED=0
+SEEN_PANES=" "
 for _f in "${OE_DELEGATE_STATE_DIR}"/*.json; do
   [[ -e "$_f" ]] || continue
   _base="$(basename "$_f" .json)"
@@ -90,16 +92,35 @@ for _f in "${OE_DELEGATE_STATE_DIR}"/*.json; do
     def clean: tostring | gsub("[\u001f\t\r\n]"; " ");
     [ (.pane // "" | clean), (.parent_pane // "" | clean),
       (.workspace // "" | clean), (.label // "" | clean) ] | join("\u001f")
-  ' "$_f" 2>/dev/null)" || continue
-  [[ -n "$_line" ]] || continue
-  # pane が %N 形でない entry は辺として解釈できないためスキップ（壊れた JSON と同扱い）
-  [[ "${_line%%$'\037'*}" =~ ^%[0-9]+$ ]] || continue
+  ' "$_f" 2>/dev/null)" || { SKIPPED=$((SKIPPED + 1)); continue; }
+  [[ -n "$_line" ]] || { SKIPPED=$((SKIPPED + 1)); continue; }
+  _pane="${_line%%$'\037'*}"
+  # pane が %N 形でない entry は辺として解釈できない（壊れた JSON と同扱い）。
+  # 同一 pane の重複 entry（key と .pane の不整合＝write 側不変条件違反）は先勝ちで捨てる
+  # — dedup しないと 2 回目の render が visited に当たり偽 [cycle] を表示する（実装SO 指摘）。
+  if ! [[ "$_pane" =~ ^%[0-9]+$ ]] || [[ "$SEEN_PANES" == *" ${_pane} "* ]]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+  SEEN_PANES+="${_pane} "
   ENTRIES+="${_line}"$'\n'
 done
 
-if [[ -z "$ENTRIES" ]]; then
-  echo "(no spawn entries for this tmux server)"
+# 読めない/解釈できない/重複の現 server entry は無言で捨てず件数を footer で開示する
+# （foreign と同型の honest degrade — 全滅時も部分スキップ時も「登記どおり」と偽らない。実装SO 指摘）。
+print_notes() {
+  [[ "$SKIPPED" -gt 0 ]] && echo "note: ${SKIPPED} entries skipped (unreadable or duplicate pane)"
   [[ "$FOREIGN" -gt 0 ]] && echo "note: ${FOREIGN} entries from other tmux servers not shown (stale)"
+  return 0
+}
+
+if [[ -z "$ENTRIES" ]]; then
+  if [[ "$SKIPPED" -gt 0 ]]; then
+    echo "(no readable spawn entries for this tmux server)"
+  else
+    echo "(no spawn entries for this tmux server)"
+  fi
+  print_notes
   exit 0
 fi
 
@@ -122,7 +143,7 @@ label_of() { # <pane> — pane-issue(.name) > registry(.label) > pane_title(aliv
     label="$(tmux display-message -p -t "$pane" '#{pane_title}' 2>/dev/null)" || label=""
   fi
   # 出力チョークポイントの sanitize（pane-issue / pane_title 由来を含む全ソース一括防御）
-  label="${label//$'\n'/ }"; label="${label//$'\r'/ }"; label="${label//$'\t'/ }"
+  label="${label//$'\n'/ }"; label="${label//$'\r'/ }"; label="${label//$'\t'/ }"; label="${label//$'\037'/ }"
   printf '%s' "${label:-?}"
 }
 
@@ -183,5 +204,5 @@ while IFS= read -r _p; do
   render "$_p" "" ""
 done < <(printf '%s' "$ENTRIES" | awk -F $'\037' '{print $1}' | sort -t% -k2 -n)
 
-[[ "$FOREIGN" -gt 0 ]] && echo "note: ${FOREIGN} entries from other tmux servers not shown (stale)"
+print_notes
 exit 0

--- a/projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md
@@ -62,3 +62,15 @@ tags: [orchestration, cockpit, spawn-tree, topology, observation, read-only, epi
 - shellcheck: `bin/oe-tree` / `tests/test_oe_tree.sh` とも指摘ゼロ（テスト側 SC2155 を 1 件修正）。
 - 実データ検証: 実行のたびに登記が動く現場をそのまま捕捉 — プロトタイプ時に居た %110 が本実装の実行時には GC 済みで新 spawn %116 が出現。「gone は次の spawn 登記まで」のスナップショット意味論が実データで実演された（DJ-OPEN-2 で受入済みの性質そのもの）。
 - doc: `bin/README.md` に oe-tree 節（意味論・root 合成・role 列なしの根拠・degrade/exit 規約・follow-up 明記）、`README.md` 構成ツリーに 1 行。
+
+## 実装SO（oe-review・2026-07-03）
+
+- **SO#1**（audit_id 20260702193221P5S74SS5ARP5・reviewed_sha a71b587・2レーン）: codex=survived / cursor=**refuted** → conservative 集約で refuted・PR 保留。cursor の material 指摘 2 件を実コード照合の上で両方採用:
+  - **failure propagation**: 読めない/不正な現 server entry を `continue` で無言スキップ → 全滅時に「(no spawn entries)」と事実に反する断言・部分スキップ時は不完全ツリーが完全に見える。foreign には footer note を出す非対称は「honest degrade」の自己矛盾 — 指摘どおり。→ SKIPPED カウンタ + footer 開示 + 全滅時は `(no readable spawn entries ...)` に変更。
+  - **偽 [cycle]**: 同一 `.pane` の重複 entry（key と .pane の不整合＝write 側不変条件違反データ）を dedup せず、2 回目の render が visited に当たり正当な子でないのに `[cycle]` と誤表示 — 到達可能（ファイル操作で作れる）。→ 収集時に先勝ち dedup し skipped として開示。
+  - 非 material 指摘（pane-issue 経路 label の US 未畳み）も安価なので同時に畳んだ。cursor が反証して潰した候補（VISITED 境界一致・cycle sweep・sanitize・degrade 同型）は実装の妥当性の裏取りとして episode に残る。
+  - 修正 commit: 56ce2c5（tests 18 チェックに拡張・shellcheck クリーン維持）。
+- **SO#2**（audit_id 202607021939281V98DFA6052R・reviewed_sha 56ce2c5）: cursor=**survived**（SO#1 指摘の修正を確認・新規 material なし）/ codex=**refuted**（新規指摘）→ conservative 集約で refuted。codex 指摘を一次照合の上採用:
+  - **ESC 等の端末制御文字の直出し**: sanitize が LF/CR/TAB/US のみで、`oe-delegate --label $'\e[2J...'` 経由で ESC が registry に到達し（oe-delegate は LF/CR しか拒否しない — 実照合済み）、人間向け cockpit 表示に画面消去・視覚偽装・OSC 端末制御が通る。`oe_reg_list` は ANSI を「別軸・scope 外」と注記するが（宛先表の脅威モデル＝レコード境界偽造）、oe-tree は表示そのものが製品なので視覚偽装が本ツールの脅威モデルに入る — material と判断。→ C0 全域 + DEL + C1（U+0000-001F/007F/0080-009F）を jq の codepoint gsub で空白へ畳む（収集経路の clean + pane-issue/pane_title 経路の `sanitize_out` チョークポイント。C1 は UTF-8 符号化形も畳めるよう byte-wise でなく codepoint 処理・jq 不能時は C0+DEL の tr へ縮退）。修正 commit: edc7fa2（tests 19 チェック・OSC/BEL タイトル偽装ケース含む）。
+  - 教訓（レーン別レンズの差）: SO#1 で cursor が「pane-issue 経路の US 未畳みは非 material」と流した箇所の上位集合を SO#2 で codex が material として拾った — 2 レーンの独立性が働いた形。
+- **SO#3**（audit_id 202607021947362XW6QQHR5P69・reviewed_sha edc7fa2）: **survived 2/2**（codex/cursor とも material なし。cursor は 19/19 テスト・shellcheck・cycle/dedup/sanitize/foreign 経路の手動追跡を明記）。実装SO ゲート通過 — PR 作成へ。

--- a/projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md
@@ -1,0 +1,64 @@
+---
+id: "01KWJ0F80R40JRHTKQHDWB8D0C"
+title: "#221 episode — spawn ツリー（親→子→孫）read-only トポロジ観測ビュー実装記録"
+date: 2026-07-03
+type: episode
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/221"
+    reason: "spawn トポロジの read-only ツリー表示（cockpit epic #169 配下）"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/177"
+    reason: "read-only 観測規律（oe-status と同クラス）の先行事例"
+tags: [orchestration, cockpit, spawn-tree, topology, observation, read-only, episode]
+---
+
+# #221 episode — spawn ツリー（親→子→孫）read-only トポロジ観測ビュー実装記録
+
+親（統括）からの委譲子セッションとして、#221「registry の `parent_pane` から spawn トポロジ（親→子→孫）を read-only でツリー表示」を実装する。`oe-list` は flat（PANE / SOURCE / LABEL）で世代・親子関係が見えず、multi-session 運用で「何が何を立てたか」「どのペインが孫か」の認知負荷が顕在化した — それを観測ビューで解くのが本作業。設計方向は issue で固定されておらず、ゼロベース設計（`predecision-exploration`）が親の明示指定。
+
+## 着手時 grounding（2026-07-03・設計前の実測）
+
+- kickoff（`.oe/kickoff-221.md`・揮発）読了 → issue #221 原文・`lib/delegate-registry.sh` 全文・`bin/oe-list` 全文・`bin/oe-activity` の liveness query（L86-98: `tmux list-panes -a` 突合、alive|gone|?、tmux 不在は ? で degrade）を読了してから設計に入った。
+- registry 実データ実測（`~/.claude/state/oe-delegate/*.json`・2026-07-03 時点）: 6 entry。**親→子→孫の実連鎖が現存**: `%49(gone) → %83 → {%85 → %110, %94}` の 3 世代 + `%1(gone) → %3` + `%73 → %114(本セッション)`。
+- 実測からの設計入力（issue 記載に加えて確認できた事実）:
+  - **root 親は registry に entry を持たない**（`parent_pane` 参照としてのみ現れる）。root のラベルは pane-issue / pane-title fallback が必要。
+  - **gone 親 × alive 子が実在する**（%49 は live panes に無いが子 %83 は alive）— 「stale の扱い」は葉ノードだけでなく中間/根ノードにも及ぶ。
+  - **GC は write path**: `oe_reg_gc` は `oe_reg_record` 時のみ走る（delegate-registry.sh L64）。観測ツールから GC を呼ぶのは read-only 規律違反になる — 設計上「gone 表示」側に強い根拠。
+  - **別 server_pid の entry は GC が消す**（`oe_reg_gc` L182: 現 server pid 以外の key を無条件 rm）。複数 tmux server 跨ぎの表示は「registry 上ほぼ存在し得ない状態」— 見せ方の論点は実質 degrade 表示の話に縮む。
+
+## 設計フェーズ（2026-07-03）
+
+- **ゼロベース設計**（`predecision-exploration`）: 探索木を `tmp/dj-221-tree.md`（gitignore・揮発）に外部化。DJ は 7 本: 表面（oe-list --tree / **新規 oe-tree** / oe-status 区画 / oe-activity --topology / JSON only）・データ源（**registry** / event log / hybrid）・ノード集合と root 合成・描画（**罫線** / インデント / flat+GEN 列）・列構成・stale（**gone 表示** / GC / 非表示）・server 跨ぎ（**現 server のみ + footer 開示**）。
+- **ゼロベース発見（初期案セット外のカテゴリ）**: event log `child_spawned` からの歴史トポロジ再構成。実測で `~/.claude/state/oe-events.jsonl` に child_spawned 23 件（spawn 時ラベル両端付き）が実在し、oe-activity はこれを方向判定（`parent_of` 導出）にのみ使いツリー描画はしない — 「現在トポロジのツリー」だけが真の空白と確認。v1 棄却の根拠: event に server_pid が無く server 再起動跨ぎで pane-id 再利用の混同が起きる / 歴史フローは oe-activity の領分（レイヤ分離）。gone root のラベル補完 hybrid は follow-up として surface。
+- **read-only の設計帰結**: `oe_reg_gc` は `oe_reg_record` 時のみ走る write path（delegate-registry.sh L64）で、別 server pid の entry を無条件 rm する副作用も持つ（L182）— 観測ツールから GC を呼ぶ選択肢は規律違反として棄却、stale は gone 表示に確定。
+- 設計SO: claim doc `tmp/dj-221-claim.md` に探索木ごと固めて `oe-refute --rubric exploration`（弱SO・2レーン）を実行 →（結果は下に追記）
+- 設計の実行可能性は SO 待機中に scratchpad プロトタイプで実データ検証: 現 registry から 3 世代チェーン（%49 gone → %83 → %85/%94 → %110）・gone root・self marker・ラベル優先順位（pane-issue > registry label）が設計どおり描画されることを確認。
+- **SO#1**（audit_id 20260702181743X06TWAHYRPY8）: verdict=**refuted 2/2**。一次照合の結果、実質的発見として採用:
+  - **role 列棄却の根拠が誤り**（両レーン指摘）: 「registry の role は常に child で情報ゼロ」は stored field としては正しいが、`oe-ident` が parent_pane 逆引きで parent/child を read-time 導出する家族概念が実在（oe-ident:60-72 + test_oe_ident.sh [3] を実照合）。v2 で根拠を差し替え: oe-ident は単一ペインの孤立表示だから role 列が要る・ツリーは関係を描くので木の形が role を搬送する。issue 文言との解釈差はユーザー承認ゲートに明示で晒す。
+  - **tmux 不在 exit 2 は観測クラスの慣例と不整合**（codex 指摘）: oe-status は degrade 継続（L164-178 実照合）・oe-activity は `?`。v2 で degrade（liveness=? + 埋込 pid グループ表示）に差し替え。
+  - **出力 sanitize 欠落**（cursor 指摘）: oe_reg_list の LF/CR 畳み（L155-162・#178 系）を oe-tree 出力にも継承。
+  - **GC×gone の時間的意味論**（cursor 指摘）: gone entry は次の `oe_reg_record` の GC までしか残らない = 本ビューは現在の登記スナップショット・歴史は oe-activity の領分。明文化して受入判断に晒す（read-only では変えられないデータ源の性質）。
+  - **テスト成果物**（両レーン指摘）: tests/test_oe_tree.sh をスコープに含める（fixture + TMUX 偽値注入 = test_oe_ident のイディオム）。
+  - 採用しなかった指摘と理由は `tmp/dj-221-tree.md` v2 節に記録（oe-ident 再利用共通化=出力契約が表示向けでパース不能・workspace 表現比較=--json follow-up の領分・「SO未実行で最良確定」=本ラウンド自体がその SO という自己言及）。
+- **SO#2**（v2 claim・audit_id 202607021823225DGRRQ4GM9TR）: verdict=**refuted 2/2**。指摘の分類と処置:
+  - **artifact 欠陥（採用・即修正）**: v2 を探索木に追記形式で足したため、本文 DJ-221-5/7 に旧記述（exit 2・旧 role 根拠）が残り claim と自己矛盾（codex）。→ 探索木を v3 に統合書き直し。
+  - **仕様化不足（採用・v3 で仕様化）**: 全森林走査は `oe_reg_list` で流用不能（生存ペイン起点 + self scoping）なのに森林構築・複数 root 順・orphan・cycle の仕様が無い（cursor #4）→ DJ-221-3 にアルゴリズム明記。テスト計画が列挙のみ（cursor #8）→ DJ-221-8 に 10 ケース仕様化。TAB sanitize の引用根拠が oe_reg_list の注記（TAB は scope 外）と矛盾（cursor #5）→ 根拠を「表示崩れ防止（oe-activity 前例）」に修正、挙動は維持。
+  - **tmux 不在挙動の再統合（採用）**: v2 の「pid グループ degrade」は未探索の新カテゴリで oe-status の degrade（多区画中の 1 区画非表示）とも別物（cursor #3）→ 3 案比較の上「stderr note + exit 2」に確定。根拠 = oe-tree は単機能 verb で全投影が tmux 依存・「degrade で残せる部分価値」が構造的に無い・lib 家族の rc=2 規約と一致。
+  - **手続き指摘（ゲートで解決 — SO では解決不能）**: role 列省略は issue 文言との deviation でユーザー承認未了のまま「確定」と扱えない（両レーン・最重要）／gone の時間的意味論の受入可否／workspace・self marker が issue 外の追加列（--json を棄却した最小スコープ判断が列追加側に未適用・cursor #6）→ これらは **DJ-OPEN 1-4 として明示し hg-1（このペインのユーザー承認）に晒す**。SO を追加で回しても人間の受入判断は代替できないため、弱SO 規律の「refuted なら確定保留」= 確定せずゲートへ、で処理。
+  - プロトタイプ揮発性（cursor #2）は test_oe_tree.sh の fixture 化（DJ-221-8 ケース 1 が %49 チェーン型）で恒久化する。
+- 設計SO 総括: 2 周とも refuted だが、SO#1 の実質的発見（role 概念・degrade 慣例・sanitize・意味論明文化・テスト）は v2/v3 に吸収済み。残余 refuted 核は「承認ゲート未了」という手続き項目に収束 — 設計は**未確定のまま** DJ-OPEN 4 点を添えて hg-1 に提示する（確定はユーザー判断後）。
+
+## ユーザー承認（hg-1・2026-07-03）
+
+- DJ-OPEN 4 点（role 列なし / workspace + (you) 追加列 / gone スナップショット意味論の受入 / tmux 不在 exit 2）を推奨付きで提示 →「推奨で OK」の明示承認。設計確定。
+- 承認時の追加確認（ユーザー質問）: 「ビューアー自体はスコープに入っているか。C-Space g で開くウィンドウ/ペインのビューアーと似た感じか」→ 実物照合の上で回答: C-Space g の実体は `display-popup` + `~/bin/tmux-claude-picker`（fzf で現セッションのペイン一覧・preview・ジャンプ。tmux 構造が対象）。oe-tree は CLI 出力が本体で対話 UI はスコープ外（#221 は「観測・表示」限定）。picker が見せるのは tmux の window/pane 構造で、spawn の親子（誰が誰を委譲したか）は tmux が知らないデータ — oe-tree はその欠けた軸を registry から出す補完関係。popup バインド 1 行（dotfiles 側）や fzf 対話化（#176/oe-status -i の系譜）は follow-up として surface。
+
+## 実装フェーズ（2026-07-03）
+
+- `bin/oe-tree`（新規・実行可能）: 承認済み設計どおり。registry 現 server 走査（US 区切り内部プロトコル・jq 側で US/TAB/LF/CR を空白に畳む）→ root 合成（parent 参照のみの pane + parent 空 entry）→ 罫線再帰描画（兄弟は pane 番号昇順・visited set の cycle guard）。liveness は `tmux list-panes -a` 突合で query 失敗は `?` degrade・`$TMUX` 不在は stderr note + exit 2。異 server entry は非表示 + footer 件数。設計外の追加安全策 1 点: **純粋 cycle（root から到達不能な輪）は森林ループで描かれず無言で消える**ことに実装中に気づき、未到達 entry の sweep（最小 pane を擬似 root に描画・cycle guard が閉じで `[cycle]`）を追加 — 「登記に在るのに見えない」偽りの防止で read-only のまま。
+- `tests/test_oe_tree.sh`（新規）: mock tmux（PATH 先頭差し替え・test_oe_jump/test_oe_select と同型）+ 実 jq + 隔離 state + TMUX 偽値 `,12345,0`。DJ-221-8 の計画 10 ケースを 11 ブロック 15 チェックに展開（3 世代チェーン=実測 %49 型 fixture・複数 root 数値順・pane-issue 優先・sanitize・cycle+`?` degrade・foreign footer・空登記・TMUX 不在 exit 2・pane_title fallback・gone 中間親・引数系）。**15/15 PASS**（初回実行）。
+- shellcheck: `bin/oe-tree` / `tests/test_oe_tree.sh` とも指摘ゼロ（テスト側 SC2155 を 1 件修正）。
+- 実データ検証: 実行のたびに登記が動く現場をそのまま捕捉 — プロトタイプ時に居た %110 が本実装の実行時には GC 済みで新 spawn %116 が出現。「gone は次の spawn 登記まで」のスナップショット意味論が実データで実演された（DJ-OPEN-2 で受入済みの性質そのもの）。
+- doc: `bin/README.md` に oe-tree 節（意味論・root 合成・role 列なしの根拠・degrade/exit 規約・follow-up 明記）、`README.md` 構成ツリーに 1 行。

--- a/projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md
@@ -3,7 +3,7 @@ id: "01KWJ0F80R40JRHTKQHDWB8D0C"
 title: "#221 episode — spawn ツリー（親→子→孫）read-only トポロジ観測ビュー実装記録"
 date: 2026-07-03
 type: episode
-status: draft
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/221"
@@ -74,3 +74,58 @@ tags: [orchestration, cockpit, spawn-tree, topology, observation, read-only, epi
   - **ESC 等の端末制御文字の直出し**: sanitize が LF/CR/TAB/US のみで、`oe-delegate --label $'\e[2J...'` 経由で ESC が registry に到達し（oe-delegate は LF/CR しか拒否しない — 実照合済み）、人間向け cockpit 表示に画面消去・視覚偽装・OSC 端末制御が通る。`oe_reg_list` は ANSI を「別軸・scope 外」と注記するが（宛先表の脅威モデル＝レコード境界偽造）、oe-tree は表示そのものが製品なので視覚偽装が本ツールの脅威モデルに入る — material と判断。→ C0 全域 + DEL + C1（U+0000-001F/007F/0080-009F）を jq の codepoint gsub で空白へ畳む（収集経路の clean + pane-issue/pane_title 経路の `sanitize_out` チョークポイント。C1 は UTF-8 符号化形も畳めるよう byte-wise でなく codepoint 処理・jq 不能時は C0+DEL の tr へ縮退）。修正 commit: edc7fa2（tests 19 チェック・OSC/BEL タイトル偽装ケース含む）。
   - 教訓（レーン別レンズの差）: SO#1 で cursor が「pane-issue 経路の US 未畳みは非 material」と流した箇所の上位集合を SO#2 で codex が material として拾った — 2 レーンの独立性が働いた形。
 - **SO#3**（audit_id 202607021947362XW6QQHR5P69・reviewed_sha edc7fa2）: **survived 2/2**（codex/cursor とも material なし。cursor は 19/19 テスト・shellcheck・cycle/dedup/sanitize/foreign 経路の手動追跡を明記）。実装SO ゲート通過 — PR 作成へ。
+
+## PR
+
+- [PR #222](https://github.com/stlwolf/ai-development-hub/pull/222)（feat(oe): spawn トポロジの read-only ツリー観測 verb oe-tree を追加）。コミット 4 件: a71b587（feat）→ 56ce2c5（fix: skip 開示 + dedup）→ edc7fa2（fix: C0/C1/DEL sanitize）→ ea1d236（docs: episode 追記）。マージ・worktree 掃除はしない（kickoff 規律・人間/親）。
+
+## Closure（episode-retrospective・heavy tier・2026-07-03）
+
+tier 判定: heavy（意図的 SO レーンを 5 回起動 = oe-refute ×2 + oe-review ×3 / 非自明な設計判断あり / SO 指摘による修正 2 回あり）。
+
+### 事実・失敗（選択的省略をしない）
+
+0. **設計フェーズの誤り一式**（採否の詳細は設計フェーズ節の SO#1/#2 記録が正本 — ここは失敗棚卸しとしての列挙）: tmux 不在挙動の二転（exit 2 → pid グループ degrade → 比較の上 exit 2 に統合）・初期案の sanitize 欠落・森林構築/複数 root/orphan/cycle の仕様化不足・テスト計画の具体性不足・TAB sanitize の引用根拠誤り（oe_reg_list の注記と矛盾）。
+1. **role 列棄却の初期根拠が誤り**: stored field（常に "child"）だけ見て「情報ゼロ」と断定したが、`oe-ident` の read-time role 導出という家族概念が実在した（設計SO#1 両レーン指摘）。結論（列なし）は維持されたが根拠を差し替えた — 結論が生き残っても根拠が死んでいることはある。
+2. **v2 改訂を追記形式にして探索木本文と矛盾を作った**（設計SO#2 codex 指摘）— working doc は統合書き直しが正・履歴は episode 側に持つ、で回復。
+3. **実装 v1 に failure propagation 欠陥**: 壊れ/不正/重複 entry の無言スキップで「登記なし」と偽る・偽 [cycle] 表示（実装SO#1 cursor 指摘）→ 56ce2c5 で修正。
+4. **ESC/端末制御文字の sanitize 漏れ**（実装SO#2 codex 指摘）→ edc7fa2 で修正。oe_reg_list の「ANSI は scope 外」注記に引っ張られ、表示ツール自身の脅威モデルで考え直すのが遅れた。
+5. episode に commit hash を誤記（5db595d と書くべきは edc7fa2）→ 事実ドリフトとして in-place 修正（kickoff のエピソード精度規律）。
+6. ツール操作の失敗: 探索木/スクリプト編集時に不可視の生制御文字（US・C0 範囲）を 2 度ソースへ混入させ、Edit の文字列一致も阻害した → `\uXXXX` 明示エスケープへ統一して回復。
+
+### 決定と根拠（詳細は本文の設計フェーズ節・確定はユーザー承認済み）
+
+- 新規 verb `oe-tree`（oe-list --tree / oe-status 区画 / event-log 再構成 / JSON only を棄却 — 棄却理由は探索木 v3 から本文に転記済み）。核: **oe-list の宛先契約（self scoping）とトポロジ全域表示は意味論が別物**。
+- registry 現在スナップショット主義（歴史は oe-activity・レイヤ分離）・gone 表示 + GC 不呼出・tmux 不在 exit 2（「degrade で残せる部分価値が構造的に無い」比較の上）・role 列なし（木の形が搬送）。
+
+### わかったこと
+
+- `oe_reg_gc` は `oe_reg_record` 時のみ走る write path で、**異 server pid の entry を無条件 rm する**（L182）— 観測ツールから GC を呼べない構造的理由・複数 server 表示が「実在し得ない状態」である理由の両方がここに帰着する。
+- event log（child_spawned）は server_pid を持たず、server 再起動を跨ぐ歴史再構成は pane-id 再利用で混同する — oe-activity の既知の制約と同根で、oe-tree が「現在」に限定する根拠。
+- `C-Space g`（tmux-claude-picker）は tmux 構造（window/pane）の対話ピッカーで、spawn 帰属（誰が誰を委譲したか）は tmux が知らないデータ — oe-tree と補完関係（承認時のユーザー質問への実物照合で確認）。
+
+### 原則（Pattern / Anti-pattern 対）
+
+- NG: producer 側 sanitize の scope 注記（oe_reg_list「ANSI は視覚偽装＝別軸・scope 外」）を消費者にそのまま流用する / OK: **表示ツールは自分の脅威モデルで sanitize クラスを決める**（人間向け表示が製品なら C0/C1/DEL 全域を codepoint で畳む）。→ #62（negative knowledge 注入）実装時に回収（routing 先: #62）。
+- NG: working doc の改訂を追記だけで済ませ本文との矛盾を残す / OK: 確定前 working doc は統合書き直し・改訂履歴は episode が持つ。
+
+### 蒸留シグナル
+
+- **Decision/ADR: 非昇格**（adr-1 の判断）。理由: 本件の決定は tool-local（表示形式・データ源選択・degrade 規約）で、新 write path・スキーマ・イベント意味論の変更がなく #114/#92/#206A 級のシステム横断影響に届かない。判断の再利用は `bin/README.md` の oe-tree 節 + 本 episode の DJ 記録で足りる。
+- skill / rule 昇格: なし。
+
+### 残課題（routing — 全件行き先付き）
+
+- `--json` 出力・gone root ラベルの event-log 補完・ラベル解決 4 重化の共通 read ヘルパ化・oe-status への observe 統合: **[PR #222](https://github.com/stlwolf/ai-development-hub/pull/222) スコープ外節に surface 済み**。採否・起票は epic [#169](https://github.com/stlwolf/ai-development-hub/issues/169) オーナー（人間/親）判断に委ねる — 子からは追わない。
+- ペイン分割レイアウト戦略（第2弾）: [#221](https://github.com/stlwolf/ai-development-hub/issues/221) 本文が別 issue と宣言済み — 起票待ち（子からは追わない）。
+- popup キーバインド / fzf 対話化: dotfiles 側 / #176 系譜 — PR #222 に surface 済み・追わない（必要になったとき hub vs dotfiles 分担で判断）。
+
+### closure gate
+
+- Context/なぜ: 冒頭 2 文で自己完結（flat oe-list で親子が追えない認知負荷）— 充足。
+- 次の消費者: (1) #169 epic の観測 UI 後続（fzf 化・observe 統合）の実装者 (2) 第2弾 issue の起票者（スコープ境界の参照元）(3) sanitize 脅威モデルの対構造は #62 実装時の注入候補。
+- evidence anchor: 揮発参照（`tmp/dj-221-tree.md`・`tmp/oe-refute-*`・`tmp/oe-review-*`）の要点（DJ と棄却理由・audit_id・verdict・レーン note）は本文へ転記済み。SO の生出力は audit_id（oe-refute/oe-review の audit jsonl）で追跡可能。
+- status: draft → **stable**・達成（受入条件 2 点とも実測検証済み・PR #222 作成済み）。
+- Step 4 外部チェック（so-compare 弱SO・`tmp/so-20260703-045437`・揮発）: codex=**refuted**（(a) 設計フェーズの採用済み指摘が失敗棚卸しから欠落 (b) frontmatter status が draft のまま宣言と矛盾）/ claude=**survived**（省略は concealment でなく圧縮と判定・軽微 1 件 = 56ce2c5 の skip 開示が bin/README 未記載）。→ (a) は本節の項目 0 として追補・(b) は frontmatter を stable に確定・claude 指摘の README 追記も反映（いずれも本 closure コミットに含む）。弱SO 規律: 両レーン実返却あり・指摘は全件処置済みで確定に進む。
+
+形式メモ: チャネル骨格で「事実・失敗」の選択的省略チェックが効いた（SO 指摘 4 件 + 自己失敗 2 件を列挙する動機になった）。「原則」の対構造は sanitize の学びに自然に嵌った。皮（KPT/YWT）は使わず。摩擦は Step 4 外部チェックの待ち時間のみ。

--- a/projects/orchestration-engine/tests/test_oe_tree.sh
+++ b/projects/orchestration-engine/tests/test_oe_tree.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# test_oe_tree.sh — oe-tree（spawn トポロジ read-only ツリー表示・#221）を検証する
+#
+# 実 tmux は起動せず PATH 先頭 mock に差し替える（test_oe_jump / test_oe_select と同型）:
+#   - tmux: list-panes は $MOCK_LIVE_PANES を返す（$MOCK_TMUX_FAIL=1 で失敗＝liveness ? 経路）。
+#           display-message は $MOCK_PANE_TITLE を返す（pane_title fallback 用）。
+#   - jq : 実体を使う（oe-tree の entry パースは実 jq のフィルタに依存）。
+# state は OE_DELEGATE_STATE_DIR / OE_PANE_ISSUE_DIR の一時 dir に隔離。
+# TMUX 偽値 "/tmp/mock-tmux,12345,0" で server pid = 12345 に固定（決定的 key 生成）。
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+_TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+[[ -n "$_TMP_DIR" && -d "$_TMP_DIR" ]] || { echo "FATAL: mktemp -d returned an invalid path: '${_TMP_DIR}'" >&2; exit 1; }
+trap 'rm -rf "$_TMP_DIR"' EXIT
+mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/lib" "$_TMP_DIR/pathbin"
+
+cp "$PROJECT_DIR/bin/oe-tree" "$_TMP_DIR/bin/oe-tree"
+chmod +x "$_TMP_DIR/bin/oe-tree"
+ln -s "$PROJECT_DIR/lib/delegate-registry.sh" "$_TMP_DIR/lib/delegate-registry.sh"
+
+# mock tmux: list-panes / display-message のみ意味を持つ（他は成功で素通し）
+cat > "$_TMP_DIR/pathbin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-panes)
+    [[ "${MOCK_TMUX_FAIL:-0}" == "1" ]] && exit 1
+    # shellcheck disable=SC2086
+    printf '%s\n' ${MOCK_LIVE_PANES:-} ;;
+  display-message)
+    printf '%s\n' "${MOCK_PANE_TITLE:-}" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$_TMP_DIR/pathbin/tmux"
+
+# 実 jq を厳選 PATH に含める（mock は tmux のみ）
+JQ_BIN="$(command -v jq)" || { echo "FATAL: jq is required to run this test" >&2; exit 1; }
+JQ_DIR="$(dirname "$JQ_BIN")"
+export PATH="${_TMP_DIR}/pathbin:${JQ_DIR}:/usr/bin:/bin"
+
+export OE_DELEGATE_STATE_DIR; OE_DELEGATE_STATE_DIR="$_TMP_DIR/state"
+export OE_PANE_ISSUE_DIR;     OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
+mkdir -p "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+
+export TMUX="/tmp/mock-tmux,12345,0"   # server pid = 12345
+export TMUX_PANE="%110"                # self（case [1] の孫）
+
+TREE="$_TMP_DIR/bin/oe-tree"
+
+PASS=0
+FAIL=0
+ck() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"; FAIL=$((FAIL + 1))
+    echo "    --- want ---"; printf '%s\n' "$expected" | sed 's/^/    /'
+    echo "    --- got ----"; printf '%s\n' "$actual"   | sed 's/^/    /'
+  fi
+}
+reset_state() {
+  rm -rf "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+  mkdir -p "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+}
+keyfor() { printf '12345_%s' "${1//[^A-Za-z0-9]/_}"; }
+mkentry() { # <pane> <label> <workspace> <parent_pane>
+  jq -cn --arg pane "$1" --arg label "$2" --arg ws "$3" --arg parent "$4" \
+    '{pane:$pane, label:$label, workspace:$ws, parent_pane:$parent, role:"child"}' \
+    > "${OE_DELEGATE_STATE_DIR}/$(keyfor "$1").json"
+}
+fixture_chain() { # 実測 %49(gone)→%83→{%85→%110, %94} 型の 3 世代チェーン
+  mkentry %83  "fresh-orch-2" "/w/biz-infra"    %49
+  mkentry %85  "#5706"        "/w/attelu.5706"  %83
+  mkentry %110 "#5706-u1"     "/w/attelu"       %85
+  mkentry %94  "#36"          "/w/ecs"          %83
+}
+
+# ----------------------------------------------------------------------------
+echo "[1] 3 世代チェーン: 罫線・世代・gone 合成 root・兄弟数値順・self marker・workspace"
+# ----------------------------------------------------------------------------
+reset_state; fixture_chain
+export MOCK_LIVE_PANES="%83 %85 %94 %110"
+expected='%49  gone   ?
+└─ %83  alive  fresh-orch-2 ~biz-infra
+   ├─ %85  alive  #5706 ~attelu.5706
+   │  └─ %110  alive  #5706-u1 ~attelu (you)
+   └─ %94  alive  #36 ~ecs'
+ck "chain render" "$expected" "$("$TREE")"
+
+# ----------------------------------------------------------------------------
+echo "[2] 複数 root の数値順 + parent 空 entry は自身が root"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %8  "second-tree" "/w/two" %7
+mkentry %60 "standalone"  "/w/one" ""
+export MOCK_LIVE_PANES="%8 %60"
+expected='%7  gone   ?
+└─ %8  alive  second-tree ~two
+%60  alive  standalone ~one'
+ck "multi-root order" "$expected" "$("$TREE")"
+
+# ----------------------------------------------------------------------------
+echo "[3] ラベル優先順位: pane-issue(.name) > registry(.label)"
+# ----------------------------------------------------------------------------
+reset_state; fixture_chain
+printf '{"name":"#5706 renamed"}' > "${OE_PANE_ISSUE_DIR}/$(keyfor %85)"
+export MOCK_LIVE_PANES="%83 %85 %94 %110"
+actual="$("$TREE" | grep -F '%85')"
+ck "pane-issue wins" '   ├─ %85  alive  #5706 renamed ~attelu.5706' "$actual"
+
+# ----------------------------------------------------------------------------
+echo "[4] label sanitize: LF/CR/TAB/US は空白へ畳む"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %60 $'bad\nlab\tx\037y' "/w/one" ""
+export MOCK_LIVE_PANES="%60"
+ck "sanitized label" '%60  alive  bad lab x y ~one' "$("$TREE")"
+
+# ----------------------------------------------------------------------------
+echo "[5] 純粋 cycle: 擬似 root で描画・[cycle] 打ち切り・無限ループなし（liveness ? 経路）"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %201 "lab201" "" %202
+mkentry %202 "lab202" "" %201
+export MOCK_TMUX_FAIL=1
+expected='%201  ?      lab201
+└─ %202  ?      lab202
+   └─ %201  [cycle]'
+ck "cycle cut + degrade ?" "$expected" "$("$TREE")"
+unset MOCK_TMUX_FAIL
+
+# ----------------------------------------------------------------------------
+echo "[6] 異 server entry: 非表示 + footer 件数開示"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %60 "standalone" "/w/one" ""
+printf '{"pane":"%%7","label":"foreign","workspace":"/w","parent_pane":"%%1","role":"child"}' \
+  > "${OE_DELEGATE_STATE_DIR}/99999__7.json"
+export MOCK_LIVE_PANES="%60"
+expected='%60  alive  standalone ~one
+note: 1 entries from other tmux servers not shown (stale)'
+ck "foreign hidden + footer" "$expected" "$("$TREE")"
+
+# ----------------------------------------------------------------------------
+echo "[7] 登記 0 件（現 server）: 空表示メッセージ + exit 0（foreign のみでも同様）"
+# ----------------------------------------------------------------------------
+reset_state
+out="$("$TREE")"; rc=$?
+ck "empty message" '(no spawn entries for this tmux server)' "$out"
+ck "empty exit 0" "0" "$rc"
+printf '{"pane":"%%7","label":"foreign","workspace":"/w","parent_pane":"%%1","role":"child"}' \
+  > "${OE_DELEGATE_STATE_DIR}/99999__7.json"
+expected='(no spawn entries for this tmux server)
+note: 1 entries from other tmux servers not shown (stale)'
+ck "foreign-only message" "$expected" "$("$TREE")"
+
+# ----------------------------------------------------------------------------
+echo "[8] TMUX 不在: stderr note + exit 2（scoping も liveness も成立しない）"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %60 "standalone" "/w/one" ""
+err="$(env -u TMUX -u TMUX_PANE "$TREE" 2>&1 >/dev/null)"; rc=$?
+ck "tmux-less exit 2" "2" "$rc"
+ck "tmux-less note" "yes" "$(printf '%s' "$err" | grep -q 'not inside tmux' && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+echo "[9] pane_title fallback: 空 label + alive のみ（pane-issue > registry > title の最後段）"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %70 "" "/w/seventy" ""
+export MOCK_LIVE_PANES="%70"
+export MOCK_PANE_TITLE="picked up title"
+ck "title fallback" '%70  alive  picked up title ~seventy' "$("$TREE")"
+unset MOCK_PANE_TITLE
+
+# ----------------------------------------------------------------------------
+echo "[10] gone 中間ノード: 親子とも登記あり・中間だけ gone でも子は描画"
+# ----------------------------------------------------------------------------
+reset_state; fixture_chain
+export MOCK_LIVE_PANES="%83 %94 %110"   # %85 が gone
+actual="$("$TREE" | grep -cE '%85  gone|%110  alive')"
+ck "gone mid keeps child" "2" "$actual"
+
+# ----------------------------------------------------------------------------
+echo "[11] 引数: --help は exit 0 / 未知引数は exit 2"
+# ----------------------------------------------------------------------------
+"$TREE" --help >/dev/null 2>&1; ck "help exit 0" "0" "$?"
+"$TREE" bogus  >/dev/null 2>&1; ck "unknown arg exit 2" "2" "$?"
+
+# ----------------------------------------------------------------------------
+echo
+echo "PASS=${PASS} FAIL=${FAIL}"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/projects/orchestration-engine/tests/test_oe_tree.sh
+++ b/projects/orchestration-engine/tests/test_oe_tree.sh
@@ -114,12 +114,15 @@ actual="$("$TREE" | grep -F '%85')"
 ck "pane-issue wins" '   ├─ %85  alive  #5706 renamed ~attelu.5706' "$actual"
 
 # ----------------------------------------------------------------------------
-echo "[4] label sanitize: LF/CR/TAB/US は空白へ畳む"
+echo "[4] label sanitize: LF/CR/TAB/US/ESC/C1 を空白へ畳む（端末制御・視覚偽装の遮断）"
 # ----------------------------------------------------------------------------
 reset_state
 mkentry %60 $'bad\nlab\tx\037y' "/w/one" ""
-export MOCK_LIVE_PANES="%60"
-ck "sanitized label" '%60  alive  bad lab x y ~one' "$("$TREE")"
+mkentry %61 $'esc\033[2Jwipe\xc2\x9bcsi' "/w/esc" ""
+export MOCK_LIVE_PANES="%60 %61"
+expected='%60  alive  bad lab x y ~one
+%61  alive  esc [2Jwipe csi ~esc'
+ck "sanitized label" "$expected" "$("$TREE")"
 
 # ----------------------------------------------------------------------------
 echo "[5] 純粋 cycle: 擬似 root で描画・[cycle] 打ち切り・無限ループなし（liveness ? 経路）"
@@ -176,6 +179,8 @@ mkentry %70 "" "/w/seventy" ""
 export MOCK_LIVE_PANES="%70"
 export MOCK_PANE_TITLE="picked up title"
 ck "title fallback" '%70  alive  picked up title ~seventy' "$("$TREE")"
+export MOCK_PANE_TITLE=$'spoof\033]0;t\007end'
+ck "title sanitize (OSC/BEL)" '%70  alive  spoof ]0;t end ~seventy' "$("$TREE")"
 unset MOCK_PANE_TITLE
 
 # ----------------------------------------------------------------------------

--- a/projects/orchestration-engine/tests/test_oe_tree.sh
+++ b/projects/orchestration-engine/tests/test_oe_tree.sh
@@ -187,7 +187,33 @@ actual="$("$TREE" | grep -cE '%85  gone|%110  alive')"
 ck "gone mid keeps child" "2" "$actual"
 
 # ----------------------------------------------------------------------------
-echo "[11] 引数: --help は exit 0 / 未知引数は exit 2"
+echo "[11] 壊れ JSON / 不正 pane / 重複 pane: skip 件数を footer 開示・有効 entry は描画"
+# ----------------------------------------------------------------------------
+reset_state
+mkentry %60 "standalone" "/w/one" ""
+printf '{broken' > "${OE_DELEGATE_STATE_DIR}/12345__901.json"
+printf '{"pane":"nope","label":"x","workspace":"","parent_pane":"","role":"child"}' \
+  > "${OE_DELEGATE_STATE_DIR}/12345__902.json"
+printf '{"pane":"%%60","label":"dup","workspace":"","parent_pane":"","role":"child"}' \
+  > "${OE_DELEGATE_STATE_DIR}/12345__903.json"
+export MOCK_LIVE_PANES="%60"
+expected='%60  alive  standalone ~one
+note: 3 entries skipped (unreadable or duplicate pane)'
+ck "partial skip disclosed" "$expected" "$("$TREE")"
+
+# ----------------------------------------------------------------------------
+echo "[12] 現 server entry が全滅（壊れのみ）: 「登記なし」と偽らず readable 無しを明示 + exit 0"
+# ----------------------------------------------------------------------------
+reset_state
+printf '{broken' > "${OE_DELEGATE_STATE_DIR}/12345__901.json"
+out="$("$TREE")"; rc=$?
+expected='(no readable spawn entries for this tmux server)
+note: 1 entries skipped (unreadable or duplicate pane)'
+ck "all-broken message" "$expected" "$out"
+ck "all-broken exit 0" "0" "$rc"
+
+# ----------------------------------------------------------------------------
+echo "[13] 引数: --help は exit 0 / 未知引数は exit 2"
 # ----------------------------------------------------------------------------
 "$TREE" --help >/dev/null 2>&1; ck "help exit 0" "0" "$?"
 "$TREE" bogus  >/dev/null 2>&1; ck "unknown arg exit 2" "2" "$?"


### PR DESCRIPTION
## 目的

multi-session オーケストレーションで委譲ツリー（親→子→孫）が深くなり、「何が何を立てたか」「どのペインが孫か」が flat な `oe-list` では追えない — spawn registry の `parent_pane` 連鎖から**現在トポロジを read-only でツリー表示**する観測 verb `oe-tree` を追加する。

Refs #221

## 変更内容

- `bin/oe-tree`（新規）: registry（`~/.claude/state/oe-delegate/`）の現 tmux server 分を走査し、森林を再構成して罫線ツリーで表示
  - 各ノード: `<pane> <liveness(alive|gone|?)> <label> [~workspace] [(you)]`。ラベルは pane-issue > registry > pane_title(alive) > `?`（`oe_reg_list` と同優先順位・honest fallback）
  - root 合成（parent 参照のみの pane）・兄弟は pane 番号昇順・cycle guard（`[cycle]` 打ち切り + 到達不能な純粋 cycle の sweep）
  - **スナップショット意味論を明文化**: gone entry は次の `oe_reg_record` 時 GC まで表示（歴史は `oe-activity` の領分・レイヤ分離）
  - **read-only 徹底**: 読むのは state ファイルと mux query のみ。`oe_reg_gc` 等の write path は不呼出（#177/#188 規律）
  - honest degrade: 読めない/重複 entry は skip 件数を footer 開示・異 server entry は非表示 + footer・liveness query 失敗は `?`・`$TMUX` 不在は exit 2（lib 家族の rc=2 規約）
  - 出力 sanitize: C0/C1/DEL を codepoint レベルで空白へ（ESC/CSI/OSC の視覚偽装・端末制御を遮断）
- `tests/test_oe_tree.sh`（新規）: mock tmux + 隔離 state で 13 ブロック 19 チェック
- doc: `bin/README.md` に oe-tree 節・`README.md` 構成ツリーに 1 行
- episode: `projects/orchestration-engine/docs/episodes/2026-07-03-episode-221-spawn-tree-view.md`

## 設計プロセス（kickoff 規律）

- ゼロベース設計（`predecision-exploration`）: 探索木 7 DJ を外部化。ゼロベース発見 = event log `child_spawned` からの歴史トポロジ再構成（23 件実在を実測）→ server_pid 無しの pane-id 混同リスクで v1 棄却・registry 主データ源に確定
- 設計SO（`oe-refute --rubric exploration` × 2周・refuted）→ 実質的発見（oe-ident の read-time role 概念・観測クラス degrade 慣例・sanitize・テスト仕様化）を吸収し、残余 4 点（role 列なし / workspace+self marker / gone 意味論 / tmux 不在 exit 2）は**ユーザー承認ゲートで確定**（推奨案で承認済み）
- 実装SO（`oe-review` × 3周）: #1 refuted（skip 無言化・偽 [cycle]）→ 修正 56ce2c5 / #2 refuted（ESC 直出し）→ 修正 edc7fa2 / **#3 survived 2/2**（audit_id 202607021947362XW6QQHR5P69）

## Test Plan（実行済み）

- [x] `tests/test_oe_tree.sh` — **19/19 PASS**（3 世代チェーン・複数 root 順序・ラベル優先順位・sanitize(LF/CR/TAB/US/ESC/C1)・cycle・foreign footer・空登記・TMUX 不在 exit 2・pane_title fallback・gone 中間親・壊れ/重複 entry の skip 開示・引数系）
- [x] `shellcheck bin/oe-tree tests/test_oe_tree.sh` — 指摘ゼロ
- [x] 実データ検証: 実 registry の 3 世代チェーン（%49 gone → %83 → %85/%94 → %110）が受入条件どおり描画されることを確認（実行中に %110 の GC・%116 の新規 spawn も観測 = スナップショット意味論の実演）
- [x] read-only 検証: write path（`oe_reg_record`/`oe_reg_gc`/リダイレクト）の呼び出しゼロを grep で確認

## スコープ外（surface のみ・実装しない）

- ペイン分割レイアウト戦略（縦分割の sprawl）— issue 明記の別 concern（第2弾）
- `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化（4 実装の重複解消）/ oe-status への observe 統合（#169 後続）/ popup キーバインド（dotfiles 側・C-Space g の tmux-claude-picker と補完関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
