### PR TITLE
fix(oe): oe-tree --pick を jump 失敗時に picker へ戻るループ化 (#227)

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -372,20 +372,23 @@ oe-tree --pick   # 森ツリーを fzf に流す → 選択 → oe-jump で focu
 - **jump は `oe-jump` 再利用**: 選んだ `%N` を `oe-jump -- %N` に渡す（`switch-client`/`select-window`/`select-pane` 権威・別 window/session 跨ぎ対応）。jump ロジックは複製しない
 - **zoom（新規）**: jump 成功後、対象 window が未 zoom のときだけ `resize-pane -Z -t <pane>` で最大化する（**対象ペイン指定** — 無指定だと popup / 現 window を掴む）。既に zoom 済み（`#{window_zoomed_flag}`=1）なら**再 `-Z` しない**（トグルで解除される事故を防ぐ・冪等）。単一 pane window は `-Z` が無害な no-op
 - **read-only は維持**: jump/zoom は registry / トポロジ**データを編集しない**（#221/#223 のデータ read-only 不変条件は保たれる）。jump+zoom は**ユーザーが明示的に命じるナビ**＝受動検出でも自動作用でもなく、`prefix+g` picker が `select-pane` するのと同カテゴリ（非検出境界の本旨に反しない）。純ビュー（引数なし / `--watch`）はデフォルトで温存
-- **gone ペイン**: 候補には残す（ビューと一貫・gone 表示自体が情報）。選ぶと `oe-jump` が「pane 無し」で rc1 → メッセージを提示して終了（popup では TTY のとき 3s hold で読めるようにしてから閉じる）
+- **gone / jump 失敗**: 候補には残す（ビューと一貫・gone 表示自体が情報）。選んで `oe-jump` が失敗（gone/未解決）すると、理由を一瞬出して（TTY のとき 3s hold）**picker に戻る**（exit せずループ・#227 hg 追修正）。失敗のたびに popup が閉じないので別ノードを選び直せる。候補は戻るたび取り直す（最新化）
 - **fzf 非在**: 番号フォールバック（`oe-select` 同型 — 候補を番号付きで出し `/dev/tty` から番号 read。木の形は番号前置で保つ）。空入力 / EOF = cancel(130)・非数値 / 範囲外 = 2
-- degrade / exit: 0=jump+zoom 成功 / 1=候補なし・jump 不能・zoom 失敗（部分成功を偽らない）/ 2=usage・fzf 自体のエラー / 130=cancel。`--pick` と `--watch` は併用不可
+- degrade / exit: 0=jump+zoom 成功 / 1=候補なし（空森）・zoom 失敗（jump 済みで部分成功を偽らない）/ 2=usage・fzf 自体のエラー・番号 fallback の不正入力 / 130=cancel（Esc・空・EOF）。**jump 失敗（gone/未解決）は exit せず picker に戻る（ループ）**。`--pick` と `--watch` は併用不可
 
 **popup キーバインドは dotfiles 側で opt-in**（hub は強制しない・責務境界 = `oe-ident` #202 / `--watch` の bind と同型）。`--watch`（観測）を別キー、`--pick`（ナビ）を別キーに割り当てる想定。推奨スニペット（`~/.tmux.conf` 等）:
 
 ```tmux
 # oe topology pick popup（例: prefix + v。キーは環境の空きに合わせる — tmux list-keys で衝突確認）
-# fzf を popup 内で動かすため -E（対話プログラムを走らせる）。選択後は jump+zoom して自然クローズ。
-bind-key v run-shell "tmux display-popup -e 'TMUX_PANE=#{pane_id}' -E -x C -y C -w 70% -h 60% -T ' oe pick ' '/path/to/repo/projects/orchestration-engine/bin/oe-tree --pick'"
+# fzf を popup 内で動かすため -E。選択後は jump+zoom して自然クローズ。
+# 直 display-popup（run-shell を使わない）: run-shell はコマンド出力を別ビューで表示するため、失敗系
+# （Esc/gone で非 0 exit や stderr）で余計なペインが一瞬出る（#227 hg で実測・撤去）。TMUX_PANE は
+# oe-tree が popup 内で display-message から自己解決するので -e 注入も不要。
+bind-key v display-popup -E -x C -y C -w 70% -h 60% -T ' oe pick ' '/path/to/repo/projects/orchestration-engine/bin/oe-tree --pick'
 ```
 
-- `-e 'TMUX_PANE=#{pane_id}'` は `(you)` マーカーの opener 注入（`--watch` と同じ・`run-shell` 経由のときだけ format が展開される）
-- bind の実適用は本 PR 外（dotfiles / 環境側）。hub は推奨スニペットを doc で示すに留める（#202/#223 と同じ hub/dotfiles 分界）。実測が要る点（popup 内 cross-session jump / fzf × popup alt-screen の相互作用）はライブ確認で詰める
+- `(you)` マーカーは oe-tree が popup 内で `display-message` から active pane を自己解決する（`--watch` と同じ・#223）。run-shell + `-e` 注入は失敗系で別ビュー表示を招くため使わない（#227 hg）
+- bind の実適用は本 PR 外（dotfiles / 環境側）。hub は推奨スニペットを doc で示すに留める（#202/#223 と同じ hub/dotfiles 分界）
 
 - follow-up（未実装・surface のみ）: `--json` 出力 / gone root ラベルの event-log 補完 / ラベル解決の共通 read ヘルパ化 / 汎用 `oe-watch` verb（他の観測 view の live 化）/ status-line 向け要約（`--summary`）/ **`--watch` から 1 キーで `--pick` を起動する glance→pick 統合（設計SO 由来・popup 相互作用が絡むため `--pick` を土台に additive に足す別 concern）**
 

--- a/projects/orchestration-engine/bin/oe-tree
+++ b/projects/orchestration-engine/bin/oe-tree
@@ -244,83 +244,84 @@ if [[ "$PICK" -eq 1 ]]; then
 
   # 候補は自身を --pick-list で再帰起動して取得。stdout = "%N<TAB>表示行" のみ／note・空森
   # メッセージは stderr（候補に混ぜない）。mapfile は macOS の bash 3.2 に無いので while-read。
-  CANDS=()
-  while IFS= read -r _l; do
-    [[ "$_l" == %[0-9]*$'\t'* ]] && CANDS+=("$_l")
-  done < <("$OE_TREE_SELF" --pick-list)
-  if [[ ${#CANDS[@]} -eq 0 ]]; then
-    echo "oe-tree: no spawn nodes to pick (see notes above; try: oe-tree)" >&2
-    pick_hold
-    exit 1
-  fi
-
-  # 選択: fzf があれば fzf、無ければ番号フォールバック（oe-select 同型）。
-  SELECTED=""
-  if command -v fzf >/dev/null 2>&1; then
-    # 1 列目（%N）は隠しキー: --delimiter TAB + --with-nth 2 で表示/検索は 2 列目のみ。
-    # ctrl-r reload は同一 --pick-list を再実行（fzf は bind を $SHELL -c で走らせるため絶対パス）。
-    rc=0
-    SELECTED="$(printf '%s\n' "${CANDS[@]}" | fzf \
-      --delimiter=$'\t' \
-      --with-nth=2 \
-      --layout=reverse \
-      --prompt='jump> ' \
-      --header='enter: jump+zoom   ctrl-r: refresh   esc: cancel' \
-      --bind="ctrl-r:reload('${OE_TREE_SELF}' --pick-list)")" || rc=$?
-    # rc 130（Ctrl-C）/ 1（no match=未選択）→ cancel(130) / rc>=2（fzf 自体のエラー）→ 2
-    if [[ "$rc" -eq 130 || "$rc" -eq 1 ]]; then
-      exit 130
-    elif [[ "$rc" -ge 2 ]]; then
-      echo "oe-tree: fzf failed (rc=${rc})" >&2
-      exit 2
+  # ループ: jump 失敗（gone/未解決）は exit せず picker に戻る（#227 hg 追修正）。抜けるのは
+  # 成功 / cancel(Esc・空・EOF) / fzf エラー / 空森 / zoom 失敗(既に移動済) のみ。候補は毎回取り直す。
+  while :; do
+    CANDS=()
+    while IFS= read -r _l; do
+      [[ "$_l" == %[0-9]*$'\t'* ]] && CANDS+=("$_l")
+    done < <("$OE_TREE_SELF" --pick-list)
+    if [[ ${#CANDS[@]} -eq 0 ]]; then
+      echo "oe-tree: no spawn nodes to pick (see notes above; try: oe-tree)" >&2
+      pick_hold
+      exit 1
     fi
-  else
-    echo "oe-tree: select a node to jump to:" >&2
-    _i=1
-    for _l in "${CANDS[@]}"; do
-      printf '%3d) %s\n' "$_i" "${_l#*$'\t'}" >&2   # 表示は %N を落とした 2 列目（木の形は保つ）
-      _i=$((_i + 1))
-    done
-    printf 'number> ' >&2
-    _reply=""
-    if ! IFS= read -r _reply <"$OE_TREE_TTY"; then exit 130; fi   # EOF=cancel
-    [[ -n "$_reply" ]] || exit 130                                # 空入力=cancel
-    if ! [[ "$_reply" =~ ^[0-9]+$ ]]; then
-      echo "oe-tree: invalid selection" >&2; exit 2
+
+    # 選択: fzf があれば fzf、無ければ番号フォールバック（oe-select 同型）。
+    SELECTED=""
+    if command -v fzf >/dev/null 2>&1; then
+      # 1 列目（%N）は隠しキー: --delimiter TAB + --with-nth 2 で表示/検索は 2 列目のみ。
+      # ctrl-r reload は同一 --pick-list を再実行（fzf は bind を $SHELL -c で走らせるため絶対パス）。
+      rc=0
+      SELECTED="$(printf '%s\n' "${CANDS[@]}" | fzf \
+        --delimiter=$'\t' \
+        --with-nth=2 \
+        --layout=reverse \
+        --prompt='jump> ' \
+        --header='enter: jump+zoom   ctrl-r: refresh   esc: cancel' \
+        --bind="ctrl-r:reload('${OE_TREE_SELF}' --pick-list)")" || rc=$?
+      # rc 130（Ctrl-C）/ 1（no match=未選択）→ cancel(130) / rc>=2（fzf 自体のエラー）→ 2
+      if [[ "$rc" -eq 130 || "$rc" -eq 1 ]]; then
+        exit 130
+      elif [[ "$rc" -ge 2 ]]; then
+        echo "oe-tree: fzf failed (rc=${rc})" >&2
+        exit 2
+      fi
+    else
+      echo "oe-tree: select a node to jump to:" >&2
+      _i=1
+      for _l in "${CANDS[@]}"; do
+        printf '%3d) %s\n' "$_i" "${_l#*$'\t'}" >&2   # 表示は %N を落とした 2 列目（木の形は保つ）
+        _i=$((_i + 1))
+      done
+      printf 'number> ' >&2
+      _reply=""
+      if ! IFS= read -r _reply <"$OE_TREE_TTY"; then exit 130; fi   # EOF=cancel
+      [[ -n "$_reply" ]] || exit 130                                # 空入力=cancel
+      if ! [[ "$_reply" =~ ^[0-9]+$ ]]; then
+        echo "oe-tree: invalid selection" >&2; exit 2
+      fi
+      # 先頭ゼロの 8 進解釈を避けて 10 進化してから範囲チェック（oe-select と同型）。
+      _idx=$((10#$_reply))
+      if [[ "$_idx" -lt 1 || "$_idx" -gt ${#CANDS[@]} ]]; then
+        echo "oe-tree: invalid selection" >&2; exit 2
+      fi
+      SELECTED="${CANDS[$((_idx - 1))]}"
     fi
-    # 先頭ゼロの 8 進解釈を避けて 10 進化してから範囲チェック（oe-select と同型）。
-    _idx=$((10#$_reply))
-    if [[ "$_idx" -lt 1 || "$_idx" -gt ${#CANDS[@]} ]]; then
-      echo "oe-tree: invalid selection" >&2; exit 2
+
+    [[ -n "$SELECTED" ]] || exit 130   # 空選択（fzf rc0 + 空 stdout 等）も cancel
+    PANE="${SELECTED%%$'\t'*}"
+    if ! [[ "$PANE" =~ ^%[0-9]+$ ]]; then
+      echo "oe-tree: could not extract pane id from selection" >&2
+      exit 1
     fi
-    SELECTED="${CANDS[$((_idx - 1))]}"
-  fi
 
-  [[ -n "$SELECTED" ]] || exit 130   # 空選択（fzf rc0 + 空 stdout 等）も cancel
-  PANE="${SELECTED%%$'\t'*}"
-  if ! [[ "$PANE" =~ ^%[0-9]+$ ]]; then
-    echo "oe-tree: could not extract pane id from selection" >&2
-    exit 1
-  fi
+    # jump（oe-jump 再利用・focus）。失敗（gone/未解決）は理由を一瞬出して picker に戻る（exit しない）。
+    if ! "${BIN_DIR}/oe-jump" -- "$PANE"; then
+      echo "oe-tree: '${PANE}' へ jump できません（gone/未解決）— picker に戻ります" >&2
+      pick_hold
+      continue
+    fi
 
-  # jump（oe-jump 再利用・focus）。gone/未解決は oe-jump が理由を stderr に出す → hold して伝える。
-  # rc は oe-jump のものを伝播（1=pane 無し/focus 失敗 / 2=環境）。
-  if "${BIN_DIR}/oe-jump" -- "$PANE"; then
-    :
-  else
-    rc=$?
-    pick_hold
-    exit "$rc"
-  fi
-
-  # zoom（新規・対象指定 ensure-zoomed）。jump は成功済み — zoom 失敗は部分成功として rc1
-  # （「ジャンプし最大化」を偽らない）。
-  if ! ensure_zoom "$PANE"; then
-    echo "oe-tree: jumped to ${PANE} but failed to zoom (resize-pane -Z)" >&2
-    pick_hold
-    exit 1
-  fi
-  exit 0
+    # zoom（対象指定 ensure-zoomed）。jump は成功済み＝既に移動 — zoom 失敗は部分成功として exit 1
+    # （「ジャンプし最大化」を偽らない・戻らない）。
+    if ! ensure_zoom "$PANE"; then
+      echo "oe-tree: jumped to ${PANE} but failed to zoom (resize-pane -Z)" >&2
+      pick_hold
+      exit 1
+    fi
+    exit 0
+  done
 fi
 
 SELF="${TMUX_PANE:-}"

--- a/projects/orchestration-engine/tests/test_oe_tree.sh
+++ b/projects/orchestration-engine/tests/test_oe_tree.sh
@@ -72,6 +72,15 @@ make_fzf() {
 [[ -n "${FZF_CANCEL:-}" ]] && exit 130
 [[ -n "${FZF_FAIL:-}" ]] && exit "$FZF_FAIL"
 [[ -n "${FZF_EMPTY:-}" ]] && exit 0
+# stateful（ループ戻り検証用）: 1 回目は $FZF_ONCE_PANE を返し、2 回目以降は cancel(130)。
+if [[ -n "${FZF_ONCE_PANE:-}" ]]; then
+  if [[ -e "${FZF_ONCE_CF:?FZF_ONCE_CF required}" ]]; then exit 130; fi
+  : > "$FZF_ONCE_CF"
+  while IFS= read -r line; do
+    [[ "${line%%$'\t'*}" == "$FZF_ONCE_PANE" ]] && { printf '%s\n' "$line"; exit 0; }
+  done
+  exit 1
+fi
 pick="${FZF_PICK_PANE:-}"
 while IFS= read -r line; do
   [[ "${line%%$'\t'*}" == "$pick" ]] && { printf '%s\n' "$line"; exit 0; }
@@ -406,12 +415,21 @@ ck "pick no re-zoom when flag=1" "" "$(grep -F 'resize-pane' "$TMUX_CALL_LOG" ||
 unset TMUX_CALL_LOG
 
 # ----------------------------------------------------------------------------
-echo "[23] --pick gone 選択: oe-jump が pane 無しで rc1 → 伝播（zoom せず）"
+echo "[23] --pick gone/jump 失敗: exit せず picker に戻る（成功/cancel のみ抜ける・#227 hg 追修正）"
 # ----------------------------------------------------------------------------
+reset_state; fixture_chain
+export MOCK_LIVE_PANES="%83 %85 %94 %110"   # %49 は gone（live 集合に無い）
+make_fzf; export MOCK_ZOOM_FLAG="0"
 export TMUX_CALL_LOG="$_TMP_DIR/calls23.log"; : > "$TMUX_CALL_LOG"
-FZF_PICK_PANE="%49" MOCK_ZOOM_FLAG="0" "$TREE" --pick </dev/null >/dev/null 2>&1; rc=$?
-ck "pick gone exit 1" "1" "$rc"
+# stateful fzf: 1 回目 gone(%49) → oe-jump 失敗 → picker に戻る → 2 回目 fzf は cancel → 130。
+# 旧挙動なら gone 選択で exit 1。130 になること自体がループ（戻り→再選択）の証拠。
+rm -f "$_TMP_DIR/cf23"
+FZF_ONCE_PANE="%49" FZF_ONCE_CF="$_TMP_DIR/cf23" "$TREE" --pick </dev/null >/dev/null 2>&1; rc=$?
+ck "pick gone loops back then cancel→130 (旧: exit1)" "130" "$rc"
 ck "pick gone no zoom" "" "$(grep -F 'resize-pane' "$TMUX_CALL_LOG" || true)"
+rm -f "$_TMP_DIR/cf23b"
+err23="$(FZF_ONCE_PANE="%49" FZF_ONCE_CF="$_TMP_DIR/cf23b" "$TREE" --pick </dev/null 2>&1 >/dev/null)"
+ck "pick gone shows 戻ります on stderr" "yes" "$(printf '%s' "$err23" | grep -q 'picker に戻ります' && echo yes || echo no)"
 unset TMUX_CALL_LOG
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`oe-tree --pick`（#227）の実使用フィードバック（hg）対応。**gone / jump 失敗のノードを選ぶと popup ごと閉じていた**のを、**picker に戻る（ループ）**ように修正。

## 課題

- `--pick` は「選択 → oe-jump → zoom → exit」の一本道で、`oe-jump` が失敗（gone/未解決）すると `pick_hold` してから **exit** → popup が閉じてしまう。ユーザーは「gone を選んでも popup が消えず、元の picker に戻ってほしい」。
- 併せて、Esc/gone 時に**余計なペインが一瞬出る**現象は、bind の `run-shell "tmux display-popup ..."` が**コマンド出力を別ビューで表示する**副作用（失敗系で非 0 exit / stderr が surface）。＝ツールコードでなく bind 層の問題。

## 修正

- **`bin/oe-tree`**: `--pick` の select+jump+zoom を `while` ループ化。**`oe-jump` 失敗（gone/未解決）は理由を一瞬出して `continue`（picker に戻る）**。ループを抜けるのは 成功 / cancel（Esc・空・EOF）/ fzf エラー / 空森 / zoom 失敗（既に移動済）のみ。候補は戻るたび取り直す（最新化）。
- **`tests/test_oe_tree.sh`**: [23] を loop-back に更新（stateful fzf mock で gone→戻る→2 回目 cancel→130・zoom なし・「picker に戻ります」を検証）。
- **`bin/README.md`**: gone/jump 失敗の挙動・exit 契約を更新。推奨 bind スニペットを **`run-shell` → 直 `display-popup`** に変更（run-shell の失敗系別ビュー表示を回避・`TMUX_PANE` は oe-tree が popup 内で自己解決するので `-e` 注入も不要）。

## 関連（本 PR 外・dotfiles）

- `prefix+v` の bind を run-shell → 直 `display-popup` に切替（Esc の余計なペインが消えたのを実測確認済み）。dotfiles 側で対応。

## 検証

- `shellcheck` rc=0（oe-tree / test）
- `test_oe_tree` **61/61**（bash 5.2.37・3.2.57 両系）— [23] loop-back 含む。既存 [1]-[22]/[24]-[26] 回帰なし。

## スコープ / 判断

- 設計判断のない小 UX fix（ループ化）＋テスト更新のため、**実装SO(oe-review) / episode は省略**（客観ゲート = テストで担保・`episode-flow-discipline` の「skip 判断を残す」に従い明記）。

Refs #227
