### PR TITLE
feat(oe): 統括 vital 監視 consumer oe-vitals を追加（#239 段階1 PR-B）

### DIFF
--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -6,7 +6,7 @@ scripts は 2 系統に分かれる（[`../README.md`](../README.md) 「2 系統
 
 - **本体エンジン**: `oe`（+ 補助 `oe-capture`）
 - **親子委譲 CLI（delegate-task 系）**: `oe-delegate` / `oe-kick` / `oe-send` / `oe-list` / `oe-select` / `oe-report` / `oe-ack`（受領印・#206A） / `oe-jump`（通知→ペインへ focus）
-- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox（PENDING=未受領数）/ timeline・#206） / `oe-undelivered`（報告未達検知 watchdog・未ack 報告 × 時間窓・cron 可・#239 段階0）
+- **観測（cockpit・read-only）**: `oe-status`（engine state/audit + delegate liveness の俯瞰） / `oe-ident`（ペイン識別子を border へ read 時投影） / `oe-activity`（親子活動ログ `oe-events.jsonl` を read 時投影・report inbox（PENDING=未受領数）/ timeline・#206） / `oe-undelivered`（報告未達検知 watchdog・未ack 報告 × 時間窓・cron 可・#239 段階0） / `oe-vitals`（統括 vital 監視 watchdog・拍動鮮度 + context% 閾値・cron 可・#239 段階1）
 
 ---
 
@@ -419,6 +419,33 @@ oe-undelivered -h | --help
 
 ---
 
+## oe-vitals — 統括 vital 監視 watchdog（#239 段階1・read-only・cron 可）
+
+statusLine 拍動 producer（PR-A・`canonical/claude/statusline/statusline-oe-heartbeat.sh`）が session 毎に書く sidecar（拍動 = `{ts, context_pct, pane}`）を **out-of-session cron から読み**、統括 session の **context% 肥大接近**（mode1 context 肥大死＝#238 中核）と **プロセス死**（pane 消滅）を検知して owner に ping する read-only 観測 verb。段階0 `oe-undelivered` の family（seen cache dedup / `wez notify` best-effort + stdout durable / exit 0 / `--window` + env + `NOW_EPOCH`）を踏襲する。**入力面は別**（`oe-undelivered` は oe-events.jsonl の frontier、本 verb は sidecar dir）。
+
+```bash
+oe-vitals                          # 既定 W=1800s / T=85% で統括 vital を判定し owner ping
+oe-vitals --window 3600            # 拍動 staleness 窓 W を 1 時間へ
+oe-vitals --threshold 90           # context% 閾値 T を 90 へ
+oe-vitals -h | --help
+```
+
+- **2 検知器**: (1) **context**（`beat fresh + pane ¬gone + context_pct > T` → handoff 促し・#238 中核）(2) **death**（`pane が tmux 確定 gone` のときのみ・beat 鮮度非依存 → crash 疑い）。`alive/? × stale` は no-op（生存/不明を死に化かさない・hang 誤検知を実装しない）。**tmux 不在時は death 検知不可・context のみ degrade 動作**（偽陽性を出すより安全側）。
+- **統括スコープ化（board 突合）**: sidecar dir には statusLine を持つ全 session の beat が入るため、board（declared 層・PR-C）の `現統括` pane（`現統括:` 宣言行の最初の `%NNN`・見出し併記は除外）と sidecar の `pane` を突合し、現統括の sidecar だけを判定する。board path は `OE_BOARD_FILE` で与える（machine-local・既定なし）。**未設定 / 未解決 / 現統括 pane の sidecar 不在 → no-op**（未設定を「死」に化かさない）。orderly handoff 後は board の `現統括` が後任へ進み前任は scope 外＝想定内 handoff は ping しない（`gone × declared` のみ crash 疑い）。
+- **出力**: stdout に FLAG（cron ログ / 手動確認の durable signal）。owner ping は `wez notify`（best-effort）。**二重通知抑止**: verb 固有 seen cache（`${OE_EVENT_DIR}/oe-vitals/seen`・キー `<kind>|<session_id>`・通知成功時のみ追記。producer の sidecar dir `oe-heartbeat/` とは別 namespace）。
+- **read-only / 非検出**: 触れるのは sidecar dir / board / tmux ペイン存在（mux query）のみ。producer の sidecar は **GC しない**（削除しない＝read-only 観測姿勢）。exit は常に 0（observer）・usage エラーのみ 2。
+- **cron 配線**（登録は owner 環境依存・自動化しない）: verb 単体では回らない。周期実行の crontab / launchd エントリ設置は deployment 手順で、段階0 `oe-undelivered` と同じ out-of-session cron に相乗りする。`OE_BOARD_FILE` を必ず設定すること（board 突合の前提）。例:
+
+  ```
+  */15 * * * * OE_BOARD_FILE="$HOME/path/to/.oe/START-HERE-board.md" /path/to/oe-vitals >> "$HOME/.claude/state/oe-vitals/cron.log" 2>&1
+  ```
+
+- **既知の制約 / 運用前提**（開示）: board 突合は sidecar の `pane` が埋まっている前提（producer の `$TMUX_PANE` 伝播依存・PR-A は session_id 主キーで pane は best-effort）。未伝播なら scope できず no-op（sidecar が全て pane 空なら明示 warn）。実 board は PR-C schema へ未 migrate でも現行 freeform 行に対応。`wez notify` の cron 到達性は未検証 → stdout が durable signal。follow-up: board が `session_id` を declare（pane 非依存化）/ context の再 ping interval / inert 時の config-health ping。
+
+関連: producer `../../../canonical/claude/statusline/statusline-oe-heartbeat.sh`（sidecar 契約の正本）/ board schema `../scripts/validate-board.sh`・`../docs/decisions/2026-07-10-decision-238-board-schema.md`（`現統括` declared 層）/ template `bin/oe-undelivered`（read-only 観測 family）。
+
+---
+
 ## 主要な環境変数
 
 | 変数 | 用途 | 既定 |
@@ -437,5 +464,10 @@ oe-undelivered -h | --help
 | `OE_EVENT_PREVIEW_MAX` | message_sent の preview 切り詰め codepoint 数 | `100` |
 | `OE_UNDELIVERED_WINDOW_SEC` | oe-undelivered: 報告未達とみなす時間窓 W（秒）。`--window` が優先 | `1800`（30分） |
 | `OE_UNDELIVERED_NOW_EPOCH` | oe-undelivered: now（epoch 秒）の上書き。主にテストの age 決定論化用 | （`date +%s`） |
+| `OE_VITALS_WINDOW_SEC` | oe-vitals: 拍動 staleness 窓 W（秒）。`--window` が優先 | `1800`（30分） |
+| `OE_VITALS_CONTEXT_THRESHOLD` | oe-vitals: context% 閾値 T（0-100 整数）。`--threshold` が優先 | `85` |
+| `OE_VITALS_NOW_EPOCH` | oe-vitals: now（epoch 秒）の上書き。主にテストの鮮度決定論化用 | （`date +%s`） |
+| `OE_BOARD_FILE` | oe-vitals: 統括スコープ化に使う board（`現統括` pane を含む）の path。未設定なら scope 不能で no-op | （なし） |
+| `OE_HEARTBEAT_DIR` | oe-vitals が読む sidecar dir（**producer PR-A と共有**の env ノブ） | `~/.claude/state/oe-heartbeat` |
 
 本体エンジン側（`OE_POLL_INTERVAL` / `OE_CB_*` / `OE_TARGET_AI_*` / `OE_VERIFY_AI_*` 等）は [`../lib/constants.sh`](../lib/constants.sh) を参照。

