### PR TITLE
feat(oe): oe-tree に対話ナビ --pick（ノード選択→jump+最大化）を追加

### DIFF
--- a/projects/orchestration-engine/README.md
+++ b/projects/orchestration-engine/README.md
@@ -47,7 +47,7 @@ projects/orchestration-engine/
 │   ├── oe-ack                 # 自分宛て報告への受領印（report_received）を打つ actor verb（#206A・frontier snapshot）
 │   ├── oe-status              # cockpit 観測UI: read-only 俯瞰（ENGINE=audit-terminal state / DELEGATE=liveness）+ 監査ログ閲覧（#177）
 │   ├── oe-activity            # 親子活動ログ（oe-events.jsonl）の read 時投影ビュー: 往復/配送/preview/子生存/受領（inbox PENDING・timeline ack 行）（#206）
-│   └── oe-tree                # spawn トポロジ（親→子→孫）の read-only 罫線ツリー表示 + --watch live 表示（registry 現 server スナップショット・#221/#223）
+│   └── oe-tree                # spawn トポロジ（親→子→孫）の read-only 罫線ツリー表示 + --watch live 表示 + --pick 対話ナビ（選択→jump+最大化）（registry 現 server スナップショット・#221/#223/#227）
 ├── lib/                       # Bash 関数ライブラリ（source 専用）
 │   ├── constants.sh           # OE_POLL_INTERVAL, OE_CB_*, OE_DATA_DIR, OE_TARGET_AI_*, OE_VERIFY_AI_* 等
 │   ├── event-bus.sh           # 親子活動ログ emit プリミティブ（child_spawned / message_sent / report_received・best-effort・#206）

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -302,14 +302,15 @@ oe-activity --timeline # 時系列: 関係内の各送信を turn 順に 1 行�
 
 関連: `lib/event-bus.sh`（emit プリミティブ・`oe-delegate` が `child_spawned` / `oe_send_line` が `message_sent` / `oe-ack` が `report_received` を発火）、`schemas/oe-events.schema.json`（レコードスキーマ・audit-log とは別系統）。設計判断は #188 DJ-188-4 を delegate 現実（session_id 不在）へ精緻化したもの。
 
-## oe-tree — spawn トポロジの read-only ツリー表示 + live 表示（#221 / #223）
+## oe-tree — spawn トポロジの read-only ツリー表示 + live 表示 + 対話ナビ（#221 / #223 / #227）
 
-spawn registry（`~/.claude/state/oe-delegate/`）の現 tmux server 分を走査し、`parent_pane` 連鎖から森林を再構成して罫線ツリーで表示する。`oe-list` が flat な宛先候補（自分の直下の子に scoping）なのに対し、oe-tree は「何が何を立てたか」「どのペインが孫か」を**現 server 全域**で描く観測ビュー（`oe-status` / `oe-activity` と同クラス）。`--watch` で poll 再描画の live 表示（tmux popup からの常用を想定・#223）。
+spawn registry（`~/.claude/state/oe-delegate/`）の現 tmux server 分を走査し、`parent_pane` 連鎖から森林を再構成して罫線ツリーで表示する。`oe-list` が flat な宛先候補（自分の直下の子に scoping）なのに対し、oe-tree は「何が何を立てたか」「どのペインが孫か」を**現 server 全域**で描く観測ビュー（`oe-status` / `oe-activity` と同クラス）。`--watch` で poll 再描画の live 表示（tmux popup からの常用を想定・#223）。`--pick` でトポロジからノードを選び、そのペインへジャンプ + 最大化する対話ナビ（#227）。
 
 ```bash
 oe-tree                      # 現 server の spawn 森林を罫線ツリーで表示（一発スナップショット）
 oe-tree --watch              # live 表示（2s poll 再描画・q / Esc / C-c で終了）
 oe-tree --watch --interval 5 # 更新間隔を変更（秒・正整数）
+oe-tree --pick               # 対話ナビ: ノードを fzf で選び jump + 最大化（fzf 非在時は番号選択）
 oe-tree -h                   # ヘルプ
 ```
 
@@ -357,9 +358,38 @@ bind-key T run-shell "tmux display-popup -e 'TMUX_PANE=#{pane_id}' -E -x C -y C 
 
 - oe-tree は PATH 登録前提にしない（絶対パスで書く。PATH に通している環境は `oe-tree --watch` で可）。dotfiles にパスを書く運用コスト（リポジトリ移動で陳腐化）は #202 と同型の受容
 - **toggle の意味論**: popup 表示中のキーは popup 内プログラムへ渡るため、tmux bind による「同キーで開閉」は構造的に不成立。開く=bind 1 キー / 閉じる=`q` or `Esc` 1 キーの 2 キー完結（hg-1 受入済み）。`display-popup -C` は別ペイン/スクリプトからの強制 close（rescue）。`-EE`（成功時のみ自動 close）は代替として存在するが、エラー保持は tool 側の 3s hold が配置非依存に同じ役割を果たすため既定にしない
