### PR TITLE
fix(oe): oe-tree を symlink 安全化し ~/bin 配布に載せる (#223)

### DIFF
--- a/projects/orchestration-engine/bin/oe-tree
+++ b/projects/orchestration-engine/bin/oe-tree
@@ -42,7 +42,15 @@
 
 set -euo pipefail
 
-BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# invoked path を symlink 解決してから lib dir を決める（~/bin 経由の symlink 起動でも
+# lib を source できるように・#223 配布対応）。macOS の readlink は -f 非対応のためループで解決。
+_oe_src="${BASH_SOURCE[0]:-$0}"
+while [[ -h "$_oe_src" ]]; do
+  _oe_dir="$(cd -P "$(dirname "$_oe_src")" && pwd)"
+  _oe_src="$(readlink "$_oe_src")"
+  case "$_oe_src" in /*) ;; *) _oe_src="$_oe_dir/$_oe_src" ;; esac
+done
+BIN_DIR="$(cd -P "$(dirname "$_oe_src")" && pwd)"
 # shellcheck source=../lib/delegate-registry.sh
 source "${BIN_DIR}/../lib/delegate-registry.sh"
 

--- a/projects/orchestration-engine/tests/test_oe_tree.sh
+++ b/projects/orchestration-engine/tests/test_oe_tree.sh
@@ -312,6 +312,17 @@ ck "fallback (you) on active pane" "yes" "$(grep -q -- '-     %94    alive  #36 
 unset MOCK_ACTIVE_PANE
 
 # ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+echo "[18] symlink 経由起動でも lib を source できる（#223 配布・symlink 安全化）"
+# ----------------------------------------------------------------------------
+reset_state; fixture_chain
+_oe_link="$_TMP_DIR/pathbin/oe-tree-linked"
+ln -sf "$PROJECT_DIR/bin/oe-tree" "$_oe_link"   # 実 hub oe-tree を指す symlink（~/bin 配布と同型）
+_direct="$("$TREE" 2>&1)"; _drc=$?              # copy: BIN_DIR=temp/bin → temp/lib
+_linked="$("$_oe_link" 2>&1)"; _lrc=$?          # symlink: readlink 解決で hub/bin → hub/lib を source
+ck "symlink 起動 rc == 直接起動 rc" "$_drc" "$_lrc"
+ck "symlink 起動 出力 == 直接起動 出力" "$_direct" "$_linked"
+
 echo
 echo "PASS=${PASS} FAIL=${FAIL}"
 [[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/sync/sync-bin.sh
+++ b/scripts/sync/sync-bin.sh
@@ -42,12 +42,13 @@ usage() {
 
 [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
 
-CMD_NAMES=("so-compare" "arena-compare" "wez" "wt-pane-issue")
+CMD_NAMES=("so-compare" "arena-compare" "wez" "wt-pane-issue" "oe-tree")
 CMD_SOURCES=(
     "${REPO_ROOT}/scripts/so-compare.sh"
     "${REPO_ROOT}/projects/arena-compare/arena-compare.sh"
     "${REPO_ROOT}/projects/wezterm-ai-mode/bin/wez"
     "${REPO_ROOT}/scripts/wt/wt-pane-issue.sh"
+    "${REPO_ROOT}/projects/orchestration-engine/bin/oe-tree"
 )
 
 main() {


### PR DESCRIPTION
## 概要

tmux popup から `oe-tree --watch` を起動する bind（#223 の live topology viewer・dotfiles 側）を張るため、`oe-tree` を `~/bin` 配布に載せる。その前提として **oe-tree の symlink 非対応（latent bug）を修正**する。

## 課題

`oe-tree` は `BIN_DIR="$(cd "$(dirname "$0")" && pwd)"` で lib dir を決め `../lib/delegate-registry.sh` を source する。`~/bin` 経由の **symlink 起動だと `$0`=symlink パスで BIN_DIR がズレ、lib source が失敗**して壊れる。兄弟の `so-compare`/`wez` は相対 source しないので symlink 安全だが、`oe-tree` は非対応だった。

## 変更

- **`oe-tree`**: `BASH_SOURCE` を **readlink ループで解決**してから `BIN_DIR` を決める（macOS の readlink は `-f` 非対応のためループ・bash3.2 安全）。symlink 起動でも lib を source できる。
- **`sync-bin.sh`**: `CMD_NAMES` / `CMD_SOURCES` に `oe-tree` を追加（`so-compare`/`wez` と同じ `~/bin` symlink 配布経路）。
- **`test_oe_tree.sh` [18]**: symlink 起動 == 直接起動 の rc/出力一致で lib 解決を実証。

## 検証

- `shellcheck` rc=0（oe-tree / sync-bin / test）
- `test_oe_tree` **35/35**（bash 5.2.37・3.2.57 両系）
- 実 symlink smoke: symlink 起動で lib source 成功（rc=0・source エラーなし）

## スコープ / 判断

- 設計判断のない機械的 fix + 配布リスト追加のため、**実装SO(oe-review) / episode は省略**（客観ゲート = symlink テストで担保・`episode-flow-discipline` の「skip 判断を残す」に従い明記）。
- `~/bin` 配布は本 PR では **oe-tree のみ**（bind の対象）。他の観測系（oe-activity / oe-status 等）の配布は必要時に別途。

Refs #223
