### PR TITLE
feat(oe): succession board schema の spec doc と advisory validator を追加

### DIFF
--- a/projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md
+++ b/projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md
@@ -1,0 +1,139 @@
+---
+id: "01KX3TKYHM8R07YY8DVT2HTHMT"
+title: "#238 段階1 board schema — cockpit 統括 succession board の declared 層契約"
+date: 2026-07-10
+type: decision
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/238"
+    reason: "統括 succession を第一級概念に。board schema = declared 層（PR-C）"
+  - type: design_context
+    ref: ".oe/ref-plan-stage1.md"
+    reason: "段階1 実装計画の正本。§2 PR-C（schema/validator の内容）・§4 Q8（置き場・粒度・advisory）"
+  - type: reference
+    ref: "projects/orchestration-engine/scripts/validate-envelope.sh"
+    reason: "踏襲した validator idiom（exit code・VERBOSE・helper 構造）"
+  - type: reference
+    ref: "projects/orchestration-engine/scripts/validate-session-state.sh"
+    reason: "同上。必須フィールド + 型 + enum を jq で検証する MVP validator の前例"
+---
+
+# #238 段階1 board schema — cockpit 統括 succession board の declared 層契約
+
+## 1. 目的・位置づけ
+
+cockpit 統括の **succession board**（START HERE board）に、構造と鮮度を強制する schema を与える。統括は使い捨てで state が正本という #238 の前提のもと、board は「統括が死んでも handoff が成立する唯一の外部化 state」である。散文の board で 4 代の handoff は成立してきたが、残る gap は **構造の欠落と鮮度の不明**（後任がどの節を頼れるか、その内容がいつ時点のものかが自明でない）だった。
+
+本 schema は上位アーキ（lean + sidecar）の **declared 層**にあたる。observed 層（watchdog）が読み取る liveness の ground truth を declared 層が補完する（例: `gone + stale` な pane が orderly handoff か crash かを、board の `現統括` / `succession` と突き合わせて判別する）。
+
+- schema の強制手段は advisory validator `projects/orchestration-engine/scripts/validate-board.sh`（後述 §4）。
+- 検証内容は 3 点: **(1) 必須 frontmatter キーの存在 / (2) 鮮度 date が N 日以内 / (3) 必須 section 見出しの存在**。
+
+## 2. 対象と非対象
+
+- **in-repo に足すもの**: 本 schema/spec doc と advisory validator script の 2 点のみ。
+- **board 実体は in-repo に足さない**。board は live な pane 番号や環境 state（machine-local で ephemeral な値）を含むため commit しない。board 実体は external の置き場（`.oe/` = gitignored、または統括の memory 領域）に置いたままにする。
+- したがって本 doc が定義するのは **契約（どんな board が valid か）**であって、特定の board インスタンスではない。schema の adoption（実 board を本 frontmatter 形式へ移行すること）は board 保守側の運用であり、PR-C の scope 外。
+
+## 3. schema 定義
+
+### 3.1 必須 frontmatter
+
+board は YAML frontmatter で始まる（1 行目が `---`、以降に閉じ `---`）。次のキーを必須とする。
+
+| キー | 型 | 説明 | 例 |
+|---|---|---|---|
+| `鮮度` | date（`YYYY-MM-DD`） | board を最後に更新した日。鮮度判定の基準 | `2026-07-10` |
+| `現統括` | string（pane） | 現統括の pane。`%NNN` 形式を推奨（YAML では `%` 始まりは引用符が要る） | `"%144"` |
+| `succession` | string | succession の状態。推奨語彙は `完了` / `進行中` / `未着手`（enum は強制しない） | `完了` |
+
+- **値の形式は advisory では強制しない**（キーの存在のみを必須とする）。正当な board variation を "invalid" と誤検知しないため、必須集合を最小に保つ方針（過剰な必須化をしない）。`現統括` の pane 形式や `succession` の語彙は推奨であって、validator は検査しない。
+
+### 3.2 必須 section
+
+現 board 準拠の H2 見出し（`## `）を必須とする。実見出しは括弧付きの注記を後続させてよい（例 `## 戦略（不変）`）ため、validator は **部分一致**で存在を確認する。
+
+| section | 役割 |
+|---|---|
+| `戦略` | 不変の方針。統括が何を目指すか |
+| `in-flight` | 現統括が担当中の委譲・queued-next |
+| `repo / 環境 state` | master HEAD・worktree・panes 等の環境スナップショット |
+| `統括規律` | succession で必ず引き継ぐ規律（HG・報告 2 段構え等） |
+| `succession 手順` | 後任がやること |
+
+- 上記以外の section（`直近やったこと` / `次タスク候補` / `gotchas` 等）は任意。board の自由度を残すため必須にしない。
+
+### 3.3 鮮度ルール
+
+- `鮮度` の date が **現在から N 日以内**であることを確認する。既定 N = 7 日。
+- N は運用ヒューリスティック（証拠に基づく閾値ではなく、運用でチューニングする値）。環境変数 `OE_BOARD_MAX_AGE_DAYS` で上書きできる。
+- 未来日付は stale 扱いにしない（誤入力の可能性はあるが advisory のため flag しない）。
+
+## 4. validator: `scripts/validate-board.sh`
+
+`validate-envelope.sh` / `validate-session-state.sh` の idiom（exit code・`--verbose`・helper 構造）を踏襲する。ただし検証対象が JSON でなく markdown + YAML frontmatter のため、frontmatter 抽出と section 見出し確認は bash のテキスト処理で行う。
+
+```bash
+# 使い方
+./scripts/validate-board.sh path/to/board.md
+./scripts/validate-board.sh path/to/board.md --verbose
+OE_BOARD_MAX_AGE_DAYS=14 ./scripts/validate-board.sh board.md   # 鮮度しきい値を上書き
+```
+
+- **exit code**: `0 = valid` / `1 = invalid`（1 件以上の WARN） / `2 = file not found / jq 不在 / usage エラー / 非数値の OE_BOARD_* env`。
+- **advisory（warn・非ブロッキング）**: validator は何もブロックしない。問題は `WARN:` 行として stderr に出し、呼び出し側（人 / cron）が対処を判断する。exit 1 は「flag された」ことを programmatic に伝える信号であって、build や hook を落とすためではない。read-only / HG 姿勢と #78 advisory-hook の前例に整合する。
+- **fail-fast しない**: 1 回の実行で全 WARN を出す（board のどこが崩れているかを一望できる）。
+- **env ノブ**:
+  - `OE_BOARD_MAX_AGE_DAYS`（既定 `7`）— 鮮度しきい値（日数）。非負整数のみ。
+  - `OE_BOARD_NOW_EPOCH` — now を固定する epoch。テストの決定化に使う（`oe-undelivered` の `OE_*_NOW_EPOCH` と同型）。非負整数のみ。
+  - いずれも非数値だと `set -u` 下の算術で cryptic に落ちる代わりに、exit 2（環境エラー）で明示的に弾く。
+- **jq の用途**: 鮮度 date（`YYYY-MM-DD`）→ epoch 変換に jq の `strptime | mktime` を使う。BSD / GNU の `date` パース差を避けられる可搬な手段。now は `date +%s`（両系可搬）。
+- **既知の制約**: frontmatter block の判定は「1 行目が `---` かつ以降に `---` 行がある」ヒューリスティック。1 行目が `---` で始まりつつ frontmatter でない（本文冒頭が水平線）board では、本文中の `---` を閉じフェンスと誤認しうる。board は frontmatter で始まる前提のため実害は小さいが、厳密化は将来課題。
+
+## 5. valid な board の最小例
+
+```markdown
+---
+鮮度: 2026-07-10
+現統括: "%144"
+succession: 完了
+---
+
+# START HERE — cockpit 統括 succession board
+
+## 戦略（不変）
+cockpit を早めに整備し運用に回して改善を続ける。
+
+## in-flight（現統括 %144 の担当）
+- アクティブな委譲: なし
+
+## repo / 環境 state
+- master: `6896289` / worktree: main のみ
+
+## 統括規律
+- HG: 子は mutation を自律発火しない。マージ・worktree 掃除は親/人間。
+
+## succession 手順
+1. このボードと MEMORY.md を読む。
+```
+
+## 6. 設計判断・根拠
+
+- **doc 型 = `decision`**: 本 doc は board 形式の契約を定義する仕様書である。type enum（`discussion`/`kickoff`/`plan`/`episode`/`decision`）に `spec` は無く、リポジトリ内で「形式仕様書」の前例である `docs/specs/document-format.md` が `type: decision` を採る。その前例に倣った。`status: draft` は運用検証を経て `stable` に昇格する想定。
+- **advisory に留める根拠**: board は HG 前提の人手保守物であり、機械が更新を強制する対象ではない。read-only / HG 姿勢、および #78 の advisory-hook 前例と整合させ、validator は検知のみ・ブロックしない。
+- **必須集合を最小に保つ根拠**: advisory validator の主リスクは「正当な board variation を invalid と誤検知」すること。よって必須は frontmatter 3 キーの存在 + 鮮度 + section 5 見出しに絞り、値の形式（pane 形・succession 語彙）は推奨に留める。
+- **jq でも date 演算だけ使う根拠**: sibling validator は JSON を jq で検証するが、board は markdown。frontmatter 抽出と見出し確認は bash のテキスト処理が素直で、jq は可搬な date→epoch 変換にのみ使う。
+
+## 7. 非対象・将来 defer
+
+- **複数 seat の board**: MVP は単一 `supervisor` board のみ。複数 seat は seat 概念自体が defer のため不要（`.oe/ref-plan-stage1.md` §4 Q8）。
+- **full JSON Schema 化**: 現状は必須 + 存在 + 鮮度の最小検証。厳密な schema 化（値の形式・enum の強制）が要るなら将来 ajv-cli 等へ移行しうる（sibling validator と同じ defer 方針）。
+- **schema の adoption**: 実 board を本 frontmatter 形式へ移行する運用は board 保守側の作業で、本 PR の scope 外。
+
+## 8. 関連リンク
+
+- Issue #238: https://github.com/stlwolf/ai-development-hub/issues/238
+- 段階1 実装計画（正本・§2 PR-C / §4 Q8）: `.oe/ref-plan-stage1.md`
+- validator: `projects/orchestration-engine/scripts/validate-board.sh`
+- 踏襲した sibling validator: `projects/orchestration-engine/scripts/validate-envelope.sh` / `projects/orchestration-engine/scripts/validate-session-state.sh`