-- follow-up（未実装・surface のみ）: `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化 / 汎用 `oe-watch` verb（他の観測 view の live 化）/ status-line 向け要約（`--summary`）/ popup 内 fzf 対話化（#176 系譜）
 
-関連 lib: `delegate-registry.sh`（`_oe_reg_server_pid` / `_oe_reg_key`・read ヘルパのみ使用）。
+### --pick（対話ナビ・#227）
+
+トポロジ表示から**ノードを選んで、そのペインへジャンプ + 最大化**する（`prefix+g` の session picker のトポロジ版 + 最大化）。`--watch` が「見る」なら `--pick` は「見て飛ぶ」導線。**別コンポーネントを作らず oe-tree 自体に足す**（森構築/描画は既存ロジックの単一ソースのまま・jump は `oe-jump` 再利用・新規は fzf 選択 + `resize-pane -Z` だけ）。
+
+```bash
+oe-tree --pick   # 森ツリーを fzf に流す → 選択 → oe-jump で focus → 対象 window を最大化
+                 # enter: jump+zoom / ctrl-r: refresh（森を取り直す）/ esc: cancel
+```
+
+- **候補生成**: 内部モード `--pick-list` が既存 render 経路そのままに `%N<TAB>表示行` を emit（森ロジックを複製しない・`--watch` の re-exec と同じ「一発実行と同一コードパス」）。`--pick` は自身を `--pick-list` で再帰起動して候補を取る。fzf は `--with-nth 2` で 2 列目（ツリー行）だけを見せ、`%N` は隠しキー。`ctrl-r` は `--pick-list` を再実行して森を取り直す
+- **jump は `oe-jump` 再利用**: 選んだ `%N` を `oe-jump -- %N` に渡す（`switch-client`/`select-window`/`select-pane` 権威・別 window/session 跨ぎ対応）。jump ロジックは複製しない
+- **zoom（新規）**: jump 成功後、対象 window が未 zoom のときだけ `resize-pane -Z -t <pane>` で最大化する（**対象ペイン指定** — 無指定だと popup / 現 window を掴む）。既に zoom 済み（`#{window_zoomed_flag}`=1）なら**再 `-Z` しない**（トグルで解除される事故を防ぐ・冪等）。単一 pane window は `-Z` が無害な no-op
+- **read-only は維持**: jump/zoom は registry / トポロジ**データを編集しない**（#221/#223 のデータ read-only 不変条件は保たれる）。jump+zoom は**ユーザーが明示的に命じるナビ**＝受動検出でも自動作用でもなく、`prefix+g` picker が `select-pane` するのと同カテゴリ（非検出境界の本旨に反しない）。純ビュー（引数なし / `--watch`）はデフォルトで温存
+- **gone ペイン**: 候補には残す（ビューと一貫・gone 表示自体が情報）。選ぶと `oe-jump` が「pane 無し」で rc1 → メッセージを提示して終了（popup では TTY のとき 3s hold で読めるようにしてから閉じる）
+- **fzf 非在**: 番号フォールバック（`oe-select` 同型 — 候補を番号付きで出し `/dev/tty` から番号 read。木の形は番号前置で保つ）。空入力 / EOF = cancel(130)・非数値 / 範囲外 = 2
+- degrade / exit: 0=jump+zoom 成功 / 1=候補なし・jump 不能・zoom 失敗（部分成功を偽らない）/ 2=usage・fzf 自体のエラー / 130=cancel。`--pick` と `--watch` は併用不可
+
+**popup キーバインドは dotfiles 側で opt-in**（hub は強制しない・責務境界 = `oe-ident` #202 / `--watch` の bind と同型）。`--watch`（観測）を別キー、`--pick`（ナビ）を別キーに割り当てる想定。推奨スニペット（`~/.tmux.conf` 等）:
+
+```tmux
+# oe topology pick popup（例: prefix + v。キーは環境の空きに合わせる — tmux list-keys で衝突確認）
+# fzf を popup 内で動かすため -E（対話プログラムを走らせる）。選択後は jump+zoom して自然クローズ。
+bind-key v run-shell "tmux display-popup -e 'TMUX_PANE=#{pane_id}' -E -x C -y C -w 70% -h 60% -T ' oe pick ' '/path/to/repo/projects/orchestration-engine/bin/oe-tree --pick'"
+```
+
+- `-e 'TMUX_PANE=#{pane_id}'` は `(you)` マーカーの opener 注入（`--watch` と同じ・`run-shell` 経由のときだけ format が展開される）
+- bind の実適用は本 PR 外（dotfiles / 環境側）。hub は推奨スニペットを doc で示すに留める（#202/#223 と同じ hub/dotfiles 分界）。実測が要る点（popup 内 cross-session jump / fzf × popup alt-screen の相互作用）はライブ確認で詰める
+
+- follow-up（未実装・surface のみ）: `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化 / 汎用 `oe-watch` verb（他の観測 view の live 化）/ status-line 向け要約（`--summary`）/ **`--watch` から 1 キーで `--pick` を起動する glance→pick 統合（設計SO 由来・popup 相互作用が絡むため `--pick` を土台に additive に足す別 concern）**
+
+関連 lib: `delegate-registry.sh`（`_oe_reg_server_pid` / `_oe_reg_key`・read ヘルパのみ使用）。隣接 verb: `oe-jump`（jump 再利用先）/ `oe-select`（fzf・番号 fallback の同型元）。
 
 ---
 

--- a/projects/orchestration-engine/bin/oe-tree
+++ b/projects/orchestration-engine/bin/oe-tree
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
-# oe-tree — spawn トポロジ（親→子→孫）を read-only でツリー表示する（#221 / live 化 #223）
+# oe-tree — spawn トポロジ（親→子→孫）を read-only でツリー表示する（#221 / live 化 #223 / 対話ナビ #227）
 #
-# usage: oe-tree [--watch [--interval N]]
+# usage: oe-tree [--watch [--interval N]] | [--pick]
 #
 # spawn registry（~/.claude/state/oe-delegate/）の現 tmux server 分を走査し、
 # parent_pane 連鎖から森林を再構成して罫線ツリーで表示する。oe-list が flat な
 # 宛先候補（自分の直下の子に scoping）なのに対し、oe-tree は「何が何を立てたか」
 # 「どのペインが孫か」を現 server 全域で描く観測ビュー（oe-activity / oe-status と
 # 同クラス）。--watch で poll 再描画の live 表示（tmux popup からの常用を想定・#223）。
+#
+# --pick（対話ナビ・#227）: 森ツリーからノードを fzf で選び、その %N へ oe-jump で
+#   focus（jump ロジックは再利用・複製しない）→ 対象 window を resize-pane -Z で最大化する。
+#   prefix+g の session picker のトポロジ版 + 最大化。森構築/描画は本ツールの既存ロジックを
+#   内部モード --pick-list（%N<TAB>表示行 を emit）で再利用し、新規に足すのは fzf 選択 +
+#   ensure-zoomed のみ。fzf 非在時は番号フォールバック（oe-select 同型）。
+#   jump/zoom は「ユーザーが明示的に命じるナビ」＝受動検出でも自動作用でもなく、registry/
+#   トポロジのデータは編集しない（#221/#223 の read-only 不変条件は保たれる・prefix+g picker が
+#   select-pane するのと同カテゴリ）。純ビュー（引数なし / --watch）はデフォルトで温存。
 #
 # 意味論（設計SO で明文化を要求された点・DJ-221-2/6）:
 #   - 本ビューは「現在の登記のスナップショット」であり歴史ではない。gone entry は
@@ -51,22 +60,27 @@ while [[ -h "$_oe_src" ]]; do
   case "$_oe_src" in /*) ;; *) _oe_src="$_oe_dir/$_oe_src" ;; esac
 done
 BIN_DIR="$(cd -P "$(dirname "$_oe_src")" && pwd)"
+# 再帰起動（--pick の候補取得 / --watch の tick 再描画 / fzf の ctrl-r reload）用の絶対パス。
+# fzf は bind を `$SHELL -c` で走らせ $0 がシェル名になるため、reload には解決済み絶対パスが要る。
+OE_TREE_SELF="${BIN_DIR}/$(basename "$_oe_src")"
 # shellcheck source=../lib/delegate-registry.sh
 source "${BIN_DIR}/../lib/delegate-registry.sh"
 
 WATCH=0
+PICK=0
+MODE=view          # view（既定・純ビュー） / picklist（内部・--pick の候補 emit）
 INTERVAL=2
 INTERVAL_SET=0
 usage_err() {
   echo "oe-tree: $1" >&2
-  echo "usage: oe-tree [--watch [--interval N]]" >&2
+  echo "usage: oe-tree [--watch [--interval N]] | [--pick]" >&2
   exit 2
 }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)
       cat >&2 <<'EOF'
-usage: oe-tree [--watch [--interval N]]
+usage: oe-tree [--watch [--interval N]] | [--pick]
 
 spawn registry の parent_pane 連鎖から親→子→孫のトポロジを罫線ツリーで表示する
 （read-only・現 tmux server の全森林）。
@@ -76,12 +90,18 @@ gone は末尾）
 
   --watch       poll 再描画の live 表示（q / Esc / C-c で終了）
   --interval N  --watch の更新間隔（秒・正整数・既定 2）
+  --pick        対話ナビ: ノードを fzf で選び、その %N へ oe-jump で focus →
+                対象 window を resize-pane -Z で最大化（fzf 非在時は番号選択）。
+                enter=jump+zoom / ctrl-r=refresh / esc=cancel。--watch とは併用不可。
 
 注: 現在の登記のスナップショット（kill は alive→gone 遷移として反映・ノードが消えるのは
-次の spawn 登記時の GC）。歴史は oe-activity を参照。
+次の spawn 登記時の GC）。歴史は oe-activity を参照。--pick の jump/zoom はユーザー起点の
+ナビでデータは read-only のまま（registry/トポロジを編集しない）。
 EOF
       exit 0 ;;
     --watch) WATCH=1 ;;
+    --pick) PICK=1 ;;
+    --pick-list) MODE=picklist ;;   # 内部用: --pick が候補（%N<TAB>表示行）を取るため自身を再帰起動する
     --interval)
       shift
       [[ $# -gt 0 ]] || usage_err "--interval requires a value"
@@ -91,6 +111,10 @@ EOF
   esac
   shift
 done
+# モードは排他: 純ビュー / --watch(live) / --pick(対話) / --pick-list(内部) は 1 つだけ。
+[[ "$WATCH" -eq 1 && "$PICK" -eq 1 ]] && usage_err "--pick and --watch are mutually exclusive"
+[[ "$MODE" == picklist && ( "$WATCH" -eq 1 || "$PICK" -eq 1 ) ]] \
+  && usage_err "--pick-list is internal and cannot be combined with --watch/--pick"
 [[ "$INTERVAL_SET" -eq 1 && "$WATCH" -eq 0 ]] && usage_err "--interval requires --watch"
 if [[ "$WATCH" -eq 1 ]]; then
   [[ "$INTERVAL" =~ ^[0-9]+$ && "$INTERVAL" -ge 1 ]] \
@@ -184,6 +208,119 @@ ${_frame}"
       [[ "$_rc" -gt 128 ]] || sleep "$INTERVAL"
     fi
   done
+fi
+
+# --- pick モード: 森ツリーからノードを選び oe-jump で focus → 対象 window を最大化（#227）---
+# 森構築/描画は本ツールの既存ロジックを再利用する（自身を --pick-list で再帰起動して候補を
+# 取る＝森ロジックを複製しない・DJ-223-6 の「フレーム=一発実行と同一コードパス」を踏襲）。
+# jump は oe-jump 再利用（jump ロジックを複製しない）。新規は fzf 選択 + ensure-zoomed のみ。
+# データは read-only のまま（jump/zoom は registry/トポロジを編集しない・ユーザー起点のナビ）。
+if [[ "$PICK" -eq 1 ]]; then
+  # 番号フォールバックの対話入力は端末から直接読む（既定 /dev/tty）。OE_TREE_TTY はテスト用シーム。
+  OE_TREE_TTY="${OE_TREE_TTY:-/dev/tty}"
+
+  # (you) の SELF freeze（--watch と同型）: popup 内では TMUX_PANE が unset（実測・#223）。
+  # 候補 emit の再帰起動へ export し、フォーカス移動前の自ペインを (you) として一貫表示する。
+  if [[ -z "${TMUX_PANE:-}" ]]; then
+    _self="$(tmux display-message -p '#{pane_id}' 2>/dev/null)" || _self=""
+    [[ -n "$_self" ]] && export TMUX_PANE="$_self"
+  fi
+
+  # popup(-E) は終了で即閉じる。jump 不能（gone 等）や zoom 失敗のメッセージを読めるよう、
+  # TTY のとき 3s hold してから抜ける（--watch の env_fail と同パターン・DJ-227-4/7）。
+  pick_hold() { if [[ -t 0 ]]; then read -r -s -t 3 -n 1 2>/dev/null || true; fi; }
+
+  # ensure_zoom <pane> — 対象 window が未 zoom のときだけ resize-pane -Z -t <pane>（冪等）。
+  # 既 zoom(1) は再 -Z しない（トグルで解除される事故を防ぐ・隔離 tmux 3.5a で実測）。
+  # flag が 0 / query 失敗（"") のときは -Z を試みる（単一 pane window では無害な no-op）。
+  # -t <pane> で対象 window に結びつけるのが要点（無指定は popup/現 window を掴む・設計SO R1）。
+  ensure_zoom() {
+    local pane="$1" zf
+    zf="$(tmux display-message -p -t "$pane" '#{window_zoomed_flag}' 2>/dev/null)" || zf=""
+    [[ "$zf" == "1" ]] && return 0
+    tmux resize-pane -Z -t "$pane" 2>/dev/null || return 1
+    return 0
+  }
+
+  # 候補は自身を --pick-list で再帰起動して取得。stdout = "%N<TAB>表示行" のみ／note・空森
+  # メッセージは stderr（候補に混ぜない）。mapfile は macOS の bash 3.2 に無いので while-read。
+  CANDS=()
+  while IFS= read -r _l; do
+    [[ "$_l" == %[0-9]*$'\t'* ]] && CANDS+=("$_l")
+  done < <("$OE_TREE_SELF" --pick-list)
+  if [[ ${#CANDS[@]} -eq 0 ]]; then
+    echo "oe-tree: no spawn nodes to pick (see notes above; try: oe-tree)" >&2
+    pick_hold
+    exit 1
+  fi
+
+  # 選択: fzf があれば fzf、無ければ番号フォールバック（oe-select 同型）。
+  SELECTED=""
+  if command -v fzf >/dev/null 2>&1; then
+    # 1 列目（%N）は隠しキー: --delimiter TAB + --with-nth 2 で表示/検索は 2 列目のみ。
+    # ctrl-r reload は同一 --pick-list を再実行（fzf は bind を $SHELL -c で走らせるため絶対パス）。
+    rc=0
+    SELECTED="$(printf '%s\n' "${CANDS[@]}" | fzf \
+      --delimiter=$'\t' \
+      --with-nth=2 \
+      --layout=reverse \
+      --prompt='jump> ' \
+      --header='enter: jump+zoom   ctrl-r: refresh   esc: cancel' \
+      --bind="ctrl-r:reload('${OE_TREE_SELF}' --pick-list)")" || rc=$?
+    # rc 130（Ctrl-C）/ 1（no match=未選択）→ cancel(130) / rc>=2（fzf 自体のエラー）→ 2
+    if [[ "$rc" -eq 130 || "$rc" -eq 1 ]]; then
+      exit 130
+    elif [[ "$rc" -ge 2 ]]; then
+      echo "oe-tree: fzf failed (rc=${rc})" >&2
+      exit 2
+    fi
+  else
+    echo "oe-tree: select a node to jump to:" >&2
+    _i=1
+    for _l in "${CANDS[@]}"; do
+      printf '%3d) %s\n' "$_i" "${_l#*$'\t'}" >&2   # 表示は %N を落とした 2 列目（木の形は保つ）
+      _i=$((_i + 1))
+    done
+    printf 'number> ' >&2
+    _reply=""
+    if ! IFS= read -r _reply <"$OE_TREE_TTY"; then exit 130; fi   # EOF=cancel
+    [[ -n "$_reply" ]] || exit 130                                # 空入力=cancel
+    if ! [[ "$_reply" =~ ^[0-9]+$ ]]; then
+      echo "oe-tree: invalid selection" >&2; exit 2
+    fi
+    # 先頭ゼロの 8 進解釈を避けて 10 進化してから範囲チェック（oe-select と同型）。
+    _idx=$((10#$_reply))
+    if [[ "$_idx" -lt 1 || "$_idx" -gt ${#CANDS[@]} ]]; then
+      echo "oe-tree: invalid selection" >&2; exit 2
+    fi
+    SELECTED="${CANDS[$((_idx - 1))]}"
+  fi
+
+  [[ -n "$SELECTED" ]] || exit 130   # 空選択（fzf rc0 + 空 stdout 等）も cancel
+  PANE="${SELECTED%%$'\t'*}"
+  if ! [[ "$PANE" =~ ^%[0-9]+$ ]]; then
+    echo "oe-tree: could not extract pane id from selection" >&2
+    exit 1
+  fi
+
+  # jump（oe-jump 再利用・focus）。gone/未解決は oe-jump が理由を stderr に出す → hold して伝える。
+  # rc は oe-jump のものを伝播（1=pane 無し/focus 失敗 / 2=環境）。
+  if "${BIN_DIR}/oe-jump" -- "$PANE"; then
+    :
+  else
+    rc=$?
+    pick_hold
+    exit "$rc"
+  fi
+
+  # zoom（新規・対象指定 ensure-zoomed）。jump は成功済み — zoom 失敗は部分成功として rc1
+  # （「ジャンプし最大化」を偽らない）。
+  if ! ensure_zoom "$PANE"; then
+    echo "oe-tree: jumped to ${PANE} but failed to zoom (resize-pane -Z)" >&2
+    pick_hold
+    exit 1
+  fi
+  exit 0
 fi
 
 SELF="${TMUX_PANE:-}"
@@ -300,17 +437,21 @@ done
 
 # 読めない/解釈できない/重複の現 server entry は無言で捨てず件数を footer で開示する
 # （foreign と同型の honest degrade — 全滅時も部分スキップ時も「登記どおり」と偽らない。実装SO 指摘）。
+# picklist モードでは note / 空森メッセージを stderr へ流す（stdout は候補行だけに保つ —
+# --pick 側が stdout を "%N<TAB>表示行" の候補列として読むため）。view モードは従来どおり stdout。
+_note_fd=1
+[[ "$MODE" == picklist ]] && _note_fd=2
 print_notes() {
-  [[ "$SKIPPED" -gt 0 ]] && echo "note: ${SKIPPED} entries skipped (unreadable or duplicate pane)"
-  [[ "$FOREIGN" -gt 0 ]] && echo "note: ${FOREIGN} entries from other tmux servers not shown (stale)"
+  [[ "$SKIPPED" -gt 0 ]] && echo "note: ${SKIPPED} entries skipped (unreadable or duplicate pane)" >&"$_note_fd"
+  [[ "$FOREIGN" -gt 0 ]] && echo "note: ${FOREIGN} entries from other tmux servers not shown (stale)" >&"$_note_fd"
   return 0
 }
 
 if [[ -z "$ENTRIES" ]]; then
   if [[ "$SKIPPED" -gt 0 ]]; then
-    echo "(no readable spawn entries for this tmux server)"
+    echo "(no readable spawn entries for this tmux server)" >&"$_note_fd"
   else
-    echo "(no spawn entries for this tmux server)"
+    echo "(no spawn entries for this tmux server)" >&"$_note_fd"
   fi
   print_notes
   exit 0
@@ -364,8 +505,14 @@ VISITED=" "
 render() { # <pane> <prefix> <child-prefix>
   local pane="$1" pfx="$2" cpfx="$3"
   local live coord label ws suffix=""
+  # picklist モードは各ノード行の先頭に隠しキー列 "%N<TAB>" を前置する（fzf の --with-nth 2 /
+  # 番号 fallback の %N 抽出用）。表示本文（$pfx 以降）は view と同一なので木の形は保たれる。
   if [[ "$VISITED" == *" ${pane} "* ]]; then
-    printf '%s%s  [cycle]\n' "$pfx" "$pane"
+    if [[ "$MODE" == picklist ]]; then
+      printf '%s\t%s%s  [cycle]\n' "$pane" "$pfx" "$pane"
+    else
+      printf '%s%s  [cycle]\n' "$pfx" "$pane"
+    fi
     return 0
   fi
   VISITED+="${pane} "
@@ -378,7 +525,11 @@ render() { # <pane> <prefix> <child-prefix>
   ws="$(entry_field_of "$pane" 3)"
   [[ -n "$ws" ]] && suffix+=" ~${ws##*/}"
   [[ -n "$SELF" && "$pane" == "$SELF" ]] && suffix+=" (you)"
-  printf '%s%-4s  %-5s  %-5s  %s%s\n' "$pfx" "$coord" "$pane" "$live" "$label" "$suffix"
+  if [[ "$MODE" == picklist ]]; then
+    printf '%s\t%s%-4s  %-5s  %-5s  %s%s\n' "$pane" "$pfx" "$coord" "$pane" "$live" "$label" "$suffix"
+  else
+    printf '%s%-4s  %-5s  %-5s  %s%s\n' "$pfx" "$coord" "$pane" "$live" "$label" "$suffix"
+  fi
   local kids n i=0 c
   kids="$(children_of "$pane")"
   n="$(printf '%s' "$kids" | grep -c . || true)"

--- a/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
@@ -117,3 +117,15 @@ tier=heavy（設計SO refuted による方針是正あり・意図的な外部�
 - README routing 申告の精緻化: `--pick` 詳細 doc は `bin/README.md`（L362-）に在り申告どおり。加えて project-level `README.md` L50 の 1 行要約が `--watch` 止まりで stale だったため `--pick`/#227 を追記（back-propagation）。
 - 実装SO の Open risks（ctrl-r 未カバー・zoomed_flag degrade）を上記残課題へ転記。
 その他は問題なし（設計SO refuted・R1/R2・preview 撤回・R5 follow-up・[26] pipefail 罠・discussion §8.4 の back-propagation は明示済みと確認）。
+
+## 追試: 実機 E2E（隔離 tmux サーバ・ユーザーセッション未接触・2026-07-05）
+
+ユーザー要望で mock なしの実機確認を実施。隔離サーバ（`tmux -L oe227live`・2 session × 2 pane）に実 pane を立て、scratch registry に森を登記し、実 `oe-jump` + 実 `resize-pane -Z` を駆動（選択は番号 fallback 経路＝jump/zoom コードパスは fzf 経路と同一）。[verified]
+
+- pick-list が実 forest から候補（`%N<TAB>座標付き表示`）を正しく生成。
+- **cross-session jump + zoom**: 別セッション B の pane を選ぶと B の active pane がその pane へ移動し（実 `select-pane`/`select-window`）、B の window が `zoomed=1`（実 `resize-pane -Z -t`）。セッション A は不変。
+- **冪等 zoom**: 既 zoom の pane を再選択しても `zoomed=1` 維持（トグル解除しない）。
+- **gone**: pane kill 後、候補に gone 表示で残り、選ぶと `oe-jump` が rc1（pane not found）を伝播。
+- 番号 fallback の空入力=130 / 範囲外=2 も実サーバで確認。teardown 済み。
+
+hg-227-a/b の更新: cross-session の `select-pane`/`select-window` + targeted zoom は**実 tmux で確認済み**。**未確認で残るのは (1) attached client を別 session へ動かす `switch-client`（headless テストは client 未接続のため no-op だった。実 popup では効くはず・要人間確認）(2) tmux popup 内での fzf 対話 UI（alt-screen 相互作用・自動化不能）**。この 2 点は `prefix+v` bind 適用時に人間が実 popup で確認する。

--- a/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
@@ -3,7 +3,7 @@ id: "01KWQ1EENZ8YKR0KS1SCSTJ305"
 title: "#227 episode — oe-tree に対話ナビ（fzf 選択 → oe-jump → resize-pane -Z 最大化）を追加"
 date: 2026-07-05
 type: episode
-status: in-development
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/227"
@@ -73,3 +73,47 @@ shellcheck: pass（rc=0）。
   - 実装中に見つけた 1 件: [26] の stderr 検出 assert が `set -uo pipefail` 下で `--pick|grep` のパイプ終了に --pick の exit 1 を拾われ誤判定 → stderr を先に変数へ取ってから grep する形（既存 [8]/[15] と同型）に修正。tool 側の欠陥ではなくテスト記述の罠。
 - テストの構造的限界（自動化不能・ライブ実測が正）: 実 popup の対話終了、popup 内 cross-session focus（hg-227-a）、fzf alt-screen × popup（hg-227-b）。mock は select-pane/resize-pane の**呼び出しと引数**までを検証。
 - **実装SO（oe-review・impl レンズ・2 レーン codex/cursor）**: verdict = **survived**（material な correctness/到達可能性/堅牢性/セキュリティ欠陥なし・reviewed_sha `0ee2cfe`・audit_id `20260704174832EM1YAVR5KTBC`）。設計SO（設計レンズ・refuted→反映済み）とは別レンズ・別ステップ。
+
+## Closure（episode-retrospective・tier=heavy）
+
+tier=heavy（設計SO refuted による方針是正あり・意図的な外部レビュー 2 種を起動・非自明な設計判断 DJ-227-1〜7）。達成度 = 達成（PR #228・SO 両方通過）。
+
+### closure gate
+- **Context / なぜ**: 冒頭に自己完結（#223 の live 表示から「見て飛ぶ + 最大化」を 1 導線に）。
+- **次の消費者**: (1) PR #228 レビュアー（Copilot/人間）。(2) `prefix+v` bind を実適用する dotfiles 作業（本 PR 外・親/人間）。(3) `--watch`→`--pick` glance 統合を検討する後続（follow-up）。
+- **follow-up routing**: 
+  - `--watch` から 1 キーで `--pick` を起動する glance→pick 統合 → **`bin/README.md` の follow-up 節に記載・別 concern**（popup 相互作用が `--pick` 着地の上に乗る additive・設計SO R5 由来）。
+  - bind の実適用（`prefix+v`）→ **dotfiles/環境側**（hub は推奨スニペット doc のみ・#202/#223 分界）。
+  - hg-227-a（popup 内 cross-session jump）/ hg-227-b（fzf alt-screen × popup）→ **ライブ実測**（自動テスト構造的限界・bind 適用時に人間が確認）。
+  - 追わない: fzf `--listen` 真 live picker（版数依存・今回不要）。
+- **status 確定**: stable（達成）。
+- **evidence anchor**: SO 証跡は揮発（`tmp/`）だが、verdict/reason・reviewed_sha・audit_id・zoom 実測結果を本文へ転記済み。探索木（`tmp/dj-227-tree.md`）の要点（DJ と棄却理由）は本文 + PR 本文へ蒸留済み。
+- **SO 証跡リンク**: 設計SO output_dir `tmp/oe-refute-20260704164920PWZN1700RBD0` / 実装SO output_dir `tmp/oe-review-20260704174832EM1YAVR5KTBC`（いずれも揮発・要点は転記済み）。
+
+### 決定と根拠（棄却した案）
+- 対話モードの形: `--pick` 独立フラグを採用。`--watch` の fzf 化（自動 reload）は fzf の定期 reload が版数依存配管になり、純ビュー温存の境界にも触れるため棄却。
+- zoom: ensure-zoomed（対象指定・冪等）採用。素の `resize-pane -Z`（トグル）は既 zoom で解除方向に倒れ、無指定は popup/現 window を掴むため棄却（実測で確認）。
+- preview: **不採用**。oe-select 流用の `capture-pane` は観測系 cockpit の非検出境界（discussion §8.4・oe-status が意図的に外した）に反する。ツリー行が座標/liveness/label を既に示すため不要。
+- oe-jump への `--zoom` フラグ追加は棄却（確定境界「新規は fzf + resize-pane -Z のみ / oe-jump 再利用」の外・1 PR = 1 論理変更に反る）。第二 consumer が現れたら昇格を再検討。
+
+### 原則（Pattern / Anti-pattern）
+- **Pattern**: 観測ビューに対話を足すとき、表示ロジックを複製せず内部モード（`--pick-list`）で「同一 render 経路 + 隠しキー列」を emit する（`--watch` re-exec と同じ「フレーム=一発実行と同一コードパス」）。tmux-claude-picker の `--list` と同型。
+- **Anti-pattern**: 兄弟 verb（oe-select）の UX 部品（capture-pane preview）を無反省に流用する。verb のクラス（観測 vs 送信選択）で境界が違い、oe-tree は観測系の非検出境界に縛られる。設計SO が捕捉。
+- **Anti-pattern（テスト）**: `set -uo pipefail` 下で `cmd|grep && echo yes || echo no` は、cmd が非 0 終了だとパイプ終了が grep 一致を隠す。stderr は先に変数へ取ってから grep する（[26] で自己検出・既存 [8]/[15] が正しい型）。
+
+### 蒸留シグナル
+- Decision 昇格: **なし**（DJ は #221/#223 の確立パターンの範囲内・新カテゴリの決定なし）。preview 非検出境界は discussion §8.4 に既出で再確認に留まる。
+- skill/rule 昇格: なし。
+
+### 残課題
+- 上記 follow-up routing のとおり（全て行き先付与済み・dangling なし）。
+- 証明できなかったこと: popup 内 cross-session jump + zoom の E2E は mock では覆えず（select-pane/resize-pane の呼び出し・引数までを検証）、ライブ実測が未了（hg-227-a/b）。bind 実適用時に人間確認。
+- 実装SO（oe-review・cursor レーン）が挙げた非 material の残リスク（揮発 `tmp/oe-review-...` からの転記）:
+  - `ctrl-r` reload はテスト未カバー（手動 smoke 依存）→ 追わない（fzf の bind 動作は fzf 責務・回帰リスク低。必要なら follow-up の watch 統合と併せて）。
+  - `#{window_zoomed_flag}` 非対応の古い tmux では冪等 zoom 保証が弱化しうる（コード上の既知 degrade。本環境 tmux 3.5a は対応・flag 未取得時は無害な no-op に倒す設計）→ 追わない（対象環境で対応済み）。
+
+### Step4 外部チェック（closure 品質・so-compare codex 1 レーン）
+出力: `tmp/so-20260705-025458/`（揮発・要点転記済み）。指摘 2 点を反映:
+- README routing 申告の精緻化: `--pick` 詳細 doc は `bin/README.md`（L362-）に在り申告どおり。加えて project-level `README.md` L50 の 1 行要約が `--watch` 止まりで stale だったため `--pick`/#227 を追記（back-propagation）。
+- 実装SO の Open risks（ctrl-r 未カバー・zoomed_flag degrade）を上記残課題へ転記。
+その他は問題なし（設計SO refuted・R1/R2・preview 撤回・R5 follow-up・[26] pipefail 罠・discussion §8.4 の back-propagation は明示済みと確認）。

