### PR TITLE
docs(skill): delegate-task に委譲時の worktree 作成分担を追記

### DIFF
--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -83,6 +83,15 @@ BIN="$REPO/projects/orchestration-engine/bin"
 子に報告させたいなら、その指示は **task / kickoff の本文に自分で書く**。戻しの送信自体は子が
 汎用の `oe-send "$PARENT_TMUX_PANE" "..."` で行う（下記「戻し」）。
 
+### worktree 作成分担（子が自作・統括は hands-off）
+
+委譲では **worktree を作るのは子**で、統括（親）は作らない。誰が作るかを取り違えると統括の pane が迷子になる。
+
+- **子が自分の worktree を作る**: 子は自分の pane で `wt switch --create <branch>` を実行し labeling する（issue 起点でも同じ）。並列委譲でも**各子がそれぞれ自分の分を作る**。
+- **統括（親）は事前作成しない・hands-off**: 親が `wt switch --create` すると親自身の pane ラベルが張り替わり迷子になる。**hands-off が統括の条件**。親がどうしても worktree を用意する稀な場合だけ、labeling を伴わない `git worktree add`（`wt switch` の pane-labeling を避ける）を使う。
+- **per-issue は end-to-end で子へ**: 各 issue の §0 洗い出し以降（設計 SO / 調査 / 実装）を統括が自分の会話で巻き取らず、issue ごとに子スレッドへ一気通貫で委譲する（親 lean）。§0 の一括 read-only 洗い出しだけは親 or 使い捨て subagent が担ってよい。
+- **マージ・worktree 掃除は親 / 人間（HG）**: 子は完了報告のみ行い、マージも worktree 掃除もしない。
+
 ---
 
 ## send（既存ペインへの送信）

--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -87,10 +87,10 @@ BIN="$REPO/projects/orchestration-engine/bin"
 
 委譲では **worktree を作るのは子**で、統括（親）は作らない。誰が作るかを取り違えると統括の pane が迷子になる。
 
-- **子が自分の worktree を作る**: 子は自分の pane で `wt switch --create <branch>` を実行し labeling する（issue 起点でも同じ）。並列委譲でも**各子がそれぞれ自分の分を作る**。
-- **統括（親）は事前作成しない・hands-off**: 親が `wt switch --create` すると親自身の pane ラベルが張り替わり迷子になる。**hands-off が統括の条件**。親がどうしても worktree を用意する稀な場合だけ、labeling を伴わない `git worktree add`（`wt switch` の pane-labeling を避ける）を使う。
+- **子が自分の worktree を作る**: 子は自分の pane で `wt switch --create <branch>` を実行する（`wt switch` がそのペインの pane-issue state＝`#N` を書き、以後 `oe-send "#N"` で指せる。issue 起点でも同じ）。並列委譲でも**各子がそれぞれ自分の分を作る**。
+- **統括（親）は事前作成しない・hands-off**: 親が `wt switch --create` すると親自身のペインの pane-issue state（`#N`）が張り替わり、親ペイン自身が迷子になる（`oe-send` の宛先解決もずれる）。**hands-off が統括の条件**。親がどうしても worktree を用意する稀な場合だけ、pane-issue state を書き換えない `git worktree add`（`wt switch` による pane-issue 更新を避ける）を使う。
 - **per-issue は end-to-end で子へ**: 各 issue の §0 洗い出し以降（設計 SO / 調査 / 実装）を統括が自分の会話で巻き取らず、issue ごとに子スレッドへ一気通貫で委譲する（親 lean）。§0 の一括 read-only 洗い出しだけは親 or 使い捨て subagent が担ってよい。
-- **マージ・worktree 掃除は親 / 人間（HG）**: 子は完了報告のみ行い、マージも worktree 掃除もしない。
+- **マージ・worktree 掃除は親 / 人間（Human Gate、HG）**: 子は完了報告のみ行い、マージも worktree 掃除もしない。
 
 ---
 


### PR DESCRIPTION
## 概要

委譲の重要原則「**子が自分の worktree を作る・統括は hands-off**」を、委譲ドメインの skill `canonical/skills/delegate-task/SKILL.md` に追記する（1 ファイルのみ）。

## なぜ canonical 化するか

この原則は、これまで 1 統括の board（machine-local）と personal memory にしか無く、**canonical（synced）に載っていなかった**。そのため別 cockpit（別プロジェクトの統括）が canonical を読んでも届かず、古い前提「worktree は親が作成」で嵌る事故が dogfooding で判明した。1 統括の local にしか無かった原則を canonical へ reconcile する。

## なぜ worktrunk-worktrees でなく delegate-task に置くか

`worktrunk-worktrees` は単体セッション（委譲もエンジンも使わない）でも使う**汎用の worktree-ops skill**であり、委譲プロセスのドメインを混ぜると汎用性が汚れる。委譲ドメインの正しい置き場は `delegate-task`。

## 変更内容

`## delegate（親 → 子の委譲）` セクション末尾に小節「worktree 作成分担（子が自作・統括は hands-off）」を追記:

- 子が自分の worktree を作る（並列委譲でも各子が自分の分を作る）
- 統括（親）は事前作成しない・hands-off が統括の条件（例外は labeling を伴わない `git worktree add`）
- per-issue は end-to-end で子へ（§0 の一括 read-only 洗い出しだけは親 or 使い捨て subagent 可）
- マージ・worktree 掃除は親 / 人間（HG）、子は完了報告のみ

## 影響範囲

- `canonical/skills/delegate-task/SKILL.md` の 1 ファイルのみ（9 行追記）。`worktrunk-worktrees` には触れていない。
- sync で各ツール（Claude / Cursor / Codex）へ配布される正本。

Refs #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