--- a/projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md
+++ b/projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md
@@ -10,7 +10,7 @@ related:
     reason: "統括 succession を第一級概念に。board schema = declared 層（PR-C）"
   - type: design_context
     ref: ".oe/ref-plan-stage1.md"
-    reason: "段階1 実装計画の正本。§2 PR-C（schema/validator の内容）・§4 Q8（置き場・粒度・advisory）"
+    reason: "段階1 実装計画の正本。§2 PR-C（schema/validator の内容）・§4 Q8（置き場・粒度・advisory）。注: .oe/ は gitignore 済みの machine-local 資料で、この checkout には含まれない（out-of-repo）。durable な上位アーキは #238 と decisions/ の succession-watchdog 決定 doc を参照。"
   - type: reference
     ref: "projects/orchestration-engine/scripts/validate-envelope.sh"
     reason: "踏襲した validator idiom（exit code・VERBOSE・helper 構造）"
@@ -134,6 +134,6 @@ cockpit を早めに整備し運用に回して改善を続ける。
 ## 8. 関連リンク
 
 - Issue #238: https://github.com/stlwolf/ai-development-hub/issues/238
-- 段階1 実装計画（正本・§2 PR-C / §4 Q8）: `.oe/ref-plan-stage1.md`
+- 段階1 実装計画（正本・§2 PR-C / §4 Q8）: `.oe/ref-plan-stage1.md`（out-of-repo・`.oe/` は gitignore 済みの machine-local。この checkout には含まれない）
 - validator: `projects/orchestration-engine/scripts/validate-board.sh`
 - 踏襲した sibling validator: `projects/orchestration-engine/scripts/validate-envelope.sh` / `projects/orchestration-engine/scripts/validate-session-state.sh`

