### PR TITLE
feat(oe): 報告未達検知 watchdog oe-undelivered を追加（段階0・read-only）

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -6,7 +6,7 @@ scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
 - **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report` / `oe-ack`（受領印・#206A） / `oe-jump`（通知→ペインへ focus）
-- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox（PENDING=未受領数）/ timeline・#206）
+- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox（PENDING=未受領数）/ timeline・#206） / `oe-undelivered`（報告未達検知 watchdog・未ack 報告 × 時間窓・cron 可・#239 段階0）
 
 ---
 
@@ -398,6 +398,27 @@ bind-key v display-popup -E -x C -y C -w 70% -h 60% -T ' oe pick ' '/path/to/rep
 
 ---
 
+## oe-undelivered — 報告未達検知 watchdog（#239 段階0・read-only・cron 可）
+
+子→親の報告（`message_sent`）のうち、親が受領印（`report_received`・#220/#206A）を打っておらず（未ack）、かつ最古の未ack報告が**時間窓 W を越えた**ものを検出し、owner に ping する read-only 観測 verb。統括死亡 / send 無言失敗で報告が虚空へ消える経路（#239 mode3・チャネル脆弱）を、**#220 の frontier（未ack）＋時間次元**で決定論的に拾う（ペイン出力は capture しない）。
+
+```bash
+oe-undelivered                  # 既定窓 30 分（1800s）で報告未達を検出し owner ping
+oe-undelivered --window 3600    # 窓を 1 時間へ
+oe-undelivered -h | --help
+```
+
+- **検知（2条件）**: `pending>0`（未ack）かつ `age = now - 最古未ack報告の ts > W`。`$TMUX_PANE` に依存せず**全 (child→parent) ペアを横断**する（`oe-activity --inbox` の self 中心と違う）。親子の向きは `child_spawned` / `report_received` / role / known-parent の複合で解決し、departed で role 空になる子（mode3 主対象）も取りこぼさない。
+- **frontier**: `oe-ack` / `oe-activity` と**同一の read 規則**（`K = min(covers_count, |ts ≤ covers_last_ts|)`・複数 ack は max・巻き戻りなし）。ack ループ本体は再構築しない（`report_received` を consume）。
+- **出力**: stdout に FLAG 全件（cron ログ / 手動確認の durable signal）。owner ping は `wez notify`（best-effort）。**二重通知抑止**: verb 固有の seen cache（`${OE_EVENT_DIR}/oe-undelivered/seen`・キー `<child>|<parent>|<oldest_ts>`）に無い新規キーのみ notify。cache は verb 自身の bookkeeping で engine state ではない。
+- **read-only / 非検出**: 触れるのは `oe-events.jsonl` と tmux ペイン存在（mux query）のみ。engine state（events/registry/session-state）は mutate しない。exit は常に 0（observer）・usage エラーのみ 2。
+- **cron 例**（登録は owner 環境依存・自動化しない）: `*/15 * * * * /path/to/oe-undelivered >> "$HOME/.claude/state/oe-undelivered/cron.log" 2>&1`。cron 間隔と W は独立に調律する。
+- **注記**: `wez notify` の cron（no TTY / mux socket）到達性は未検証 → stdout が durable な signal。frontier read 規則は `oe-ack` / `oe-activity` に続く3つ目の copy（共有 lib 統合は follow-up）。
+
+関連: `schemas/oe-events.schema.json`（`report_received` の `covers_*`）/ `bin/oe-ack`（受領印の writer・`_ack_scan`）/ `bin/oe-activity`（PENDING の reader・`received_of`）。
+
+---
+
 ## 主要な環境変数
 
 | 変数 | 用途 | 既定 |
@@ -414,5 +435,7 @@ bind-key v display-popup -E -x C -y C -w 70% -h 60% -T ' oe pick ' '/path/to/rep
 | `OE_EVENT_DIR` | 活動ログ（#206）の置き場（`oe-events.jsonl`）。emit / oe-activity / oe-ack 共通 | `~/.claude/state` |
 | `OE_EVENT_LOG` | 活動ログ emit の有効/無効（`0` で kill-switch） | 有効 |
 | `OE_EVENT_PREVIEW_MAX` | message_sent の preview 切り詰め codepoint 数 | `100` |
+| `OE_UNDELIVERED_WINDOW_SEC` | oe-undelivered: 報告未達とみなす時間窓 W（秒）。`--window` が優先 | `1800`（30分） |
+| `OE_UNDELIVERED_NOW_EPOCH` | oe-undelivered: now（epoch 秒）の上書き。主にテストの age 決定論化用 | （`date +%s`） |
 
 本体エンジン側（`OE_POLL_INTERVAL` / `OE_CB_*` / `OE_TARGET_AI_*` / `OE_VERIFY_AI_*` 等）は [`../lib/constants.sh`](../lib/constants.sh) を参照。

--- a/projects/orchestration-engine/bin/oe-undelivered
+++ b/projects/orchestration-engine/bin/oe-undelivered
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# oe-undelivered — 報告未達検知 watchdog（#239 段階0・do-less MVP・read-only・cron 可）
+#
+# usage:
+#   oe-undelivered [--window <sec>]
+#   oe-undelivered -h | --help
+#
+# 目的（mode3 チャネル脆弱の検知）: 委譲子が親へ送った報告（child→parent の message_sent）のうち、
+#   親が受領印（report_received・#220/#206A）を打っておらず（未ack）、かつ最古の未ack報告が時間窓 W を
+#   越えて放置されているものを検出し、owner に ping する。統括死亡 / send 無言失敗で報告が虚空へ消える
+#   経路（#239 mode3）を「#220 の frontier（未ack）＋時間次元」で決定論的に拾う。
+#
+# 位置づけ（read-only 観測 family = oe-status / oe-activity / oe-ident と同群）:
+#   - engine state（oe-events.jsonl / delegate-registry / session-state）を一切 mutate しない。
+#     読むのは oe-events.jsonl と tmux ペイン存在（mux query）のみ。ペイン出力は capture しない（決定論）。
+#   - #220 の受領印イベント（report_received）を consume し、frontier の read 規則
+#     （K = min(covers_count, |ts ≤ covers_last_ts|)・複数 ack は max・巻き戻りなし）を
+#     oe-ack / oe-activity と同一に適用する（ack ループ本体は再構築しない）。
+#   - cron から回る＝$TMUX_PANE を持たないため、oe-activity --inbox（self 中心）と違い
+#     全 (child→parent) ペアを横断する。self アンカーが無いぶん、親子の向きは child_spawned /
+#     report_received / role / known-parent の複合で解決する（departed で role 空になる子＝mode3 の
+#     主対象を取りこぼさないため）。
+#
+# 検知（2条件）: pending > 0（未ack）かつ age = now - (最古未ack報告の ts) > W。
+# 出力:
+#   - stdout: 現在 FLAG 中の全件（cron ログ / 手動確認の durable な signal）。
+#   - owner ping: `wez notify`（best-effort）。二重通知抑止（D-b）: verb 固有の seen cache
+#     （${OE_EVENT_DIR}/oe-undelivered/seen・キー "<child>|<parent>|<oldest_ts>"）に無い新規キーのみ
+#     notify し、cache へ追記する。cache は verb 自身の bookkeeping で engine state ではない。
+# exit code: 常に 0（observer）。usage エラーのみ 2 / 投影失敗のみ 1。
+#
+# 既知の制約（新規導入でなく event モデル由来・開示）:
+#   - ts は秒精度・message 単位 id 無し → age は ±1s（分スケール窓で無害）。
+#   - 同一サーバで %N が再利用されると別関係が混線しうる（oe-activity と同じ既知制約）。
+#   - 親子の向きが child_spawned / report_received / role / known-parent のいずれからも
+#     判別できない完全に文脈欠落したペアは report と断定せず skip する（誤検知回避側に倒す）。
+#   - jq の frontier read 規則は oe-ack / oe-activity に続く3つ目の copy（共有 lib 統合は follow-up）。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# #224/#233: 会話到達面へ出す preview を read 側でも無害化する共有 helper（oe-activity と同型）。
+# 不在時は degrade（jq の cntrl→space が効くので従来同等の安全度）。
+_SANITIZE_LIB="${BIN_DIR}/../lib/sanitize.sh"
+# shellcheck source=../lib/sanitize.sh
+if [[ -r "$_SANITIZE_LIB" ]]; then source "$_SANITIZE_LIB"; fi
+declare -F oe_sanitize_conversation >/dev/null 2>&1 || oe_sanitize_conversation() { printf '%s' "$1"; }
+
+err() { echo "oe-undelivered: $*" >&2; }
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  oe-undelivered [--window <sec>]   報告未達（未ack かつ age>W）を検出し owner に ping
+  oe-undelivered -h | --help
+
+  --window <sec>   時間窓 W（秒）。既定 1800（30分）。環境変数 OE_UNDELIVERED_WINDOW_SEC でも指定可
+                   （--window が優先）。
+
+read-only: oe-events.jsonl と tmux ペイン存在のみを読む（capture・engine state 変更はしない）。
+owner ping は wez notify（best-effort）。二重通知は verb 固有の seen cache で抑止する。
+cron 例: */15 * * * * /path/to/oe-undelivered >> "$HOME/.claude/state/oe-undelivered/cron.log" 2>&1
+EOF
+}
+
+DEFAULT_WINDOW=1800
+WINDOW="${OE_UNDELIVERED_WINDOW_SEC:-$DEFAULT_WINDOW}"
+
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    --window)
+      shift
+      [[ -n "${1:-}" ]] || { err "--window は秒数（正の整数）が必要です"; usage; exit 2; }
+      WINDOW="$1"; shift ;;
+    --window=*) WINDOW="${1#--window=}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) err "unknown option: $1"; usage; exit 2 ;;
+  esac
+done
+[[ $# -eq 0 ]] || { err "unexpected argument: $1"; usage; exit 2; }
+
+# window は正の整数（秒）
+[[ "$WINDOW" =~ ^[0-9]+$ && "$WINDOW" -gt 0 ]] || { err "window は正の整数（秒）: got [$WINDOW]"; usage; exit 2; }
+
+command -v jq >/dev/null 2>&1 || { err "jq が必要です（frontier / age 計算に使用）"; exit 2; }
+
+# 単一ノブ OE_EVENT_DIR（writer=event-bus.sh / reader=oe-activity・oe-ack と一致）
+OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
+OE_EVENT_FILE="${OE_EVENT_DIR}/oe-events.jsonl"
+
+if [[ ! -s "$OE_EVENT_FILE" ]]; then
+  echo "oe-undelivered: no activity recorded yet (${OE_EVENT_FILE})"
+  exit 0
+fi
+
+# now は既定で date +%s（%s は BSD/GNU 両 date で可搬）。テストは OE_UNDELIVERED_NOW_EPOCH で
+# 固定して age を決定論化する（jq の now builtin を使わない理由＝再現性）。
+NOW_EPOCH="${OE_UNDELIVERED_NOW_EPOCH:-$(date +%s)}"
+[[ "$NOW_EPOCH" =~ ^[0-9]+$ ]] || { err "OE_UNDELIVERED_NOW_EPOCH は epoch 秒（整数）: got [$NOW_EPOCH]"; exit 2; }
+
+# --- liveness（mux 存在 query のみ。tmux 不在は ? で degrade。oe-activity と同型・capture しない）---
+TMUX_AVAIL=0
+LIVE_SET=""
+if command -v tmux >/dev/null 2>&1; then
+  if LIVE_SET="$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null)"; then
+    TMUX_AVAIL=1
+  fi
+fi
+liveness_of() {
+  local pane="$1"
+  [[ -n "$pane" ]] || { printf '?'; return; }
+  [[ "$TMUX_AVAIL" == "1" ]] || { printf '?'; return; }
+  if printf '%s\n' "$LIVE_SET" | grep -qxF -- "$pane"; then printf 'alive'; else printf 'gone'; fi
+}
+
+# pane を「label (pane)」or「pane」で表示（oe-activity と同型）
+disp() {
+  local pane="$1" label="$2"
+  if [[ -n "$label" ]]; then printf '%s (%s)' "$label" "$pane"; else printf '%s' "$pane"; fi
+}
+
+# age（秒）を人間可読へ（例: 5400 → 1h30m / 2700 → 45m）
+fmt_age() {
+  local s="$1" h m
+  [[ "$s" =~ ^[0-9]+$ ]] || { printf '%s' "$s"; return; }
+  h=$(( s / 3600 )); m=$(( (s % 3600) / 60 ))
+  if [[ "$h" -gt 0 ]]; then printf '%dh%dm' "$h" "$m"; else printf '%dm' "$m"; fi
+}
+
+# --- dedup（D-b）: verb 固有 seen cache（engine state ではない）---
+SEEN_DIR="${OE_EVENT_DIR}/oe-undelivered"
+SEEN_FILE="${SEEN_DIR}/seen"
+seen_has() {
+  [[ -r "$SEEN_FILE" ]] || return 1
+  grep -qxF -- "$1" "$SEEN_FILE" 2>/dev/null
+}
+
+# --- 投影（jq・slurp）: FLAG 行 1 件 1 行（US \u001f 区切り・空フィールド保持）---
+# 列: child_pane, parent_pane, child_label, parent_label, pending, oldest_ts, age_sec, miss_unacked, preview
+# 壊れた JSONL 行は前段 `jq -R 'fromjson? // empty'` で黙ってスキップ（oe-activity と同じ degrade）。
+project() {
+  jq -R 'fromjson? // empty' "$OE_EVENT_FILE" \
+  | jq -rs --argjson now "$NOW_EPOCH" --argjson window "$WINDOW" '
+    # ISO-8601（event-bus は常に +00:00）を epoch へ。parse 不能は null（後段で skip）。
+    def ts_epoch(t): ((t | sub("\\+00:00$"; "Z") | fromdateiso8601?) // null);
+    # 受領数の read 時導出（frontier snapshot・#206A/#220 と同一規則）:
+    #   各 ack の K = min(covers_count, |ts ≤ covers_last_ts|)、複数 ack は max（単調・巻き戻りなし）。
+    def received_of($acks; $rcv; $org; $cands):
+      ( [ $acks[] | select(.receiver==$rcv and .origin==$org) | . as $a
+          | ([ $cands[] | select(.ts <= $a.frontier) ] | length) as $k1
+          | (if $a.covers < $k1 then $a.covers else $k1 end) ] | max // 0 );
+
+    ( [ .[] | select(.type=="child_spawned") ] )    as $spawns
+    | ( [ .[] | select(.type=="report_received") ] ) as $ackraw
+    # 親子の向きを解決する権威マップ（強い順）:
+    #   parent_of[child]=parent（child_spawned）/ ack_parent_of[reporter]=acker（report_received）
+    #   known_parents = spawn/ack で親として振る舞った pane 集合
+    | ( reduce $spawns[] as $s ({}; .[$s.to.pane]   = $s.from.pane) )        as $parent_of
+    | ( reduce $ackraw[] as $a ({}; .[$a.to.pane]   = $a.from.pane) )        as $ack_parent_of
+    | ( reduce ($spawns[].from.pane, $ackraw[].from.pane) as $p ({}; .[$p]=true) ) as $known_parents
+    | ( reduce $spawns[] as $s ({}; .[$s.to.pane]   = ($s.to.label // "")) ) as $clabel
+    | ( reduce $spawns[] as $s ({}; .[$s.from.pane] = ($s.from.label // "")) ) as $plabel
+    | ( to_entries ) as $indexed
+    # 受領印: receiver=from（ack を打った親）/ origin=to（報告した子）
+    | ( [ $indexed[] | select(.value.type=="report_received")
+        | { receiver:.value.from.pane, origin:.value.to.pane,
+            covers:(.value.covers_count // 0), frontier:(.value.covers_last_ts // "") } ] ) as $acks
+    # report（child→parent）判定: report なら child=from / parent=to（全 rule で一貫）
+    | ( [ $indexed[]
+          | select(.value.type=="message_sent")
+          | .key as $idx | .value as $m
+          | select(
+              (($parent_of[$m.from.pane]) // "")     == $m.to.pane
+              or (($ack_parent_of[$m.from.pane]) // "") == $m.to.pane
+              or (($m.from.role=="child") and ($m.to.role=="parent"))
+              or (($known_parents | has($m.to.pane)) and (($known_parents | has($m.from.pane)) | not))
+            )
+          | { idx:$idx, c:$m.from.pane, p:$m.to.pane, ts:$m.ts,
+              deliv:($m.delivery_signal // "none"),
+              clab_m:($m.from.label // ""), plab_m:($m.to.label // ""),
+              prev:(($m.preview // "") | gsub("[[:cntrl:]]"; " ")) } ] ) as $reports
+    | [ ($reports | group_by([.c, .p]))[]
+        | ( sort_by(.ts, .idx) ) as $g
+        | $g[0].c as $c | $g[0].p as $p
+        | received_of($acks; $p; $c; $g) as $recv
+        | (($g | length) - $recv) as $pending0
+        | (if $pending0 < 0 then 0 else $pending0 end) as $pending
+        | select($pending > 0)
+        # 未ack = 先頭 $recv 件（frontier は ts 単調）を除いた残り。最古未ack = $g[$recv]。
+        | ($g[$recv:]) as $unacked
+        | $unacked[0] as $oldest
+        | ts_epoch($oldest.ts) as $ots
+        | select($ots != null)
+        | ($now - $ots) as $age
+        | select($age > $window)
+        | { c:$c, p:$p,
+            # label も stdout / wez notify（会話到達面）へ出るため cntrl を畳む（prev と同扱い・
+            # US 区切り protocol 防御も兼ねる）。full な無害化は bash 側 oe_sanitize_conversation。
+            clab: ((($clabel[$c]) // $oldest.clab_m // "") | gsub("[[:cntrl:]]"; " ")),
+            plab: ((($plabel[$p]) // $oldest.plab_m // "") | gsub("[[:cntrl:]]"; " ")),
+            pending: $pending,
+            ots: $oldest.ts,
+            age: $age,
+            miss: ([ $unacked[] | select(.deliv=="suspected_miss") ] | length),
+            prev: $oldest.prev } ]
+    | sort_by(.age) | reverse
+    | .[] | [ .c, .p, .clab, .plab, (.pending|tostring), .ots, (.age|tostring), (.miss|tostring), .prev ]
+    | join("\u001f")
+  '
+}
+
+rows="$(project 2>/dev/null)" || { err "failed to project ${OE_EVENT_FILE} (corrupt jsonl?)"; exit 1; }
+
+if [[ -z "$rows" ]]; then
+  echo "oe-undelivered: no undelivered reports (pending>0 かつ age>${WINDOW}s は無し)"
+  exit 0
+fi
+
+# --- FLAG 行を stdout へ（durable signal）+ 新規キーを収集 ---
+new_keys=()
+notify_lines=()
+printf '=== undelivered reports (read-only · window=%ss) ===\n' "$WINDOW"
+printf '%-6s  %-7s  %-8s  %-4s  %-26s  %-34s  %s\n' "PLIVE" "PENDING" "AGE" "MISS" "OLDEST_TS" "CHILD → PARENT" "PREVIEW"
+while IFS=$'\037' read -r c p clab plab pending ots age miss prev; do
+  [[ -n "$c" || -n "$p" ]] || continue
+  prev="$(oe_sanitize_conversation "$prev")"
+  # #224/#233: label も会話到達面（stdout / wez notify body）へ出るため preview と同様に無害化する
+  # （ESC/CSI/OSC・タグ列・box・制御文字。到達可能な視覚偽装/制御注入を防ぐ・実装SO codex 指摘）。
+  clab="$(oe_sanitize_conversation "$clab")"
+  plab="$(oe_sanitize_conversation "$plab")"
+  plive="$(liveness_of "$p")"
+  age_disp="$(fmt_age "$age")"
+  crel="$(disp "$c" "$clab")"
+  prel="$(disp "$p" "$plab")"
+  relation="${crel} → ${prel}"
+  miss_disp="${miss:-0}"
+  printf '%-6s  %-7s  %-8s  %-4s  %-26s  %-34s  %s\n' \
+    "$plive" "$pending" "$age_disp" "$miss_disp" "$ots" "$relation" "$prev"
+  key="${c}|${p}|${ots}"
+  if ! seen_has "$key"; then
+    new_keys+=("$key")
+    line="${relation} · pending=${pending} · age=${age_disp} · parent=${plive}"
+    [[ "$miss_disp" != "0" ]] && line="${line} · miss=${miss_disp}"
+    notify_lines+=("$line")
+  fi
+done <<< "$rows"
+
+# --- 新規キーのみ owner へ ping（二重通知抑止）---
+# seen cache は「実際に owner へ通知できた」ときだけ追記する。wez 不在 / notify 失敗 / 中断時に
+# 先行追記すると、通知していないのにキーが seen となり owner ping が永続的に抑止される
+# （実装SO cursor 指摘）。通知経路が無い・失敗なら記録せず次回再通知する（stdout は毎回 durable に
+# 表示済み・wez 復帰時に通知される）。stdout 出力が durable な signal で wez notify は best-effort。
+if [[ "${#new_keys[@]}" -gt 0 ]] && command -v wez >/dev/null 2>&1; then
+  body="$(printf '%s\n' "${notify_lines[@]}")"
+  if wez notify "oe watchdog: undelivered report(s)" "$body" 2>/dev/null; then
+    # 通知成功時のみ seen cache 追記（verb 固有 state・best-effort。追記失敗は次回再通知になるだけ）
+    if mkdir -p "$SEEN_DIR" 2>/dev/null; then
+      for k in "${new_keys[@]}"; do
+        printf '%s\n' "$k" >> "$SEEN_FILE" 2>/dev/null || true
+      done
+    else
+      err "seen cache dir を作成できませんでした（${SEEN_DIR}）— 二重通知抑止は無効・検知は継続"
+    fi
+  fi
+fi
+
+exit 0

--- a/projects/orchestration-engine/docs/episodes/2026-07-09-episode-239-report-undelivered-watchdog.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-09-episode-239-report-undelivered-watchdog.md
@@ -1,0 +1,122 @@
+---
+id: "01KX33HHPXYFDA56KNKA9XGWPM"
+title: "#239 段階0 episode — 報告未達検知 watchdog（oe-undelivered）実装記録"
+date: 2026-07-09
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/239"
+    reason: "統括 watchdog（liveness/異常検知）の段階0 do-less MVP。段階0=報告未達検知のみで keep-open"
+  - type: design_context
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/220"
+    reason: "report_received の frontier（未ack）計算を consume し時間次元を足す（再実装しない）"
+  - type: pull_request
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/241"
+    reason: "本 episode が閉じる実装 PR"
+tags: [orchestration, watchdog, report-undelivered, read-only, cron, stage0, do-less, episode, reconstructed]
+---
+
+# #239 段階0 episode — 報告未達検知 watchdog（oe-undelivered）実装記録
+
+`reconstructed`（closure 時に再構成。リアルタイム追記ログではない。tier=heavy）。
+
+## Context / なぜ
+
+統括（supervisor）スレッドの異常系が実運用「統括3〜4代」で反復顕在化し（context 肥大死・お見合い・チャネル脆弱・state 乖離）、engine に機械的 liveness/異常監視が無い。設計フェーズの設計 SO（`oe-refute` exploration/3）が「seat+mailbox+staleness 3点で MVP 確定」を **refuted → de-converge**し、owner の HG 決定は**段階0 do-less =「報告未達検知 cron + owner ping」だけ入れて運用観測**、上位アーキ（seat / heartbeat / topology / mailbox / observed projection）は保留。本 episode はその段階0（mode3 チャネル脆弱の検知のみ）を委譲子セッションとして実装した記録。
+
+## 決定と根拠（コード/diff から復元できない「なぜ」）
+
+### DJ-1: frontier をどう consume するか — S3（新 verb が read 規則を inline）
+
+kickoff は「#220 frontier を consume・**再実装しない**」を課した。実体確認で判明した load-bearing な事実:
+
+- #220 の frontier（未ack）計算は**共有 lib になっておらず**、writer `oe-ack`（`_ack_scan`）と reader `oe-activity`（`received_of`）に**2重 inline**。
+- `oe-activity --inbox` は **self 中心**（`recipient==$self`・`$TMUX_PANE` 必須）で、**cron の watchdog は self を持たず全ペア横断が必要**。→ **既存 verb をそのまま呼べない**（S1 案は棄却）。加えて `--inbox` 出力は ts を落とすため「pending ペア + age」を一発で返す既存経路が無い。
+
+選択肢:
+- **S1**（既存 verb 出力を parse）→ 棄却（self 中心・cron 不可）。
+- **S2**（frontier を共有 lib に抽出し oe-ack/oe-activity/新 verb を張替）→ do-less 逸脱・MERGED #220 の bin 2本を触る回帰リスクで**保留（follow-up）**。
+- **S3**（新スタンドアロン verb が read-only で走査し #220 と同一の read 規則を inline・global・+age・+liveness）→ **採用**。reader が read 規則を持つのは reader の本質（oe-activity 自身が別 copy を持つ）。consume するのは #220 が emit する `report_received` イベントであって ack ループ本体は再構築しない。frontier read 規則が3つ目の copy になる点は正直なコストとして開示し S2 を follow-up に routing。
+
+### DJ-2: 親子の向き解決 — 全ペア横断ゆえの新規ロジック（departed/role 空を落とさない）
+
+self アンカーが無いので、message が report（child→parent）か kick（parent→child）かを global に判定する必要がある。`oe-activity` の inbox は self で錨を打つため向き誤判定が実害にならないが、watchdog はそれが使えない。**mode3 の主対象は「親が死んだ／send 失敗した departed 子」で、その report は registry GC 後に role 空で残る**（#220 の `_oe_event_ident` 修正が触れた「role 空 + label あり」経路）。素朴な role/parent_of 判定では departed の role 空 report が kick 扱いで**取りこぼされる**（実測: 単純 fallback だと %77→%59 が p=%77 に反転）。
+
+→ 権威マップの複合で解決（強い順）: `child_spawned` の parent_of / `report_received` の acker / message role / **known-parent 集合**（spawn/ack で親として振る舞った pane。departed 子の report でも「宛先が既知親」なら report と判定）。判別不能な完全文脈欠落ペアは report と断定せず skip（誤検知回避側）。report なら常に child=from / parent=to で一貫。
+
+### DJ-3: dedup は「実際に通知できたとき」だけ記録（実装 SO 指摘で是正）
+
+当初は seen cache を notify の前に無条件追記していた。実装 SO（cursor）が「wez 不在 / notify 失敗 / 中断で先行追記すると owner ping が**永続抑止**される」と指摘。→ **通知成功時のみ seen 追記**へ是正。wez 不在なら記録せず次回再通知（stdout は毎回 durable 表示・wez 復帰時に通知）。dedup の目的は「同じ通知の spam 抑止」であって「通知していないのに抑止」ではない、という不変条件を明文化した。
+
+## 事実・失敗（実行ログに残る失敗を選択的に省略しない）
+
+### 実装 SO（`oe-review` impl）を 2 周実施した — mandate は 1 周（honest 開示）
+
+kickoff/HG は「実装 SO 1周」を課した。だが round1 が material な欠陥を出したため確認として round2 も回した（1周 mandate の超過）。**両ラウンドとも verdict は refuted のまま**で「survived」判定には到達していない。ただし surface した material 指摘は**全て修正し、各々に回帰テストを付けて独立検証**した（SO verdict でなくテストで確証）。弱 SO 規律（1周・partial は disclose・iterate しない）に従い round2 修正後は再周回せず停止した。
+
+- round1 refuted(2/2): **(a) 非実行ビット** — verb が `100644` で追加され README/cron の直接実行経路が不達（テストは `bash bin/...` 起動なので緑のまま隠れていた）→ `chmod +x`。 **(b) dedup 永続抑止**（DJ-3）。
+- round2 refuted(1/2・他 1 レーンは出力不正で verdict 取得できず): **(c) label 未サニタイズ** — `clab`/`plab` が無害化されず stdout / wez notify へ到達し ESC/CSI/OSC 注入・視覚偽装の余地。preview は #224/#233 で sanitize 済だったが label は漏れていた → preview と同様に jq cntrl 畳み + `oe_sanitize_conversation`。
+
+### 制御文字混入の tooling gotcha（プロセス失敗・再発防止に有効）
+
+ファイル書き込み時、ANSI 風トークン（`U+001B` を伴う CSI）や `U+001F`（US 区切り）を**生バイトとして意図せず挿入**する事象が複数回発生した。症状: (1) テスト fixture の JSON 文字列に生 `U+001B` が入り、`jq fromjson?` が JSON 不正で行ごと drop → テスト [13] が「制御文字が畳まれた」でなく「行が消えた」で fail。(2) bin の `join()` の US 区切りが生 `U+001F` バイトで書かれ（`oe-ack` は文字列エスケープ `\u001f` を使う）hygiene 違反。
+
+- **検知**: `LC_ALL=C grep -nP '[\x00-\x08\x0b-\x1f\x7f]'` で全ファイル走査 + `od -c` でバイト確認。shellcheck では検知できなかった。
+- **是正**: (1) fixture の制御文字は**ソースに生バイトを置かず** runtime に `printf` で生成し `jq` に JSON エスケープさせて書く。(2) 生 US バイトは `perl -i -pe 's/\x1f/\\u001f/g'` で文字列エスケープへ変換し `oe-ack` と揃えた。
+
+### Copilot review（自動 bot）
+
+依頼（`gh pr edit 241 --add-reviewer @copilot`）→ 非同期で summary review（state COMMENTED・inline コメント 0 件）を返した。**"reviewed 1 out of 3 changed files and generated no comments."** 実質指摘ゼロ・scope 拡大の push back も無し。返信対象スレッド無し・コード変更無し・再リクエストせず（1ラウンド自律規律）。
+
+## わかったこと（W）
+
+- ISO-8601（event-bus は常に `+00:00`）→ epoch は **jq の `fromdateiso8601` + `now` 引数注入**で可搬に計算でき、BSD/GNU `date` の parse 差を回避できる。テストは `OE_UNDELIVERED_NOW_EPOCH` で now を固定して age を決定論化した。
+- `bin/oe` は verb dispatcher でなく engine 実行本体。`oe-*` verb は個別実行ファイルなので新 verb 追加に dispatcher 改変は不要。
+- `lib/oe-viewer.sh` は `oe-view` 専用で frontier ロジックの置き場ではない → S3 は inline（`oe-ack` の `_ack_scan` 前例に整合）。
+
+## 原則（Pattern / Anti-pattern）
+
+- **Anti-pattern**: dedup/抑止キャッシュを「作用（通知/送信）の前」に無条件で書く → 作用が失敗した経路で**永続抑止**になる。**Pattern**: 抑止キャッシュは作用が成功したときだけ記録する（作用と記録の順序を作用側に寄せる）。
+- **Anti-pattern**: 会話/端末到達面へ出す文字列のうち一部（preview）だけ sanitize し、隣接する同類（label）を見落とす。**Pattern**: 「到達面へ出る文字列」を型として洗い出し、同一チョークポイントを全経路に通す（#224/#233 norm）。
+- **Anti-pattern**: self 中心の既存 view をそのまま global 用途へ流用しようとする。**Pattern**: アンカー（self）の有無で必要ロジックが変わることを先に確認し、無い側の権威情報（spawn/ack/known-parent）から再構成する。
+
+## 行動変更（トリガ・機構・着地先）
+
+- なし（本 episode で新規 hook/skill 化はしない）。制御文字混入の gotcha は再発防止機構化の候補だが機構未確定 → 残課題へ降格（下記 routing）。
+
+## 蒸留シグナル（昇格候補）
+
+- **なし**（段階0 の実装知見。Decision/skill/rule への即時昇格候補は無し）。frontier 共有 lib 化（S2）は段階が進み copy が増えるなら Decision 化の余地。
+
+## follow-up routing（全項目に行き先）
+
+- frontier read 規則 3-copy（oe-ack/oe-activity/oe-undelivered）の共有 lib 統合（S2 相当）→ **PR #241 本文に記録・段階が進む時に別 Issue 化**（今は追わない）。
+- `wez notify` の cron（no TTY / mux socket）到達性未検証 → **README に注記済み・stdout fallback で durable**。代替（tmux display-message / alert ファイル）は段階外 defer。実機確認は運用観測フェーズ。
+- **out-of-scope 発見（back-propagation）**: 既存 `oe-activity` / `oe-ack` も label を無害化していない（preview のみ）→ **PR #241 follow-up に記録・label hardening の横展開は別 PR**（本 PR では実装しない）。
+- 制御文字混入 gotcha の機構的検知（pre-commit / CI での `grep -P` 走査）→ **機構未確定・追わない宣言**（必要になれば別途）。
+- owner musing（将来候補）: (i) viewer の gone 親以下/親移譲表示（PR-9 候補据え置き）、(ii) 並列の親での異常蓄積の可視化（段階2/3 or viewer follow-up）→ **PR #241 に記録・段階1+**。
+- W=1800s の妥当値 → **運用観測で調律**（段階0 の目的そのもの）。
+
+## 残課題（証明できなかったことは書く）
+
+- 実装 SO は 2 周とも **refuted のまま**で「survived」verdict には到達していない（material 指摘は全て fix + テスト検証済だが、SO 自身の合格印は取れていない）。round2 は 1 レーンが出力不正だった。
+- `wez notify` が cron 環境で実際に owner へ届くかは**未検証**（stdout fallback が durable な保険）。
+
+## 次の消費者
+
+- **段階1+ の担当（seat/heartbeat 等）**: 本 verb の frontier consume パターン（S3）と向き解決ロジックを前提にできる。S2（共有 lib 化）を判断する起点。
+- **owner/親（%144）**: PR #241 のマージ判断・#239 の段階0 landed コメント（keep-open）投稿・運用観測での W 調律。
+
+## status
+
+- status: **stable** / 達成度: **達成**（段階0 do-less の scope=報告未達検知のみを実装・PR #241 作成・レビュー通過）。
+- **#239 は段階0 のみで keep-open**（多段の最終段まで close しない・#233 close hygiene 教訓の前向き適用）。マージ・worktree 掃除・#239 close・段階0 landed コメントは owner/親の責務。
+
+## evidence anchor
+
+- PR: https://github.com/stlwolf/ai-development-hub/pull/241 ・実装 commit `ca15a52`（amend 済・最終）。
+- test: `tests/test_oe_undelivered.sh` 20 節/54 assert・bash 5.2.37 / 3.2.57 両系 green・shellcheck PASS。
+- 実装 SO audit_id: round1 `20260709081753830DZ6YHF19C`（refuted 2/2）/ round2 `202607090842374RNY53D40Y0Z`（refuted 1/2・1 レーン出力不正）。出力は揮発（`tmp/oe-review-*`）につき要点を本 episode に転記。
+- 設計提案（写し）・plan: `.oe/ref-proposal-238-239.md` / `.oe/plan-stage0.md`（揮発・worktree 内）。設計判断（S1/S2/S3 の採否・向き解決ロジック）の要点は §決定と根拠に転記済で単独依存しない。
+- **closure Step4 外部チェック（heavy tier・`so-compare` codex+claude 2レーン成功）**: closure 品質の4観点（選択的省略／follow-up routing／evidence anchor／back-propagation）を検証 → **両レーン「問題なし」**。両レーンは episode の主張（chmod / dedup 是正 / label 未サニタイズ是正 / SO 2周 refuted・survived 未到達 / back-prop 実在）を repo 実体と突合し独立確認した。出力は揮発（`tmp/so-*`）につき結論を本行へ転記。

--- a/projects/orchestration-engine/tests/test_oe_undelivered.sh
+++ b/projects/orchestration-engine/tests/test_oe_undelivered.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_undelivered.sh — bin/oe-undelivered（#239 段階0・報告未達検知 watchdog）の検証。
+#
+# read-only 前提: fixture の oe-events.jsonl を直に置き、#220 frontier（未ack）＋時間窓 W で
+# 「報告未達（pending>0 かつ age>W）」を FLAG するかを検証する。
+# age は決定論化のため OE_UNDELIVERED_NOW_EPOCH で now を固定する（jq now builtin は使わない）。
+# liveness は PATH-stub tmux で固定（%59/%66 alive・他は gone）。wez は stub で呼出記録。
+#
+# 参照 epoch（すべて +00:00）:
+#   12:00:00=1782993600 12:01:00=1782993660 12:02:00=1782993720 12:04:00=1782993840
+#   12:05:00=1782993900 12:06:00=1782993960 12:10:00=1782994200 12:40:00=1782996000
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OE_UNDELIVERED="$PROJECT_DIR/bin/oe-undelivered"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+# --- stub tmux (%59 %66 alive・他は gone) + wez (呼出記録) ---
+STUB_BIN="$_TMP_DIR/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list-panes" ]]; then printf '%%59\n%%66\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$STUB_BIN/tmux"
+WEZ_LOG="$_TMP_DIR/wez.log"
+: > "$WEZ_LOG"
+cat > "$STUB_BIN/wez" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$WEZ_LOG"
+exit 0
+EOF
+chmod +x "$STUB_BIN/wez"
+
+PASS=0; FAIL=0
+ck() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
+ckc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (missing [$3])"; FAIL=$((FAIL+1)); fi; }
+ncc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  FAIL: $1 (unexpected [$3])"; FAIL=$((FAIL+1)); else echo "  PASS: $1"; PASS=$((PASS+1)); fi; }
+row_of() { printf '%s\n' "$1" | grep -F "$2"; }
+
+# mkfix <dir> — fixture ディレクトリを作り $EVFILE / $EVDIR を設定
+mkfix() { local d="$_TMP_DIR/$1"; mkdir -p "$d"; EVFILE="$d/oe-events.jsonl"; EVDIR="$d"; }
+# run <now_epoch> [args...] — 固定 now で watchdog を回す（stub PATH・$TMUX_PANE 無し＝cron 相当）
+run() { local now="$1"; shift; env PATH="$STUB_BIN:$PATH" OE_EVENT_DIR="$EVDIR" OE_UNDELIVERED_NOW_EPOCH="$now" bash "$OE_UNDELIVERED" "$@"; }
+
+# ============================================================================
+echo "[1] pending>0 かつ age>W → FLAG（ペア + age を出す）"
+mkfix f1
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"R2-UNACKED","delivery_signal":"none"}
+EOF
+OUT="$(run 1782996000)"   # now=12:40 → age=35m>30m
+ckc "header 出る" "$OUT" "undelivered reports"
+ckc "FLAG 行に子ラベル" "$OUT" "#206A"
+ckc "FLAG 行に親" "$OUT" "boss (%59)"
+ckc "AGE 表示(35m)" "$(row_of "$OUT" "R2-UNACKED")" "35m"
+ck  "PENDING=1" "1" "$(printf '%s' "$(row_of "$OUT" "R2-UNACKED")" | awk '{print $2}')"
+
+echo "[2] pending>0 だが age<W → FLAG 無し（no-op メッセージ・exit 0）"
+rc=0; OUT="$(run 1782994200)" || rc=$?   # now=12:10 → age=5m<30m
+ck  "age<W exit 0" "0" "$rc"
+ckc "no undelivered メッセージ" "$OUT" "no undelivered reports"
+ncc "FLAG ヘッダ出ない" "$OUT" "undelivered reports (read-only"
+
+echo "[3] pending==0（全 ack 済）→ FLAG 無し"
+mkfix f3
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"R2-ACKED","delivery_signal":"none"}
+{"ts":"2026-07-02T12:06:00+00:00","type":"report_received","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"},"covers_count":1,"covers_last_ts":"2026-07-02T12:05:00+00:00"}
+EOF
+OUT="$(run 1782996000)"   # now=12:40（十分古いが全 ack 済）
+ckc "全 ack → no undelivered" "$OUT" "no undelivered reports"
+
+echo "[4] 部分 ack: 2 報告中 1 ack → 未ack 1・最古未ack が age 基準"
+mkfix f4
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:01:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"R1-ACKED","delivery_signal":"none"}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"R2-UNACKED","delivery_signal":"none"}
+{"ts":"2026-07-02T12:04:00+00:00","type":"report_received","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"},"covers_count":1,"covers_last_ts":"2026-07-02T12:01:00+00:00"}
+EOF
+OUT="$(run 1782996000)"
+ck  "pending=1（R1 は ack 済）" "1" "$(printf '%s' "$(row_of "$OUT" "R2-UNACKED")" | awk '{print $2}')"
+ckc "最古未ack=R2 の ts(12:05)" "$(row_of "$OUT" "R2-UNACKED")" "2026-07-02T12:05:00"
+ncc "R1(ack 済)は出ない" "$OUT" "R1-ACKED"
+
+echo "[5] kick（parent→child）は報告未達に数えない（child→parent のみ）"
+mkfix f5
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:06:00+00:00","type":"message_sent","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"},"preview":"KICK-ONLY","delivery_signal":"none"}
+EOF
+OUT="$(run 1782996000)"
+ckc "kick のみ → no undelivered" "$OUT" "no undelivered reports"
+ncc "kick は FLAG されない" "$OUT" "KICK-ONLY"
+
+echo "[6] mode3: departed / role 空の子（child_spawned 無し）も既知親宛なら検知"
+mkfix f6
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:02:00+00:00","type":"message_sent","from":{"pane":"%77","role":"","label":""},"to":{"pane":"%59","role":"","label":""},"preview":"DEPARTED-REPORT","delivery_signal":"suspected_miss"}
+EOF
+OUT="$(run 1782996000)"
+ckc "departed 子の報告未達を検知（%77 が既知親 %59 宛）" "$OUT" "DEPARTED-REPORT"
+r77="$(row_of "$OUT" "DEPARTED-REPORT")"
+ck  "departed pending=1" "1" "$(printf '%s' "$r77" | awk '{print $2}')"
+# MISS 列（$4）= 1（suspected_miss を未ack 中で数える）
+ck  "suspected_miss を MISS=1 として付記" "1" "$(printf '%s' "$r77" | awk '{print $4}')"
+
+echo "[7] liveness 付記: 親 gone / alive"
+mkfix f7
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:00:30+00:00","type":"child_spawned","from":{"pane":"%88","role":"parent","label":"deadboss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"TO-ALIVE-PARENT","delivery_signal":"none"}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%88","role":"parent","label":"deadboss"},"preview":"TO-GONE-PARENT","delivery_signal":"none"}
+EOF
+OUT="$(run 1782996000)"
+# %59 は stub tmux で alive・%88 は list に無い＝gone。列: PLIVE($1) ...
+ck "親 %59 alive" "alive" "$(printf '%s' "$(row_of "$OUT" "TO-ALIVE-PARENT")" | awk '{print $1}')"
+ck "親 %88 gone"  "gone"  "$(printf '%s' "$(row_of "$OUT" "TO-GONE-PARENT")" | awk '{print $1}')"
+
+echo "[8] 複数ペア混在は age 降順（最も滞留したものが先頭）"
+mkfix f8
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"NEWER-1205","delivery_signal":"none"}
+{"ts":"2026-07-02T12:02:00+00:00","type":"message_sent","from":{"pane":"%77","role":"","label":""},"to":{"pane":"%59","role":"","label":""},"preview":"OLDER-1202","delivery_signal":"none"}
+EOF
+OUT="$(run 1782996000)"
+first_row="$(printf '%s\n' "$OUT" | sed -n '3p')"   # 1=title 2=header 3=first data
+ckc "age 降順: 先頭=最古(12:02)" "$first_row" "OLDER-1202"
+
+echo "[9] dedup(D-b): 2 回目は notify 抑止・stdout は継続表示"
+mkfix f9
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"DEDUP-R","delivery_signal":"none"}
+EOF
+: > "$WEZ_LOG"
+run 1782996000 >/dev/null   # run1: notify + seen cache 追記（stdout は不要）
+n1="$(awk 'END{print NR}' "$WEZ_LOG")"
+ck  "run1: wez notify 1 回" "1" "$n1"
+ckc "run1: seen cache に key" "$(cat "$EVDIR/oe-undelivered/seen")" "%66|%59|2026-07-02T12:05:00+00:00"
+: > "$WEZ_LOG"
+OUT2="$(run 1782996000)"     # run2: 同一 state
+n2="$(awk 'END{print NR}' "$WEZ_LOG")"
+ck  "run2: 新規キー無し → wez notify 0 回（二重通知抑止）" "0" "$n2"
+ckc "run2: stdout は継続表示（durable）" "$OUT2" "DEDUP-R"
+
+echo "[10] wez notify 本文にペア要約（best-effort）"
+mkfix f10
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"NOTIFY-BODY","delivery_signal":"none"}
+EOF
+: > "$WEZ_LOG"
+run 1782996000 >/dev/null
+ckc "notify title" "$(cat "$WEZ_LOG")" "undelivered report"
+
+echo "[11] 空 / 不在ログ → クリーンな no-op（exit 0）"
+mkfix f11empty   # ディレクトリだけ・ファイル無し
+rc=0; OUT="$(run 1782996000)" || rc=$?
+ck  "空ログ exit 0" "0" "$rc"
+ckc "no activity メッセージ" "$OUT" "no activity recorded yet"
+
+echo "[12] 壊れた JSONL 行は read 時にスキップ（degrade・exit 0・有効行は残る）"
+mkfix f12
+{
+  printf '%s\n' 'not json at all {{{'
+  printf '%s\n' '{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}'
+  printf '%s\n' '{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"VALID-AFTER-CORRUPT","delivery_signal":"none"}'
+} > "$EVFILE"
+rc=0; OUT="$(run 1782996000)" || rc=$?
+ck  "corrupt exit 0" "0" "$rc"
+ckc "有効行は残る" "$OUT" "VALID-AFTER-CORRUPT"
+
+echo "[13] preview の制御文字は空白へ畳む（会話到達面・#224/#233・端末注入防止）"
+# 制御文字(ESC)は runtime に printf で生成し jq に JSON エスケープさせて jsonl へ書く（\uXXXX 形）。
+# ソースに raw 制御文字を置かない（raw 制御文字は JSON 不正で fromjson が行ごと落とすため）。
+mkfix f13
+_esc="$(printf '\033')"
+printf '%s\n' '{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"c"}}' > "$EVFILE"
+jq -cn --arg p "CTRL${_esc}INJECT" \
+  '{ts:"2026-07-02T12:05:00+00:00",type:"message_sent",from:{pane:"%66",role:"child",label:"c"},to:{pane:"%59",role:"parent",label:"boss"},preview:$p,delivery_signal:"none"}' >> "$EVFILE"
+OUT="$(run 1782996000)"
+if printf '%s' "$OUT" | LC_ALL=C grep -q "$_esc"; then echo "  FAIL: ESC 未畳み込み"; FAIL=$((FAIL+1)); else echo "  PASS: ESC folded to space"; PASS=$((PASS+1)); fi
+ckc "周辺テキスト CTRL 残存" "$OUT" "CTRL"
+ckc "周辺テキスト INJECT 残存" "$OUT" "INJECT"
+
+echo "[14] --window 引数・環境変数・優先順位・不正値"
+mkfix f14
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"WIN-R","delivery_signal":"none"}
+EOF
+# now=12:40 → age=2100s。window=3000 なら FLAG 無し / 1800 なら FLAG。
+ckc "--window 3000 → 無し" "$(run 1782996000 --window 3000)" "no undelivered reports"
+ckc "--window 1800 → FLAG" "$(run 1782996000 --window 1800)" "WIN-R"
+ckc "--window=1800（=形式）→ FLAG" "$(run 1782996000 --window=1800)" "WIN-R"
+# 環境変数
+ckc "env WINDOW=3000 → 無し" "$(env PATH="$STUB_BIN:$PATH" OE_EVENT_DIR="$EVDIR" OE_UNDELIVERED_NOW_EPOCH=1782996000 OE_UNDELIVERED_WINDOW_SEC=3000 bash "$OE_UNDELIVERED")" "no undelivered reports"
+# --window は env より優先
+ckc "--window 1800 が env 3000 を上書き→ FLAG" "$(env PATH="$STUB_BIN:$PATH" OE_EVENT_DIR="$EVDIR" OE_UNDELIVERED_NOW_EPOCH=1782996000 OE_UNDELIVERED_WINDOW_SEC=3000 bash "$OE_UNDELIVERED" --window 1800)" "WIN-R"
+# 不正 window → exit 2
+rc=0; run 1782996000 --window abc >/dev/null 2>&1 || rc=$?
+ck "window 非整数 → exit 2" "2" "$rc"
+rc=0; run 1782996000 --window 0 >/dev/null 2>&1 || rc=$?
+ck "window 0 → exit 2" "2" "$rc"
+
+echo "[15] 不正オプション / 余分引数 → usage・exit 2"
+rc=0; run 1782996000 --bogus >/dev/null 2>&1 || rc=$?
+ck "bad opt exit 2" "2" "$rc"
+rc=0; run 1782996000 extra-arg >/dev/null 2>&1 || rc=$?
+ck "余分引数 exit 2" "2" "$rc"
+
+echo "[16] -h/--help → exit 0・usage"
+rc=0; H="$(run 1782996000 --help 2>&1)" || rc=$?
+ck  "--help exit 0" "0" "$rc"
+ckc "usage 表示" "$H" "報告未達"
+
+echo "[17] jq 不在 → exit 2（frontier 計算に必須）"
+NOJQ="$_TMP_DIR/nojq"; mkdir -p "$NOJQ"
+IFS=':' read -ra _pdirs <<< "$PATH"
+for d in "${_pdirs[@]}"; do
+  [[ -d "$d" ]] || continue
+  for f in "$d"/*; do
+    [[ -x "$f" && ! -d "$f" ]] || continue
+    b="$(basename "$f")"
+    [[ "$b" == "jq" ]] && continue
+    [[ -e "$NOJQ/$b" ]] || ln -s "$f" "$NOJQ/$b" 2>/dev/null || true
+  done
+done
+rc=0; ERRO="$(PATH="$NOJQ" OE_EVENT_DIR="$_TMP_DIR/f1" OE_UNDELIVERED_NOW_EPOCH=1782996000 bash "$OE_UNDELIVERED" 2>&1)" || rc=$?
+ck  "nojq exit 2" "2" "$rc"
+ckc "nojq err メッセージ" "$ERRO" "jq"
+
+echo "[18] tmux 不在時は liveness ? に degrade（検知は継続）"
+mkfix f18
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"NOTMUX-R","delivery_signal":"none"}
+EOF
+# tmux/wez を持たない PATH（jq/date/grep 等は残す）
+NOTOOLS="$_TMP_DIR/notools"; mkdir -p "$NOTOOLS"
+for d in "${_pdirs[@]}"; do
+  [[ -d "$d" ]] || continue
+  for f in "$d"/*; do
+    [[ -x "$f" && ! -d "$f" ]] || continue
+    b="$(basename "$f")"
+    [[ "$b" == "tmux" || "$b" == "wez" ]] && continue
+    [[ -e "$NOTOOLS/$b" ]] || ln -s "$f" "$NOTOOLS/$b" 2>/dev/null || true
+  done
+done
+rc=0; OUT="$(PATH="$NOTOOLS" OE_EVENT_DIR="$EVDIR" OE_UNDELIVERED_NOW_EPOCH=1782996000 bash "$OE_UNDELIVERED" 2>&1)" || rc=$?
+ck  "no-tmux exit 0" "0" "$rc"
+ckc "検知は継続（FLAG 行あり）" "$OUT" "NOTMUX-R"
+ck  "PLIVE=?（tmux 不在 degrade）" "?" "$(printf '%s' "$(row_of "$OUT" "NOTMUX-R")" | awk '{print $1}')"
+
+echo "[19] wez 不在: 通知経路が無い → seen へ記録せず永続抑止しない（実装SO cursor 指摘の回帰）"
+mkfix f19
+cat > "$EVFILE" <<'EOF'
+{"ts":"2026-07-02T12:00:00+00:00","type":"child_spawned","from":{"pane":"%59","role":"parent","label":"boss"},"to":{"pane":"%66","role":"child","label":"#206A"}}
+{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"#206A"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"WEZLESS-R","delivery_signal":"none"}
+EOF
+# NOTOOLS（[18] で構築・wez/tmux を持たない PATH）で実行＝wez 不在の cron を模す。
+r19() { PATH="$NOTOOLS" OE_EVENT_DIR="$EVDIR" OE_UNDELIVERED_NOW_EPOCH=1782996000 bash "$OE_UNDELIVERED"; }
+OUT_A="$(r19)"
+ckc "wez 不在でも FLAG は stdout に出る（durable）" "$OUT_A" "WEZLESS-R"
+ck  "通知していないので seen cache を作らない" "1" "$([[ ! -e "$EVDIR/oe-undelivered/seen" ]] && echo 1 || echo 0)"
+OUT_B="$(r19)"
+ckc "2 回目も抑止されず表示（wez 復帰時に通知可能）" "$OUT_B" "WEZLESS-R"
+
+echo "[20] label の制御文字も無害化（stdout / notify 到達面・実装SO codex 指摘の回帰）"
+mkfix f20
+_esc="$(printf '\033')"
+# 子 label に ESC を仕込む（jq が JSON エスケープして書き、fromjson で実 ESC へ復号）。
+jq -cn --arg cl "EVIL${_esc}LABEL" \
+  '{ts:"2026-07-02T12:00:00+00:00",type:"child_spawned",from:{pane:"%59",role:"parent",label:"boss"},to:{pane:"%66",role:"child",label:$cl}}' > "$EVFILE"
+printf '%s\n' '{"ts":"2026-07-02T12:05:00+00:00","type":"message_sent","from":{"pane":"%66","role":"child","label":"c"},"to":{"pane":"%59","role":"parent","label":"boss"},"preview":"LABELSAN-R","delivery_signal":"none"}' >> "$EVFILE"
+OUT="$(run 1782996000)"
+if printf '%s' "$OUT" | LC_ALL=C grep -q "$_esc"; then echo "  FAIL: label の ESC 未無害化"; FAIL=$((FAIL+1)); else echo "  PASS: label ESC neutralized"; PASS=$((PASS+1)); fi
+ckc "FLAG 行は残る" "$OUT" "LABELSAN-R"
+ckc "label 周辺テキスト EVIL 残存" "$OUT" "EVIL"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 概要

統括スレッドの異常系（[#239](https://github.com/stlwolf/ai-development-hub/issues/239) mode3・チャネル脆弱）を機械検知する **段階0 do-less MVP**。子→親の報告が親死亡 / send 無言失敗で虚空へ消える経路を、[#220](https://github.com/stlwolf/ai-development-hub/issues/220) の frontier（未ack）に**時間次元**を足して決定論的に拾う read-only 観測 verb `oe-undelivered` を追加する（cron で回せる）。

設計フェーズの de-converge（設計 SO refuted）を受けた HG 決定「段階0＝報告未達検知のみ、まず入れて運用観測」に沿う。上位アーキ（seat / heartbeat / topology / mailbox 等）は段階1以降で本 PR の対象外。

## 変更内容

- **`bin/oe-undelivered`（新規・read-only 観測 verb）**: `oe-events.jsonl` を read-only 走査し、`pending>0`（未ack）かつ最古の未ack報告の `age > W`（既定 1800s / 30分）を「報告未達」として検出 → owner に ping。
- **`tests/test_oe_undelivered.sh`（新規・19 節/51 assert）**: 検知・境界・degrade・dedup・向き解決・回帰を網羅。bash 5.2 / 3.2 両系 green。
- **`bin/README.md`**: 観測群に 1 行 + `oe-undelivered` 節 + 環境変数 2 行を追記。

`oe-ack` / `oe-activity` / `event-bus.sh` / `schemas/*` / `bin/oe` は**不変**（純加算・回帰ゼロ）。

## 検知ロジック（2条件）

- `pending > 0`（未ack）: [#220](https://github.com/stlwolf/ai-development-hub/issues/220) と**同一の frontier read 規則**（`K = min(covers_count, |ts ≤ covers_last_ts|)`・複数 ack は max・巻き戻りなし）を inline 適用。ack ループ本体（`oe-ack` / 受領プロトコル）は再構築せず、`report_received` イベントを consume する。
- `age = now - (最古未ack報告の ts) > W`: 時間窓 W は `--window <sec>` / `OE_UNDELIVERED_WINDOW_SEC` で上書き可（既定 1800s）。運用観測での調律を前提とした出発点。
- **cron 前提で `$TMUX_PANE` を持たず、全 (child→parent) ペアを横断**（`oe-activity --inbox` の self 中心とは異なる）。親子の向きは `child_spawned` / `report_received`(acker) / role / known-parent の複合で解決し、**departed で role 空になる子（mode3 の主対象）も取りこぼさない**。
- 付記（判定には使わない・triage 材料）: 親 liveness（mux 存在 query のみ・capture しない）/ `suspected_miss` 件数。
- 出力は age 降順（最も滞留したものが先頭）。

## read-only / 決定論

- 触れるのは `oe-events.jsonl` と tmux ペイン存在（mux query）のみ。**engine state（events / registry / session-state）を mutate しない**・**ペイン出力を capture しない**（`oe-status` / `oe-activity` と同契約）。
- owner ping は `wez notify`（best-effort）+ **stdout fallback 常時**（cron 到達性の保険）。preview は `oe-activity` と同じ sanitize/cntrl 畳みを通す（会話到達面の無害化・#224/#233）。
- 二重通知抑止（D-b）: verb 固有の seen cache（`${OE_EVENT_DIR}/oe-undelivered/seen`）に無い新規キーのみ notify。**seen は実際に通知できたときだけ追記**（wez 不在 / notify 失敗時は永続抑止しない）。cache は verb 自身の bookkeeping で engine state ではない。
- exit code: 常に 0（observer）・usage エラーのみ 2 / 投影失敗のみ 1。

## Test plan（実行済み）

- [x] `shellcheck bin/oe-undelivered tests/test_oe_undelivered.sh` PASS
- [x] `tests/test_oe_undelivered.sh` 20 節/54 assert — **bash 5.2.37 / 3.2.57 両系 green**
  - 検知（age>W FLAG / age<W no-op / pending==0 / 部分 ack）・kick 除外・departed(role 空)検知・liveness 付記・age 降順・dedup（2 回目抑止 + wez 不在で永続抑止しない回帰）・空/不在/破損 jsonl degrade・制御文字無害化・`--window`/env/優先/不正値・不正オプション・`-h`・jq 不在。
- [x] 隣接回帰: `test_oe_ack`（41）/ `test_oe_activity`（70）/ `test_event_bus`（62）両系 green（既存ファイル不変ゆえ純確認）。

## 実装 SO（`oe-review` impl・1周）

`oe-review --lanes 2 --base master`（codex / cursor・実装者 Claude を除く多様性）。mandate は 1 周だが確認のため 2 周実施し、surface した material 指摘を**すべて修正**、各々に回帰テストを追加した（各修正は SO verdict に依らずテストで独立検証済み）。

- **round1 refuted（2/2）**:
  - **(1) 実行ビット欠落**（codex）: verb が `100644` で追加され README/cron の直接実行経路が不達 → `chmod +x`（`100755`・他 verb と揃う）。
  - **(2) 二重通知抑止の永続化バグ**（cursor）: seen cache が notify 成否・wez 存在と無関係に先行追記され、notify 失敗 / wez 後付け / 中断で owner ping が永続抑止 → **通知成功時のみ追記**へ修正・回帰テスト [19]。
- **round2 refuted（1/2・他 1 レーンは出力不正で verdict 取得できず）**:
  - **(3) label 未サニタイズ**（codex）: `clab`/`plab` が無害化されず stdout / wez notify へ到達し ESC/CSI/OSC 注入・視覚偽装の余地 → preview と同様に jq cntrl 畳み + `oe_sanitize_conversation` で無害化・回帰テスト [20]。
- 弱 SO 規律（1 周・partial は disclose・iterate しない）に従い round2 の修正後は再周回せず停止。全 material 指摘は fix + テスト済み。追加周回が要れば owner 判断で。

## follow-up（本 PR では実装しない・記録のみ）

- frontier read 規則が `oe-ack` / `oe-activity` に続く**3つ目の copy** → 共有 lib への統合（S2 相当）。
- **out-of-scope 発見**: 既存 `oe-activity` / `oe-ack` は label を無害化していない（preview のみ sanitize）。本 PR は watchdog 側のみ塞いだ。同じ label hardening の横展開余地あり（別 PR・本 PR では実装しない）。
- **`wez notify` の cron（no TTY / mux socket）到達性は未検証** → 現状は stdout が durable な signal。届かない場合の代替（`tmux display-message` / alert ファイル）は段階外 defer。README に注記済み。
- owner musing（将来候補・観測性）: (i) viewer の gone 親以下 / 親移譲表示（PR-9 候補据え置き）、(ii) 並列の親での異常蓄積の可視化（段階2/3 or viewer follow-up）。

## スコープ外（段階1以降・別 issue/PR）

seat record / mailbox / re-parenting / heartbeat producer / context% / topology 表示 / malform proxy 検知 / observed projection / run-state schema。

Refs #239