--- a/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
@@ -66,3 +66,10 @@ oe-tree 単一ツール拡張として実装（別コンポーネントなし）
 - fzf cancel→130 / error→2、番号フォールバック: 有効→jump+zoom・範囲外/非数値→2・空→130、空森→rc1。
 
 shellcheck: pass（rc=0）。
+
+## テスト・実装SO
+
+- `test_oe_tree.sh`: [19]-[26] を追加（モード排他・`--pick-list` 形式/stderr 分離・fzf jump+zoom ターゲット・冪等 zoom・gone 伝播・fzf cancel/error/empty・番号 fallback・空森）。**全 60 PASS**（既存 [1]-[18] 回帰込み）。`test_oe_jump`(38)/`test_oe_select`(35) も回帰なし。
+  - 実装中に見つけた 1 件: [26] の stderr 検出 assert が `set -uo pipefail` 下で `--pick|grep` のパイプ終了に --pick の exit 1 を拾われ誤判定 → stderr を先に変数へ取ってから grep する形（既存 [8]/[15] と同型）に修正。tool 側の欠陥ではなくテスト記述の罠。
+- テストの構造的限界（自動化不能・ライブ実測が正）: 実 popup の対話終了、popup 内 cross-session focus（hg-227-a）、fzf alt-screen × popup（hg-227-b）。mock は select-pane/resize-pane の**呼び出しと引数**までを検証。
+- **実装SO（oe-review・impl レンズ・2 レーン codex/cursor）**: verdict = **survived**（material な correctness/到達可能性/堅牢性/セキュリティ欠陥なし・reviewed_sha `0ee2cfe`・audit_id `20260704174832EM1YAVR5KTBC`）。設計SO（設計レンズ・refuted→反映済み）とは別レンズ・別ステップ。