--- a/projects/orchestration-engine/docs/episodes/2026-07-10-episode-238-board-schema-validator.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-10-episode-238-board-schema-validator.md
@@ -1,0 +1,73 @@
+---
+id: "01KX3WP95QCFT8RXSK919Z4FDP"
+title: "#238 段階1 PR-C — board schema + advisory validator の実装と2段レビュー"
+date: 2026-07-10
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/238"
+    reason: "統括 succession を第一級概念に。board schema = declared 層（PR-C）"
+  - type: pull_request
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/244"
+    reason: "本 episode が閉じる実装 PR"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md"
+    reason: "本 PR が定義した schema 契約の正本"
+---
+
+# #238 段階1 PR-C — board schema + advisory validator の実装と2段レビュー
+
+> `reconstructed`: 本 episode は作業完了後にまとめて書いた。リアルタイム追記ログではないため、同じ証拠価値では扱わない。
+
+## Context / なぜ
+
+#238「統括 succession を第一級概念に」の段階1 は3 PR に分かれ（PR-A statusline producer / PR-B watchdog consumer / PR-C board schema）、本作業は **PR-C**（declared 層）を親 pane `%144` から委譲されたもの。cockpit 統括の succession board に構造と鮮度を強制する schema と advisory validator を与える。board 実体は machine-local・ephemeral のため commit せず、in-repo には spec doc と validator のみを足す（plan `.oe/ref-plan-stage1.md` §2 PR-C / §4 Q8）。
+
+## 事実・失敗（実行ログに残るもの・選択的省略しない）
+
+初回実装（commit `b3ddd52`）は shellcheck clean・bash 3.2/5.2 両系で 20/20 green だった。にもかかわらず**2 段のレビューで計 5 件の到達可能な欠陥が見つかった**。テスト green が正しさを保証しなかったのが本 episode の主眼。
+
+- **実装 SO（`oe-review`・弱・2 レーン・audit `2026070916203622EHG3X4RCTR`）→ verdict refuted（2/2）**。material 3 件（親が一次再現で確認のうえ修正）:
+  - (a) 鮮度 キー欠落時、値抽出パイプ `grep '^鮮度:' | head | sed` が `set -euo pipefail` 下で grep 非マッチ→pipefail 死し、**section 検査と最終 summary に到達しない**。「全 WARN 一括出力」の契約破り。→ `{ grep || true; }` で吸収。
+  - (b) 空 frontmatter block（`---` のみ）を **valid 扱い**。`[[ -n "$FRONTMATTER" ]]` でキー検査全体を skip していた。→ block の有無（`FM_PRESENT`）と中身を分離し、block があればキー検査を走らせる。
+  - (c) 非数値 `OE_BOARD_*` env が `set -u`+算術で cryptic に落ちる。自 doc の「env エラー→exit 2」と不一致。→ 整数チェックを算術前に置き exit 2。
+- **Copilot review（routine bot・PR #244）→ 2 件（両方採用・commit `312b5ba`）**:
+  - (d) 鮮度 キーは在るが**値が空**（`鮮度:` のみ）だと date check を素通りして exit 0。これは (a) 修正でキー正規表現を `^鮮度:` に緩めた副作用の残り。→ キー宣言時に空値を format 不正として WARN（キー欠落の二重 WARN は回避）。
+  - (e) `related` の `.oe/ref-plan-stage1.md` は gitignore 済みで checkout に含まれず、読者が辿れない。→ out-of-repo である旨を明示。
+
+## 決定と根拠（diff から復元できない「なぜ」）
+
+- **doc 型を `decision` にした**: 「schema/spec doc」の type enum に `spec` は無い。repo 内の形式仕様前例 `docs/specs/document-format.md` が `type: decision` を採るため、それに倣った（新 type を作らない）。
+- **jq を date 演算だけに使った**: sibling validator は JSON を jq で検証するが board は markdown。frontmatter 抽出・見出し確認は bash のテキスト処理が素直で、jq は鮮度 date→epoch の可搬変換（`strptime|mktime`）にのみ使う。BSD/GNU の `date -j -f` vs `-d` 差を避ける狙い。棄却案: `date` で直接パース（両系分岐が要る）。
+- **必須集合を最小に保った**: 値の形式（pane 形・succession 語彙）は強制せず存在のみ必須。advisory validator の主リスク「正当な variation を invalid と誤検知」を避けるため。ただし鮮度だけは date check が中核契約なので、空値は (d) で WARN する（最小主義と契約強制の線引き）。
+
+## わかったこと（W）
+
+- `set -euo pipefail` + `$(pipe | grep | ...)` は、テストが「マッチする経路」しか通っていないと **非マッチ経路の pipefail 死を見逃す**。テスト green は非マッチ分岐の健全性を保証しない。既存 sibling が `H2_LINES` 側だけ `|| true` を持っていたのは、まさにこの落とし穴を1箇所で踏んでいた痕跡だった。
+- 「block の**有無**」と「block の**中身**」を1つの `[[ -n ]]` に畳むと、空 block が"無い"側に倒れて検査を素通りする。存在と内容は別変数で持つべき。
+- 正規表現を緩める修正（(a) の副作用で `^鮮度:[[:space:]]`→`^鮮度:`）は、別の素通り経路（空値 (d)）を開けうる。1つの gate を緩めたら隣接 gate の再確認が要る。
+
+## 原則（Pattern / Anti-pattern）
+
+- **Anti-pattern**: `set -e`/`pipefail` 下で `VAR="$(... | grep PATTERN | ...)"` を、PATTERN 非マッチが正常系なのにガードなしで書く → 非マッチで script 途中終了。
+- **Pattern**: 正常系で非マッチしうる grep は `{ grep ... || true; }` で包むか、`if grep -q ...; then` の条件文（set -e 抑止）に置く。到達判定と値抽出を分ける。
+
+## 蒸留シグナル
+
+- 昇格候補: **なし**（skill/rule への昇格はしない）。上の Anti/Pattern 対は既存 `diff-audit` skill の Bash 堅牢性観点に既に含まれる粒度で、独立 rule 化するほどではない。negative knowledge（#62）注入の候補としては (a)/(d) の「gate を緩めると隣接 gate が開く」が弱いシグナル。
+
+## 残課題（routing 済み）
+
+- **frontmatter 閉じフェンス判定のヒューリスティック**（1 行目 `---`+以降 `---`）: 本文冒頭が水平線の board で誤認しうる。→ 行き先: **spec doc に「既知の制約」として開示済み**（追わない・実害小）。SO cursor も非 primary と判定。
+- **#238 本体**: keep-open。board schema は段階1 の declared 層のみ。PR-A/PR-B（watchdog）と seat 系は別 PR / 段階2。→ 行き先: **#238（多段のため PR merge≠close）**。
+- **マージ・worktree 掃除・#238 close**: owner/親の HG。→ 行き先: **親 `%144` へ報告済み**。
+
+## closure gate
+
+- Context / なぜ: 上記（自己完結）。
+- 次の消費者: **owner（マージ判断）** と **PR-A/PR-B 実装者**（declared×observed の相補＝gone×stale の crash/handoff 判別で board の `現統括`/`succession` を突合する設計が本 schema に依存）。
+- follow-up routing: 上記「残課題」で全件行き先付与。
+- status: **stable**（達成）。マージは owner。
+- evidence anchor: 実装 SO audit `2026070916203622EHG3X4RCTR`（出力 `tmp/oe-review-2026070916203622EHG3X4RCTR/` は揮発）。verdict=refuted・material 3 件は上「事実・失敗」に転記済み。Copilot 2 件は PR #244 の返信スレッド（`discussion_r3553348905` / `r3553349014`）に durable 化。
+- Step4 外部チェック（heavy tier）: 本 episode の closure 品質を `so-compare`（codex/claude 2 レーン）で focused check（出力 `tmp/so-20260710-015327/` は揮発）。**結果: 2/2 とも 4 観点（選択的省略なし / follow-up 全件 routing / 揮発証跡の要点転記 / back-propagation 漏れなし）で PASS**。claude レーンは SO 2 レーンの material dedup（codex=a/b・cursor=a/c → 和集合 3 件）が正しいこと、4 欠陥すべてに回帰テスト [10]-[13] が付くことも確認。

