### PR TITLE
fix(oe): 会話到達 preview を write+read サニタイズし malform 注入を抑制

### DIFF
--- a/projects/orchestration-engine/bin/oe-ack
+++ b/projects/orchestration-engine/bin/oe-ack
@@ -27,6 +27,10 @@ source "${BIN_DIR}/../lib/event-bus.sh"
 # shellcheck source=../lib/delegate-registry.sh
 source "${BIN_DIR}/../lib/delegate-registry.sh"
 
+# #224: preview echo（会話到達面）を read 側でも無害化する共有 helper。event-bus.sh 経由で
+# 既に source 済みだが、未ロード時は degrade（cntrl gsub は _ack_scan 側で効く・従来同等）。
+declare -F oe_sanitize_conversation >/dev/null 2>&1 || oe_sanitize_conversation() { printf '%s' "$1"; }
+
 err() { echo "oe-ack: $*" >&2; }
 
 usage() {
@@ -102,6 +106,8 @@ _ack_scan() {
       | [ ($msgs | length | tostring),
           (if ($msgs|length) > 0 then $msgs[-1].ts else "" end),
           ($received | tostring),
+          # #224: タグ列等の無害化は write-time＋read-time（_ack_one が echo 前に
+          # oe_sanitize_conversation を通す）。ここの cntrl→space は US 区切り protocol 防御で温存。
           (if ($msgs|length) > 0 then (($msgs[-1].preview // "") | gsub("[[:cntrl:]]"; " ")) else "" end) ]
       | join("\u001f")'
 }
@@ -124,6 +130,7 @@ _ack_one() {
   oe_event_report_received "$SELF" "$other" "$total" "$last_ts"
   # 開示 affordance: 何を受領印したかを acker が即検証できるように出す。
   # 直前に読んだ内容と最終 preview が食い違えば、ack 直前に新着が割り込んだサイン。
+  last_prev="$(oe_sanitize_conversation "$last_prev")"   # #224: read 側の会話到達面無害化
   echo "oe-ack: acked ${pending} 件（累計 ${total}）from ${disp} / 最終: ${last_ts} 「${last_prev}」" >&2
 }
 

--- a/projects/orchestration-engine/bin/oe-activity
+++ b/projects/orchestration-engine/bin/oe-activity
@@ -37,6 +37,15 @@ set -euo pipefail
 
 err() { echo "oe-activity: $*" >&2; }
 
+# #224: 会話到達面へ出す preview を read 側でも無害化する。write-time（event-bus）は新規 event しか
+# 覆えず、legacy / 外部編集で壊れた / write-time 失敗の raw preview が tool-call タグ列や box-drawing
+# を伴って会話へ再露出しうる（実装SO=oe-review 検出）。共有 helper を通し単一実装で塞ぐ。
+_SANITIZE_LIB="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/../lib/sanitize.sh"
+# shellcheck source=../lib/sanitize.sh
+if [[ -r "$_SANITIZE_LIB" ]]; then source "$_SANITIZE_LIB"; fi
+# lib 不在時は degrade（jq 投影の cntrl gsub は効くのでタグ列のみ無処理＝従来同等の安全度）。
+declare -F oe_sanitize_conversation >/dev/null 2>&1 || oe_sanitize_conversation() { printf '%s' "$1"; }
+
 # 単一ノブ OE_EVENT_DIR（writer=event-bus.sh と一致）。reader 専用の別ノブは footgun なので持たない。
 OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
 OE_EVENT_FILE="${OE_EVENT_DIR}/oe-events.jsonl"
@@ -144,6 +153,9 @@ project() {
               clab_m: (if $r.c==$m.from.pane then $m.from.label else $m.to.label end),
               plab_m: (if $r.p==$m.from.pane then $m.from.label else $m.to.label end),
               deliv: ($m.delivery_signal // "none"),
+              # #224: タグ列/box/court の無害化は write-time（event-bus）＋ read-time（下流の
+              # bash ループが oe_sanitize_conversation を通す）で行う。ここの jq cntrl→space は
+              # 「US 区切りを join 前に潰す protocol 防御」＝別役割なので温存する（US 混入で列ズレ防止）。
               prev:  (($m.preview // "") | gsub("[[:cntrl:]]"; " ")) } ] ) as $msgs
     # inbox は自分宛の報告だけに絞る
     | ( if $mode=="inbox" then [ $msgs[] | select(.recipient==$self) ] else $msgs end ) as $fmsgs
@@ -213,6 +225,7 @@ if [[ "$MODE" == "timeline" ]]; then
   printf '%-4s  %-26s  %-7s  %-16s  %-30s  %s\n' "TURN" "TS" "DIR" "DELIVERY" "RELATION" "PREVIEW"
   while IFS=$'\037' read -r turn ts dir deliv c p clab plab prev; do
     [[ -n "$ts" ]] || continue
+    prev="$(oe_sanitize_conversation "$prev")"   # #224: read 側の会話到達面無害化
     relation="$(disp "$p" "$plab") → $(disp "$c" "$clab")"
     printf '%-4s  %-26s  %-7s  %-16s  %-30s  %s\n' "$turn" "$ts" "$dir" "$deliv" "$relation" "$prev"
   done <<< "$rows"
@@ -229,6 +242,7 @@ fi
 
 while IFS=$'\037' read -r c p clab plab trips deliv miss pend prev; do
   [[ -n "$c" || -n "$p" ]] || continue
+  prev="$(oe_sanitize_conversation "$prev")"   # #224: read 側の会話到達面無害化
   live="$(liveness_of "$c")"     # 送信元 ＝ 子(worker)の生存
   deliv_disp="$deliv"
   [[ "${miss:-0}" -gt 0 ]] 2>/dev/null && deliv_disp="${deliv} (×${miss})"

--- a/projects/orchestration-engine/docs/episodes/2026-07-05-episode-224-capture-sanitize.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-05-episode-224-capture-sanitize.md
@@ -1,0 +1,92 @@
+---
+id: "01KWS5J28047ZKDH72CNDPD1NC"
+title: "#224 episode — capture サニタイズ核（会話到達 preview の write+read 無害化・第一増分）"
+date: 2026-07-05
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/224"
+    reason: "長寿命 orchestration セッションで capture 経由の malform 注入が連鎖する問題の第一増分"
+  - type: pull_request
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/232"
+    reason: "本 episode の実装 PR"
+  - type: design_so
+    ref: "oe-refute exploration / audit 20260705115744F109S5B1ZPT9 (verdict=refuted)"
+    reason: "予決定探索: 「oe-activity が唯一の会話面」前提を反証し read-time→write-time へ再導出"
+  - type: impl_so
+    ref: "oe-review round1 20260705123250AXYFZVVSQ97T (refuted) / round2 20260705124608Q50W2KMZ0A34 (survived)"
+    reason: "実装SO: write-only の read-side 穴 + env silent-bypass を検出 → write+read+guard に是正"
+  - type: reuse
+    ref: "../../bin/oe-tree"
+    reason: "sanitize_out（jq -Rrs 主 + tr fallback・出力チョークポイント）idiom を踏襲"
+  - type: reuse
+    ref: "../../lib/event-bus.sh"
+    reason: "OE_EVENT_PREVIEW_MAX の非数値ガード（fail-safe coerce）を OE_SANITIZE_MAX_CP へ横展開"
+tags: [orchestration, engine, capture, sanitize, malform, tool-call, predecision-exploration, oe-review, episode]
+---
+
+> `reconstructed`: 本 episode は closure 時に作業を振り返って再構成したもの。リアルタイム追記ログではない。
+
+## Context / なぜ
+
+長寿命・ツール密な orchestration 統括セッションで、子ペインの壊れた出力（生の tool-call タグ列・box-drawing・制御文字）が capture 経由で親コンテキストへ注入され、親が自己回帰で模倣して tool-call malform が連鎖・悪化する。本増分はその最大レバレッジの具体核だけを潰す（頻度を下げる反復の第一歩）。着手時の非自明な発見が方針を2度変えた（下記）。
+
+## 事実・失敗（選択的省略なし）
+
+- **予決定探索 SO（oe-refute exploration）が初期案を refuted**。当初「生の会話到達面は `oe-activity` の preview 投影だけ」と実査で結論しかけたが、2/2 レーンが `oe-ack` も同一 `event-bus.preview` field を読んで stderr に echo する（= 2 つ目の consumer）点を指摘。source 直読で confirm。→ 前提が崩れ read-time→write-time へ再導出。
+- **実装SO（oe-review）round1 が実装を refuted**（2 material 欠陥・E2E 確認済み）:
+  - (A) `OE_SANITIZE_MAX_CP` 非数値だと `jq --argjson max` が失敗→jq 全体失敗→`tr` fallback へ落ち、**tag 無害化ごと silent bypass**（raw preview が jsonl に保存）。
+  - (B) read 側（oe-activity/oe-ack）が tag 無害化せず、legacy/破損/write 失敗の raw preview が会話面へ再露出。
+  - → env guard 追加 ＋ read-time 併用に是正し round2 で survived。
+- 途中、jq の Unicode エスケープで複数回つまずいた（下記 W）。
+
+## 決定と根拠（diff から復元できない why）
+
+- **DJ-4 write vs read（2度転回）**: read-only(初期) → **write-time**(探索: `.preview` は ≥2 consumer が読む共有投影ゆえ event-bus 1 箇所が DRY) → **write+read 併用**(実装SO: write-only は legacy/破損/write 失敗の raw を read 側で止められない)。helper が**冪等**（`< invoke` を再無害化しない・`[court]` は `^court$` に非マッチ・truncate 再適用も同結果）なので二重適用は安全＝belt-and-suspenders が成立。
+- **DJ-2 除去 vs neutralize → neutralize**: 削除は文脈が飛び隣接テキストが誤結合し、**誤爆時の被害が「削除=データ喪失」より「変形=軽微な視覚ノイズ」で小さい**。over-removal 懸念（DJ-3 の court）にも neutralize が効く。
+- **DJ-3 court は行頭孤立のみ**（`(?m)^[ \t]*court[ \t]*$`）: mid-sentence/複数語行/識別子を守る。tag neutralize が primary、court は補助（same-line malform は tag 側で捕捉）。
+- **tag パターンは short + 名前空間の open/close を捕捉**（issue 列挙の3トークンから拡張）: 実装SO cursor の under-capture 指摘を先取り。`<div>` 等は不介入（over-capture ゼロをテストで固定）。
+- **env guard は fail-safe coerce**（非数値→既定 4000）: 隣接コード `OE_EVENT_PREVIEW_MAX` と同方針。fail-open（silent bypass）を fail-safe（既定で主防御を必ず効かせる）へ。
+
+## わかったこと（W）
+
+- `event-bus.preview` は audit 本体でなく**既に 100cp lossy な表示用投影**で、`oe-activity` と `oe-ack` の≥2 consumer が読む。この構造把握が「write-time が DRY」の根拠であり、同時に「legacy raw が read 側に残る」穴の根拠でもあった（同じ事実の裏表）。
+- jq の Unicode エスケープは**二層**で挙動が逆: `\uXXXX` は**単一**バックスラッシュ（jq 文字列パーサが実文字へ変換→oniguruma はリテラルを見る）、oniguruma native の `\x{HHHH}` は**二重**バックスラッシュ（jq を素通しさせ oniguruma に解釈させる）。box-drawing 範囲は `\\x{2500}-\\x{257f}`（二重）で確定。制御は `[[:cntrl:]]`（native）。
+- 安全パラメータ（env）が**主防御を silent に無効化する fail-open** は、隣接コードが同種を既修正でも新規箇所で再発しうる。ゲート（テスト）で env 境界を固定しないと回帰する。
+
+## 原則（negative knowledge 候補・→ #62）
+
+- **Anti-pattern**: 安全変換の閾値/パラメータを外部入力（env）から取り、不正値で**変換全体が例外→fallback で主防御を bypass**する（fail-open）。設定 typo 1 つで防御が丸ごと消える。
+- **Pattern**: 不正値は安全側の既定へ coerce し、主防御を常に効かせる（fail-safe）。境界値をテストで固定する。
+- **Pattern**: 同一の表示用データを複数 consumer が読むなら、無害化は「write で clean 化」＋「read で冪等に再無害化」の**二重チョークポイント**が legacy/破損/write 失敗を含めて堅牢。冪等性が前提条件。
+
+## 検証（ゲート）
+
+- engine テスト suite **27 ファイル**が **bash 3.2.57 / 5.2.37 両系で green**（#231 の 3.2 互換化を rebase 済み）。
+- `test_sanitize.sh`（28 ケース: 無害化/truncate/**誤爆しない**/env guard/jq 不在 fallback）、event-bus write-time、oe-activity/oe-ack read-side、oe-send payload-echo guard、stage-miss ノイズ抑制。
+- `shellcheck` rc=0（変更 10 ファイル）。実装SO(oe-review) round2 = **survived**。
+
+## 残課題（routing 済み）
+
+いずれも本 PR スコープ外。行き先を明示する（primary/oe-select/根因/Phase5 は「親への完了報告に併記→親が Issue 化を上位判断」に束ねる。未作成の Issue 番号は親判断待ちで空のまま routing 先を親に固定）。
+
+- **primary malform 経路**（エージェントが生 `wez pane capture`/`tmux capture-pane` を直貼付）の抑止 = behavioral/運用ガイド/エージェント規律。真のレバーだが文字列制御では消えない。→ routing: **親への完了報告に併記 → 親が behavioral guide の Issue 化を判断**。
+- `oe-select` の fzf `--preview`（live capture の TUI 描画・event-log 非経由）→ routing: **親報告に併記 → primary 経路と同束で follow-up Issue 化判断**（別データソース。会話ベクタは弱いが未サニタイズ）。
+- 根因調査（汚染 vs 長コンテキスト劣化）→ routing: **親判断で別 Issue 化（未作成）**。Phase 5 設計入力は **#105 / #108** に接続。
+- tag under-capture 残余（短形 close・大文字 `Court`）→ routing: **PR #232 本文に明記済み（永続行き先）**。低 materiality・observed malform は捕捉済み・観測されたら追加。
+
+## back-propagation
+
+- 親 direction（`.oe/direction-224.md`・gitignore・非永続）の前提「`oe-activity` の preview 投影が**唯一の実在する会話到達面**」は、予決定探索（oe-refute）で**誤りと判明** — `oe-ack` が同一 `event-bus.preview` field を読む2つ目の consumer だった。本 episode/PR は反証後の正しい像（≥2 consumer）で実装済み。親所有の doc は子が改変しないため、**この前提の supersede を親への完了報告で明示**する（source への back-propagation）。
+
+## 蒸留シグナル
+
+- 昇格候補: **negative knowledge（#62）** = 上記「fail-open な安全 env パラメータ」Anti-pattern と「二重チョークポイント＋冪等」Pattern。skill/rule 化までは要さない（1 事例）。Decision 昇格は不要（既存 ADR 方針の適用範囲）。
+
+## closure
+
+- **次の消費者**: 親スレッド（完了確認 + primary 経路の behavioral guide を Issue 化する上位判断）。以後 engine で「会話到達面へ載せる文字列」を扱う作業が `oe_sanitize_conversation` の適用点前例として参照可能。
+- **evidence anchor**: SO 出力は `tmp/`（揮発）だが、verdict/reason を本 episode と PR 本文へ転記済み（design SO refuted→write-time / impl SO round1 refuted 2欠陥→round2 survived）。commit/PR #232/テスト suite が永続アンカー。親 direction（方針A・write-time・oe-select は follow-up）は `.oe/`（gitignore・非永続）ゆえ要点を本文へ転記。
+- **status**: stable / 達成度: 達成（核サニタイズ landed・全ゲート green・実装SO survived。primary 経路は設計どおりスコープ外）。
+- **Step4 外部チェック（closure 品質）**: `so-compare`（codex）で実施。出力 `tmp/so-20260705-215745/`（揮発）。結果＝失敗省略なし・揮発パス問題なしだが、**routing 弱（oe-select/根因の行き先曖昧）と back-propagation 漏れ（親 direction の誤前提を supersede 明示せず）を指摘** → 上記「残課題」の routing 明確化と「back-propagation」節の追加で反映済み。

--- a/projects/orchestration-engine/lib/delegate-send.sh
+++ b/projects/orchestration-engine/lib/delegate-send.sh
@@ -109,7 +109,13 @@ _oe_send_finalize() {
   # する（既定は rc 不変・#154）。fast submit を未着と誤判定し得るため opt-in（二重 submit 回避）。
   # 入力欄に内容が残る（折返し/省略で payload と完全一致しない）ケースは unknown 扱いで warn しない（Copilot 指摘）。
   if [[ "$saw_staged" == "0" && "$staged" == "0" ]] && ! _oe_send_has_content "$input"; then
-    echo "oe_send_line: finalize: payload not observed staged or submitted on ${pane} (possible stage miss / fast submit)" >&2
+    # #224: 既定（signal-miss opt-out）では warn を出さない。suspected-miss は fast-submit の
+    # 誤検知を多く含み既定では rc も変えない（no-op）ため、既定パスの warn は純ノイズになる。
+    # genuine な失敗シグナルは opt-in（OE_SEND_SIGNAL_MISS=1）側で warn + rc=4（oe_send_line）
+    # として残す。state machine（return 3）は不変＝echo だけを opt-in にゲートする。
+    if [[ "${OE_SEND_SIGNAL_MISS:-0}" == "1" ]]; then
+      echo "oe_send_line: finalize: payload not observed staged or submitted on ${pane} (possible stage miss / fast submit)" >&2
+    fi
     return 3
   fi
   # それ以外（base_proc=1・非安定・折返し等）= unknown → 撃たない

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -25,6 +25,12 @@ if ! declare -F _oe_reg_key >/dev/null 2>&1; then
   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/delegate-registry.sh" 2>/dev/null || true
 fi
 
+# #224: 会話到達面へ載る preview を write-time で無害化する共有 helper（多重 source は冪等）。
+if ! declare -F oe_sanitize_conversation >/dev/null 2>&1; then
+  # shellcheck source=sanitize.sh
+  source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sanitize.sh" 2>/dev/null || true
+fi
+
 # delegate-registry.sh が source されない（_oe_reg_key を他所が定義済 等）/ 環境で未設定でも、
 # 未定義の state dir で `/${pid}_*.json` のように root 配下を誤って glob しないよう、registry と
 # 同じ既定値をここでもフォールバック設定する（best-effort・Copilot 指摘）。
@@ -138,6 +144,14 @@ oe_event_message_sent() {
   case "$maxc" in ''|*[!0-9]*) echo "oe_event_message_sent: OE_EVENT_PREVIEW_MAX='${maxc}' は非数値 → 100 を使用" >&2; maxc=100 ;; esac
   # delivery_signal を suspected_miss|none に正規化（未知値は none）。
   case "$delivery" in suspected_miss|none) ;; *) delivery="none" ;; esac
+  # #224: 会話到達面（oe-activity/oe-ack が読む preview）へ載る前に write-time で無害化する。
+  # ここ1箇所で全 read consumer を drift なくカバーする（DJ-4=write-time）。tool-call タグ列・
+  # box-drawing・制御文字・行頭孤立 court を無害化。この後の 100cp truncate は preview 長の
+  # 責務として据え置く（helper 既定 OE_SANITIZE_MAX_CP はこれより十分大きく干渉しない）。
+  # read 側（oe-activity/oe-ack）の [[:cntrl:]] gsub は US 区切り protocol 防御として温存する。
+  # best-effort: サニタイズが万一失敗しても emit を落とさず raw preview で続行（set -e 下でも安全）。
+  local _san
+  if _san="$(oe_sanitize_conversation "$preview")"; then preview="$_san"; fi
   extra="$(jq -cn --arg p "$preview" --arg d "$delivery" --argjson n "$maxc" \
     '{preview: (if ($p|length) > $n then ($p[0:$n] + "…") else $p end), delivery_signal: $d}' 2>/dev/null)" || return 0
   oe_event_emit "message_sent" "$fp" "$frole" "$flabel" "$tp" "$trole" "$tlabel" "$extra"

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -30,6 +30,10 @@ if ! declare -F oe_sanitize_conversation >/dev/null 2>&1; then
   # shellcheck source=sanitize.sh
   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sanitize.sh" 2>/dev/null || true
 fi
+# source 失敗（欠落/権限/source エラー）でも emit は best-effort・noise-free を保つ: 未定義なら
+# no-op へフォールバック定義し、oe_event_message_sent 内の呼び出しが `command not found` を
+# stderr へ漏らすのを防ぐ（Copilot 指摘・oe-activity/oe-ack と同型の degrade）。
+declare -F oe_sanitize_conversation >/dev/null 2>&1 || oe_sanitize_conversation() { printf '%s' "$1"; }
 
 # delegate-registry.sh が source されない（_oe_reg_key を他所が定義済 等）/ 環境で未設定でも、
 # 未定義の state dir で `/${pid}_*.json` のように root 配下を誤って glob しないよう、registry と

--- a/projects/orchestration-engine/lib/sanitize.sh
+++ b/projects/orchestration-engine/lib/sanitize.sh
@@ -41,6 +41,10 @@ oe_sanitize_conversation() {
   # env typo で主防御が丸ごと無効化されるのを防ぐため、非数値は安全側の既定へ coerce する
   # （event-bus.sh の OE_EVENT_PREVIEW_MAX ガードと同方針・fail-open でなく fail-safe）。
   case "$max" in ''|*[!0-9]*) max=4000 ;; esac
+  # 先頭ゼロ（例 05・007）は数字のみガードを通るが、RFC 8259 が JSON 数値の先頭ゼロを禁じるため
+  # `jq --argjson max 05` は jq 版によっては parse 失敗し jq 経路ごと tr fallback へ縮退＝主防御が
+  # bypass されうる（Copilot 指摘）。10 進正規化して jq 版に依らず確実に数値を渡す（fail-safe 貫徹）。
+  max=$((10#$max))
   if command -v jq >/dev/null 2>&1; then
     if printf '%s' "$1" | jq -Rrs --argjson max "$max" '
         gsub("\\x1b\\[[0-9;?]*[ -/]*[@-~]"; "")

--- a/projects/orchestration-engine/lib/sanitize.sh
+++ b/projects/orchestration-engine/lib/sanitize.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+# sanitize.sh — 会話到達面向けの capture/preview サニタイズ（source 専用・#224）
+#
+# 長寿命・ツール密な orchestration 統括セッションで、子ペインの壊れた出力（生の
+# tool-call タグ列・box-drawing・制御文字）が会話コンテキストへ注入され、親が自己回帰で
+# 模倣して tool-call malform が連鎖する経路を断つための共有チョークポイント。
+# 「会話に載る文字列」を保存/投影する側が本 helper を通す（#224 は write-time 側＝
+# event-bus.sh:oe_event_message_sent が preview 保存前に通す）。
+#
+# 実装形態は oe-tree:sanitize_out と同型: jq を主エンジンにし、jq 不在時のみ tr へ縮退する。
+#
+# 除去 vs neutralize（DJ-2）: タグ列/court は「削除」でなく「無害化」する。削除は文脈を
+# 飛ばし隣接テキストを誤結合させ、誤爆（正当テキストの巻き込み）時の被害も大きい。
+# 無害化はトークンを壊して tool-call として解釈されない形にしつつ文脈を残す。
+
+# 会話へ載せる文字数の上限（codepoint）。<=0 で truncate 無効。
+OE_SANITIZE_MAX_CP="${OE_SANITIZE_MAX_CP:-4000}"
+
+# oe_sanitize_conversation <text>
+#   会話到達面へ載せる前の無害化結果を stdout へ返す。段階（順序に意味あり）:
+#     1. ANSI/CSI エスケープ列の除去（ESC 起点。cntrl 畳みより前＝ESC を潰す前に列ごと消す）
+#     2. tool-call タグ列の neutralize: "<" 直後に空白を挿入し、tool-call トークンとして連続
+#        しない形へ壊す（DJ-2）。対象は open/close 両方かつ短形・antml 名前空間形の両方:
+#          <invoke / </invoke / <function_calls / </function_calls / <… / </antml…
+#        issue 列挙の <invoke・<function_calls・</antml に加え、observed の短形 open と実構文の
+#        名前空間形をまとめて捕捉する（実装SO cursor 指摘の under-capture を塞ぐ）。<div> 等は不介入。
+#     3. 行頭孤立トークン court の neutralize: 行全体が court の行のみ [court] へ（DJ-3）。
+#        mid-sentence / 複数語行 / 識別子（"The court ruled" 等）は不介入＝正当テキストの誤爆防止。
+#        cntrl 畳みより前＝行境界(\n)が生きているうちに (?m) で判定する。
+#     4. box-drawing（U+2500–257F）の除去。
+#     5. 残る制御文字を空白へ（[[:cntrl:]]: ESC/US/CR/TAB/NL/DEL 等）。read 側の US 区切り
+#        protocol 防御（oe-activity/oe-ack の同 gsub）とは層が別（こちらは write-time の無害化）。
+#     6. codepoint 上限で truncate（超過時のみ末尾へ …）。
+#   jq 不在時は tr で制御文字のみ空白化する best-effort（タグ/box/court/truncate は無処理）。
+#   主消費者（event-bus.sh）は jq 必須経路なので、tr fallback は他所からの直呼び用の安全網。
+oe_sanitize_conversation() {
+  local max="${OE_SANITIZE_MAX_CP:-4000}"
+  # OE_SANITIZE_MAX_CP が非数値/空だと `jq --argjson max` が失敗 → jq 全体が失敗 → tag/box/court
+  # 無害化ごと tr fallback へ silent bypass し、raw preview が素通りする（実装SO=oe-review 検出）。
+  # env typo で主防御が丸ごと無効化されるのを防ぐため、非数値は安全側の既定へ coerce する
+  # （event-bus.sh の OE_EVENT_PREVIEW_MAX ガードと同方針・fail-open でなく fail-safe）。
+  case "$max" in ''|*[!0-9]*) max=4000 ;; esac
+  if command -v jq >/dev/null 2>&1; then
+    if printf '%s' "$1" | jq -Rrs --argjson max "$max" '
+        gsub("\\x1b\\[[0-9;?]*[ -/]*[@-~]"; "")
+        | gsub("<(?=antml:|/antml|/?invoke|/?function_calls)"; "< ")
+        | gsub("(?m)^[ \t]*court[ \t]*$"; "[court]")
+        | gsub("[\\x{2500}-\\x{257f}]"; "")
+        | gsub("[[:cntrl:]]"; " ")
+        | if ($max > 0 and (length > $max)) then (.[0:$max] + "…") else . end
+      ' 2>/dev/null; then
+      return 0
+    fi
+    # jq 実行失敗（想定外入力等）は tr fallback へ落ちる。
+  fi
+  printf '%s' "$1" | LC_ALL=C tr '\000-\037\177' ' '
+}

--- a/projects/orchestration-engine/lib/sanitize.sh
+++ b/projects/orchestration-engine/lib/sanitize.sh
@@ -13,7 +13,8 @@
 # 飛ばし隣接テキストを誤結合させ、誤爆（正当テキストの巻き込み）時の被害も大きい。
 # 無害化はトークンを壊して tool-call として解釈されない形にしつつ文脈を残す。
 
-# 会話へ載せる文字数の上限（codepoint）。<=0 で truncate 無効。
+# 会話へ載せる文字数の上限（codepoint）。0 で truncate 無効（明示的なエスケープハッチ）。
+# 負数・非数値は typo とみなし安全側の既定 4000 へ coerce する（下の guard 参照）＝無効化はしない。
 OE_SANITIZE_MAX_CP="${OE_SANITIZE_MAX_CP:-4000}"
 
 # oe_sanitize_conversation <text>

--- a/projects/orchestration-engine/tests/test_delegate_send.sh
+++ b/projects/orchestration-engine/tests/test_delegate_send.sh
@@ -145,14 +145,15 @@ MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_proc)" )
 oe_send_line "%5" "PAY11" >/dev/null 2>&1
 ck "edge processing は submitted 扱い・撃たない" "1" "$(enter_count)"
 
-echo "[12] finalize: stage_miss_suspect（一度も staged 観測せず空）→ warn のみ・撃たない・rc 不変"
+echo "[12] finalize: stage_miss_suspect（既定=opt-out）→ 撃たない・rc 不変・warn ノイズを出さない（#224）"
 reset_fin
 MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_empty)" )
 # サブシェル($(...))にすると MOCK_SENDKEYS_LOG が親に伝播しないため、stderr はファイルへ。
 rc=0; oe_send_line "%5" "PAY12" >/dev/null 2>"$ERRFILE" || rc=$?
 ck "stage_miss でも rc=0（rc 透過）" "0" "$rc"
 ck "stage_miss は撃たない（transport の1回のみ）" "1" "$(enter_count)"
-ck "stage_miss warn を出す" "yes" "$(grep -q 'possible stage miss' "$ERRFILE" && echo yes || echo no)"
+# #224: 既定パス（SIGNAL_MISS 未設定）は rc も変えない no-op なので warn は純ノイズ → 抑制する。
+ck "stage_miss(既定) は warn を出さない（#224 ノイズ抑制）" "no" "$(grep -q 'possible stage miss' "$ERRFILE" && echo yes || echo no)"
 
 echo "[13] finalize: base_staged（送信前から入力欄に内容）→ 無条件 unknown・撃たない"
 reset_fin
@@ -227,12 +228,26 @@ MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_empty)" )
 rc=0; OE_SEND_SIGNAL_MISS=1 oe_send_line "%5" "PAY22" >/dev/null 2>"$ERRFILE" || rc=$?
 ck "opt-in 時の未着候補は rc=4" "4" "$rc"
 ck "rc=4 でも追加 submit しない（transport の Enter 1回のみ）" "1" "$(enter_count)"
+# #224: genuine な失敗シグナルは opt-in 側で残す（warn を出す）。既定[12]との対比。
+ck "opt-in 時は genuine signal として warn を出す（#224）" "yes" "$(grep -q 'possible stage miss' "$ERRFILE" && echo yes || echo no)"
 
 echo "[23] transport 失敗の明示伝播: send-keys 失敗 → rc=2（|| rc=\$? 文脈でも握り潰さない・#154 SO 指摘）"
 reset_fin
 MOCK_CAP_SEQ=( "$(scr_empty)" )
 rc=0; MOCK_SENDKEYS_FAIL=1 oe_send_line "%5" "PAY23" >/dev/null 2>&1 || rc=$?
 ck "send-keys 失敗は rc=2 で伝播（errexit に頼らない）" "2" "$rc"
+
+echo "[24] #224 payload-echo guard: payload を stdout に出さない（bin/oe-send もこの primitive を通す）"
+# oe-send / oe-delegate の送信実体は oe_send_line。payload を会話へ echo し返さない
+# （出すのは stderr の診断のみ）ことを回帰ロックする。stdout だけ捕捉し stderr は捨てる。
+reset_fin
+MOCK_CAP_SEQ=( "$(scr_empty)" "$(scr_staged 'GUARDPAY24')" )
+guard_out="$(oe_send_line "%5" "GUARDPAY24" 2>/dev/null)"
+ck "stdout に payload を出さない" "" "$(printf '%s' "$guard_out" | grep -F 'GUARDPAY24' || true)"
+# --no-enter（ステージのみ）でも stdout に出さない
+reset_fin
+guard_out2="$(oe_send_line "%5" "GUARDPAY24B" "0" 2>/dev/null)"
+ck "--no-enter でも stdout に payload を出さない" "" "$(printf '%s' "$guard_out2" | grep -F 'GUARDPAY24B' || true)"
 
 echo "=== RESULT: pass=${pass} fail=${fail} ==="
 [[ "$fail" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_event_bus.sh
+++ b/projects/orchestration-engine/tests/test_event_bus.sh
@@ -216,5 +216,23 @@ oe_event_report_received "%59" "%66" 1 "2026-07-02T10:30:00+00:00"
 ck "ack from.role empty (not label)" ""           "$(last | jq -r .from.role)"
 ck "ack from.label = pane-issue label" "#206 inbox" "$(last | jq -r .from.label)"
 
+echo "[17] #224: preview を write-time で無害化して保存（tool-call タグ/box-drawing/制御文字）"
+# 制御文字/box はソースにリテラル直書きせず printf 8進で生成（#224 NEGATIVE KNOWLEDGE）:
+#   \342\224\200 = U+2500 '─'（box-drawing） / \037 = US（制御文字）
+reset_events
+PL="$(printf '<invoke name="Bash">\342\224\200\037end')"
+oe_event_message_sent "%66" "%59" "$PL" "none"
+ck "stored preview sanitized" '< invoke name="Bash"> end' "$(last | jq -r .preview)"
+
+echo "[18] #224: 誤爆しない — 正当な court を含む送信の preview は壊れない"
+reset_events
+oe_event_message_sent "%66" "%59" "The court ruled today" "none"
+ck "legit court prose intact" "The court ruled today" "$(last | jq -r .preview)"
+
+echo "[19] #224: 100cp truncate（preview 長の責務）は helper 無害化後も従来どおり効く"
+reset_events
+oe_event_message_sent "%66" "%59" "$(printf 'あ%.0s' {1..150})" "none"
+ck "still 100+… after sanitize" "101" "$(last | jq -r '.preview|length')"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_ack.sh
+++ b/projects/orchestration-engine/tests/test_oe_ack.sh
@@ -149,5 +149,13 @@ OUT9b="$(env PATH="$STUB_BIN:$PATH" TMUX="oe,${PID},0" TMUX_PANE="%59" OE_EVENT_
 ckc "回復後は no-op"           "$OUT9b" "nothing to ack"
 ck  "行数不変"                 "$before9" "$(grep -c '' "$PARTIAL")"
 
+echo "[13] #224: preview echo（会話到達面）を read 側で無害化（legacy/破損 raw preview 対策・実装SO 検出）"
+mkdir -p "$_TMP_DIR/rawtag"
+# raw <invoke> を含む未ack report を置く → pending>0 で echo 経路に入り、最終 preview が無害化される
+printf '%s\n' '{"ts":"2026-07-03T09:00:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"<invoke name=\"Bash\">raw","delivery_signal":"none"}' > "$_TMP_DIR/rawtag/oe-events.jsonl"
+RTACK="$(env PATH="$STUB_BIN:$PATH" TMUX="oe,${PID},0" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/rawtag" bash "$OE_ACK" '%66' 2>&1)"
+ckc "ack echo: tag neutralized (< invoke)" "$RTACK" "< invoke"
+if printf '%s' "$RTACK" | grep -qF '<invoke'; then echo "  FAIL: ack echo に raw <invoke 残存"; FAIL=$((FAIL+1)); else echo "  PASS: ack echo の raw <invoke 除去"; PASS=$((PASS+1)); fi
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_activity.sh
+++ b/projects/orchestration-engine/tests/test_oe_activity.sh
@@ -257,5 +257,20 @@ ck "overview に PENDING ヘッダは無い" "0" "$(printf '%s\n' "$AOV" | sed -
 ck  "overview trips は kick 込み 5"    "5" "$(printf '%s' "$ov66" | awk '{print $2}')"
 ckc "overview 最新 preview"            "$ov66" "ACK-R4-NEW"
 
+echo "[22] #224: read 側で raw preview の tool-call タグ列/box-drawing を無害化（legacy/破損 event 対策・実装SO 検出）"
+mkdir -p "$_TMP_DIR/rawtag"
+# legacy/破損で jsonl に raw <invoke> + box-drawing(U+2500 は JSON ─) が残った状況を再現。
+# write-time サニタイズを経ていない raw preview が会話面へ再露出しないことを検証（ゲート要件）。
+{
+  printf '%s\n' '{"ts":"2026-06-22T18:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"p"},"to":{"pane":"%66","role":"child","label":"c"}}'
+  printf '%s\n' '{"ts":"2026-06-22T18:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"c"},"to":{"pane":"%59","role":"parent","label":"p"},"preview":"<invoke name=\"Bash\">─BOX","delivery_signal":"none"}'
+} > "$_TMP_DIR/rawtag/oe-events.jsonl"
+RT="$(env PATH="$STUB_BIN:$PATH" TMUX_PANE="%59" OE_EVENT_DIR="$_TMP_DIR/rawtag" bash "$OE_ACTIVITY" --timeline)"
+ckc "read: tag neutralized (< invoke)" "$RT" "< invoke"
+if printf '%s' "$RT" | grep -qF '<invoke'; then echo "  FAIL: raw <invoke 残存"; FAIL=$((FAIL+1)); else echo "  PASS: raw <invoke 除去"; PASS=$((PASS+1)); fi
+_BOXC="$(printf '\342\224\200')"
+if printf '%s' "$RT" | LC_ALL=C grep -qF "$_BOXC"; then echo "  FAIL: box-drawing 残存"; FAIL=$((FAIL+1)); else echo "  PASS: box-drawing 除去"; PASS=$((PASS+1)); fi
+ckc "read: 周辺テキスト BOX 残存" "$RT" "BOX"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_sanitize.sh
+++ b/projects/orchestration-engine/tests/test_sanitize.sh
@@ -81,6 +81,9 @@ ck "空白のみでも tag 無害化"     '< invoke x>' "$(OE_SANITIZE_MAX_CP=' 
 ck "空値でも tag 無害化"         '< invoke x>' "$(OE_SANITIZE_MAX_CP='' oe_sanitize_conversation '<invoke x>')"
 # 負数は無効化(disable)でなく coerce（jq が走り tag 無害化される＝silent bypass しない・Copilot 指摘）
 ck "負数は coerce・無効化しない"  '< invoke x>' "$(OE_SANITIZE_MAX_CP=-5 oe_sanitize_conversation '<invoke x>')"
+# 先頭ゼロは 10 進正規化され jq 版に依らず数値化される＝tr fallback へ縮退せず bypass しない（Copilot 指摘）
+ck "先頭ゼロ 050 正規化・bypass しない" '< invoke x>' "$(OE_SANITIZE_MAX_CP=050 oe_sanitize_conversation '<invoke x>')"
+ck "先頭ゼロ 05 は 5 として truncate"   'abcde…'      "$(OE_SANITIZE_MAX_CP=05 oe_sanitize_conversation 'abcdef')"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_sanitize.sh
+++ b/projects/orchestration-engine/tests/test_sanitize.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# test_sanitize.sh — lib/sanitize.sh:oe_sanitize_conversation の単体テスト（#224）
+#
+# 検証: tool-call タグ列/box-drawing/制御文字の無害化・truncate・**誤爆しない**
+#       （court を含む正常英文/コード・比較演算子の < が壊れない）。
+# 実 tmux 不要。jq は実体（fallback 経路は PATH からmasking して別途検証）。
+#
+# fixture 方針（#224 NEGATIVE KNOWLEDGE）: 制御文字/ESC/box-drawing をソースに**リテラル直書き
+# しない**。JSON/jq を壊す & レビュー不能になるため、すべて printf の 8 進エスケープで生成する
+#   ESC=\033  US=\037  DEL=\177  box(U+2500 系)=\342\224\200 等
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+# shellcheck source=../lib/sanitize.sh
+source "$PROJECT_DIR/lib/sanitize.sh"
+
+PASS=0; FAIL=0
+ck() { # <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1));
+  else echo "  FAIL: $1"; echo "     want=[$2]"; echo "     got =[$3]"; FAIL=$((FAIL+1)); fi
+}
+
+echo "[1] tool-call タグ列の neutralize（short/名前空間・open/close）"
+ck "invoke short open"       '< invoke name="Bash">'  "$(oe_sanitize_conversation '<invoke name="Bash">')"
+ck "invoke ns open"          "$(printf '< %s:invoke>' antml)"  "$(oe_sanitize_conversation "$(printf '<%s:invoke>' antml)")"
+ck "function_calls open"     '< function_calls>'      "$(oe_sanitize_conversation '<function_calls>')"
+ck "invoke short close"      'x < /invoke> y'         "$(oe_sanitize_conversation 'x </invoke> y')"
+ck "antml ns close"          "$(printf 'x < /%s:invoke> y' antml)"  "$(oe_sanitize_conversation "$(printf 'x </%s:invoke> y' antml)")"
+
+echo "[2] 誤爆しない（over-capture 防止）"
+ck "plain <div> untouched"   '<div>'                  "$(oe_sanitize_conversation '<div>')"
+ck "less-than op untouched"  'a < b and c<d'          "$(oe_sanitize_conversation 'a < b and c<d')"
+
+echo "[3] 行頭孤立 court のみ neutralize（DJ-3・誤爆防止が最重要）"
+ck "isolated court"          '[court]'                "$(oe_sanitize_conversation 'court')"
+ck "court + trailing ws"     '[court]'                "$(oe_sanitize_conversation 'court   ')"
+ck "prose court untouched"   'The court ruled today'  "$(oe_sanitize_conversation 'The court ruled today')"
+ck "courthouse untouched"    'courthouse'             "$(oe_sanitize_conversation 'courthouse')"
+ck "mid court untouched"     'go to court now'        "$(oe_sanitize_conversation 'go to court now')"
+ck "code court untouched"    'const court = 1;'       "$(oe_sanitize_conversation 'const court = 1;')"
+
+echo "[4] box-drawing 除去（U+2500 系: ─ │ ┌ ╮ を printf 8進で生成）"
+ck "box removed"             'ab'  "$(oe_sanitize_conversation "$(printf 'a\342\224\200\342\224\202\342\224\214\342\225\256b')")"
+
+echo "[5] 制御文字の除去/無害化（ESC/ANSI/US/CR/DEL を printf 8進で生成）"
+ck "ANSI CSI removed"        'ared'  "$(oe_sanitize_conversation "$(printf 'a\033[31mred\033[0m')")"
+ck "US -> space"             'a b'   "$(oe_sanitize_conversation "$(printf 'a\037b')")"
+ck "CR -> space"             'a b'   "$(oe_sanitize_conversation "$(printf 'a\015b')")"
+ck "DEL -> space"            'a b'   "$(oe_sanitize_conversation "$(printf 'a\177b')")"
+
+echo "[6] truncate（codepoint 上限・マルチバイト安全）"
+ck "truncate fires"          'abcde…'  "$(OE_SANITIZE_MAX_CP=5 oe_sanitize_conversation 'abcdefghij')"
+ck "no truncate under max"   'abc'     "$(OE_SANITIZE_MAX_CP=5 oe_sanitize_conversation 'abc')"
+ck "truncate multibyte-safe" "$(printf '\343\201\202%.0s' $(seq 1 5))…" "$(OE_SANITIZE_MAX_CP=5 oe_sanitize_conversation "$(printf '\343\201\202%.0s' $(seq 1 10))")"
+ck "max<=0 disables"         'abcdefghij' "$(OE_SANITIZE_MAX_CP=0 oe_sanitize_conversation 'abcdefghij')"
+
+echo "[7] 複合（1 入力に複数ハザード）"
+ck "combined"                '[court]'  "$(oe_sanitize_conversation 'court')"
+ck "tag + box + ctrl"        '< invoke x> b'  "$(oe_sanitize_conversation "$(printf '<invoke x>\342\224\200\037b')")"
+
+echo "[8] jq 不在 fallback（tr で制御文字のみ空白化・タグ/box/court は無処理・best-effort）"
+# jq は /usr/bin にも在る（システム jq）ため PATH をシステム dir に絞っても jq が残る。
+# tr だけを symlink した専用 dir を唯一の PATH にして「jq 不在・tr あり」を厳密に作る。
+_FBBIN="$(mktemp -d)"; ln -s "$(command -v tr)" "$_FBBIN/tr"
+# 関数は source 済み。引数は printf(builtin) で先に展開し、関数実行時のみ PATH を絞る
+# （command -v jq が $_FBBIN に無く失敗→tr fallback へ）。fresh bash を起こさないので bash 解決不要。
+_fbin="$(printf 'a\037<invoke>')"
+fb="$(PATH="$_FBBIN" oe_sanitize_conversation "$_fbin")"
+rm -rf "$_FBBIN"
+# fallback は制御文字（US \037）のみ空白化。タグ <invoke> は無処理で残る（best-effort の明示）。
+ck "fallback strips control, tags untouched" 'a <invoke>' "$fb"
+
+echo "[9] 環境値ガード: OE_SANITIZE_MAX_CP 非数値でも tag 無害化を silent bypass しない（実装SO 検出）"
+# 非数値だと jq --argjson が失敗し tr fallback（制御文字のみ）へ落ちて tag が素通る回帰を防ぐ。
+ck "非数値 abc でも tag 無害化"  '< invoke x>' "$(OE_SANITIZE_MAX_CP=abc oe_sanitize_conversation '<invoke x>')"
+ck "空白のみでも tag 無害化"     '< invoke x>' "$(OE_SANITIZE_MAX_CP=' ' oe_sanitize_conversation '<invoke x>')"
+ck "空値でも tag 無害化"         '< invoke x>' "$(OE_SANITIZE_MAX_CP='' oe_sanitize_conversation '<invoke x>')"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_sanitize.sh
+++ b/projects/orchestration-engine/tests/test_sanitize.sh
@@ -56,7 +56,7 @@ echo "[6] truncate（codepoint 上限・マルチバイト安全）"
 ck "truncate fires"          'abcde…'  "$(OE_SANITIZE_MAX_CP=5 oe_sanitize_conversation 'abcdefghij')"
 ck "no truncate under max"   'abc'     "$(OE_SANITIZE_MAX_CP=5 oe_sanitize_conversation 'abc')"
 ck "truncate multibyte-safe" "$(printf '\343\201\202%.0s' $(seq 1 5))…" "$(OE_SANITIZE_MAX_CP=5 oe_sanitize_conversation "$(printf '\343\201\202%.0s' $(seq 1 10))")"
-ck "max<=0 disables"         'abcdefghij' "$(OE_SANITIZE_MAX_CP=0 oe_sanitize_conversation 'abcdefghij')"
+ck "max=0 disables truncate" 'abcdefghij' "$(OE_SANITIZE_MAX_CP=0 oe_sanitize_conversation 'abcdefghij')"
 
 echo "[7] 複合（1 入力に複数ハザード）"
 ck "combined"                '[court]'  "$(oe_sanitize_conversation 'court')"
@@ -79,6 +79,8 @@ echo "[9] 環境値ガード: OE_SANITIZE_MAX_CP 非数値でも tag 無害化�
 ck "非数値 abc でも tag 無害化"  '< invoke x>' "$(OE_SANITIZE_MAX_CP=abc oe_sanitize_conversation '<invoke x>')"
 ck "空白のみでも tag 無害化"     '< invoke x>' "$(OE_SANITIZE_MAX_CP=' ' oe_sanitize_conversation '<invoke x>')"
 ck "空値でも tag 無害化"         '< invoke x>' "$(OE_SANITIZE_MAX_CP='' oe_sanitize_conversation '<invoke x>')"
+# 負数は無効化(disable)でなく coerce（jq が走り tag 無害化される＝silent bypass しない・Copilot 指摘）
+ck "負数は coerce・無効化しない"  '< invoke x>' "$(OE_SANITIZE_MAX_CP=-5 oe_sanitize_conversation '<invoke x>')"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 目的 / 背景

長寿命・ツール密な orchestration 統括セッションで、子ペインの壊れた出力（生の tool-call タグ列・box-drawing・制御文字）が capture 経由で親コンテキストへ注入され、親が自己回帰で模倣して tool-call malform が連鎖・悪化する。本 PR は **capture サニタイズ核（第一増分）** として、その最大レバレッジの具体核だけを潰す（一発全解ではなく頻度を下げる反復の第一歩）。

実査の結果、oe-* で「生の会話到達面」は **event-bus の message preview**（`oe-activity` / `oe-ack` が読む同一 field）だった。primary な malform 経路（エージェントが生 `wez pane capture` / `tmux capture-pane` を直叩き→貼付）は oe-* の外＝本 PR のスコープ外（behavioral 側で別途）。

## 変更内容

- **`lib/sanitize.sh`（新規）**: 共有 helper `oe_sanitize_conversation`（jq 主・bash 3.2 は `tr` fallback、`oe-tree:sanitize_out` 同型）。
  - tool-call タグ列を **neutralize**（削除でなく無害化＝文脈保持・誤爆被害最小）。short 形と `antml:` 名前空間形の open/close を捕捉。
  - **行頭孤立 `court` のみ** neutralize（`(?m)^[ \t]*court[ \t]*$`）。正当英文 "The court ruled" / `courthouse` / コード識別子は不介入。
  - box-drawing（U+2500–257F）・制御文字・ANSI/CSI を除去。codepoint truncate。
  - `OE_SANITIZE_MAX_CP` 非数値は安全側の既定へ coerce（env typo で主防御が silent bypass するのを防ぐ・fail-safe）。
- **`lib/event-bus.sh`**: preview を保存前に **write-time** で無害化（新規 event を log 時点で clean 化）。best-effort（失敗時は raw で続行・`set -e` 下でも安全）。
- **`bin/oe-activity` / `bin/oe-ack`**: **read-time** でも共有 helper を通す。write-time は新規 event しか覆えず、legacy / 破損 / write 失敗の raw preview が会話面へ再露出しうるため（実装SO 検出）。jq の `[[:cntrl:]]` gsub は US 区切りの protocol 防御として別役割で温存。
- **`lib/delegate-send.sh`**: `stage miss` 警告を opt-in（`OE_SEND_SIGNAL_MISS=1`）にゲート。既定は fast-submit 誤検知が多く rc も変えない no-op ゆえ純ノイズなので抑制。genuine な失敗シグナルは opt-in 側に残す。

## 設計判断（証跡）

- **予決定探索**（`oe-refute --rubric exploration`・2 レーン）: 当初の「read-time・`oe-activity` のみ」案は **refuted**。`oe-ack` が同一 preview field の 2 つ目 consumer である点を見落としていた。→ **write-time**（event-bus 1 箇所で全 consumer カバー）へ再導出し確定。
- **実装SO**（`oe-review`・2 レーン）: write-time only は (A) `OE_SANITIZE_MAX_CP` 非数値で tag 無害化が silent bypass、(B) read 側が legacy/破損 raw preview を無害化しない、の 2 欠陥で **refuted**。→ **write+read 併用 ＋ env guard** に是正（helper は冪等なので二重適用は安全）。再レビューで **survived**。

## テスト / ゲート

- `tests/test_sanitize.sh`（新規・28 ケース）: 無害化 / truncate / **誤爆しない** / env guard / jq 不在 fallback。
- `tests/test_event_bus.sh`: write-time サニタイズ・100cp truncate 併存・誤爆しない。
- `tests/test_oe_activity.sh` / `tests/test_oe_ack.sh`: **read 側**で raw preview のタグ列/box を無害化。
- `tests/test_delegate_send.sh`: `stage miss` ノイズ抑制（既定 off / opt-in on）・payload-echo guard。
- `shellcheck` rc=0（変更ファイル全て）。
- engine テスト suite（27 ファイル）が **bash 3.2.57 と 5.2.37 両系で green**（#231 の 3.2 互換化を rebase 済み）。

## スコープ外 / follow-up（本 PR では実装せず）

- **primary 経路**（生 `wez pane capture` / `tmux capture-pane` の直貼付）の抑止＝behavioral / 運用ガイド / エージェント規律。真のレバーだが文字列制御では消えない。
- `oe-select` の fzf `--preview`（生 `tmux capture-pane` を TUI 描画）: live pane 由来の別データソースで event-log 非経由。人間向け TUI ＝会話ベクタは弱いが未サニタイズ。
- 根因調査（コンテキスト汚染 vs 長コンテキスト劣化の切り分け・実証）／ Phase 5（#105 / #108）設計入力。
- タグ under-capture の残余（低 materiality）: 短形の close（`</invoke>` 等）は `</antml` 名前空間 close のみ捕捉、行頭 `Court`（大文字）は case-sensitive で不介入。observed malform（小文字短形 open ＋ 名前空間 close）は捕捉済み。

Refs #224