--- a/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
@@ -129,3 +129,12 @@ tier=heavy（設計SO refuted による方針是正あり・意図的な外部�
 - 番号 fallback の空入力=130 / 範囲外=2 も実サーバで確認。teardown 済み。
 
 hg-227-a/b の更新: cross-session の `select-pane`/`select-window` + targeted zoom は**実 tmux で確認済み**。**未確認で残るのは (1) attached client を別 session へ動かす `switch-client`（headless テストは client 未接続のため no-op だった。実 popup では効くはず・要人間確認）(2) tmux popup 内での fzf 対話 UI（alt-screen 相互作用・自動化不能）**。この 2 点は `prefix+v` bind 適用時に人間が実 popup で確認する。
+
+## 追試2: 実 popup・ライブセッションでの人間実操作（2026-07-05・ユーザー実行）
+
+ユーザーが本番セッションで `tmux display-popup -E '... oe-tree --pick'` を 2 回実行（`bin/README.md` の推奨スニペット同型）。read-only クエリで確認した結果 [verified]:
+
+- 1 回目: 候補（登記 4 件: `%125` #36-topo / `%131` #227 / `%85` #5706 / `%94` #36）から `%125`(#36-topo) を選択 → active pane が `%125`（window `0:1`）へ移動し `0:1` が `zoomed=1`。
+- 2 回目: `%131`(#227) を選択 → active が `%131`（window `0:3`）へ移動し `0:3` が `zoomed=1`。1 回目の `0:1` は最大化のまま（飛び元/前回対象を unzoom しない＝設計どおり）。
+
+これで **hg-227-b（tmux popup 内での fzf 対話 UI・alt-screen 相互作用）= 実機確認済み**（popup 内で fzf が描画・キー選択を受け付け、選択が 2 回とも成立）。**jump + targeted zoom は実 attached client でも確認済み**（cross-window・同一 session）。**hg-227-a のうち cross-session `switch-client`（client を別 session へ移動）だけは未確認のまま**（ユーザーの pane が全て session `0` のため cross-session hop が発生せず。select 系 + zoom は隔離サーバの追試1で確認済み）。→ 実運用で別 session の子が立った時に自然に確認される（追わない残課題）。

--- a/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md
@@ -1,0 +1,68 @@
+---
+id: "01KWQ1EENZ8YKR0KS1SCSTJ305"
+title: "#227 episode — oe-tree に対話ナビ（fzf 選択 → oe-jump → resize-pane -Z 最大化）を追加"
+date: 2026-07-05
+type: episode
+status: in-development
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/227"
+    reason: "oe-tree --watch（#223）の表示から prefix+g picker 同様に「選んだペインへ移動＋最大化」する導線を単一ツール拡張で足す"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/223"
+    reason: "oe-tree --watch の re-exec パターン（DJ-223-6・フレーム=一発実行と同一コードパス）を pick 候補生成に踏襲"
+  - type: reuse
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/179"
+    reason: "jump は oe-jump を再利用（jump ロジックを複製しない）"
+tags: [orchestration, cockpit, spawn-tree, topology, pick, fzf, jump, zoom, tmux, read-only, episode]
+---
+
+# #227 episode — oe-tree に対話ナビ（fzf 選択 → oe-jump → 最大化）を追加
+
+親（統括）からの委譲子セッションとして #227 を実装する。設計・実装は人間とこのペインで直接、完了確認のみ親へ。マージ・worktree 掃除はしない。
+
+動機: #223 で `oe-tree --watch`（live トポロジ）が landed。その表示から `prefix+g` の session picker と同じく「選んだペインへ移動」＋「移動時に最大化」を1つの導線にしたい。設計方針は確定済み（親と合意）: **別コンポーネントを作らず oe-tree 自体に対話モードを足す**（森ロジックは oe-tree 1 箇所・jump は oe-jump 再利用・新規は fzf 選択 + `resize-pane -Z` のみ・データ read-only 維持・純ビューは温存）。
+
+## 設計フェーズ（predecision-exploration・ゼロベース）
+
+開放点 5 つ（対話モードの形 / zoom 意味論 / gone ペイン / fzf 非在 degrade / popup 内挙動）＋横断小 DJ をゼロベースで探索。探索木は確定前証跡として `tmp/dj-227-tree.md` に記録（predecision-exploration 手順4）。
+
+確定（初期案）:
+- DJ-227-1: 独立フラグ `--pick`（一発 fzf picker + `ctrl-r` 手動 reload）。`--watch` の fzf 化（自動 reload）は版数依存配管で不採用。
+- DJ-227-2: 内部モード `--pick-list` が render 経路そのままに `%N<TAB>表示行` を emit（森ロジック複製なし・tmux-claude-picker `--list` と同型）。
+- DJ-227-3: zoom は対象指定 `resize-pane -Z -t <pane>` + `window_zoomed_flag` を見た ensure-zoomed（冪等）。
+- DJ-227-4: gone ペインは候補に残す（ビュー一貫性）。選択時は oe-jump の rc1 を提示。
+- DJ-227-5: fzf 非在は番号フォールバック（oe-select 同型）。
+- DJ-227-6: popup は `-E` 自然クローズ（明示 close 結合を作らない）。
+
+## 設計SO（oe-refute --rubric exploration・2 レーン codex/cursor）
+
+verdict = **refuted**（2/2 material 反証・audit_id `20260704164920PWZN1700RBD0`）。SO は breadth/grounding レンズで実質的な指摘を返し、以下 2 件を **一次照合・実測で確認**して設計に取り込んだ（procedural な「最良断定は早い」は #221/#223 と同じ SO→人間承認→実装→実測の順で解消）。
+
+- **R1 zoom 対象バグ（real・修正）**: 無指定 `resize-pane -Z` は popup/現 window を掴む到達可能パス。→ `-t "$pane"` 指定 + ensure-zoomed に修正。**隔離 tmux 3.5a で実測**: `resize-pane -Z -t %0`（別 window）で対象だけ zoomed=1・現 window 不変。`display-message -p -t %0 '#{window_zoomed_flag}'` が対象の flag を返す。既 zoom で再 `-Z` すると flag 1→0（トグルの取消し事故＝案A 棄却・ensure-zoomed 採用を実証）。[verified]
+- **R2 preview の read-only 境界違反（real・撤回）**: 初期案は oe-select 流用で `tmux capture-pane` preview を付けていた。→ discussion `2026-06-19-discussion-cockpit-observation-ui.md` §8.4（「検出=ペイン出力の走査」・観測系 cockpit は capture-pane を preview から意図的に除外して境界統一）と oe-tree header L31-35（read set を registry/pane-issue/存在・座標・pane_title に限定）を一次確認。→ **preview を採用しない**（観測系 airtight 境界を維持・ツリー行が座標/liveness/label を既に示す）。[verified]
+- R3 fallback「家族規約」是正: oe-status -i は plain overview へ degrade（番号型でない）。主張を「oe-select（同じ選択系 verb）と同型」に是正。
+- R4 フラグ命名（新 DJ-227-7）: `-i` は oe-status の observe 用と意味が割れるため却下、nav を名づける `--pick` を採用。
+- R5 `--watch` hybrid（glance 中に 1 キーで pick）: SO 由来の未探索カテゴリ。**follow-up にスコープアウト**（popup 相互作用依存が強い・`--pick` を土台に additive 可・1 PR = 1 論理変更）。
+- R6 fzf field 契約明確化: `--delimiter $'\t' --with-nth 2` + `${sel%%$'\t'*}` で %N 抽出（tmux-claude-picker 同型）。
+
+ユーザー承認: 「とりあえずそれで」＝ revised 設計で実装着手を承認（このペインで直接）。
+
+## 実装フェーズ（随時追記）
+
+oe-tree 単一ツール拡張として実装（別コンポーネントなし）。加えた要素:
+
+- フラグ: `--pick`（対話ナビ）/ `--pick-list`（内部・候補 emit）。`MODE=view|picklist`。`--pick ⊥ --watch`・`--pick-list` 単独/内部を usage エラーで排他。
+- 候補生成: 既存 render 経路に `MODE=picklist` のとき `%N<TAB>表示行` の隠しキー列を前置（森ロジック複製なし）。note/空森メッセージは picklist では stderr へ流し stdout を候補列に保つ。
+- `--pick` driver: 自身を `--pick-list` で再帰起動（`OE_TREE_SELF` 絶対パス）→ fzf（`--delimiter $'\t' --with-nth 2` + `ctrl-r:reload`）or 番号フォールバック（`OE_TREE_TTY` シーム）→ `${sel%%$'\t'*}` で %N 抽出 → `oe-jump -- %N`（再利用）→ `ensure_zoom`。
+- `ensure_zoom`: `display-message -t <pane> '#{window_zoomed_flag}'` を見て 1 以外なら `resize-pane -Z -t <pane>`（対象指定・冪等）。gone/zoom 失敗は popup 用に TTY 3s hold。
+- exit 契約: 0=jump+zoom / 1=候補なし・jump/zoom 失敗 / 2=usage・fzf エラー / 130=cancel。
+
+手元 smoke（mock tmux/fzf・隔離）で確認した挙動 [verified]:
+- view 回帰: 従来出力と一致（MODE gating が既定を汚さない）。
+- `--pick-list`: `%N<TAB>表示行`・note は stderr・空森は stdout 空。
+- `--pick`(fzf): 選択 → `select-pane -t %N` + `resize-pane -Z -t %N`（**設計SO R1 の対象指定を実測確認**）。
+- 冪等 zoom: flag=1 で `resize-pane` 非呼び出し。gone 選択: oe-jump rc1 伝播。
+- fzf cancel→130 / error→2、番号フォールバック: 有効→jump+zoom・範囲外/非数値→2・空→130、空森→rc1。
+
+shellcheck: pass（rc=0）。

--- a/projects/orchestration-engine/tests/test_oe_tree.sh
+++ b/projects/orchestration-engine/tests/test_oe_tree.sh
@@ -26,10 +26,15 @@ mkdir -p "$_TMP_DIR/bin" "$_TMP_DIR/lib" "$_TMP_DIR/pathbin"
 cp "$PROJECT_DIR/bin/oe-tree" "$_TMP_DIR/bin/oe-tree"
 chmod +x "$_TMP_DIR/bin/oe-tree"
 ln -s "$PROJECT_DIR/lib/delegate-registry.sh" "$_TMP_DIR/lib/delegate-registry.sh"
+# --pick は隣接 oe-jump を再利用する（jump ロジック複製なし・#227）。同じ temp/bin に symlink し、
+# oe-jump 自身の lib 解決（../lib/delegate-registry.sh）が temp/lib（上の symlink）を指すようにする。
+ln -s "$PROJECT_DIR/bin/oe-jump" "$_TMP_DIR/bin/oe-jump"
 
 # mock tmux: list-panes / display-message のみ意味を持つ（他は成功で素通し）
 cat > "$_TMP_DIR/pathbin/tmux" <<'EOF'
 #!/usr/bin/env bash
+# 呼び出しを log（--pick の jump/zoom ターゲット検証用・TMUX_CALL_LOG 設定時のみ）。
+[[ -n "${TMUX_CALL_LOG:-}" ]] && printf 'tmux %s\n' "$*" >> "$TMUX_CALL_LOG"
 case "${1:-}" in
   list-panes)
     [[ "${MOCK_TMUX_FAIL:-0}" == "1" ]] && exit 1