--- a/projects/orchestration-engine/scripts/validate-board.sh
+++ b/projects/orchestration-engine/scripts/validate-board.sh
@@ -108,13 +108,16 @@ if [[ "$FM_PRESENT" -eq 1 ]]; then
 
   # --- (2) 鮮度 date が N 日以内か ---
   log "checking 鮮度 freshness (<= ${MAX_AGE_DAYS} days)..."
-  # grep 非マッチ（鮮度 欠落）でも pipefail/set -e で途中終了しないよう { grep || true; } で吸収し、
-  # section 検査と最終 summary に必ず到達させる（全 WARN 一括出力の契約を守る）。
-  FRESH_RAW="$(printf '%s\n' "$FRONTMATTER" \
-    | { grep -E '^鮮度:' || true; } | head -1 \
-    | sed -E 's/^鮮度:[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//')"
-  if [[ -n "$FRESH_RAW" ]]; then
-    if [[ "$FRESH_RAW" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  # 鮮度 キーが宣言されている場合のみ値を検査する（キー欠落は REQUIRED_KEYS ループで WARN 済み・
+  # ここで二重に出さない）。値が空なら date check を素通りさせず format 不正として WARN する。
+  # 到達判定の grep は if 条件（set -e 抑止）。抽出側は { grep || true; } で pipefail 死を回避する。
+  if printf '%s\n' "$FRONTMATTER" | grep -qE '^鮮度:'; then
+    FRESH_RAW="$(printf '%s\n' "$FRONTMATTER" \
+      | { grep -E '^鮮度:' || true; } | head -1 \
+      | sed -E 's/^鮮度:[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//')"
+    if [[ -z "$FRESH_RAW" ]]; then
+      warn "鮮度 has an empty value (must be YYYY-MM-DD)"
+    elif [[ "$FRESH_RAW" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
       BOARD_EPOCH="$(jq -n --arg d "$FRESH_RAW" '$d | strptime("%Y-%m-%d") | mktime' 2>/dev/null || true)"
       if [[ -z "$BOARD_EPOCH" ]]; then
         warn "鮮度 is not a parseable date: ${FRESH_RAW}"
@@ -128,7 +131,6 @@ if [[ "$FM_PRESENT" -eq 1 ]]; then
       warn "鮮度 must be YYYY-MM-DD, got: ${FRESH_RAW}"
     fi
   fi
-  # 鮮度 キー自体の欠落は上の REQUIRED_KEYS ループで WARN 済み。
 fi
 
 # --- (3) 必須 section 見出しの存在 ---

--- a/projects/orchestration-engine/scripts/validate-board.sh
+++ b/projects/orchestration-engine/scripts/validate-board.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-board.sh — cockpit 統括 succession board（declared 層）の advisory 検証
+#
+# 使用例:
+#   ./scripts/validate-board.sh path/to/board.md
+#   ./scripts/validate-board.sh path/to/board.md --verbose
+#   OE_BOARD_MAX_AGE_DAYS=14 ./scripts/validate-board.sh board.md   # 鮮度しきい値の上書き
+#
+# Exit codes:
+#   0 = valid（すべての check を満たす）
+#   1 = invalid（1件以上の WARN。board 構造/鮮度に問題）
+#   2 = file not found / jq not found / usage エラー
+#
+# 位置づけ:
+#   #238 succession board の schema（frontmatter + 必須 section）を強制する。board は
+#   markdown なので、JSON を検証する validate-envelope.sh / validate-session-state.sh とは
+#   入力形式が違う。exit code・VERBOSE・helper 構造の idiom は踏襲しつつ、検証対象は
+#   (1) YAML frontmatter の必須キー存在 / (2) 鮮度 date が N 日以内 / (3) 必須 section 見出しの存在。
+#   schema 定義の正本は docs/decisions/2026-07-10-decision-238-board-schema.md。
+#
+# advisory（warn・非ブロッキング）:
+#   read-only/HG 姿勢 + #78 advisory-hook 前例に整合し、本 validator は何もブロックしない。
+#   問題は WARN 行として stderr に出し、呼び出し側（人/cron）が対処を判断する。exit 1 は
+#   「flag された」ことを programmatic に伝える信号であって、build/hook を落とすためのものではない。
+#   fail-fast はせず、1回の実行で全 WARN を出す（board のどこが崩れているか一望できる）。
+#
+# jq の用途:
+#   鮮度 date（YYYY-MM-DD）→ epoch 変換に jq の strptime|mktime を使う。BSD/GNU date の
+#   パース差（-j -f vs -d）を避けられる可搬な方法。now は date +%s（両系可搬）。
+
+VERBOSE=0
+if [[ "${2:-}" == "--verbose" ]]; then
+  VERBOSE=1
+fi
+
+log() {
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    echo "[validate-board] $*" >&2
+  fi
+}
+
+WARN_COUNT=0
+warn() {
+  echo "WARN: $*" >&2
+  WARN_COUNT=$((WARN_COUNT + 1))
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is not installed" >&2
+  exit 2
+fi
+
+TARGET="${1:-}"
+if [[ -z "$TARGET" ]]; then
+  echo "Usage: $0 <board.md> [--verbose]" >&2
+  exit 2
+fi
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "ERROR: file not found: $TARGET" >&2
+  exit 2
+fi
+
+# 鮮度しきい値（日数）と now（テスト決定化用の epoch 上書き）。
+# 既定 7 日は運用ヒューリスティック（証拠に基づく閾値ではない・運用でチューニング）。
+MAX_AGE_DAYS="${OE_BOARD_MAX_AGE_DAYS:-7}"
+NOW_EPOCH="${OE_BOARD_NOW_EPOCH:-$(date +%s)}"
+
+# 非数値の env は算術比較前に弾く（set -u 下の cryptic な arithmetic エラーでなく、
+# doc どおり exit 2 = 環境エラーで返す）。
+if ! [[ "$MAX_AGE_DAYS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: OE_BOARD_MAX_AGE_DAYS must be a non-negative integer: $MAX_AGE_DAYS" >&2
+  exit 2
+fi
+if ! [[ "$NOW_EPOCH" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: OE_BOARD_NOW_EPOCH must be a non-negative integer (epoch): $NOW_EPOCH" >&2
+  exit 2
+fi
+
+# --- (1) YAML frontmatter 抽出 + 必須キー ---
+log "checking YAML frontmatter block..."
+
+# frontmatter = 1行目が '---' で、以降に閉じ '---' がある場合のみ block ありと判定する。
+# block の有無（FM_PRESENT）と中身（FRONTMATTER・空でありうる）を区別する:
+# 空 block（--- のみ）を valid 扱いしないため、block がある限りキー検査は走らせる。
+FM_PRESENT=0
+FRONTMATTER=""
+if [[ "$(sed -n '1p' "$TARGET")" == "---" ]] \
+  && sed -n '2,$p' "$TARGET" | grep -qxF -- '---'; then
+  FM_PRESENT=1
+  FRONTMATTER="$(awk 'NR==1 && $0=="---"{f=1; next} f && $0=="---"{exit} f{print}' "$TARGET")"
+else
+  warn "YAML frontmatter block not found (1行目 '---' + 閉じ '---' が必要)"
+fi
+
+if [[ "$FM_PRESENT" -eq 1 ]]; then
+  log "checking required frontmatter keys..."
+  # 必須 frontmatter キー（存在のみを必須。値の形式は advisory では強制しない＝
+  # 正当な variation の誤検知を避ける）。キー宣言の有無を見るため colon の直後は問わない。
+  REQUIRED_KEYS=("鮮度" "現統括" "succession")
+  for key in "${REQUIRED_KEYS[@]}"; do
+    if ! printf '%s\n' "$FRONTMATTER" | grep -qE "^${key}:"; then
+      warn "missing required frontmatter key: ${key}"
+    fi
+  done
+
+  # --- (2) 鮮度 date が N 日以内か ---
+  log "checking 鮮度 freshness (<= ${MAX_AGE_DAYS} days)..."
+  # grep 非マッチ（鮮度 欠落）でも pipefail/set -e で途中終了しないよう { grep || true; } で吸収し、
+  # section 検査と最終 summary に必ず到達させる（全 WARN 一括出力の契約を守る）。
+  FRESH_RAW="$(printf '%s\n' "$FRONTMATTER" \
+    | { grep -E '^鮮度:' || true; } | head -1 \
+    | sed -E 's/^鮮度:[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//')"
+  if [[ -n "$FRESH_RAW" ]]; then
+    if [[ "$FRESH_RAW" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      BOARD_EPOCH="$(jq -n --arg d "$FRESH_RAW" '$d | strptime("%Y-%m-%d") | mktime' 2>/dev/null || true)"
+      if [[ -z "$BOARD_EPOCH" ]]; then
+        warn "鮮度 is not a parseable date: ${FRESH_RAW}"
+      else
+        AGE_DAYS=$(( (NOW_EPOCH - BOARD_EPOCH) / 86400 ))
+        if [[ "$AGE_DAYS" -gt "$MAX_AGE_DAYS" ]]; then
+          warn "board is stale: 鮮度=${FRESH_RAW} (${AGE_DAYS} days old > ${MAX_AGE_DAYS})"
+        fi
+      fi
+    else
+      warn "鮮度 must be YYYY-MM-DD, got: ${FRESH_RAW}"
+    fi
+  fi
+  # 鮮度 キー自体の欠落は上の REQUIRED_KEYS ループで WARN 済み。
+fi
+
+# --- (3) 必須 section 見出しの存在 ---
+log "checking required section headings..."
+# 現 board 準拠の H2 見出し。実見出しは接尾（括弧付き注記）を持つため部分一致で判定する。
+REQUIRED_SECTIONS=("戦略" "in-flight" "repo / 環境 state" "統括規律" "succession 手順")
+H2_LINES="$(grep -E '^##[[:space:]]' "$TARGET" || true)"
+for section in "${REQUIRED_SECTIONS[@]}"; do
+  if ! printf '%s\n' "$H2_LINES" | grep -qF -- "$section"; then
+    warn "missing required section heading: ${section}"
+  fi
+done
+
+# --- 結果 ---
+if [[ "$WARN_COUNT" -eq 0 ]]; then
+  echo "OK: $TARGET"
+  exit 0
+else
+  echo "INVALID: $TARGET (${WARN_COUNT} issue(s); advisory)" >&2
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_validate_board.sh
+++ b/projects/orchestration-engine/tests/test_validate_board.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_validate_board.sh — scripts/validate-board.sh（#238 段階1 PR-C・board schema）の検証。
+#
+# board schema の 3 check を fixture で網羅する:
+#   (1) 必須 frontmatter キーの存在 / (2) 鮮度 date が N 日以内 / (3) 必須 section 見出しの存在。
+# 鮮度は決定論化のため OE_BOARD_NOW_EPOCH で now を固定する（date +%s は使わない）。
+# validator は test_envelope.sh と同じく subprocess で叩き、内側 validator を本テストと同じ
+# bash（${BASH}）で起動して bash 3.2 / 5.x 両系ゲートを実効化する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$PROJECT_DIR/scripts/validate-board.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+# 固定 now = 2026-07-12（UTC）。鮮度 2026-07-10 → age 2（fresh）、2026-06-01 → age 41（stale）。
+NOW="$(jq -n '"2026-07-12" | strptime("%Y-%m-%d") | mktime')"
+
+PASS=0; FAIL=0
+ck()  { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
+ckc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (missing [$3] in: $2)"; FAIL=$((FAIL+1)); fi; }
+ncc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  FAIL: $1 (unexpected [$3])"; FAIL=$((FAIL+1)); else echo "  PASS: $1"; PASS=$((PASS+1)); fi; }
+
+RUN_RC=0; RUN_OUT=""
+# run <now_epoch> [args...] — 固定 now で validator を回し、stdout+stderr と exit code を捕捉。
+run() {
+  local now="$1"; shift
+  local out rc=0
+  out="$(env OE_BOARD_NOW_EPOCH="$now" "$BASH" "$VALIDATOR" "$@" 2>&1)" || rc=$?
+  RUN_RC="$rc"; RUN_OUT="$out"
+}
+
+# 完全に valid な board を書き出す（各テストで必要な行を削って崩す）。
+write_valid_board() {
+  cat > "$1" <<'EOF'
+---
+鮮度: 2026-07-10
+現統括: "%144"
+succession: 完了
+---
+
+# START HERE — cockpit 統括 succession board
+
+## 戦略（不変）
+cockpit を早めに整備し運用に回す。
+
+## in-flight（現統括 %144 の担当）
+- アクティブな委譲: なし
+
+## repo / 環境 state
+- master: `6896289` / worktree: main のみ
+
+## 統括規律
+- HG: 子は mutation を自律発火しない。
+
+## succession 手順
+1. このボードと MEMORY.md を読む。
+EOF
+}
+
+# ============================================================================
+echo "[1] valid board → exit 0 / OK"
+B="$_TMP_DIR/valid.md"; write_valid_board "$B"
+run "$NOW" "$B"
+ck  "exit 0"    "0" "$RUN_RC"
+ckc "OK 出力"   "$RUN_OUT" "OK: $B"
+
+echo "[2] frontmatter 欠落 → exit 1 / WARN frontmatter"
+B="$_TMP_DIR/no-frontmatter.md"
+cat > "$B" <<'EOF'
+# START HERE — cockpit 統括 succession board
+
+## 戦略（不変）
+x
+
+## in-flight（現統括）
+- なし
+
+## repo / 環境 state
+- master: `6896289`
+
+## 統括規律
+- HG
+
+## succession 手順
+1. read
+EOF
+run "$NOW" "$B"
+ck  "exit 1"          "1" "$RUN_RC"
+ckc "WARN frontmatter" "$RUN_OUT" "frontmatter block not found"
+
+echo "[3] 必須 section 欠落（統括規律を削除）→ exit 1 / WARN section"
+B="$_TMP_DIR/missing-section.md"; write_valid_board "$B"
+# 統括規律 節（見出し + 本文行）を削除
+grep -v '統括規律' "$B" | grep -v '子は mutation' > "$B.tmp" && mv "$B.tmp" "$B"
+run "$NOW" "$B"
+ck  "exit 1"        "1" "$RUN_RC"
+ckc "WARN section"  "$RUN_OUT" "missing required section heading: 統括規律"
+ncc "戦略 は誤検知しない" "$RUN_OUT" "missing required section heading: 戦略"
+
+echo "[4] 鮮度 古い → exit 1 / WARN stale"
+B="$_TMP_DIR/stale.md"; write_valid_board "$B"
+sed 's/^鮮度: .*/鮮度: 2026-06-01/' "$B" > "$B.tmp" && mv "$B.tmp" "$B"
+run "$NOW" "$B"
+ck  "exit 1"      "1" "$RUN_RC"
+ckc "WARN stale"  "$RUN_OUT" "board is stale"
+ckc "鮮度値を出す" "$RUN_OUT" "2026-06-01"
+
+echo "[5] 必須 frontmatter キー欠落（現統括を削除）→ exit 1 / WARN key"
+B="$_TMP_DIR/missing-key.md"; write_valid_board "$B"
+sed '/^現統括:/d' "$B" > "$B.tmp" && mv "$B.tmp" "$B"
+run "$NOW" "$B"
+ck  "exit 1"     "1" "$RUN_RC"
+ckc "WARN key"   "$RUN_OUT" "missing required frontmatter key: 現統括"
+
+echo "[6] 鮮度が不正な形式 → exit 1 / WARN format"
+B="$_TMP_DIR/bad-date.md"; write_valid_board "$B"
+sed 's/^鮮度: .*/鮮度: 2026\/07\/10/' "$B" > "$B.tmp" && mv "$B.tmp" "$B"
+run "$NOW" "$B"
+ck  "exit 1"        "1" "$RUN_RC"
+ckc "WARN 形式"     "$RUN_OUT" "鮮度 must be YYYY-MM-DD"
+
+echo "[7] file not found → exit 2"
+run "$NOW" "$_TMP_DIR/does-not-exist.md"
+ck  "exit 2"          "2" "$RUN_RC"
+ckc "file not found"  "$RUN_OUT" "file not found"
+
+echo "[8] 鮮度しきい値の境界: age==N は fresh / age==N+1 は stale"
+B="$_TMP_DIR/edge-fresh.md"; write_valid_board "$B"
+sed 's/^鮮度: .*/鮮度: 2026-07-05/' "$B" > "$B.tmp" && mv "$B.tmp" "$B"   # age=7（既定 N=7）
+run "$NOW" "$B"
+ck  "age==7 fresh exit 0" "0" "$RUN_RC"
+B="$_TMP_DIR/edge-stale.md"; write_valid_board "$B"
+sed 's/^鮮度: .*/鮮度: 2026-07-04/' "$B" > "$B.tmp" && mv "$B.tmp" "$B"   # age=8
+run "$NOW" "$B"
+ck  "age==8 stale exit 1" "1" "$RUN_RC"
+
+echo "[9] OE_BOARD_MAX_AGE_DAYS 上書きで古い board も fresh 扱い"
+B="$_TMP_DIR/override.md"; write_valid_board "$B"
+sed 's/^鮮度: .*/鮮度: 2026-06-01/' "$B" > "$B.tmp" && mv "$B.tmp" "$B"   # age=41
+rc=0
+OUT="$(env OE_BOARD_NOW_EPOCH="$NOW" OE_BOARD_MAX_AGE_DAYS=60 "$BASH" "$VALIDATOR" "$B" 2>&1)" || rc=$?
+ck  "MAX=60 で fresh exit 0" "0" "$rc"
+ckc "OK 出力" "$OUT" "OK: $B"
+
+echo "[10] frontmatter あり・鮮度 欠落 → set -e で落ちず section 検査に到達（全 WARN 一括）"
+B="$_TMP_DIR/no-fresh.md"; write_valid_board "$B"
+sed '/^鮮度:/d' "$B" > "$B.tmp" && mv "$B.tmp" "$B"
+# section も1つ落とし「鮮度欠落でも section WARN が出る＝途中終了していない」を確認
+grep -v 'succession 手順' "$B" | grep -v 'このボードと MEMORY' > "$B.tmp" && mv "$B.tmp" "$B"
+run "$NOW" "$B"
+ck  "exit 1"                       "1" "$RUN_RC"
+ckc "鮮度 欠落 WARN"               "$RUN_OUT" "missing required frontmatter key: 鮮度"
+ckc "鮮度欠落でも section 検査到達" "$RUN_OUT" "missing required section heading: succession 手順"
+ckc "INVALID summary 到達"         "$RUN_OUT" "INVALID:"
+
+echo "[11] 空 frontmatter block（--- のみ）→ 必須キー 3 つを WARN（valid 扱いしない）"
+B="$_TMP_DIR/empty-fm.md"
+{
+  printf -- '---\n---\n\n# START HERE\n\n'
+  printf '## 戦略\nx\n## in-flight\nx\n## repo / 環境 state\nx\n## 統括規律\nx\n## succession 手順\nx\n'
+} > "$B"
+run "$NOW" "$B"
+ck  "exit 1"              "1" "$RUN_RC"
+ckc "鮮度 欠落 WARN"      "$RUN_OUT" "missing required frontmatter key: 鮮度"
+ckc "現統括 欠落 WARN"    "$RUN_OUT" "missing required frontmatter key: 現統括"
+ckc "succession 欠落 WARN" "$RUN_OUT" "missing required frontmatter key: succession"
+
+echo "[12] 非数値 env → exit 2（環境エラー・cryptic な arithmetic エラーにしない）"
+B="$_TMP_DIR/valid2.md"; write_valid_board "$B"
+rc=0; OUT="$(env OE_BOARD_MAX_AGE_DAYS=abc "$BASH" "$VALIDATOR" "$B" 2>&1)" || rc=$?
+ck  "MAX_AGE_DAYS 非数値 exit 2" "2" "$rc"
+ckc "env エラーメッセージ"       "$OUT" "OE_BOARD_MAX_AGE_DAYS must be"
+rc=0; OUT="$(env OE_BOARD_NOW_EPOCH=notanumber "$BASH" "$VALIDATOR" "$B" 2>&1)" || rc=$?
+ck  "NOW_EPOCH 非数値 exit 2" "2" "$rc"
+
+# --- サマリ ---
+echo ""
+echo "=== Results: PASS=$PASS FAIL=$FAIL ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/projects/orchestration-engine/tests/test_validate_board.sh
+++ b/projects/orchestration-engine/tests/test_validate_board.sh
@@ -179,6 +179,14 @@ ckc "env エラーメッセージ"       "$OUT" "OE_BOARD_MAX_AGE_DAYS must be"
 rc=0; OUT="$(env OE_BOARD_NOW_EPOCH=notanumber "$BASH" "$VALIDATOR" "$B" 2>&1)" || rc=$?
 ck  "NOW_EPOCH 非数値 exit 2" "2" "$rc"
 
+echo "[13] 鮮度 キーあり・値が空 → exit 1 / WARN empty（date check を素通りさせない）"
+B="$_TMP_DIR/empty-fresh.md"; write_valid_board "$B"
+sed 's/^鮮度: .*/鮮度:/' "$B" > "$B.tmp" && mv "$B.tmp" "$B"
+run "$NOW" "$B"
+ck  "exit 1"        "1" "$RUN_RC"
+ckc "WARN empty 値" "$RUN_OUT" "鮮度 has an empty value"
+ncc "missing key の二重 WARN を出さない" "$RUN_OUT" "missing required frontmatter key: 鮮度"
+
 # --- サマリ ---
 echo ""
 echo "=== Results: PASS=$PASS FAIL=$FAIL ==="


### PR DESCRIPTION
## 目的

#238 段階1 の **PR-C（declared 層）**。cockpit 統括の succession board（START HERE board）に、構造と鮮度を強制する schema と advisory validator を与える。上位アーキ（lean + sidecar）の declared 層にあたり、observed 層（watchdog）の liveness ground truth を補完する。

実装計画の正本は `.oe/ref-plan-stage1.md`（§2 PR-C / §4 Q8）。PR-A（producer）/ PR-B（consumer）とは独立・並行。

## 変更内容（in-repo に足すのは 2 点のみ）

- **spec doc** `projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md`
  - 必須 frontmatter（`鮮度` / `現統括` / `succession`）+ 必須 section 5 種（`戦略` / `in-flight` / `repo / 環境 state` / `統括規律` / `succession 手順`）+ 鮮度 N 日ルールを定義。
  - board 実体は commit しない理由（machine-local・ephemeral な pane 番号 / 環境 state を含む）と、値の形式を advisory では強制しない（必須集合を最小に保ち誤検知を避ける）方針を記載。
- **validator** `projects/orchestration-engine/scripts/validate-board.sh`
  - `validate-envelope.sh` / `validate-session-state.sh` の idiom 踏襲（exit `0=valid` / `1=invalid` / `2=not found・jq 不在・env エラー`・`--verbose`）。
  - markdown board から (1) frontmatter 必須キー存在 / (2) 鮮度 date が N 日以内 / (3) 必須 section 見出し存在 を check。
  - **advisory（warn・非ブロッキング）**: 何もブロックせず `WARN:` を出す。fail-fast せず 1 回で全 WARN を出す。read-only / HG 姿勢と #78 advisory-hook 前例に整合。
  - 鮮度 date→epoch は jq `strptime | mktime` で可搬に演算（BSD / GNU の `date` 差を回避）。しきい値は `OE_BOARD_MAX_AGE_DAYS`（既定 7）、now 固定は `OE_BOARD_NOW_EPOCH`（テスト決定化）で上書き可。

## 検証

- 新規 `projects/orchestration-engine/tests/test_validate_board.sh`（`test_envelope.sh` の validator 起動前例に倣う）。valid / frontmatter 欠落 / section 欠落 / 古い鮮度 / 鮮度形式不正 / 境界（age==N fresh・N+1 stale）/ env 上書き / not-found / 鮮度キー欠落 / 空 frontmatter / 非数値 env を網羅。
- **bash 5.2 / 3.2.57 両系で 31/31 green**、`shellcheck` clean。既存 test は改変なし。
- 実 board（旧・freeform header 形式）に対しても動作確認: frontmatter 未採用を advisory に flag しつつ 5 section は正しく認識（schema は forward-looking）。

## 実装 SO（oe-review・弱・2 レーン）

audit `2026070916203622EHG3X4RCTR`。初回 refuted の material 指摘を reconcile 済み（親側で一次再現も確認）:

- 鮮度 欠落時に `set -e` / `pipefail` で途中終了し section 検査・summary に届かない → `{ grep || true }` で吸収。
- 空 frontmatter block（`---` のみ）を valid 扱い → block 有無とキー検査を分離し、block がある限りキー検査を走らせる。
- 非数値 `OE_BOARD_*` env が cryptic に落ちる → exit 2（環境エラー）で明示的に弾く（doc とも整合）。

いずれも回帰テストを追加。既知の制約（frontmatter 閉じフェンス判定のヒューリスティック）は spec doc に開示。

## scope 境界

- **README は触らない**（PR-B と同一ファイル追記 hotspot 回避。validator の説明は spec doc に集約）。
- board 実体（`.oe/` の START HERE board）は commit しない。
- statusline producer（PR-A）/ consumer（PR-B）は本 PR の対象外。

## 影響範囲・リスク

- 追加のみ（新規 3 ファイル）。既存挙動への影響なし。
- validator は read-only・no mutation・advisory。主リスクは「正当な board variation を invalid と誤検知」で、必須集合を最小に保ち緩和。

Refs #238