--- a/projects/orchestration-engine/bin/oe-vitals
+++ b/projects/orchestration-engine/bin/oe-vitals
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# oe-vitals — 統括の vital 監視 consumer（#239 段階1 PR-B・read-only・cron 可）
+#
+# usage:
+#   oe-vitals [--window <sec>] [--threshold <pct>]
+#   oe-vitals -h | --help
+#
+# 目的（mode1 context 肥大死 / プロセス死の機械化）: statusLine 拍動 producer（PR-A・
+#   statusline-oe-heartbeat.sh）が session 毎に書く sidecar（拍動 = {ts, context_pct, pane}）を
+#   out-of-session の cron から読み、統括 session の vital（拍動鮮度 + context% 負荷）を判定して
+#   owner に ping する。#238 の中核「context 閾値 handoff の自己申告脱却」に最短で届ける観測 verb。
+#
+# 位置づけ（read-only 観測 family = oe-status / oe-activity / oe-undelivered と同群）:
+#   - engine state（oe-events.jsonl / delegate-registry / session-state）も producer の sidecar も
+#     一切 mutate しない。読むのは sidecar dir と board file と tmux ペイン存在（mux query）のみ。
+#     ペイン出力は capture しない（決定論）。GC（停止 session の sidecar 掃除）は producer data の
+#     mutation ゆえ行わない（read-only 観測姿勢・任意の bookkeeping は seen cache のみ）。
+#   - 入力面が段階0 と別: `oe-undelivered` は oe-events.jsonl の frontier（未ack）を読むが、本 verb は
+#     sidecar dir を読む。→ frontier read の jq（oe-undelivered の「3つ目の copy」）は再コピーしない。
+#
+# 2つの検知器を正しく分離する（設計SO の反証を反映した改訂版・設計の肝）:
+#   1. context% 閾値（mode1 context 肥大死＝#238 中核・確度が高い）:
+#        beat fresh + pane が gone でない（alive or ?）+ context_pct > T → handoff 期 → ping。
+#        beat fresh は「ctx 値が信頼できる＝直近まで書けている」ことを担保する。
+#   2. death（プロセス死＝crash・pane 消滅）:
+#        pane が tmux で **確定 gone** のときのみ ping（beat 鮮度に依存しない）。
+#        当初は「beat-staleness＝プロセス死検知」（生存プロセスは refreshInterval の fixed timer で beat を
+#        撃ち続けるから）としたが、設計SO(codex/claude/cursor)が反証: (a)tmux 不在/socket 不通の `?` を
+#        `¬alive` として death 扱いし cron で偽 crash ping を出す、(b)「idle でも beat 継続」premise は
+#        実機未検証で death の linchpin にできない。→ death は **確定 gone のみ**に絞る。これで ? は死に
+#        ならず、idle-premise は death の前提から外れ、gone×fresh も即検知される（旧設計の最大 W 遅延を解消）。
+#   alive×stale / ?×stale は no-op（生存/不明を死に化かさない・「alive×stale→hang」は実装しない）。
+#   代償: tmux 不在時は death を検知できない（context のみ degrade 動作）。これは偽陽性を出すより安全側。
+#
+# 真理値表（統括 session のみ対象・board 突合で scope 化した後）:
+#   | pane      | beat 鮮度 | context% | 解釈                       | 動作                       |
+#   |-----------|-----------|----------|----------------------------|----------------------------|
+#   | alive / ? | fresh     | > T      | context 肥大接近（#238 中核）| ping（handoff 促し）        |
+#   | alive / ? | fresh     | ≤ T      | 健全                       | なし                       |
+#   | alive / ? | stale     | —        | 生存/不明×拍動停止（idle 等）| なし（死に化かさない・開示穴）|
+#   | gone      | fresh/stale| —       | プロセス終了（crash 疑い）  | ping（1回・board 突合で判別）|
+#   | 不在      | —         | —        | producer 未設定 — 死ではない | なし（未設定を検知に化かさない）|
+#
+# 統括スコープ化（board 突合・MVP）: sidecar dir には statusLine を持つ全 session の beat が入る
+#   （統括に限らない）。consumer は統括 session だけを対象化する。board（declared 層・PR-C）の
+#   `現統括` pane と、sidecar の pane を突合し、現統括の sidecar だけを判定する。board は machine-local
+#   （gitignored `.oe/`・commit しない）ゆえ path は OE_BOARD_FILE で与える（既定なし）。board が
+#   未設定 / 未解決なら統括を特定できず no-op（検知に化かさない）。
+#
+# gone×stale の crash/handoff 曖昧性は board 突合そのものが解く: orderly handoff 後は board の
+#   `現統括` が後任 pane に進むため、停止した前任の sidecar は現統括と一致せず scope 外になる
+#   （＝想定内の handoff は ping しない）。board がまだ死んだ pane を `現統括` と declare したまま
+#   その pane が gone×stale なら crash 疑い → ping（declared が observed の ground truth を補完）。
+#   seen cache は「session 毎に 1 回だけ ping」して二重通知を抑止する。
+#
+# ping 経路（oe-undelivered と同一）: `wez notify`（best-effort）+ stdout が durable な signal +
+#   verb 固有 seen cache（${OE_EVENT_DIR}/oe-vitals/seen・キー "<kind>|<session_id>"・通知成功時のみ
+#   追記）で二重通知を抑止する。cache は verb 自身の bookkeeping で engine state ではない。
+# exit code: 常に 0（observer）。usage エラーのみ 2 / sidecar 投影失敗は個別 skip。
+#
+# 既知の制約（新規導入でなく producer 契約 / 環境由来・開示）:
+#   - board 突合は sidecar の `pane` が埋まっている前提。producer は pane=${TMUX_PANE:-} を書くため、
+#     statusLine 実行 env に $TMUX_PANE が伝播しないと pane は空になり、現統括 pane と突合できず
+#     統括を特定できない（＝検知が no-op に落ちる）。この場合は「絶対 fresh の統括 sidecar が居ても
+#     scope できない」ことを honest に stdout へ出す。
+#   - board の `現統括` は PR-C frontmatter 形（`現統括: "%144"`）と現行 freeform 行（`現統括: pane
+#     `%158``）の双方に対応するため、`現統括` marker 以降の最初の `%NNN` を現統括 pane とする heuristic。
+#   - `wez notify` の cron（no TTY / mux socket）到達性は段階0 から未検証 → stdout が durable signal。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# #224/#233: 会話到達面へ出す文字列（stdout / wez notify body）を無害化する共有 helper（oe-undelivered
+# と同型）。不在時は degrade（jq の cntrl→space が効くので従来同等の安全度）。
+_SANITIZE_LIB="${BIN_DIR}/../lib/sanitize.sh"
+# shellcheck source=../lib/sanitize.sh
+if [[ -r "$_SANITIZE_LIB" ]]; then source "$_SANITIZE_LIB"; fi
+declare -F oe_sanitize_conversation >/dev/null 2>&1 || oe_sanitize_conversation() { printf '%s' "$1"; }
+
+err() { echo "oe-vitals: $*" >&2; }
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  oe-vitals [--window <sec>] [--threshold <pct>]   統括の拍動鮮度 + context% を判定し owner に ping
+  oe-vitals -h | --help
+
+  --window <sec>      拍動 staleness 窓 W（秒）。既定 1800（30分・producer の beat 間隔 ≪ W）。
+                      環境変数 OE_VITALS_WINDOW_SEC でも指定可（--window が優先）。
+  --threshold <pct>   context% 閾値 T（0-100 整数）。既定 85。context_pct > T で ping。
+                      環境変数 OE_VITALS_CONTEXT_THRESHOLD でも指定可（--threshold が優先）。
+
+statusLine 拍動 producer（PR-A）が書く sidecar を読み、board（OE_BOARD_FILE）の現統括 pane と突合して
+統括 session だけを対象化する。read-only: sidecar / board / tmux ペイン存在のみを読む（capture・engine
+state 変更・sidecar 掃除はしない）。owner ping は wez notify（best-effort）。二重通知は verb 固有の
+seen cache で抑止する。
+cron 例: */15 * * * * OE_BOARD_FILE=/path/to/.oe/START-HERE-board.md /path/to/oe-vitals >> "$HOME/.claude/state/oe-vitals/cron.log" 2>&1
+EOF
+}
+
+DEFAULT_WINDOW=1800
+DEFAULT_THRESHOLD=85
+WINDOW="${OE_VITALS_WINDOW_SEC:-$DEFAULT_WINDOW}"
+THRESHOLD="${OE_VITALS_CONTEXT_THRESHOLD:-$DEFAULT_THRESHOLD}"
+
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    --window)
+      shift
+      [[ -n "${1:-}" ]] || { err "--window は秒数（正の整数）が必要です"; usage; exit 2; }
+      WINDOW="$1"; shift ;;
+    --window=*) WINDOW="${1#--window=}"; shift ;;
+    --threshold)
+      shift
+      [[ -n "${1:-}" ]] || { err "--threshold は 0-100 の整数が必要です"; usage; exit 2; }
+      THRESHOLD="$1"; shift ;;
+    --threshold=*) THRESHOLD="${1#--threshold=}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) err "unknown option: $1"; usage; exit 2 ;;
+  esac
+done
+[[ $# -eq 0 ]] || { err "unexpected argument: $1"; usage; exit 2; }
+
+# window は正の整数（秒）
+[[ "$WINDOW" =~ ^[0-9]+$ && "$WINDOW" -gt 0 ]] || { err "window は正の整数（秒）: got [$WINDOW]"; usage; exit 2; }
+# threshold は 0-100 の整数
+[[ "$THRESHOLD" =~ ^[0-9]+$ && "$THRESHOLD" -le 100 ]] || { err "threshold は 0-100 の整数: got [$THRESHOLD]"; usage; exit 2; }
+
+command -v jq >/dev/null 2>&1 || { err "jq が必要です（sidecar / context% 判定に使用）"; exit 2; }
+
+# sidecar dir は producer（PR-A）と同一の env ノブ OE_HEARTBEAT_DIR を共有する（consumer は producer が
+# 書いた dir を読む）。既定は producer と一致させる。default はここでインライン宣言し env で上書き可
+# （lib/event-bus.sh idiom）。constants.sh には足さない（engine/project-relative 専用）。
+OE_HEARTBEAT_DIR="${OE_HEARTBEAT_DIR:-${HOME:-}/.claude/state/oe-heartbeat}"
+
+# 統括スコープ化に使う board。machine-local（gitignored `.oe/`）ゆえ既定 path は持たず OE_BOARD_FILE で
+# 与える。未設定 / 未解決なら統括を特定できず no-op（検知に化かさない）。
+OE_BOARD_FILE="${OE_BOARD_FILE:-}"
+
+# 単一ノブ OE_EVENT_DIR（oe-undelivered / event-bus.sh と一致）配下に verb 固有 seen cache を置く。
+# 注: 名前空間衝突回避のため seen dir は oe-vitals/（producer の sidecar dir = oe-heartbeat/ とは別）。
+OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
+SEEN_DIR="${OE_EVENT_DIR}/oe-vitals"
+SEEN_FILE="${SEEN_DIR}/seen"
+
+# now は既定で date +%s（%s は BSD/GNU 両 date で可搬）。テストは OE_VITALS_NOW_EPOCH で固定して
+# 鮮度判定を決定論化する。
+NOW_EPOCH="${OE_VITALS_NOW_EPOCH:-$(date +%s)}"
+[[ "$NOW_EPOCH" =~ ^[0-9]+$ ]] || { err "OE_VITALS_NOW_EPOCH は epoch 秒（整数）: got [$NOW_EPOCH]"; exit 2; }
+
+# --- liveness（mux 存在 query のみ。tmux 不在は ? で degrade。oe-undelivered と同型・capture しない）---
+TMUX_AVAIL=0
+LIVE_SET=""
+if command -v tmux >/dev/null 2>&1; then
+  if LIVE_SET="$(tmux list-panes -a -F '#{pane_id}' 2>/dev/null)"; then
+    TMUX_AVAIL=1
+  fi
+fi
+liveness_of() {
+  local pane="$1"
+  [[ -n "$pane" ]] || { printf '?'; return; }
+  [[ "$TMUX_AVAIL" == "1" ]] || { printf '?'; return; }
+  if printf '%s\n' "$LIVE_SET" | grep -qxF -- "$pane"; then printf 'alive'; else printf 'gone'; fi
+}
+
+# age（秒）を人間可読へ（例: 5400 → 1h30m / 2700 → 45m）。oe-undelivered:fmt_age と同型。
+fmt_age() {
+  local s="$1" h m
+  [[ "$s" =~ ^[0-9]+$ ]] || { printf '%s' "$s"; return; }
+  h=$(( s / 3600 )); m=$(( (s % 3600) / 60 ))
+  if [[ "$h" -gt 0 ]]; then printf '%dh%dm' "$h" "$m"; else printf '%dm' "$m"; fi
+}
+
+# --- dedup: verb 固有 seen cache（engine state ではない）---
+seen_has() {
+  [[ -r "$SEEN_FILE" ]] || return 1
+  grep -qxF -- "$1" "$SEEN_FILE" 2>/dev/null
+}
+
+# --- board 突合: 現統括 pane を解決する（PR-C frontmatter 形 / 現行 freeform 行の両対応）---
+# `現統括` marker 以降の最初の `%NNN` を現統括 pane とする。前任 pane（同じ行の後方に併記されうる）は
+# marker 直後の最初の1件を取ることで除外する。board 不在 / marker 不在 / pane 不在は空を返す。
+# 設計SO(cursor)の反証: `現統括` を colon 無しで grep すると board の見出し `## in-flight（現統括 %144
+# の担当）` のような **stale pane を含む注記行**を誤 match しうる（実 board で確認）。宣言行は `現統括:`
+# （colon 付き）ゆえ colon を必須にして見出しの併記を除外する。
+resolve_supervisor_pane() {
+  local bf="$1" line
+  [[ -n "$bf" && -r "$bf" ]] || { printf ''; return; }
+  line="$(grep -m1 -- '現統括:' "$bf" 2>/dev/null)" || true
+  [[ -n "$line" ]] || { printf ''; return; }
+  printf '%s' "$line" | sed -E 's/.*現統括//' | grep -oE '%[0-9]+' | head -1
+}
+# board の succession 状態を best-effort で抽出（death FLAG の human 向け注記のみ・logic は分岐しない）。
+# 同上（設計SO 反証）: 宣言 `succession:` の colon を必須にし、見出し `## succession 手順` を除外する。
+resolve_succession() {
+  local bf="$1" line val
+  [[ -n "$bf" && -r "$bf" ]] || { printf ''; return; }
+  line="$(grep -m1 -- 'succession:' "$bf" 2>/dev/null)" || true
+  [[ -n "$line" ]] || { printf ''; return; }
+  # `succession:` 以降を次の区切り（`/` または全角括弧）まで取り、markdown 強調とスペースを除く。
+  val="$(printf '%s' "$line" | sed -E 's/.*succession:?[[:space:]]*//; s#[[:space:]]*/.*##; s/（.*//; s/[*`]//g; s/[[:space:]]*$//')"
+  printf '%s' "$val"
+}
+
+SUP="$(resolve_supervisor_pane "$OE_BOARD_FILE")"
+
+# --- sidecar 群を集める（set -u 下の空配列展開を避けるため件数を先に見る）---
+shopt -s nullglob
+files=("$OE_HEARTBEAT_DIR"/*.json)
+shopt -u nullglob
+total_sidecars=${#files[@]}
+
+if [[ "$total_sidecars" -eq 0 ]]; then
+  echo "oe-vitals: no heartbeat recorded yet (${OE_HEARTBEAT_DIR}) — producer 未配備 or 未実行"
+  exit 0
+fi
+
+if [[ -z "$SUP" ]]; then
+  echo "oe-vitals: 統括を特定できません（board 未設定/未解決）。sidecar は ${total_sidecars} 件あるが scope できず検知なし。"
+  echo "  hint: OE_BOARD_FILE に board（declared 層・現統括 pane を含む）path を与えてください。"
+  exit 0
+fi
+
+# --- 現統括 pane に一致する sidecar を選ぶ（複数一致=pane 再利用は最新 ts を採用）---
+# empty_pane_count = pane 空の sidecar 数。全 sidecar が pane 空なら board 突合の前提（sidecar.pane が
+# 埋まっている）が崩れており、producer の $TMUX_PANE 未伝播（PR-A session_id 主キー vs PR-B pane 突合の
+# 契約差）を honest に signal する材料にする（設計SO codex/cursor の指摘）。
+sup_sid=""; sup_ts=-1; sup_ctx="0"; sup_pane=""; empty_pane_count=0
+if [[ "$total_sidecars" -gt 0 ]]; then
+  for f in "${files[@]}"; do
+    [[ -e "$f" ]] || continue
+    # 壊れた / object でない JSON は黙って skip（degrade）。US 区切りで ts/context_pct/pane を投影。
+    parsed="$(jq -r 'select(type=="object") | "\(.ts // 0)|\(.context_pct // 0)|\(.pane // "")"' "$f" 2>/dev/null)" || continue
+    [[ -n "$parsed" ]] || continue
+    IFS='|' read -r p_ts p_ctx p_pane <<< "$parsed"
+    [[ -n "$p_pane" ]] || { empty_pane_count=$((empty_pane_count + 1)); continue; }
+    [[ "$p_pane" == "$SUP" ]] || continue
+    [[ "$p_ts" =~ ^[0-9]+$ ]] || continue
+    if [[ "$p_ts" -gt "$sup_ts" ]]; then
+      sup_ts="$p_ts"; sup_ctx="$p_ctx"; sup_pane="$p_pane"; sup_sid="$(basename "$f" .json)"
+    fi
+  done
+fi
+
+if [[ -z "$sup_sid" ]]; then
+  # board は現統括 pane を declare したが、その pane を持つ sidecar が無い（producer 未設定 or
+  # $TMUX_PANE 未伝播で pane 空）＝拍動が絶対 fresh でも scope できない。「不在」を「死」に化かさない。
+  echo "oe-vitals: 現統括 ${SUP} の heartbeat が見つかりません（producer 未設定 or pane 未伝播）→ 検知なし。"
+  if [[ "$empty_pane_count" -gt 0 ]]; then
+    # 設計SO 反証: PR-A は session_id 主キー・pane は best-effort（空でも契約は保たれる）。pane 空だと
+    # board（pane declare）と突合できず watchdog が inert 化する。この症状を明示的に開示する。
+    echo "  warn: sidecar ${total_sidecars} 件中 ${empty_pane_count} 件が pane 空（\$TMUX_PANE 未伝播の疑い）。board 突合は sidecar.pane に依存するため統括を scope できません。"
+  fi
+  echo "  note: producer が sidecar に pane を書けているか（statusLine env の \$TMUX_PANE 伝播）を確認してください。"
+  exit 0
+fi
+
+# --- 検知（統括 sidecar 1 件に真理値表を適用）---
+age=$(( NOW_EPOCH - sup_ts ))
+[[ "$age" -lt 0 ]] && age=0   # 未来 ts（時計ずれ）は 0 秒扱い（fresh 側・誤検知回避）
+plive="$(liveness_of "$sup_pane")"
+
+is_fresh=0
+[[ "$age" -le "$WINDOW" ]] && is_fresh=1
+over_threshold=0
+# context_pct は float でありうる（producer は数値化して書く）。bash の -gt は整数専用ゆえ awk で比較。
+if awk -v c="$sup_ctx" -v t="$THRESHOLD" 'BEGIN{ exit !((c+0) > (t+0)) }' 2>/dev/null; then
+  over_threshold=1
+fi
+
+# 2 検知器（設計SO の反証を反映して改訂）:
+#   death   : pane が tmux で **確定 gone**（`plive=="gone"`）のときのみ。beat 鮮度に依存しない。
+#             → 設計SO(codex/claude/cursor)の反証: 旧述語 `stale ∧ ¬alive` は tmux 不在/socket 不通の
+#               `?` を death 扱いし、cron で **偽 crash ping** を出す経路があった（? は gone でない）。
+#               また staleness 単独 death は「idle でも beat 継続」の未検証 premise が linchpin だった。
+#               death を確定 gone に絞ると (1)? は死にならない (2)idle-premise が death の前提から外れる
+#               (3)gone×fresh も即検知（旧設計の最大 W 遅延を解消）。tmux 不在時は death 検知不可（開示）。
+#   context : fresh（beat 新鮮＝ctx 値が信頼可）かつ pane が gone でない（alive or ?）かつ ctx>T（mode1 中核）。
+#             ? でも fresh beat は「直近まで書けていた＝実質 alive」ゆえ context は degrade して動く。
+#   alive×stale / ?×stale は no-op（生存/不明を death に化かさない・hang 誤検知を実装しない）。
+flag_kind=""
+if [[ "$plive" == "gone" ]]; then
+  flag_kind="death"
+elif [[ "$is_fresh" -eq 1 && "$over_threshold" -eq 1 ]]; then
+  flag_kind="context"
+fi
+
+if [[ -z "$flag_kind" ]]; then
+  if [[ "$is_fresh" -eq 1 ]]; then
+    state="は健全"; reason="検知なし"
+  else
+    # beat stale だが pane が gone でない（alive or ?）: 生存/不明×拍動停止。死に化かさず no-op（開示穴）。
+    state=""; reason="検知なし（beat stale だが pane が gone でない＝death は確定 gone でのみ判定・alive/?×stale は no-op）"
+  fi
+  echo "oe-vitals: 現統括 ${SUP}${state}（beat $( [[ $is_fresh -eq 1 ]] && echo fresh || echo stale )/$(fmt_age "$age") · ctx=${sup_ctx}% · pane=${plive} · W=${WINDOW}s · T=${THRESHOLD}%）→ ${reason}。"
+  exit 0
+fi
+
+# --- FLAG 行を stdout へ（durable signal）+ 新規キーを収集 ---
+sup_ctx_disp="$(oe_sanitize_conversation "$sup_ctx")"
+sup_sid_disp="$(oe_sanitize_conversation "$sup_sid")"
+age_disp="$(fmt_age "$age")"
+beat_disp="$( [[ $is_fresh -eq 1 ]] && echo fresh || echo stale )(${age_disp})"
+
+if [[ "$flag_kind" == "context" ]]; then
+  note="context 肥大接近（>${THRESHOLD}%）— handoff 促し"
+else
+  succ="$(oe_sanitize_conversation "$(resolve_succession "$OE_BOARD_FILE")")"
+  note="プロセス死（crash 疑い・board が現統括のまま pane 消滅）· board succession=${succ:-?}"
+fi
+
+printf '=== supervisor vitals (read-only · window=%ss · threshold=%s%%) ===\n' "$WINDOW" "$THRESHOLD"
+printf '%-8s  %-6s  %-14s  %-6s  %-28s  %-8s  %s\n' "KIND" "PLIVE" "BEAT" "CTX%" "SESSION" "PANE" "NOTE"
+printf '%-8s  %-6s  %-14s  %-6s  %-28s  %-8s  %s\n' \
+  "$flag_kind" "$plive" "$beat_disp" "$sup_ctx_disp" "$sup_sid_disp" "$sup_pane" "$note"
+
+# --- 新規キーのみ owner へ ping（二重通知抑止・session 毎 kind 毎に 1 回）---
+# seen cache は「実際に owner へ通知できた」ときだけ追記する（oe-undelivered と同じ規律）: wez 不在 /
+# notify 失敗時に先行追記すると、通知していないのにキーが seen となり owner ping が永続的に抑止される。
+key="${flag_kind}|${sup_sid}"
+if ! seen_has "$key" && command -v wez >/dev/null 2>&1; then
+  if [[ "$flag_kind" == "context" ]]; then
+    title="oe watchdog: supervisor context high"
+  else
+    title="oe watchdog: supervisor process death"
+  fi
+  body="現統括 ${sup_pane} (${sup_sid_disp}) · ${flag_kind} · beat=${beat_disp} · ctx=${sup_ctx_disp}% · ${note}"
+  if wez notify "$title" "$body" 2>/dev/null; then
+    if mkdir -p "$SEEN_DIR" 2>/dev/null; then
+      printf '%s\n' "$key" >> "$SEEN_FILE" 2>/dev/null || true
+    else
+      err "seen cache dir を作成できませんでした（${SEEN_DIR}）— 二重通知抑止は無効・検知は継続"
+    fi
+  fi
+fi
+
+exit 0

--- a/projects/orchestration-engine/bin/oe-vitals
+++ b/projects/orchestration-engine/bin/oe-vitals
@@ -141,7 +141,8 @@ OE_BOARD_FILE="${OE_BOARD_FILE:-}"
 
 # 単一ノブ OE_EVENT_DIR（oe-undelivered / event-bus.sh と一致）配下に verb 固有 seen cache を置く。
 # 注: 名前空間衝突回避のため seen dir は oe-vitals/（producer の sidecar dir = oe-heartbeat/ とは別）。
-OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
+# HOME 未設定でも set -u で abort しないよう ${HOME:-} で守る（producer と同方針・実装SO codex 指摘）。
+OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME:-}/.claude/state}"
 SEEN_DIR="${OE_EVENT_DIR}/oe-vitals"
 SEEN_FILE="${SEEN_DIR}/seen"
 
@@ -187,10 +188,13 @@ seen_has() {
 # （colon 付き）ゆえ colon を必須にして見出しの併記を除外する。
 resolve_supervisor_pane() {
   local bf="$1" line
-  [[ -n "$bf" && -r "$bf" ]] || { printf ''; return; }
+  [[ -n "$bf" && -r "$bf" ]] || { printf ''; return 0; }
   line="$(grep -m1 -- '現統括:' "$bf" 2>/dev/null)" || true
-  [[ -n "$line" ]] || { printf ''; return; }
-  printf '%s' "$line" | sed -E 's/.*現統括//' | grep -oE '%[0-9]+' | head -1
+  [[ -n "$line" ]] || { printf ''; return 0; }
+  # 実装SO(claude/codex)指摘: `現統括:` 宣言はあるが %NNN が無い board では末尾 grep が rc1 を返し、
+  # set -o pipefail 下で pipeline→関数→SUP="$(...)" と伝播して set -e が script を落とす（exit 0
+  # 契約違反・graceful no-op に到達不能）。→ `|| true` で pane 未解決は空返し＝統括未解決の no-op へ流す。
+  printf '%s' "$line" | sed -E 's/.*現統括//' | grep -oE '%[0-9]+' | head -1 || true
 }
 # board の succession 状態を best-effort で抽出（death FLAG の human 向け注記のみ・logic は分岐しない）。
 # 同上（設計SO 反証）: 宣言 `succession:` の colon を必須にし、見出し `## succession 手順` を除外する。

--- a/projects/orchestration-engine/docs/episodes/2026-07-11-episode-239-pr-b-vitals-consumer.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-11-episode-239-pr-b-vitals-consumer.md
@@ -1,0 +1,73 @@
+---
+id: "01KX7JPRJF7BW1QHYC7J6JSA72"
+title: "#239 段階1 PR-B episode — oe-vitals consumer（設計SO + 実装SO が両方 refuted → reconcile）"
+date: 2026-07-11
+type: episode
+status: stable
+related:
+  - type: plan
+    ref: ../plans/2026-07-11-plan-239-pr-b-vitals-consumer.md
+    reason: "本 episode の設計判断（DJ-1..6）と SO ゲート結果の正本"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/239"
+    reason: "watchdog（producer=PR-A・consumer=PR-B）。多段のため keep-open"
+  - type: pr
+    ref: "https://github.com/stlwolf/ai-development-hub/pull/246"
+    reason: "本 episode が記録する PR-B"
+tags: [orchestration, watchdog, heartbeat, consumer, second-opinion, "issue-239", reconstructed]
+---
+
+# #239 段階1 PR-B episode — oe-vitals consumer
+
+> **reconstructed**: リアルタイム追記でなく PR 作成後にまとめて執筆。追記ログと同じ証拠価値は持たない。
+
+## Context / なぜ
+
+cockpit 統括は使い捨て・state が正本（#238）。統括が context 肥大や crash で倒れたのを **自己申告に頼らず機械検知**したい。PR-A（statusLine 拍動 producer）が session 毎に sidecar へ `{ts, context_pct, pane}` を書くので、PR-B はそれを out-of-session cron から読んで統括の vital を判定し owner に ping する consumer を足す。親 `%158` からの委譲。
+
+## 次の消費者
+
+- **段階2 の watchdog 設計者**（observed projection / mode2 お見合い / seat 導入を判断する人）。本 episode の「board 突合の key-mismatch」節が Alt-A（board が session_id を declare）を検討する入口。
+- **owner（cron 配備時）**: 運用前提（`OE_BOARD_FILE` 必須・pane 伝播依存）を deployment 時に読む。
+
+## 決定と根拠（コード/diff から復元できない「なぜ」）
+
+- **verb 名 `oe-vitals`**: 候補 `oe-heartbeat` を棄却した決め手は「読みやすさ」ではなく **namespace の物理衝突** — verb 固有 seen cache dir が producer の sidecar dir `~/.claude/state/oe-heartbeat/` と同一パスになる。命名が state レイアウトの衝突を生む具体例で、sister verb の分離は命名で担保した。
+- **death 判定を「beat staleness」→「tmux 確定 gone」へ転回**（設計SO 起点）: kickoff は「beat-staleness＝プロセス死検知」と framing した（生存プロセスは refreshInterval の fixed timer で beat を撃ち続けるから）。だがこの premise は **PR-A 自身が「実機未検証」と記していた**。staleness に death を載せると、PR-B の death 信頼性が上流の未検証 premise を linchpin として継承する。設計SO がここを突いた（+ tmux 不在の `?` を `¬alive` と見なし cron で偽 crash ping する経路）。→ death を tmux が確定できる **hard signal（gone）**に移し、premise 依存と偽陽性を同時に断った。代償（tmux 不在時 death 不可）は偽陽性より安全側と判断。
+- **succession を logic に使わない**: crash/handoff の判別は board 突合そのもの（handoff 後は `現統括` が後任へ進み前任は scope 外）に委ね、`succession` 値は human 注記に留めた。曖昧な declared 値で分岐を増やすより、scope 化に判別を吸収させる方が壊れにくい。
+
+## わかったこと（W）
+
+- **truth-table completeness ≠ implementation completeness**。4分岐の真理値表は「見た目」完備でも、`?`（tmux 不明）や境界の degrade セルが未規定/未テストのまま残り、そこで observer の中核契約（偽陽性ゼロ / exit 0）が破れた。設計SO・実装SO が拾ったのは全て **未テストの degrade / error セル**（`?×stale`・`現統括:` あり pane 無し・HOME 未設定）。
+- read-only observer でも `set -euo pipefail` は罠を持つ: `grep` の no-match rc1 が pipeline→コマンド置換→`set -e` と伝播し「exit 常に 0」契約を静かに破る。producer が `${HOME:-}` で守っていた箇所を consumer で `${HOME}` に戻していた（既存パターンの踏襲漏れ）。
+
+## 原則（Pattern / Anti-pattern）
+
+- **Anti**: observer の安全性主張（「偽陽性を出さない」）を、上流の**未検証 premise**（refreshInterval-idle）に載せる。→ **Pattern**: 死活は「不明（`?`）」を死に倒さず、確定できる hard signal でのみ発火させる（不明は no-op・偽陽性回避を最優先）。
+- **Anti**: declared 層（board）と observed 層（sidecar）を**異なる主キー**（pane vs session_id）で突合し、片方が best-effort（空になりうる）なのに単一 bridge にする → 静かに inert 化。→ **Pattern**: bridge が best-effort なら「解決不能」を明示 signal（warn）にして「異常なし」と区別する。恒久解は declared 側を安定キー（session_id）に寄せる（Alt-A）。
+
+## 事実・失敗（選択的省略なし）
+
+- **設計SO**（`oe-refute` exploration/3・audit `20260710165558WHKWV6XCJXXA`）: **refuted 3/3**。material 反証 M1（`?×stale`偽death・実バグ）/ M6（board 見出しの古い pane 誤 match・実バグ）を code fix、M3（gone×fresh 遅延）を解消、M2/M4/M5/M7/M8/M9/M10 を disclose。
+- **実装SO**（`oe-review`/3・audit `20260711025400M3MK3ZMARMG3`）: **refuted 2/3**（cursor survived）。I1（pipefail 落ちで exit 0 契約違反）/ I2（`${HOME}` unbound）を code fix。
+- 各 material 反証に回帰テストを追加。**77/77 green（bash 5.2.37 / 3.2.57・shellcheck clean）**。Copilot は 0 指摘（clean overview）。
+- 詳細な反証×対応表は plan doc に durable 化（本 episode では非自明な接続のみ）。
+
+## 蒸留シグナル
+
+- **昇格候補あり**: **Alt-A（board が `session_id` を declare → consumer は `<sid>.json` を直 read）** は M2/M7 の構造依存を根から解く。board schema（PR-C）変更を伴うため PR-B scope 外だが、段階2 or watchdog 改善の **Issue / Decision 候補**。→ routing 下記。
+- skill/rule 昇格: 今回の Anti/Pattern（不明を死に倒さない・best-effort bridge の明示 signal）は negative knowledge（#62）注入候補になりうるが、単発ゆえ今は episode 記録に留める。
+
+## 残課題（routing）
+
+- **Alt-A（board に session_id）**: → 段階2 watchdog 改善で Issue 化候補（owner 判断）。本 PR では disclose のみ。
+- **context の再 ping / escalation interval**（現状 session×kind で 1回）: → 運用観測後に判断（decision-pacing）。追わない宣言はせず plan doc の follow-up に保持。
+- **inert watchdog の config-health owner ping**（現状 stdout のみ）: → kickoff の no-op 方針を尊重し defer。owner が inert 可視化を望めば additive。
+- **cron / launchd 実設置**: → deployment 手順（本 PR scope 外・README に例示済）。
+- **マージ・worktree 掃除**: → 親/owner の HG（実装子は追わない）。
+
+## status
+
+**stable**・達成度: **達成**（PR-B の要件＝read-only 姉妹 verb + 真理値表 + board 突合 + 両 SO ゲート通過 を満たし PR #246 landing）。多段の一段ゆえ #239 は keep-open。
+
+Step4 辞退: 別途の closure-quality SO は実施せず / 既存チェックで覆った観点: 省略チェック（失敗＝両 SO refutal を本文の headline に明示・選択的省略なし）・routing（全 follow-up に行き先付与）・evidence anchor（SO audit_id / verdict を本文と plan doc へ転記・揮発 tmp/ 依存を解消）・back-propagation（SO 反証は code + plan へ反映済）/ 未実施観点と判断: なし（4観点すべて低リスクで本文が自己完結）。

--- a/projects/orchestration-engine/docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md
+++ b/projects/orchestration-engine/docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md
@@ -1,0 +1,163 @@
+---
+id: "01KX6F1C8E4FTRRSWCSGFRTG8T"
+title: "#239 段階1 PR-B plan — oe-vitals（統括 vital 監視 consumer・閾値/staleness）"
+date: 2026-07-11
+type: plan
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/239"
+    reason: "watchdog（producer=PR-A・consumer=PR-B）。多段のため keep-open"
+  - type: kickoff
+    ref: ".oe/kickoff-pr-b-consumer.md"
+    reason: "本 plan の入力（委譲 kickoff・machine-local）。verb 名と board 突合の機構を実装子に委ねる指定"
+  - type: design_context
+    ref: "projects/orchestration-engine/bin/oe-undelivered"
+    reason: "段階0 の read-only 観測 family。本 verb が template として踏襲する substrate"
+  - type: design_context
+    ref: "canonical/claude/statusline/statusline-oe-heartbeat.sh"
+    reason: "PR-A producer。本 consumer が read する sidecar 契約（パス + JSON 形）の正本"
+  - type: design_context
+    ref: "projects/orchestration-engine/docs/decisions/2026-07-10-decision-238-board-schema.md"
+    reason: "PR-C board schema。統括スコープ化の board 突合が依拠する declared 層契約"
+tags: [orchestration, watchdog, heartbeat, consumer, context-threshold, liveness, cockpit, "issue-239"]
+so:
+  design: weak
+  impl: weak
+  reason: "上位アーキ（lean + sidecar・seat defer）は HG 確定・不可逆性が低い。本 plan が確定するのは実装レベルの設計判断（verb 名・board 突合の機構・検知述語・env 設計）で、いずれも read-only 追加＝可逆。設計SO=oe-refute --rubric exploration（本 plan の DJ を対象・1周）、実装SO=oe-review（reviewed diff）。両方を弱 SO で当てる（engine 作業は設計SO+実装SO 両方が規律）"
+---
+
+# #239 段階1 PR-B plan — oe-vitals（統括 vital 監視 consumer）
+
+> 駆動層: kickoff（`.oe/kickoff-pr-b-consumer.md`）→ 実装 → **本プラン（設計判断の外部化）** → 設計SO（oe-refute exploration・本ペイン）→ reconcile → 実装SO（oe-review）→ PR → episode closure → 親 %158 へ報告。
+> 注: 実装は plan 化に先行して着地済み（下記スコープ）。owner の追加指示「設計も SO 必要」を受け、実装子が新規に下した設計判断を本 plan に外部化し、設計SO で zero-base 反証を受けてから PR にする。設計SO で material 反証が出れば着地済みコードを rework する。
+
+## Context / 前提
+
+- 親 `%158` から委譲された子セッション。**マージ・worktree 掃除はしない**（親/owner の HG）。実装子は worktree 作成 → 実装 → テスト → SO → PR 作成 → 報告まで。
+- PR-B = statusLine 拍動 producer（PR-A・master マージ済 `7f741e6`）が session 毎に書く sidecar を **out-of-session cron から読み**、統括の **context% 肥大接近（mode1・#238 中核）** と **プロセス死** を検知して owner に ping する read-only 姉妹 verb。段階0 `oe-undelivered` の観測 family（`liveness_of` / `disp` / `fmt_age` / seen cache dedup / owner ping / exit 0 / `--window`+env+`NOW_EPOCH`）を template として踏襲する（再実装しない）。
+- **入力面が段階0 と別**: `oe-undelivered` は oe-events.jsonl の frontier（未ack）を読むが、PR-B は **sidecar dir** を読む。→ frontier read の jq は再コピーしない。
+- 上位アーキ（lean + sidecar・seat defer）と Q3-Q8 推奨は HG 確定済（親 plan `.oe/plan-stage1.md` §2/§4）。本 plan の射程は **その下の実装レベル設計判断のみ**。
+
+## sidecar 契約（PR-A が正本・本 consumer が read）
+
+- パス: `${OE_HEARTBEAT_DIR:-${HOME}/.claude/state/oe-heartbeat}/<session_id>.json`
+- 内容: `{"ts":<epoch秒>, "context_pct":<0-100>, "pane":"<tmux pane|空>"}`。`pane` は producer 実行 env の `${TMUX_PANE:-}`（伝播しなければ空）。
+
+## 設計判断（DJ・設計SO の反証対象）
+
+### DJ-1 verb 名 = `oe-vitals`
+
+消費側 = 統括の **vital（生体徴候）監視**。拍動鮮度（生きているか）+ context% 負荷（健全か）の 2 vital を読んで owner に警告する。
+
+- **検討した代替（zero-base）**:
+  - `oe-heartbeat`: producer（`statusline-oe-heartbeat.sh`）と "heartbeat" namespace が衝突。さらに verb 固有 seen cache dir が `${OE_EVENT_DIR}/oe-heartbeat/` = **producer の sidecar dir `~/.claude/state/oe-heartbeat/` と同一パスで衝突**する（consumer の bookkeeping が producer の data dir に混入）。方向も曖昧（producer が heartbeat を出すのか consumer が出すのか）。
+  - `oe-liveness`: #239 タイトル liveness と直結するが、設計が明示的に否定する「hang/liveness 誤検知（alive×stale→hang）」を名前が招く。かつ **中核である context% 検知を過小表現**する（liveness は 2 検知器の弱い方）。
+  - `oe-vitals`: 両検知器（拍動鮮度 + context% 負荷）を包摂し、producer と namespace 衝突せず、消費側の意味づけ（読んで判定して ping）に合う。
+- **決定**: `oe-vitals`。seen cache は `${OE_EVENT_DIR}/oe-vitals/`（producer の `oe-heartbeat/` と別 namespace）。
+
+### DJ-2 統括スコープ化 = board 突合（MVP・kickoff 推奨）
+
+sidecar dir には statusLine を持つ全 session の beat が入る（統括に限らない）。consumer は統括 session だけを対象化する必要がある。
+
+- **決定**: board（declared 層・PR-C）の `現統括` pane と sidecar の `pane` を突合し、一致する sidecar だけを判定する。board path は `OE_BOARD_FILE` で与える。
+- **現統括 pane の抽出**: `現統括` marker 以降の **最初の `%NNN`**。PR-C frontmatter 形（`現統括: "%144"`）と **現行 freeform 行**（`現統括: pane `%158``・前任 pane が後方に併記されうる）の両対応。実 board は PR-C schema 未 migrate（現統括 は freeform 行）ゆえ両対応が必要。
+- **検討した代替**: (b) sidecar に `role:"supervisor"` marker を載せる → producer（PR-A）改変が要る＝触ってはいけないファイル。(c) delegate-registry の role 突合 → 新規結合が増え board 突合より重い。→ (a) board 突合が最小で PR-C と地続き。
+
+### DJ-3 2 検知器の述語（真理値表の実装・**設計SO の反証で改訂**）
+
+- **context 検知**（mode1 context 肥大死・#238 中核・確度が高い）: `fresh ∧ ¬gone ∧ context_pct > T` → ping（handoff 促し）。
+- **death 検知**（プロセス死・crash / pane 消滅）: **`plive == gone`（tmux 確定 gone）のみ**・beat 鮮度に依存しない → ping（1回・dedup）。
+  - **改訂の経緯（設計SO 反証）**: 当初は `stale ∧ ¬alive`（beat-staleness＝プロセス死検知）だったが、3レーンが (a) tmux 不在/socket 不通の `?` を `¬alive` として death 扱いし cron で **偽 crash ping** を出す、(b)「idle でも beat 継続」premise が実機未検証で death の linchpin にできない、と反証。→ death を **確定 gone のみ**に絞った。これで `?` は死にならず、idle-premise は death の前提から外れ、`gone×fresh` も即検知（旧設計の最大 W 遅延を解消）。代償: tmux 不在時は death 検知不可（context のみ degrade）＝偽陽性より安全側。
+- **`alive/? × stale` は no-op**: 生存プロセスは `refreshInterval` の fixed timer で beat を撃ち続ける前提（beat が止まるのはプロセス死 / pane 消滅の時だけ）。「alive×stale→hang」は実装しない（未検証 premise + 偽陽性回避）。
+- 真理値表（改訂後）:
+
+  | pane      | beat 鮮度  | context% | 解釈                         | 動作                          |
+  |-----------|-----------|----------|------------------------------|-------------------------------|
+  | alive / ? | fresh     | `> T`    | context 肥大接近（#238 中核）| ping（handoff 促し）           |
+  | alive / ? | fresh     | `≤ T`    | 健全                         | なし                          |
+  | alive / ? | stale     | —        | 生存/不明×拍動停止（idle 等）| なし（死に化かさない・開示穴）  |
+  | gone      | fresh/stale| —       | プロセス終了（crash 疑い）    | ping（1回・board 突合で判別）   |
+  | 不在      | —         | —        | producer 未設定 — 死ではない | なし（未設定を検知に化かさない）|
+
+### DJ-4 gone×stale の crash/handoff 判別 = board 突合そのものが解く
+
+orderly handoff 後は board の `現統括` が後任 pane へ進むため、停止した前任の sidecar は現統括と一致せず **scope 外**になる（＝想定内の handoff は ping しない）。board がまだ死んだ pane を `現統括` と declare したままその pane が gone×stale なら **crash 疑い** → ping（declared が observed の ground truth を補完）。succession 状態は death FLAG の human 向け注記に best-effort で併記するが、**logic は succession で分岐しない**（過剰設計を避け、判別は board 突合 + seen cache に委ねる）。
+
+### DJ-5 `OE_BOARD_FILE` は既定なし・欠落は no-op
+
+board は machine-local（gitignored `.oe/`・commit しない）ゆえ普遍的な既定 path を持たない。`OE_BOARD_FILE` 未設定 / 未解決 / 現統括 pane の sidecar 不在 → **no-op**（honest に stdout へ理由を出す）。**「未設定」を「死」に化かさない**（producer 未配備・pane 未伝播を検知に化けさせない）。deployment（cron エントリ）で `OE_BOARD_FILE` を設定する前提。
+
+### DJ-6 GC しない・env ノブ
+
+- **GC 非実装**: 停止 session の sidecar 掃除（削除）は producer data の mutation ゆえ行わない（read-only 観測姿勢を貫く。kickoff は GC 任意・最小で可 → 最小＝やらない）。mutation は verb 固有 seen cache への追記のみ（`oe-undelivered` と同クラス）。
+- **env / フラグ**: `--window` + `OE_VITALS_WINDOW_SEC`（既定 1800s・W ≫ beat 間隔 N）/ `--threshold` + `OE_VITALS_CONTEXT_THRESHOLD`（既定 85・単一閾値・二段 warn/critical は入れない）/ `OE_VITALS_NOW_EPOCH`（テスト決定化）/ `OE_HEARTBEAT_DIR`（producer と共有・sidecar dir）/ `OE_BOARD_FILE` / `OE_EVENT_DIR`（seen cache 置き場）。default はインライン宣言・`constants.sh` には足さない。
+
+## 開放している運用前提（disclose・silently drop しない）
+
+- board 突合は sidecar の `pane` が埋まっている前提（producer の `$TMUX_PANE` 伝播依存）。伝播しないと現統括 pane と突合できず scope 不能で no-op に落ちる。
+- 実 board は PR-C schema 未 migrate（現統括 は freeform 行）。extraction は両対応だが heuristic（marker 後の最初の `%NNN`）。
+- `wez notify` の cron（no TTY / mux socket）到達性は段階0 から未検証 → **stdout が durable signal**。
+- ping 経路・stdout・seen cache dedup・exit 0 は `oe-undelivered` と同一クラス（blast radius 低）。主リスクは誤 ping（W/T チューニング + seen cache で抑止）。
+
+## 設計SO ゲート結果（`oe-refute --rubric exploration --lanes 3`・1周・弱SO）
+
+- **verdict: refuted（3/3・conservative 集約）** / audit_id `20260710165558WHKWV6XCJXXA` / lanes 3（codex/claude/cursor 全 success＝full 3レーン返却・partial なし）。出力（揮発）: `tmp/oe-refute-20260710165558WHKWV6XCJXXA/`。
+- 1周・iterate せず。material 反証を code + 本 plan に reconcile（de-converge）。上位アーキ（lean+sidecar）は HG 確定ゆえ SO 対象外。
+- **material 反証と対応**:
+
+  | # | 反証（レーン） | 妥当性 | 対応 |
+  |---|---|---|---|
+  | M1 | `?×stale → 偽 death`（`stale∧¬alive` が tmux 不在の `?` を death 扱い・cron で偽 crash ping）(codex/claude/cursor) | 正しい・実バグ | **code fix**: death を `plive==gone` のみに。回帰テスト [20] |
+  | M2 | PR-A（session_id 主キー）vs PR-B（pane 突合）契約差: pane 空だと scope 不能で watchdog inert 化 (cursor/codex/claude) | 正しい・構造依存 | **disclose 強化 + code**: 全 sidecar pane 空を warn（[23]）。再設計は follow-up（Alt-A/C）|
+  | M3 | `gone×fresh×high` が no-op → 最大 W 遅延 + 汎用 death ラベル (claude/cursor) | 正しい | **code fix**: death=gone は gone×fresh も即検知（[21]）。ctx% は FLAG 行に表示 |
+  | M4 | `alive×stale×high` 取りこぼし（best-effort beat 落ちを認めつつ alive=fresh 前提）(cursor/claude) | 妥当 | **accept + disclose**: 未検証 idle-premise ゆえ action しない（偽陽性回避）＝開示穴 |
+  | M6 | board 抽出 `grep '現統括'` が見出し `## in-flight（現統括 %OLD の担当）` の **stale pane** を誤 match しうる (cursor・実 board で verified) | 正しい・実バグ | **code fix**: `grep '現統括:'`（colon 宣言のみ）。succession も同様。回帰テスト [22] |
+  | M5 | context の one-shot dedup は高 ctx 継続でも再 ping しない (cursor) | 妥当 | **disclose + follow-up**（再 ping/escalation）。MVP は 1回（spam 回避・stdout durable）|
+  | M7 | pane 再利用で別 session の beat が最新 ts 勝ちで統括を上書きしうる (cursor) | 妥当・既知同種 | **disclose**（Alt-A で解消可）|
+  | M8 | board 更新 lag 中の gone×declared → 一時的 偽 crash ping (cursor) | 妥当 | **disclose**（seen cache 1回で緩和・succession 分岐は入れない判断を維持）|
+  | M9 | verb 名 `oe-vitals` は family（状態/対象の名詞）に対し抽象 metaphor (cursor) | 妥当・非致命 | **disclose**（namespace 分離の利得が上回る・PR で提案）|
+  | M10 | inert watchdog（設定漏れ/未解決/pane 未伝播）で owner ping 無し・stdout のみ (codex/claude) | 妥当 | **disclose + follow-up**（config-health ping）。kickoff の no-op 方針を尊重し本 PR は stdout 明示に留める |
+
+- **spot-check（独立検証）**: load-bearing な M1/M6 を回帰テストで機械検証（[20] `?×stale`→no death・[22] 見出し除外→%NEW 解決）。73/73 green（bash 5.2/3.2.57・shellcheck clean）。
+- **de-converge**: board 突合 MVP の骨格は3レーンとも方向を否定せず維持。偽陽性経路（M1/M6=実バグ）を修正し、構造依存（M2/M7/M8）と運用穴（M4/M5/M10）を開示、再設計案を follow-up に surface。
+
+## 探索した代替（設計SO が surface・follow-up へ defer）
+
+- **Alt-A: board が `session_id`（ULID）を declare → consumer は `<sid>.json` を直 read**（pane 非依存で M2/M7 を解消）。defer 理由: board schema（PR-C・マージ済）変更 + handoff 手順更新が要る＝PR-B scope 外。**最有力の後継**。
+- **Alt-C: `oe-events.jsonl` 相関で統括 session を動的解決（board 不要）**。defer 理由: 統括が parent として event 痕跡を持つ前提 + 相関 jq＝重い（別 PR）。
+- **Alt: config-health owner ping**（inert watchdog を dedup 付きで 1回 ping）。defer 理由: kickoff の「未設定は no-op」方針。owner が inert 可視化を望むなら additive に足す。
+
+## スコープ / 触るファイル
+
+- 新規: `projects/orchestration-engine/bin/oe-vitals`（**着地済み**・read-only observer）。
+- 新規: `projects/orchestration-engine/tests/test_oe_vitals.sh`（**着地済み**・19 ケース / 62 assertion）。
+- 追記: `projects/orchestration-engine/bin/README.md`（oe-vitals 節 + observation family 索引 + env 表）。
+- 新規（本 plan）: `docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md`。
+- 触らない: `bin/oe-undelivered` / `lib/event-bus.sh` / `oe-activity` / `lib/constants.sh` / `sync-claude.sh` / producer（PR-A）/ validator（PR-C）。
+
+## ステップ（TODO + Gate interleaved）
+
+1. [済] 実装 `bin/oe-vitals` + `tests/test_oe_vitals.sh`。shellcheck clean・bash 5.2.37 / 3.2.57 両系 62/62 green。
+2. [済] 本 plan doc に設計判断（DJ-1..6）を外部化。
+3. **REVIEW（設計SO）**: `oe-refute --rubric exploration --lanes 3`（claim = DJ-1..6 + 開放前提・self-contained）。material 反証を code + 本 plan へ reconcile。→ status を draft から更新。
+4. **REVIEW（実装SO）**: `oe-review --lanes 3`（reviewed diff）。material 反証を reconcile + 回帰テスト追加。
+5. `bin/README.md` へ oe-vitals doc 追記（cron 配線は deployment 手順として記載・`OE_BOARD_FILE` 要求を明記）。
+6. **GATE**: SO 修正後に shellcheck + bash 両系 green を再確認。
+7. episode closure（`docs/episodes/`・standard〜heavy・非自明な接続のみ・後追いなら `reconstructed` 明示）。
+8. commit（`feat(oe): ...`）+ PR（verb 名提案 + DJ trace + cron/board 運用前提の disclose・Refs #239・close しない）。
+9. **REVIEW（Copilot）**: 依頼 → 未返信スレッドの妥当な指摘に1ラウンド対応 → 返信で停止。
+10. 報告: `.oe/report-pr-b.md`（implementer-contract 形式）を正本に、親 `%158` へ `oe-send`（single-quote）で要約 + path 送信。
+
+## 最終検証
+
+- 設計SO / 実装SO の verdict + material 反証の reconcile 内容を確認（弱SO・1周・partial は開示・0 はなし）。
+- shellcheck clean + bash 5.2.37 / 3.2.57 両系で `test_oe_vitals.sh` 全 PASS を再確認。
+- `oe-vitals` を fixture で直接実行し、真理値表4分岐 + scope化（非統括 sidecar 無視）+ dedup + degrade（tmux/wez/jq 不在）の振る舞いを観測。
+
+## スコープ外（Post-Completion・注記のみ）
+
+- board の PR-C schema への migrate（board 保守側の運用・PR-C 決定 doc §7）。
+- cron / launchd エントリの実設置（deployment 手順・doc 記載に留める）。
+- sidecar GC（残骸量が実運用で問題化したら follow-up）。
+- 低 context の hang（プロセス生存 × context 低 × model 停止）は beat も context% も動かず取りこぼす（段階1 は owner 目視・親 plan §5 の既知の穴）。

--- a/projects/orchestration-engine/docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md
+++ b/projects/orchestration-engine/docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md
@@ -128,6 +128,19 @@ board は machine-local（gitignored `.oe/`・commit しない）ゆえ普遍的
 - **Alt-C: `oe-events.jsonl` 相関で統括 session を動的解決（board 不要）**。defer 理由: 統括が parent として event 痕跡を持つ前提 + 相関 jq＝重い（別 PR）。
 - **Alt: config-health owner ping**（inert watchdog を dedup 付きで 1回 ping）。defer 理由: kickoff の「未設定は no-op」方針。owner が inert 可視化を望むなら additive に足す。
 
+## 実装SO ゲート結果（`oe-review --lanes 3`・reviewed diff・弱SO・別レンズ）
+
+- **verdict: refuted（2/3）** / audit_id `20260711025400M3MK3ZMARMG3` / reviewed_sha `b7f266a` / diff_base master / lanes 3（codex・claude refuted / cursor survived）。出力（揮発）: `tmp/oe-review-20260711025400M3MK3ZMARMG3/`。設計SO と別 audit stream（lens=impl）。
+- **material 反証と対応**（いずれも実バグ・fix + 回帰テスト）:
+
+  | # | 反証（レーン） | 対応 |
+  |---|---|---|
+  | I1 | `resolve_supervisor_pane` 末尾 pipeline が `現統括:` 宣言あり・`%NNN` 無しのとき grep rc1 → pipefail→`SUP="$(...)"`→set -e で script exit 1（exit 0 契約違反・graceful no-op 到達不能）(claude/codex) | 末尾に `\|\| true`。pane 未解決は空返し＝統括未解決 no-op へ。回帰テスト [24] |
+  | I2 | `OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"` の裸 `${HOME}` が set -u 下で HOME 未設定時 unbound → 落ちる (codex) | `${HOME:-}` に（producer と同方針）。回帰テスト [25] |
+
+- cursor は survived（真理値表・seen 規律・board 抽出・bash 堅牢性を反証的に確認）。
+- fix 後 **77/77 green**（bash 5.2.37 / 3.2.57・shellcheck clean）。**設計SO + 実装SO の両ゲートを通過**（両方 refuted → material 反証を reconcile・弱SO ゆえ各1周）。
+
 ## スコープ / 触るファイル
 
 - 新規: `projects/orchestration-engine/bin/oe-vitals`（**着地済み**・read-only observer）。

--- a/projects/orchestration-engine/tests/test_oe_vitals.sh
+++ b/projects/orchestration-engine/tests/test_oe_vitals.sh
@@ -271,5 +271,18 @@ ckc "heartbeat 見つからない" "$OUT" "heartbeat が見つかりません"
 ckc "pane 空を明示（未伝播の疑い）" "$OUT" "pane 空"
 ncc "死に化かさない" "$OUT" "プロセス死"
 
+echo "[24] board に 現統括: 宣言はあるが %NNN 無し → graceful no-op（pipefail 落ちの回帰・実装SO 指摘）"
+mkfix f24; write_sidecar sup "$FRESH" 91 "%158"
+printf '%s\n' "# board" "" "現統括: （未定・pane 未記載）" "succession: 進行中" > "$BOARD"
+rc=0; OUT="$(run "$NOW")" || rc=$?
+ck  "exit 0（set -e で落ちない）" "0" "$rc"
+ckc "統括を特定できない no-op" "$OUT" "統括を特定できません"
+
+echo "[25] HOME 未設定 + OE_EVENT_DIR 未設定 → unbound で落ちない（exit 0・実装SO codex 指摘）"
+mkfix f25; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 40 "%158"
+rc=0; OUT="$(env -u HOME -u OE_EVENT_DIR PATH="$STUB_BIN:$PATH" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_VITALS_NOW_EPOCH="$NOW" bash "$OE_VITALS" 2>&1)" || rc=$?
+ck  "HOME/OE_EVENT_DIR 未設定でも exit 0" "0" "$rc"
+ckc "健全（正常に判定まで到達）" "$OUT" "は健全"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_vitals.sh
+++ b/projects/orchestration-engine/tests/test_oe_vitals.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test_oe_vitals.sh — bin/oe-vitals（#239 段階1 PR-B・統括 vital 監視 consumer）の検証。
+#
+# read-only 前提: fixture の sidecar 群（<sid>.json = {ts, context_pct, pane}）を直に置き、board
+# （OE_BOARD_FILE）の現統括 pane と突合して統括 session だけを対象化し、真理値表
+# （alive×fresh×high / alive×fresh×low / gone×stale / absent / alive×stale）を検証する。
+# 鮮度は決定論化のため OE_VITALS_NOW_EPOCH で now を固定する（date +%s は使わない）。
+# liveness は PATH-stub tmux で固定（%158 alive・他は gone）。wez は stub で呼出記録。
+# sidecar / board は jq / printf で runtime 生成し、生制御文字をソースに置かない（#239 の Write 化け罠）。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OE_VITALS="$PROJECT_DIR/bin/oe-vitals"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+
+# --- stub tmux (%158 alive・他は gone) + wez (呼出記録) ---
+STUB_BIN="$_TMP_DIR/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list-panes" ]]; then printf '%%158\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$STUB_BIN/tmux"
+WEZ_LOG="$_TMP_DIR/wez.log"; : > "$WEZ_LOG"
+cat > "$STUB_BIN/wez" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$WEZ_LOG"
+exit 0
+EOF
+chmod +x "$STUB_BIN/wez"
+
+# --- 特定ツールを欠いた PATH を作る（tmux/wez 不在・jq 不在の degrade 検証用）---
+IFS=':' read -ra _pdirs <<< "$PATH"
+build_path_without() {  # build_path_without <dir> <tool>...
+  local dest="$1"; shift; mkdir -p "$dest"; local d f b skip t
+  for d in "${_pdirs[@]}"; do
+    [[ -d "$d" ]] || continue
+    for f in "$d"/*; do
+      [[ -x "$f" && ! -d "$f" ]] || continue
+      b="$(basename "$f")"; skip=0
+      for t in "$@"; do [[ "$b" == "$t" ]] && skip=1; done
+      [[ "$skip" -eq 1 ]] && continue
+      [[ -e "$dest/$b" ]] || ln -s "$f" "$dest/$b" 2>/dev/null || true
+    done
+  done
+}
+NOTOOLS="$_TMP_DIR/notools"; build_path_without "$NOTOOLS" tmux wez
+NOJQ="$_TMP_DIR/nojq"; build_path_without "$NOJQ" jq
+
+PASS=0; FAIL=0
+ck() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
+ckc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (missing [$3])"; FAIL=$((FAIL+1)); fi; }
+ncc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  FAIL: $1 (unexpected [$3])"; FAIL=$((FAIL+1)); else echo "  PASS: $1"; PASS=$((PASS+1)); fi; }
+row_of() { printf '%s\n' "$1" | grep -F "$2"; }
+
+# mkfix <name> — sidecar dir + state dir + board を作り $SIDEDIR / $STATEDIR / $BOARD を設定
+mkfix() {
+  local d="$_TMP_DIR/$1"
+  SIDEDIR="$d/heartbeat"; STATEDIR="$d/state"; BOARD="$d/board.md"
+  mkdir -p "$SIDEDIR" "$STATEDIR"; : > "$BOARD"
+}
+# write_sidecar <sid> <ts> <ctx-json> <pane> — sidecar を jq で安全に書く（生制御文字を置かない）
+write_sidecar() {
+  jq -cn --argjson ts "$2" --argjson ctx "$3" --arg pane "$4" \
+    '{ts:$ts, context_pct:$ctx, pane:$pane}' > "$SIDEDIR/$1.json"
+}
+# board_frontmatter <pane> <succ> — PR-C schema 形（YAML frontmatter）
+board_frontmatter() { printf '%s\n' "---" "鮮度: 2026-07-10" "現統括: \"$1\"" "succession: $2" "---" "" "# board" > "$BOARD"; }
+# board_freeform <pane> <succ> — 現行 board 形（frontmatter 無し・1 行に併記・前任 pane %157 も後方併記）
+# backtick は board markup の literal（command 展開ではない）ゆえ single-quote 維持。
+# shellcheck disable=SC2016
+board_freeform() { printf '# START HERE\n\n鮮度: 2026-07-10 / 現統括: pane `%s`（統括5代目・前 seat `%%157`）/ succession: **%s**（...）\n' "$1" "$2" > "$BOARD"; }
+
+# run <now> [args...] — 固定 now で consumer を回す（stub PATH・cron 相当・board/dir を env で隔離）
+run() { local now="$1"; shift; env PATH="$STUB_BIN:$PATH" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$now" bash "$OE_VITALS" "$@"; }
+
+NOW=1000000     # 基準 now（epoch）。fresh=age≤W / stale=age>W を offset で作る。
+FRESH=$((NOW-60))       # age 60s（≤1800）
+STALE=$((NOW-3600))     # age 3600s（>1800）
+
+# ============================================================================
+echo "[1] board 突合 + alive×fresh×high → FLAG context + owner ping"
+mkfix f1; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+: > "$WEZ_LOG"
+rc=0; OUT="$(run "$NOW")" || rc=$?
+ck  "exit 0（observer）" "0" "$rc"
+ckc "header 出る" "$OUT" "supervisor vitals"
+ckc "KIND=context の note" "$OUT" "context 肥大接近"
+ckc "handoff 促し" "$OUT" "handoff"
+ckc "現統括 pane %158 が行に出る" "$(row_of "$OUT" "context 肥大接近")" "%158"
+ck  "wez notify 1 回" "1" "$(awk 'END{print NR}' "$WEZ_LOG")"
+
+echo "[2] alive×fresh×low（ctx≤T）→ FLAG 無し（健全・exit 0）"
+mkfix f2; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 50 "%158"
+rc=0; OUT="$(run "$NOW")" || rc=$?
+ck  "exit 0" "0" "$rc"
+ckc "健全メッセージ" "$OUT" "は健全"
+ncc "context FLAG 出ない" "$OUT" "context 肥大接近"
+
+echo "[3] gone×stale → FLAG death + ping（board が現統括のまま pane 消滅＝crash 疑い）"
+mkfix f3; board_frontmatter "%157" "進行中"; write_sidecar sup "$STALE" 40 "%157"   # %157 は stub で gone
+: > "$WEZ_LOG"
+OUT="$(run "$NOW")"
+ckc "death FLAG" "$OUT" "プロセス死"
+ckc "PLIVE=gone" "$(row_of "$OUT" "プロセス死")" "gone"
+ckc "board succession 併記（進行中）" "$OUT" "board succession=進行中"
+ck  "wez notify 1 回" "1" "$(awk 'END{print NR}' "$WEZ_LOG")"
+
+echo "[4] absent: board は現統括を declare するが該当 pane の sidecar 無し → 検知なし（死に化かさない）"
+mkfix f4; board_frontmatter "%158" "完了"; write_sidecar other "$FRESH" 99 "%199"   # 別 pane のみ
+OUT="$(run "$NOW")"
+ckc "heartbeat 見つからない" "$OUT" "heartbeat が見つかりません"
+ncc "context FLAG は出ない" "$OUT" "context 肥大接近"
+ncc "death FLAG も出ない" "$OUT" "プロセス死"
+
+echo "[5] alive×stale → FLAG 無し（hang 誤検知を実装しない）"
+mkfix f5; board_frontmatter "%158" "完了"; write_sidecar sup "$STALE" 40 "%158"   # %158 alive だが beat stale
+OUT="$(run "$NOW")"
+ckc "健全扱い（検知なし）" "$OUT" "検知なし"
+ncc "death FLAG 出ない（alive なので）" "$OUT" "プロセス死"
+ncc "context FLAG 出ない（stale なので）" "$OUT" "context 肥大接近"
+
+echo "[6] 非統括 sidecar は無視（scope 化）: 統括 %158 は健全・別 session %199 が高 ctx でも FLAG しない"
+mkfix f6; board_frontmatter "%158" "完了"
+write_sidecar sup "$FRESH" 40 "%158"     # 統括: 健全
+write_sidecar noise "$FRESH" 99 "%199"   # 非統括: 高 ctx（無視されるべき）
+OUT="$(run "$NOW")"
+ckc "統括は健全" "$OUT" "は健全"
+ncc "非統括の高 ctx で context FLAG しない" "$OUT" "context 肥大接近"
+
+echo "[7] board 未設定（OE_BOARD_FILE 空）→ scope できず検知なし"
+mkfix f7; write_sidecar sup "$FRESH" 91 "%158"   # board は空
+OUT="$(env PATH="$STUB_BIN:$PATH" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" bash "$OE_VITALS")"
+ckc "統括を特定できない旨" "$OUT" "統括を特定できません"
+ncc "FLAG しない" "$OUT" "context 肥大接近"
+
+echo "[8] sidecar dir 空 → no heartbeat（exit 0）"
+mkfix f8; board_frontmatter "%158" "完了"   # sidecar 無し
+rc=0; OUT="$(run "$NOW")" || rc=$?
+ck  "exit 0" "0" "$rc"
+ckc "no heartbeat メッセージ" "$OUT" "no heartbeat recorded yet"
+
+echo "[9] dedup: 2 回目は notify 抑止・stdout は継続表示（durable）"
+mkfix f9; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+: > "$WEZ_LOG"
+run "$NOW" >/dev/null   # run1: notify + seen 追記
+ck  "run1: wez notify 1 回" "1" "$(awk 'END{print NR}' "$WEZ_LOG")"
+ckc "run1: seen cache に key" "$(cat "$STATEDIR/oe-vitals/seen")" "context|sup"
+: > "$WEZ_LOG"
+OUT2="$(run "$NOW")"
+ck  "run2: 新規キー無し → wez notify 0 回（二重通知抑止）" "0" "$(awk 'END{print NR}' "$WEZ_LOG")"
+ckc "run2: stdout は継続表示" "$OUT2" "context 肥大接近"
+
+echo "[10] context_pct null → 0 扱い（閾値以下・健全）・crash しない"
+mkfix f10; board_frontmatter "%158" "完了"
+jq -cn --argjson ts "$FRESH" --arg pane "%158" '{ts:$ts, context_pct:null, pane:$pane}' > "$SIDEDIR/sup.json"
+rc=0; OUT="$(run "$NOW")" || rc=$?
+ck  "exit 0" "0" "$rc"
+ckc "null ctx → 健全（0 扱い）" "$OUT" "は健全"
+
+echo "[11] --window / --threshold + env + 優先順位 + 不正値"
+mkfix f11; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 80 "%158"   # ctx=80
+ckc "既定 T=85 → ctx80 は健全" "$(run "$NOW")" "は健全"
+ckc "--threshold 70 → ctx80 で FLAG" "$(run "$NOW" --threshold 70)" "context 肥大接近"
+ckc "--threshold=70（=形式）→ FLAG" "$(run "$NOW" --threshold=70)" "context 肥大接近"
+ckc "env THRESHOLD=70 → FLAG" "$(env PATH="$STUB_BIN:$PATH" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" OE_VITALS_CONTEXT_THRESHOLD=70 bash "$OE_VITALS")" "context 肥大接近"
+ckc "--threshold 90 が env 70 を上書き → 健全" "$(env PATH="$STUB_BIN:$PATH" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" OE_VITALS_CONTEXT_THRESHOLD=70 bash "$OE_VITALS" --threshold 90)" "は健全"
+# --window: STALE(age3600) を window で fresh/stale 切替（%158 alive なので stale でも death は出ない=健全/検知なし）
+mkfix f11b; board_frontmatter "%158" "完了"; write_sidecar sup "$STALE" 91 "%158"
+ckc "--window 4000 → beat fresh 扱い → 高 ctx で context FLAG" "$(run "$NOW" --window 4000)" "context 肥大接近"
+ckc "既定 window 1800 → stale 扱い（alive×stale）→ 検知なし" "$(run "$NOW")" "検知なし"
+# 不正値
+rc=0; run "$NOW" --threshold abc >/dev/null 2>&1 || rc=$?; ck "threshold 非整数 → exit 2" "2" "$rc"
+rc=0; run "$NOW" --threshold 101 >/dev/null 2>&1 || rc=$?; ck "threshold 101 → exit 2" "2" "$rc"
+rc=0; run "$NOW" --window abc >/dev/null 2>&1 || rc=$?; ck "window 非整数 → exit 2" "2" "$rc"
+rc=0; run "$NOW" --window 0 >/dev/null 2>&1 || rc=$?; ck "window 0 → exit 2" "2" "$rc"
+
+echo "[12] 不正オプション / 余分引数 → usage・exit 2"
+mkfix f12; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+rc=0; run "$NOW" --bogus >/dev/null 2>&1 || rc=$?; ck "bad opt exit 2" "2" "$rc"
+rc=0; run "$NOW" extra-arg >/dev/null 2>&1 || rc=$?; ck "余分引数 exit 2" "2" "$rc"
+
+echo "[13] -h/--help → exit 0・usage"
+mkfix f13; board_frontmatter "%158" "完了"
+rc=0; H="$(run "$NOW" --help 2>&1)" || rc=$?
+ck  "--help exit 0" "0" "$rc"
+ckc "usage 表示" "$H" "統括の拍動鮮度"
+
+echo "[14] jq 不在 → exit 2"
+mkfix f14; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+rc=0; ERRO="$(PATH="$NOJQ" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" bash "$OE_VITALS" 2>&1)" || rc=$?
+ck  "nojq exit 2" "2" "$rc"
+ckc "nojq err メッセージ" "$ERRO" "jq"
+
+echo "[15] tmux 不在 → liveness ? に degrade・検知は継続（fresh×high は context FLAG）"
+mkfix f15; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+rc=0; OUT="$(PATH="$NOTOOLS" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" bash "$OE_VITALS" 2>&1)" || rc=$?
+ck  "no-tmux exit 0" "0" "$rc"
+ckc "検知は継続（context FLAG）" "$OUT" "context 肥大接近"
+ckc "PLIVE=?（tmux 不在 degrade）" "$(row_of "$OUT" "context 肥大接近")" "?"
+
+echo "[16] wez 不在: 通知経路なし → seen へ記録せず永続抑止しない（stdout は durable）"
+mkfix f16; board_frontmatter "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+r16() { PATH="$NOTOOLS" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" bash "$OE_VITALS"; }
+OUT_A="$(r16)"
+ckc "wez 不在でも FLAG は stdout に出る" "$OUT_A" "context 肥大接近"
+ck  "通知していないので seen cache を作らない" "1" "$([[ ! -e "$STATEDIR/oe-vitals/seen" ]] && echo 1 || echo 0)"
+OUT_B="$(r16)"
+ckc "2 回目も抑止されず表示" "$OUT_B" "context 肥大接近"
+
+echo "[17] board freeform 形（frontmatter 無し・前任 %157 併記）でも現統括 %158 を解決"
+mkfix f17; board_freeform "%158" "完了"; write_sidecar sup "$FRESH" 91 "%158"
+OUT="$(run "$NOW")"
+ckc "freeform 現統括を解決し FLAG" "$OUT" "context 肥大接近"
+ckc "現統括 %158（前任 %157 でない）" "$(row_of "$OUT" "context 肥大接近")" "%158"
+ncc "前任 %157 を統括と誤認しない" "$(row_of "$OUT" "context 肥大接近")" "%157"
+
+echo "[18] pane 再利用: 現統括 pane を持つ sidecar 複数 → 最新 ts を採用"
+mkfix f18; board_frontmatter "%158" "完了"
+write_sidecar old "$STALE" 99 "%158"   # 古い・高 ctx（採用されない）
+write_sidecar new "$FRESH" 40 "%158"   # 新しい・低 ctx（採用される）
+OUT="$(run "$NOW")"
+ckc "最新 ts の sidecar（低 ctx）→ 健全" "$OUT" "は健全"
+ncc "古い高 ctx を採用しない" "$OUT" "context 肥大接近"
+
+echo "[19] board succession の制御文字は無害化（death FLAG の会話到達面・#224/#233）"
+mkfix f19; write_sidecar sup "$STALE" 40 "%157"   # %157 gone×stale → death
+_esc="$(printf '\033')"
+# succession 値に ESC を仕込む（（ の前・抽出範囲内）。生 ESC は printf runtime 生成でソースに置かない。
+# backtick は board markup の literal ゆえ single-quote 維持。
+# shellcheck disable=SC2016
+printf '# board\n\n鮮度: 2026-07-10 / 現統括: pane `%%157` / succession: DONE%sEVIL（x）\n' "$_esc" > "$BOARD"
+OUT="$(run "$NOW")"
+if printf '%s' "$OUT" | LC_ALL=C grep -q "$_esc"; then echo "  FAIL: succession の ESC 未無害化"; FAIL=$((FAIL+1)); else echo "  PASS: succession ESC neutralized"; PASS=$((PASS+1)); fi
+ckc "death FLAG は出る" "$OUT" "プロセス死"
+ckc "succession 周辺テキスト残存" "$OUT" "EVIL"
+
+echo "[20] ?×stale → death を出さない（設計SO 反証の回帰: tmux 不在で偽 crash ping しない）"
+mkfix f20; board_frontmatter "%157" "完了"; write_sidecar sup "$STALE" 40 "%157"
+rc=0; OUT="$(PATH="$NOTOOLS" OE_HEARTBEAT_DIR="$SIDEDIR" OE_BOARD_FILE="$BOARD" OE_EVENT_DIR="$STATEDIR" OE_VITALS_NOW_EPOCH="$NOW" bash "$OE_VITALS" 2>&1)" || rc=$?
+ck  "exit 0" "0" "$rc"
+ncc "?×stale で death を出さない（確定 gone のみ death）" "$OUT" "プロセス死"
+ckc "no-op（検知なし）" "$OUT" "検知なし"
+
+echo "[21] gone×fresh → 即 death（旧設計の W 遅延を解消・確定 gone は鮮度非依存）"
+mkfix f21; board_frontmatter "%157" "完了"; write_sidecar sup "$FRESH" 40 "%157"   # %157 は stub で gone・beat fresh
+OUT="$(run "$NOW")"
+ckc "gone×fresh でも death" "$OUT" "プロセス死"
+ckc "beat は fresh 表示" "$(row_of "$OUT" "プロセス死")" "fresh"
+
+echo "[22] board 見出しの（現統括 %OLD の担当）を誤 match しない（colon 宣言のみ拾う）"
+mkfix f22; write_sidecar sup "$FRESH" 91 "%158"
+printf '%s\n' "# board" "" "## in-flight（現統括 %144 の担当）" "" '現統括: "%158"' "succession: 完了" > "$BOARD"
+OUT="$(run "$NOW")"
+ckc "declaration の %158 を解決し context FLAG" "$OUT" "context 肥大接近"
+ckc "現統括=%158" "$(row_of "$OUT" "context 肥大接近")" "%158"
+ncc "見出しの stale %144 を誤採用しない" "$(row_of "$OUT" "context 肥大接近")" "%144"
+
+echo "[23] pane 未伝播（sidecar 全て pane 空）→ 明示 warn・死に化かさない"
+mkfix f23; board_frontmatter "%158" "完了"
+write_sidecar a "$FRESH" 91 ""   # pane 空
+write_sidecar b "$FRESH" 50 ""   # pane 空
+OUT="$(run "$NOW")"
+ckc "heartbeat 見つからない" "$OUT" "heartbeat が見つかりません"
+ckc "pane 空を明示（未伝播の疑い）" "$OUT" "pane 空"
+ncc "死に化かさない" "$OUT" "プロセス死"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 概要

#239 段階1 の **最後の1本（PR-B）**。statusLine 拍動 producer（[PR #245](https://github.com/stlwolf/ai-development-hub/pull/245)・PR-A・マージ済）が session 毎に書く sidecar を **out-of-session cron から読み**、統括 session の **context% 肥大接近**（mode1 context 肥大死＝#238 中核）と **プロセス死**（pane 消滅）を検知して owner に ping する **read-only 姉妹 verb `oe-vitals`** を追加する。段階0 `oe-undelivered`（[PR #241](https://github.com/stlwolf/ai-development-hub/pull/241)）の観測 family を template として踏襲（入力面は sidecar dir・frontier jq は再コピーしない）。

producer / board schema は先着マージ済みのため、README 追記の衝突相手はなし。

## verb 名の提案: `oe-vitals`

kickoff が命名を実装子に委ねたため提案する。候補比較:

- `oe-heartbeat` — producer（`statusline-oe-heartbeat.sh`）と "heartbeat" namespace が衝突。verb 固有 seen cache dir が producer の sidecar dir `~/.claude/state/oe-heartbeat/` と **同一パスで衝突**する。方向も曖昧。
- `oe-liveness` — 設計が明示的に否定する「hang/liveness 誤検知」を名前が招き、中核の context% 検知を過小表現。
- **`oe-vitals`（採用）** — 拍動鮮度 + context% 負荷の 2 vital を包摂し、producer と namespace 衝突せず、消費側（読んで判定して ping）の意味づけに合う。seen cache は別 namespace `~/.claude/state/oe-vitals/`。
  - 設計SO は「family（`oe-status`/`oe-activity`/`oe-undelivered` は名詞）に対し `oe-vitals` はやや抽象 metaphor」と指摘（非致命）。namespace 分離の利得を優先した。

## 検知ロジック（2 検知器・真理値表）

| pane | beat 鮮度 | context% | 動作 |
|---|---|---|---|
| alive / ? | fresh | `> T` | **ping**（context 肥大接近・handoff 促し・#238 中核） |
| alive / ? | fresh | `≤ T` | なし（健全） |
| alive / ? | stale | — | なし（生存/不明×拍動停止・死に化かさない） |
| gone | fresh/stale | — | **ping**（プロセス死・crash 疑い・1回 dedup） |
| 不在 | — | — | なし（producer 未設定 — 死ではない） |

- **death は tmux 確定 `gone` のみ**で判定（beat 鮮度非依存）。`alive/? × stale` は no-op（「alive×stale→hang」は実装しない）。tmux 不在時は death 検知不可・context のみ degrade 動作（偽陽性を出すより安全側）。
- **統括スコープ化 = board 突合**: board（declared 層・PR-C）の `現統括:` 宣言行の `%NNN` と sidecar の `pane` を突合し、現統括の sidecar だけを判定。`OE_BOARD_FILE` で board を与える（machine-local・既定なし）。PR-C frontmatter 形と現行 freeform 行の両対応。orderly handoff 後は board の `現統括` が後任へ進むため前任は scope 外＝想定内 handoff は ping しない。

## SO ゲート（設計SO + 実装SO・両方通過）

engine 作業の規律に従い両レンズを弱SO（各1周）で当てた。両方 refuted → material 反証を reconcile。

**設計SO**（`oe-refute --rubric exploration --lanes 3`・refuted 3/3）— 実バグ2件を修正:
- **death 述語 `stale∧¬alive` が tmux 不在の `?` を death 扱い** → cron で偽 crash ping。→ death を **確定 `gone` のみ**に。
- **board 現統括抽出 `grep '現統括'` が見出し `## in-flight（現統括 %144 の担当）` の古い pane を誤 match** しうる（実 board で確認）。→ `grep '現統括:'`（colon 宣言のみ）に。
- 他: gone×fresh の検知遅延を解消・pane 未伝播を明示 warn。

**実装SO**（`oe-review --lanes 3`・refuted 2/3・cursor survived）— 実バグ2件を修正:
- `resolve_supervisor_pane` の末尾 pipeline が `現統括:` 宣言あり・`%NNN` 無しのとき grep rc1 → `pipefail`→`set -e` で script が exit 1（**exit 0 契約違反**）。→ `|| true` で graceful no-op へ。
- `OE_EVENT_DIR` の default の裸 `${HOME}` が `set -u` 下で HOME 未設定時に unbound で落ちる。→ `${HOME:-}` に。

各 material 反証に回帰テストを追加。設計判断・SO 結果の詳細は plan doc（`projects/orchestration-engine/docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md`）に durable 化。

## 運用前提（disclose・silently drop しない）

- **board 突合は sidecar の `pane` が埋まっている前提**（producer の `$TMUX_PANE` 伝播依存・PR-A は session_id 主キーで pane は best-effort）。未伝播なら scope できず no-op（sidecar が全て pane 空なら明示 warn）。
- **cron 配線は deployment 手順**（verb は届けるが cron 設置は別・自動化しない）。段階0 `oe-undelivered` と同じ out-of-session cron に相乗り。**`OE_BOARD_FILE` を必ず設定**すること。README に配線例を記載。
- `wez notify` の cron 到達性は未検証 → **stdout が durable signal**。

## follow-up（本 PR scope 外・surface のみ）

- **Alt-A**: board が `session_id`（ULID）を declare → pane 非依存で scope（pane 未伝播・pane 再利用に耐える・最有力後継）。board schema（PR-C）変更を伴うため別 PR。
- context の再 ping / escalation interval（現状は session×kind で 1回）。
- inert watchdog（設定漏れ）時の config-health owner ping（現状 stdout のみ）。

## テスト

- `tests/test_oe_vitals.sh`（25 ケース / 77 assertion）: 真理値表4分岐 + 統括スコープ化（非統括無視）+ board 両形式 + seen dedup + degrade（tmux/wez/jq 不在）+ SO 反証の回帰（`?×stale`→no death / gone×fresh→death / 見出し除外 / pipefail 落ち / HOME unbound）。
- **bash 5.2.37 / 3.2.57 両系 green・`shellcheck` clean**。

## 触ったファイル

- 新規 `projects/orchestration-engine/bin/oe-vitals` / `tests/test_oe_vitals.sh` / `docs/plans/2026-07-11-plan-239-pr-b-vitals-consumer.md`
- 追記 `projects/orchestration-engine/bin/README.md`（verb doc + 観測 family 索引 + env 表）

Refs #239