@@ -40,20 +45,47 @@ case "${1:-}" in
       printf '%s\n' ${MOCK_LIVE_PANES:-}
     fi ;;
   display-message)
-    if [[ "$*" == *'#{pane_id}'* ]]; then
+    if [[ "$*" == *'#{window_zoomed_flag}'* ]]; then
+      printf '%s\n' "${MOCK_ZOOM_FLAG:-0}"    # --pick ensure_zoom 用（既定 0=未 zoom）
+    elif [[ "$*" == *'#{pane_id}'* ]]; then
       printf '%s\n' "${MOCK_ACTIVE_PANE:-}"
     else
       printf '%s\n' "${MOCK_PANE_TITLE:-}"
     fi ;;
-  *) exit 0 ;;
+  *) exit 0 ;;                                 # resize-pane / switch-client / select-* は成功で素通し
 esac
 EOF
 chmod +x "$_TMP_DIR/pathbin/tmux"
 
-# 実 jq を厳選 PATH に含める（mock は tmux のみ）
+# 実 jq は pathbin に symlink して使う（mock は tmux/fzf のみ）。JQ_DIR を PATH に足すと、
+# そこに同居する実 fzf（/opt/homebrew/bin）まで拾って fzf 有無の切替テストが崩れるため、
+# jq だけを隔離 pathbin に持ち込み PATH から JQ_DIR を外す（test_oe_select の実 fzf 除外と同方針）。
 JQ_BIN="$(command -v jq)" || { echo "FATAL: jq is required to run this test" >&2; exit 1; }
