### PR TITLE
fix(oe): --task-file の異常系（空/不在/不正パス）を明示エラー + exit 2 で validation

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -19,6 +19,8 @@ bash bin/oe "タスク記述"
 bash bin/oe --task-file <path>
 ```
 
+- `--task-file <path>` の異常系は暗黙にフォールバックせず、明示エラーを stderr に出して **exit 2**（usage エラー）で弾く（#99）。対象: パス未指定 / 不在パス / ディレクトリ / 非通常ファイル / 読めない（権限）/ **空ファイル**（空は既定タスクへ暗黙フォールバックしていた挙動を廃止）。
+
 関連 lib: `envelope.sh` / `spawn.sh` / `capture.sh` / `verify.sh` / `monitor.sh` / `audit.sh` / `cleanup.sh` / `constants.sh`
 
 ## oe-capture — ペイン capture（本体エンジン補助）

--- a/projects/orchestration-engine/bin/oe
+++ b/projects/orchestration-engine/bin/oe
@@ -45,15 +45,36 @@ oe_main() {
   # 後方互換: bin/oe "<text>" 形式も引き続き動作。
   local task_description
   if [[ "${1:-}" == "--task-file" ]]; then
-    if [[ -z "${2:-}" ]]; then
+    # --task-file 異常系の仕様 (#99): 空 / 不在 / 不正パス (ディレクトリ・非通常ファイル・権限) を
+    # 明示エラー + exit 2 (usage エラー) で弾く。文言・exit code は bin/oe-capture の validation
+    # 規約に揃える。これにより「空ファイルが暗黙に既定タスクへフォールバック」「読めないファイルが
+    # set -e 下の cat 失敗で exit 1 + 生エラー」といった暗黙挙動を排除する。
+    local task_file="${2:-}"
+    if [[ -z "$task_file" ]]; then
       echo "oe: --task-file requires a path argument" >&2
       return 2
     fi
-    if [[ ! -f "$2" ]]; then
-      echo "oe: --task-file: file not found: $2" >&2
+    if [[ ! -e "$task_file" ]]; then
+      echo "oe: --task-file: file not found: $task_file" >&2
       return 2
     fi
-    task_description="$(cat "$2")"
+    if [[ -d "$task_file" ]]; then
+      echo "oe: --task-file: path is a directory, not a file: $task_file" >&2
+      return 2
+    fi
+    if [[ ! -f "$task_file" ]]; then
+      echo "oe: --task-file: not a regular file: $task_file" >&2
+      return 2
+    fi
+    if [[ ! -r "$task_file" ]]; then
+      echo "oe: --task-file: file not readable: $task_file" >&2
+      return 2
+    fi
+    if [[ ! -s "$task_file" ]]; then
+      echo "oe: --task-file: file is empty: $task_file" >&2
+      return 2
+    fi
+    task_description="$(cat "$task_file")"
     shift 2
   fi
   task_description="${task_description:-${*:-Run orchestration task}}"

--- a/projects/orchestration-engine/docs/episodes/2026-07-06-episode-99-task-file-error-handling.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-06-episode-99-task-file-error-handling.md
@@ -1,0 +1,59 @@
+---
+id: "01KWTX1QBXHWZWD4JQAAFWQAGG"
+title: "#99 episode — oe --task-file の異常系（空/不在/不正パス）を明示エラー + exit 2 で validation"
+date: 2026-07-06
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/99"
+    reason: "--task-file の異常系が未処理で暗黙挙動だった点を、明示エラー + exit 2 で validation"
+  - type: reuse
+    ref: "projects/orchestration-engine/bin/oe-capture"
+    reason: "既存 validation 規約（echo >&2 + return 2 = usage エラー）を踏襲・新規発明しない"
+tags: [orchestration, oe, task-file, validation, error-handling, exit-code, bash-3.2, episode, reconstructed]
+---
+
+# #99 episode — oe `--task-file` 異常系の validation
+
+> `reconstructed`: リアルタイム追記でなく closure 時（実装完了後・PR/レビュー前）に再構成。証拠価値はリアルタイム追記ログと同列に扱わない。
+
+親（統括）からの委譲子セッションとして #99 を実装。人間とのやり取りはこのペインで直接、完了確認のみ親へ。マージ・worktree 掃除はしない。
+
+## Context / なぜ
+
+`bin/oe --task-file <path>` は Step 4-4（#91）で「Markdown を shell expansion 経由で渡す破綻を避ける」ために追加された入口。だが異常系が半端で、**暗黙挙動**が残っていた。特に空ファイルが問題で、これは Step 4-4 の episode 時点で派生 Issue 候補として明示的に surface されていた（`docs/episodes/2026-05-18-episode-step-4-4-implementation.md` の「派生2」）。本 issue はそれを回収する内向きブラッシュアップ。
+
+## closure gate
+
+- 次の消費者: PR レビュアー（人間 / Copilot）と、`--task-file` の異常系仕様を参照する将来の engine 変更者。`bin/README.md` の oe 節に仕様を 1 行反映済み。
+- follow-up routing:
+  - 空白のみファイル（改行/空白だけで非0バイト）: 本 PR は「空 = 0バイト（`-s`）」に限定し、空白のみは素通り（→ `task_description` に空白が入る）。**追わない（defer）** — issue の「空ファイル」は 0バイトと解釈、Minimal Scope。実害（空白タスクで spawn）が観測されたら別 issue 化。親へ out-of-scope finding として申し送る。
+- status: stable。達成度 = **達成**（異常系3種＝空/不在/不正パスを exit 2 で弾き、テスト + 両 bash ゲート + shellcheck 通過）。
+
+## 決定と根拠（コード/diff から復元できない「なぜ」）
+
+- **exit code は全ケース 2**: 迷いなし。`bin/oe-capture` の usage/format エラーが `echo >&2 + return 2` で一貫しており、既存 `--task-file` チェック（パス未指定/不在）も既に return 2 だった。新規発明せず踏襲。→ kickoff の「exit code 規約に迷いがあれば predecision-exploration」は不要と判断（迷いが無い）。
+- **「空」を `-s`（0バイト）で判定・空白のみは対象外**: 棄却案 = 読み込み後に `${content//[[:space:]]/}` で内容ベース判定（空白のみも捕捉）。棄却理由 = (1) issue の文言が「空ファイル」= 0バイトを指す (2) `-s` は cat 前の安価な stat で、`file is empty` という曖昧さのない文言に 1:1 対応 (3) Minimal Scope + edge は出たら対応（exhaustion-before-conclusion §Scope の ~80% 方針）。
+- **不正パスをディレクトリ/非通常ファイル/権限に分解**: 旧実装は `! -f` 一本で、ディレクトリを「file not found」と誤報し、読めないファイルは `-f` を通過して `set -e` 下の `cat` 失敗で **exit 1 + 生の cat エラー**に化けていた（= 暗黙挙動）。`-e`→`-d`→`! -f`→`! -r`→`! -s` の順に分解し、各々固有文言 + exit 2 に統一。順序が意味を持つ（`-d` を `! -f` より先に置かないと「is a directory」を出せない／`-r` を `cat` より前に置かないと exit 1 に化ける）。
+
+## わかったこと（W）
+
+- 空ファイルの暗黙フォールバック経路は `task_description="$(cat "$2")"`（空）→ `task_description="${task_description:-${*:-Run orchestration task}}"` の連鎖。`:-` が空文字も unset 扱いするため、ユーザーが渡したつもりのタスクが黙って既定 `"Run orchestration task"` に化けて spawn まで到達していた。
+- 異常系は全て `oe_board_apply`（= 最初の wez 接触）より前に return するため、テストは wez なしで subprocess 実行できる（temp `OE_DATA_DIR` で state/audit を隔離）。`bin/oe` は末尾で `oe_main` を無条件実行し source できないため、subprocess が唯一の検証手段。
+- テストの両 bash 系ゲートを実効化するため、内側 `bin/oe` を `"$BASH"`（テスト実行中のインタプリタ）で起動した（`bash`(PATH) 任せだと 3.2 で回しても内側が 5.x になり得る）。
+
+## 蒸留シグナル
+
+なし。既存パターン（oe-capture validation・ADR-005 bash 3.2 互換）の適用に留まり、Decision / skill / rule 昇格候補なし。
+
+## SO / Step4 の扱い
+
+- 実装SO（oe-review）省略: 設計判断が薄く（exit 2 は既存パターンで一意）、客観ゲート（異常系テスト + 両 bash green + shellcheck rc=0）が合否を機械判定する。kickoff の省略許可に従い明記。
+- Step4（外部 closure チェック）: 本 episode は standard tier（heavy トリガ該当なし＝失敗/撤回なし・意図的 SO なし・調査主成果でない・非自明設計判断なし・昇格候補なし）。Step4 は heavy 限定のため対象外。
+
+## テスト結果
+
+- `tests/test_oe_task_file.sh`（新規・5 ケース10 アサーション）: 空/不在/ディレクトリ/パス未指定/権限なし → 全て exit 2 + 期待文言。bash 3.2.57・5.2.37 両系 green。
+- engine 全 suite（`tests/test_*.sh` 28 ファイル）: 両 bash 系で red=0。
+- `shellcheck bin/oe tests/test_oe_task_file.sh` rc=0。

--- a/projects/orchestration-engine/tests/test_oe_task_file.sh
+++ b/projects/orchestration-engine/tests/test_oe_task_file.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_task_file.sh — bin/oe --task-file の異常系 validation 検証 (#99)。
+#
+# 異常系 3 種 (空ファイル / 不在パス / 不正パス=ディレクトリ・非通常ファイル・権限) が
+# 明示エラー + exit 2 で弾かれ、暗黙の既定タスクフォールバックや set -e 下の cat 失敗 (exit 1) に
+# 陥らないことを検証する。異常系は spawn (oe_board_apply / wez) 到達前に return するため wez 不要
+# (temp OE_DATA_DIR で state/audit を隔離)。
+#
+# bin/oe は末尾で oe_main を無条件実行するため source できない。よって subprocess 実行で検証する。
+# 内側の bin/oe は本テストと同じ bash (${BASH}) で起動し、bash 3.2 / 5.x 両系ゲートを実効化する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OE="$PROJECT_DIR/bin/oe"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+export OE_DATA_DIR="$_TMP_DIR"   # engine の state/audit を temp に隔離 (実 ~/.claude を汚さない)
+
+PASS=0; FAIL=0
+ck()    { if [[ "$2" == "$3"    ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
+cksub() { if [[ "$3" == *"$2"*  ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want substr=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
+
+# 異常系は stdout に何も出さず stderr にエラーを出して exit 2。combined capture で message を検証する。
+RUN_RC=0; RUN_ERR=""
+run() {
+  local out rc=0
+  out="$("$BASH" "$OE" "$@" 2>&1)" || rc=$?
+  RUN_RC="$rc"; RUN_ERR="$out"
+}
+
+echo "[1] 空ファイル: 暗黙に既定タスクへフォールバックせず exit 2"
+empty="$_TMP_DIR/empty.md"; : > "$empty"
+run --task-file "$empty"
+ck    "exit 2"  "2" "$RUN_RC"
+cksub "message" "file is empty" "$RUN_ERR"
+
+echo "[2] 不在パス: exit 2"
+run --task-file "$_TMP_DIR/does-not-exist.md"
+ck    "exit 2"  "2" "$RUN_RC"
+cksub "message" "file not found" "$RUN_ERR"
+
+echo "[3] 不正パス (ディレクトリ): 'file not found' でなく 'is a directory' で exit 2"
+adir="$_TMP_DIR/adir"; mkdir -p "$adir"
+run --task-file "$adir"
+ck    "exit 2"  "2" "$RUN_RC"
+cksub "message" "is a directory" "$RUN_ERR"
+
+echo "[4] パス引数なし: exit 2"
+run --task-file
+ck    "exit 2"  "2" "$RUN_RC"
+cksub "message" "requires a path argument" "$RUN_ERR"
+
+echo "[5] 不正パス (読めない=権限なし): set -e の cat 失敗 (exit 1) でなく exit 2"
+if [[ "$(id -u)" -ne 0 ]]; then
+  noread="$_TMP_DIR/noread.md"; echo "task" > "$noread"; chmod 000 "$noread"
+  run --task-file "$noread"
+  ck    "exit 2"  "2" "$RUN_RC"
+  cksub "message" "not readable" "$RUN_ERR"
+  chmod u+rwx "$noread" 2>/dev/null || true
+else
+  echo "  SKIP: root では -r が権限ビットを迂回するため権限ケースを飛ばす"
+fi
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_task_file.sh
+++ b/projects/orchestration-engine/tests/test_oe_task_file.sh
@@ -55,7 +55,20 @@ run --task-file
 ck    "exit 2"  "2" "$RUN_RC"
 cksub "message" "requires a path argument" "$RUN_ERR"
 
-echo "[5] 不正パス (読めない=権限なし): set -e の cat 失敗 (exit 1) でなく exit 2"
+echo "[5] 不正パス (非通常ファイル=FIFO): 'file not found' でなく 'not a regular file' で exit 2"
+# ディレクトリは -d 分岐で先に return するため ! -f 分岐は素通りする。FIFO で ! -f 分岐を直接カバーする。
+# ! -f は cat 前に return 2 するため FIFO 読取でブロックしない。
+if command -v mkfifo >/dev/null 2>&1; then
+  fifo="$_TMP_DIR/afifo"; mkfifo "$fifo"
+  run --task-file "$fifo"
+  ck    "exit 2"  "2" "$RUN_RC"
+  cksub "message" "not a regular file" "$RUN_ERR"
+  rm -f "$fifo"
+else
+  echo "  SKIP: mkfifo 不在"
+fi
+
+echo "[6] 不正パス (読めない=権限なし): set -e の cat 失敗 (exit 1) でなく exit 2"
 if [[ "$(id -u)" -ne 0 ]]; then
   noread="$_TMP_DIR/noread.md"; echo "task" > "$noread"; chmod 000 "$noread"
   run --task-file "$noread"


### PR DESCRIPTION
## 概要

`bin/oe --task-file <path>` の異常系（空 / 不在 / 不正パス）を明示エラー + `exit 2` で弾く validation を追加。現状これらが未処理で暗黙の挙動になっていた点を解消する。

Refs #99, #91

## 背景

`--task-file` は #91（Step 4-4）で Markdown を shell expansion 経由で渡す破綻を避けるために追加された入口だが、異常系が半端だった。空ファイルの挙動明記は Step 4-4 episode の派生2 として surface 済み。

| ケース | 修正前 | 修正後 |
|---|---|---|
| パス未指定 | `exit 2`（既対応） | 維持 |
| 不在パス | `file not found` / `exit 2`（既対応） | 維持 |
| **空ファイル** | `cat` 空 → 既定タスク `"Run orchestration task"` へ**暗黙フォールバック**して spawn 続行 | `file is empty` / `exit 2` |
| ディレクトリ | `! -f` に落ち `file not found`（存在するのに誤報） | `path is a directory` / `exit 2` |
| 読めない（権限） | `-f` 通過 → `set -e` 下の `cat` 失敗で `exit 1` + 生の cat エラー | `file not readable` / `exit 2` |

## 変更内容

- `bin/oe`: `--task-file` の validation を `-e`（不在）→ `-d`（ディレクトリ）→ `! -f`（非通常ファイル）→ `! -r`（権限）→ `! -s`（空）の順に分解し、各々固有文言 + `exit 2` に統一。文言・exit code は `bin/oe-capture` の usage エラー規約を踏襲。
- `tests/test_oe_task_file.sh`（新規）: 異常系5ケース（空/不在/ディレクトリ/パス未指定/権限なし）を subprocess 実行で `exit 2` + 期待文言を検証。
- `bin/README.md`: oe 節に `--task-file` 異常系の仕様を1行反映。
- episode closure（`docs/episodes/2026-07-06-episode-99-task-file-error-handling.md`）。

## テスト

- `tests/test_oe_task_file.sh`（新規・5ケース10アサーション）: bash 3.2.57 / 5.2.37 両系で green。
- engine 全 suite（`tests/test_*.sh` 28ファイル）: 両 bash 系で red=0。
- `shellcheck bin/oe tests/test_oe_task_file.sh` rc=0。

## スコープ / 補足

- **Minimal Scope**: `--task-file` の異常系のみ。他の異常系・機能追加はしない。
- 実装SO（oe-review）は省略（設計判断が薄く exit 2 は既存パターンで一意・客観テストゲートで合否判定）。
- **follow-up（追わない）**: 「空」は 0バイト（`-s`）で判定。空白のみのファイル（改行/空白だけで非0バイト）は素通りする。issue の「空ファイル」を 0バイトと解釈した Minimal Scope の帰結。実害が観測されたら別 issue 化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