-JQ_DIR="$(dirname "$JQ_BIN")"
-export PATH="${_TMP_DIR}/pathbin:${JQ_DIR}:/usr/bin:/bin"
+ln -s "$JQ_BIN" "$_TMP_DIR/pathbin/jq"
+export PATH="${_TMP_DIR}/pathbin:/usr/bin:/bin"
+
+# mock fzf（make_fzf/rm_fzf で有無を切替）。候補は "%N<TAB>表示行"。TAB 区切りの first-field(%N)が
+# $FZF_PICK_PANE に一致する行を返す。FZF_CANCEL=130 / FZF_FAIL=<n> / FZF_EMPTY=空 stdout+rc0。
+make_fzf() {
+  cat > "$_TMP_DIR/pathbin/fzf" <<'EOF'
+#!/usr/bin/env bash
+[[ -n "${FZF_CANCEL:-}" ]] && exit 130
+[[ -n "${FZF_FAIL:-}" ]] && exit "$FZF_FAIL"
+[[ -n "${FZF_EMPTY:-}" ]] && exit 0
+pick="${FZF_PICK_PANE:-}"
+while IFS= read -r line; do
+  [[ "${line%%$'\t'*}" == "$pick" ]] && { printf '%s\n' "$line"; exit 0; }
+done
+exit 1
+EOF
+  chmod +x "$_TMP_DIR/pathbin/fzf"
+}
+rm_fzf() { rm -f "$_TMP_DIR/pathbin/fzf"; }
+
+# --pick 番号フォールバックの tty シーム（/dev/tty は非対話で開けない）。OE_TREE_TTY で差し替える。
+OE_TREE_TTY_FILE="$_TMP_DIR/tty-input"
+feed_tty() { printf '%s\n' "$1" > "$OE_TREE_TTY_FILE"; }
+feed_tty_empty() { : > "$OE_TREE_TTY_FILE"; }
 
 export OE_DELEGATE_STATE_DIR; OE_DELEGATE_STATE_DIR="$_TMP_DIR/state"
 export OE_PANE_ISSUE_DIR;     OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
@@ -322,6 +354,101 @@ _direct="$("$TREE" 2>&1)"; _drc=$?              # copy: BIN_DIR=temp/bin → tem
 _linked="$("$_oe_link" 2>&1)"; _lrc=$?          # symlink: readlink 解決で hub/bin → hub/lib を source
 ck "symlink 起動 rc == 直接起動 rc" "$_drc" "$_lrc"
 ck "symlink 起動 出力 == 直接起動 出力" "$_direct" "$_linked"
+
+# ============================================================================
+# 対話ナビ --pick / --pick-list（#227）
+# 実 fzf は PATH から除外済み（make_fzf/rm_fzf で mock の有無を切替）。jump は隣接 oe-jump を
+# 再利用し、mock tmux が select-pane/resize-pane を TMUX_CALL_LOG に記録する。実 popup の
+# 対話終了・cross-session focus は自動テストの構造的限界（hg-227-a/b はライブ実測が正・episode 記録）。
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+echo "[19] モード排他: --pick+--watch / --pick-list+--watch は exit 2"
+# ----------------------------------------------------------------------------
+"$TREE" --pick --watch      >/dev/null 2>&1; ck "pick+watch exit 2" "2" "$?"
+"$TREE" --pick-list --watch >/dev/null 2>&1; ck "pick-list+watch exit 2" "2" "$?"
+
+# ----------------------------------------------------------------------------
+echo "[20] --pick-list: 隠しキー列 %N<TAB> を前置・stdout は候補のみ・note は stderr"
+# ----------------------------------------------------------------------------
+reset_state; fixture_chain
+export MOCK_LIVE_PANES="%83 %85 %94 %110"
+pl_out="$("$TREE" --pick-list 2>/dev/null)"
+ck "pick-list key col + display (%110)" "yes" \
+  "$(printf '%s\n' "$pl_out" | awk -F '\t' '$1=="%110" && $2 ~ /%110   alive  #5706-u1 ~attelu \(you\)/ {print "yes"; exit}')"
+ck "pick-list 5 nodes = 5 keyed lines" "5" "$(printf '%s\n' "$pl_out" | grep -c $'\t')"
+printf '{"pane":"%%7","label":"f","workspace":"/w","parent_pane":"%%1","role":"child"}' \
+  > "${OE_DELEGATE_STATE_DIR}/99999__7.json"
+ck "pick-list note not in stdout" "" "$("$TREE" --pick-list 2>/dev/null | grep 'note:' || true)"
+ck "pick-list note on stderr" "yes" \
+  "$("$TREE" --pick-list 2>&1 >/dev/null | grep -q 'not shown (stale)' && echo yes || echo no)"
+
+# ----------------------------------------------------------------------------
+echo "[21] --pick (fzf): alive 選択 → oe-jump focus + 対象指定 zoom（resize-pane -Z -t %N）"
+# ----------------------------------------------------------------------------
+reset_state; fixture_chain
+export MOCK_LIVE_PANES="%83 %85 %94 %110"
+make_fzf
+export TMUX_CALL_LOG="$_TMP_DIR/calls21.log"; : > "$TMUX_CALL_LOG"
+FZF_PICK_PANE="%85" MOCK_ZOOM_FLAG="0" "$TREE" --pick </dev/null >/dev/null 2>&1; rc=$?
+ck "pick jump+zoom exit 0" "0" "$rc"
+ck "pick oe-jump select-pane target" "yes" "$(grep -qF 'select-pane -t %85' "$TMUX_CALL_LOG" && echo yes || echo no)"
+ck "pick zoom targets selected pane (-t)" "yes" "$(grep -qF 'resize-pane -Z -t %85' "$TMUX_CALL_LOG" && echo yes || echo no)"
+unset TMUX_CALL_LOG
+
+# ----------------------------------------------------------------------------
+echo "[22] --pick 冪等 zoom: 既 zoom(flag=1) は再 -Z しない（トグルで解除される事故を防ぐ）"
+# ----------------------------------------------------------------------------
+export TMUX_CALL_LOG="$_TMP_DIR/calls22.log"; : > "$TMUX_CALL_LOG"
+FZF_PICK_PANE="%85" MOCK_ZOOM_FLAG="1" "$TREE" --pick </dev/null >/dev/null 2>&1; rc=$?
+ck "pick already-zoomed exit 0" "0" "$rc"
+ck "pick no re-zoom when flag=1" "" "$(grep -F 'resize-pane' "$TMUX_CALL_LOG" || true)"
+unset TMUX_CALL_LOG
+
+# ----------------------------------------------------------------------------
+echo "[23] --pick gone 選択: oe-jump が pane 無しで rc1 → 伝播（zoom せず）"
+# ----------------------------------------------------------------------------
+export TMUX_CALL_LOG="$_TMP_DIR/calls23.log"; : > "$TMUX_CALL_LOG"
+FZF_PICK_PANE="%49" MOCK_ZOOM_FLAG="0" "$TREE" --pick </dev/null >/dev/null 2>&1; rc=$?
+ck "pick gone exit 1" "1" "$rc"
+ck "pick gone no zoom" "" "$(grep -F 'resize-pane' "$TMUX_CALL_LOG" || true)"
+unset TMUX_CALL_LOG
+
+# ----------------------------------------------------------------------------
+echo "[24] --pick (fzf) 分岐: cancel→130 / no-match→130 / fzf error→2 / empty→130"
+# ----------------------------------------------------------------------------
+FZF_CANCEL=1        "$TREE" --pick </dev/null >/dev/null 2>&1; ck "fzf cancel 130" "130" "$?"
+FZF_PICK_PANE="%zz" "$TREE" --pick </dev/null >/dev/null 2>&1; ck "fzf no-match 130" "130" "$?"
+FZF_FAIL=3          "$TREE" --pick </dev/null >/dev/null 2>&1; ck "fzf error 2" "2" "$?"
+FZF_EMPTY=1         "$TREE" --pick </dev/null >/dev/null 2>&1; ck "fzf empty 130" "130" "$?"
+
+# ----------------------------------------------------------------------------
+echo "[25] --pick 番号フォールバック（fzf 非在）: 有効→jump+zoom / 範囲外・非数値→2 / 空→130"
+# ----------------------------------------------------------------------------
+rm_fzf
+export MOCK_ZOOM_FLAG="0"
+# 候補順（画面配置順・座標なしは末尾）: 1)%49 gone 2)%83 3)%85 4)%110 5)%94。番号3=%85。
+export TMUX_CALL_LOG="$_TMP_DIR/calls25.log"; : > "$TMUX_CALL_LOG"
+feed_tty "3"; OE_TREE_TTY="$OE_TREE_TTY_FILE" "$TREE" --pick >/dev/null 2>&1; rc=$?
+ck "number select exit 0" "0" "$rc"
+ck "number select jump+zoom %85" "yes" "$(grep -qF 'resize-pane -Z -t %85' "$TMUX_CALL_LOG" && echo yes || echo no)"
+unset TMUX_CALL_LOG
+feed_tty "99";  OE_TREE_TTY="$OE_TREE_TTY_FILE" "$TREE" --pick >/dev/null 2>&1; ck "number out-of-range 2" "2" "$?"
+feed_tty "abc"; OE_TREE_TTY="$OE_TREE_TTY_FILE" "$TREE" --pick >/dev/null 2>&1; ck "number non-numeric 2" "2" "$?"
+feed_tty_empty; OE_TREE_TTY="$OE_TREE_TTY_FILE" "$TREE" --pick >/dev/null 2>&1; ck "number empty 130" "130" "$?"
+
+# ----------------------------------------------------------------------------
+echo "[26] --pick 候補なし（空森）: rc1・stdout 空・メッセージは stderr"
+# ----------------------------------------------------------------------------
+reset_state
+out="$("$TREE" --pick </dev/null 2>/dev/null)"; rc=$?
+ck "pick empty forest exit 1" "1" "$rc"
+ck "pick empty forest stdout empty" "" "$out"
+# stderr を先に変数へ取ってから grep する（`--pick|grep` を直に繋ぐと pipefail が --pick の
+# exit 1 を拾い、grep が一致しても && 側に進めない）。
+err="$("$TREE" --pick </dev/null 2>&1 >/dev/null)"
+ck "pick empty forest msg on stderr" "yes" \
+  "$(printf '%s' "$err" | grep -q 'no spawn nodes to pick' && echo yes || echo no)"
 
 echo
 echo "PASS=${PASS} FAIL=${FAIL}"


### PR DESCRIPTION
## 目的

`oe-tree --watch`（#223 の live トポロジ表示）から、`prefix+g` の session picker と同じく「選んだペインへ移動」＋「移動時に最大化」を1つの導線にする。**別コンポーネントは作らず** oe-tree 自体に対話モード `--pick` を足す（森構築/描画は既存ロジックの単一ソースのまま・jump は `oe-jump` 再利用・新規は fzf 選択 + `resize-pane -Z` のみ）。

Refs #227, #169, #223

## 変更内容

- `oe-tree --pick`: 森ツリーを fzf に流して選択 → `oe-jump` で focus → 対象 window を最大化（`enter`=jump+zoom / `ctrl-r`=refresh / `esc`=cancel）。fzf 非在時は番号フォールバック（`oe-select` 同型）。`--pick` ⊥ `--watch`。
- 内部モード `--pick-list`: 既存 render 経路そのままに `%N<TAB>表示行`（隠しキー列）を emit（森ロジックを複製しない・`--watch` の re-exec と同じ「一発実行と同一コードパス」）。note/空森メッセージは picklist では stderr へ流し stdout を候補列に保つ。
- ensure-zoomed: jump 成功後、対象 window が未 zoom のときだけ `resize-pane -Z -t <pane>`（**対象ペイン指定**・冪等）。既 zoom（`#{window_zoomed_flag}`=1）なら再 `-Z` しない（トグルで解除される事故を防ぐ）。
- gone ペイン選択は `oe-jump` の rc1 を伝播（popup では TTY 3s hold で読める）。
- README に `--pick` の仕様と推奨 bind スニペット（`prefix+v` 例）を追記。bind の実適用は本 PR 外（dotfiles/環境側・#202/#223 の hub/dotfiles 分界）。

## 設計プロセス（蒸留パイプライン）

- **ゼロベース設計**（`predecision-exploration`）で開放点5つ + 横断小 DJ を探索（探索木は確定前証跡として記録）。
- **設計SO**（`oe-refute --rubric exploration`・2 レーン）= **refuted**。material な指摘2件を実測確認して反映:
  - zoom の対象指定バグ（無指定 `resize-pane -Z` は popup/現 window を掴む）→ `-t <pane>` + ensure-zoomed。隔離 tmux 3.5a で実測。
  - preview の read-only 境界違反（`capture-pane` は観測系 cockpit の非検出境界に反する・discussion §8.4）→ preview 不採用。
- **実装SO**（`oe-review`・impl レンズ・2 レーン）= **survived**（material 欠陥なし・reviewed_sha `0ee2cfe`）。
- episode: `projects/orchestration-engine/docs/episodes/2026-07-05-episode-227-oe-tree-pick.md`

## テスト・影響範囲

- `test_oe_tree.sh` に `--pick` / `--pick-list` の 18 assert を追加（モード排他・形式/stderr 分離・jump/zoom ターゲット・冪等 zoom・gone 伝播・fzf 分岐・番号 fallback・空森）。**全 60 PASS**。
- `shellcheck` clean。`test_oe_jump`(38) / `test_oe_select`(35) 回帰なし。
- 純ビュー（`oe-tree` / `--watch`）は不変（既存 [1]-[18] PASS で回帰確認）。データ read-only 維持。
- 自動化不能でライブ実測が正の点（実 popup 対話終了 / popup 内 cross-session jump / fzf × popup alt-screen）は episode に hg-227-a/b として記録。

## レビュー時の注意

- 実装者 Claude は SO レーンから除外済み（設計SO=oe-refute / 実装SO=oe-review とも別レーン）。
- マージ・worktree 掃除はしない（人間/親が実施）。
