### PR TITLE
feat(oe): 手動起動 pane 登記の oe-register verb を追加

### DIFF
--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -28,6 +28,7 @@ description: 親子 Claude Code セッション間の委譲操作を行う。del
 | `oe-delegate` | 親 → 子 | 子ペインを起動（spawn）し、最初のキックを送る。registry に登録 |
 | `oe-send` | 任意 → 任意 | 既存ペインへ 1 行 / キックオフを送る汎用入口。宛先はラベル or `%N` |
 | `oe-list` | — | 宛先候補を source 列付きで一覧（誤送信防止） |
+| `oe-register` | — | 手動起動 pane を登記（`root`=自己 root / `link %N`=相手を自分の下に）。spawn を経ない pane を oe-tree / cockpit に現す |
 | `oe-report` | 子 → 親 | （legacy）子→親の申し送り。**戻しは oe-send に一本化**（論点E で整理） |
 
 `oe-delegate` = spawn + `oe-send`（キック）の合成。送信の実体は `oe-send` に集約されている。
@@ -133,6 +134,24 @@ BIN="$REPO/projects/orchestration-engine/bin"
 
 ---
 
+## register（手動起動 pane を登記・#259）
+
+`oe-delegate` を経ずに手動起動した pane は spawn registry に出ないため、`oe-tree` / cockpit（`oe-select` / `--pick`）に現れず、委譲関係も登記されない。`oe-register` で登記する。
+
+```bash
+# 手動起動した統括 pane を自分自身で root 登記（oe-tree に root として現す）
+"$BIN/oe-register" root --label "#N"
+
+# 既存の相手ペイン %N を自分の下に子として登記（spawn を経ない委譲の登記）
+"$BIN/oe-register" link "%37" --label "#150"
+```
+
+- `link` の guard: target 非生存 / `%self` / 生存する別親の子 → 拒否（他人の子の横取り防止・`--force` で reparent）。orphan（親 gone）は引き取り可・既に自分の子は冪等
+- `root` の guard: 生きた親を持つ委譲子の自己 root 化（cold-start 手順の誤実行など）は拒否（detach 防止・`--force` で明示 re-root）
+- 登記後は `oe-send "#N"` / `oe-list` / `oe-tree` が通常どおり解決する（registry の record を書くだけ・既存挙動は不変）
+
+---
+
 ## 戻し（子 → 親）
 
 delegate は report を内包しないので、**戻しは汎用の `oe-send` で行う**。子に渡っている
@@ -185,6 +204,7 @@ delegate は report を内包しないので、**戻しは汎用の `oe-send` �
 - `projects/orchestration-engine/bin/oe-delegate` — 子ペイン起動 + キック（spawn + send）
 - `projects/orchestration-engine/bin/oe-send` — 既存ペインへの汎用送信
 - `projects/orchestration-engine/bin/oe-list` — 宛先候補の一覧
+- `projects/orchestration-engine/bin/oe-register` — 手動起動 pane の登記（自己 root / 既存 pane の委譲 link・#259）
 - `projects/orchestration-engine/bin/oe-report` — 子→親の報告（legacy。戻しは oe-send に一本化）
 - `projects/orchestration-engine/lib/delegate-send.sh` — 改行拒否の 1 行 safe-send
 - `projects/orchestration-engine/lib/delegate-registry.sh` — アドレッシング（record/resolve/list/gc）

--- a/canonical/skills/doc-flow-guardrail/SKILL.md
+++ b/canonical/skills/doc-flow-guardrail/SKILL.md
@@ -97,6 +97,7 @@ memory が無くても、このスキル1本を読めばフロー + 参照ポイ
 1. フロー地図（①）と routing 表（下記）で、いま居る層と次に通すゲートを掴む。
 2. 委譲するなら固定節テンプレ（②）を brief に貼り、可変節を埋める。
 3. spec の詳細は「spec 解決規約」で `document-format.md` を開く。
+4. 手動起動した統括ペインは `oe-register root` で自己登記する（spawn を経ないため registry に出ず oe-tree / cockpit `--pick` に現れない → 登記で root として可視化・jump 可）。既存 pane を自分の下へ委譲登記するなら `oe-register link %N`。
 
 **統括 succession の復旧は本スキルの範囲外**（engine track・#238/#239）。誤 close / resume からの復帰手順（board `現統括:` を新 pane へ張替 → 孤児 sidecar 掃除 → 検証。死んだ親の下へ再 parenting しない＝後継は並列 peer）は discussion `projects/orchestration-engine/docs/discussions/2026-07-13-discussion-supervisor-succession-recovery-and-observability.md`（§4-2 / §4-3 / §5(0)）を参照する。自動化 verb `oe-reseat` は仮称・未実装。
 

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -133,6 +133,23 @@ oe-list
 
 関連 lib: `delegate-registry.sh`
 
+## oe-register — 自己 root 登記 / 既存 pane の委譲 link（#259）
+
+手動起動した pane（spawn を経ないため registry に出ない）を登記し `oe-tree` / cockpit に現す。`root` で自分を root として、`link %N` で相手 %N を自分の下の子として登記する。
+
+```bash
+oe-register root [--label <#N|name>] [-w WORKSPACE] [--force]
+oe-register link <%N> [--label <#N|name>] [-w WORKSPACE] [--force]
+```
+
+- `root` … 自ペイン（`$TMUX_PANE`）を `parent_pane=""` の root entry として登記（手動起動の統括を可視化）
+- `link <%N>` … 相手 %N を自分の下の子として登記（spawn を経ない委譲関係の登記）
+- guard（verb 側・横取り/事故防止）: `link` は target 非生存 / `%self`（self-cycle）/ 生存する別親の子 → 拒否（`--force` で reparent）・orphan は引き取り可・既に自分の子は冪等。`root` は生きた親を持つ委譲子の自己 root 化を拒否（`--force` で明示 re-root）
+- `--label` は LF/CR を fail-fast 拒否。tmux 内必須（`TMUX_PANE`）・jq 必須
+- 既存 verb・lib の write path（`oe_reg_record`）は無変更。本 verb はそれを呼ぶだけ（additive）
+
+関連 lib: `delegate-registry.sh`（record/GC）。読取側 `oe-ident` / `event-bus.sh` の role 導出は「自 entry かつ parent_pane 非空」＝自己 root を `child` と誤導出しない（#259）
+
 ## oe-select — 宛先をインタラクティブに選んで送信
 
 `oe-list` と同一ソースの候補から fzf（無ければ番号 read）で 1 件選び、pane id を抽出して `oe-send` へ素通しする。既定で自ペインを候補から除外する。

--- a/projects/orchestration-engine/bin/oe-ident
+++ b/projects/orchestration-engine/bin/oe-ident
@@ -17,7 +17,7 @@
 #
 #   role 導出（registry 読取のみ・書込なし）:
 #     parent = この pane を parent_pane に持つ子 entry が在る（＝子を spawn した）
-#     child  = この pane 自身の spawn entry が在る（oe_reg_record が role:"child" で記録）
+#     child  = この pane 自身の spawn entry が在り かつ parent_pane 非空（#259: parent 空の自己 root は child でない）
 #     （両方なら parent を優先）
 #
 # 例: parent #202 pane-identity / child #179 / #204 toolkit（spawn 関係なし=role 無し） / （空）
@@ -53,7 +53,10 @@ fi
 own="${OE_DELEGATE_STATE_DIR}/${key}.json"
 is_child=0
 if [[ -f "$own" ]]; then
-  is_child=1
+  # role=child は「自 entry が在り かつ parent_pane 非空」に限る（#259）。parent 空の自己 root
+  # entry（oe-register root）を child と誤導出しない。既存 entry は全て parent 非空ゆえ既存データに挙動不変。
+  own_parent="$(jq -r '.parent_pane // empty' "$own" 2>/dev/null)"
+  [[ -n "$own_parent" ]] && is_child=1
   [[ -z "$label" ]] && label="$(jq -r '.label // empty' "$own" 2>/dev/null)"
 fi
 

--- a/projects/orchestration-engine/bin/oe-register
+++ b/projects/orchestration-engine/bin/oe-register
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# oe-register — 自分を root 登録 / 相手を自分の下に link する（親子委譲レジストリの登記 verb）
+#
+# usage:
+#   oe-register root [--label <#N|name>] [-w WORKSPACE] [--force]
+#   oe-register link <%N> [--label <#N|name>] [-w WORKSPACE] [--force]
+#
+# root: 自ペイン（$TMUX_PANE）を parent_pane="" の root entry として登記する。手動起動した
+#       統括 pane を oe-tree / cockpit に現す（spawn を経ないため今まで registry に出なかった）。
+# link: 既存の相手ペイン %N を自分（$TMUX_PANE）の下に子として登記する。手動起動 pane 間の
+#       委譲関係を登記する（spawn を経ない委譲の受け皿）。
+#
+# guard は verb 側に持つ（registry は pane ごと 1 ファイル・last-write-wins のため lib では持てない）:
+#   link: target %N が非生存 → 拒否（record 直後の GC で無言 no-op になるのを防ぐ）/ target==self
+#         （self-cycle・oe-tree で [cycle] 化）→ 拒否 / 既存 entry の parent が生存かつ別 pane →
+#         拒否（他人の子の横取り防止・--force で上書き）/ orphan（親 gone）→ 引き取り可 /
+#         既に自分の子 → 冪等。
+#   root: 自 entry が生きた親を持つ（委譲された子が cold-start 手順で誤って自己 root 化）→ 拒否
+#         （detach 防止・--force で明示 re-root）/ 既に root or orphan → 許可。
+#
+# registry の write path（oe_reg_record）は無変更。本 verb はそれを呼ぶだけ（additive・#259）。
+# oe-tree の root 判定 = parent 空の entry を root 描画。self-parent は [cycle] 化するため空 parent が正。
+
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/delegate-registry.sh
+source "${BIN_DIR}/../lib/delegate-registry.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  oe-register root [--label <#N|name>] [-w WORKSPACE] [--force]
+  oe-register link <%N> [--label <#N|name>] [-w WORKSPACE] [--force]
+
+  root                自ペイン（$TMUX_PANE）を root として登記（parent_pane="" で record）
+  link <%N>           相手ペイン %N を自分の下に子として登記（parent_pane=$TMUX_PANE で record）
+  --label <#N|name>   registry 登録ラベル（省略可。表示は pane-issue > registry.label > pane_title）
+  -w, --workspace DIR entry の workspace（root 既定=カレント / link 既定=対象 pane の cwd）
+  --force             guard を上書き（link: 生存別親の reparent / root: 生きた親からの re-root）
+  -h, --help          このヘルプを表示
+
+環境変数:
+  TMUX_PANE           tmux 内で自動設定される自ペイン ID（必須）
+EOF
+}
+
+# --- tmux / jq 前提 ---
+SELF="${TMUX_PANE:-}"
+[[ -n "$SELF" ]] || { echo "oe-register: TMUX_PANE is not set — must run inside a tmux session" >&2; exit 1; }
+command -v tmux >/dev/null 2>&1 || { echo "oe-register: tmux is required" >&2; exit 2; }
+command -v jq   >/dev/null 2>&1 || { echo "oe-register: jq is required" >&2; exit 2; }
+
+# --- subcommand ---
+MODE="${1:-}"
+case "$MODE" in
+  root|link) shift ;;
+  -h|--help) usage; exit 0 ;;
+  "")  echo "oe-register: subcommand required (root|link)" >&2; usage; exit 2 ;;
+  *)   echo "oe-register: unknown subcommand: ${MODE} (expected root|link)" >&2; usage; exit 2 ;;
+esac
+
+# --- フラグ + 位置引数 ---
+LABEL=""
+WORKSPACE=""
+WS_EXPLICIT=0
+FORCE=0
+TARGET=""   # link mode のみ
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label)
+      [[ $# -ge 2 ]] || { echo "oe-register: --label requires a value" >&2; exit 2; }
+      # 改行を含むラベルは oe_reg_list 出力を複数行化し消費者の行パースに偽 %N 行を紛れ込ませ得る
+      # （oe-delegate --label と同じ fail-fast）。
+      if [[ "$2" == *$'\n'* || "$2" == *$'\r'* ]]; then
+        echo "oe-register: --label must be a single line (no newline)" >&2; exit 2
+      fi
+      LABEL="$2"; shift 2 ;;
+    -w|--workspace)
+      [[ $# -ge 2 ]] || { echo "oe-register: --workspace requires a value" >&2; exit 2; }
+      WORKSPACE="$2"; WS_EXPLICIT=1; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    -*) echo "oe-register: unknown option: $1" >&2; usage; exit 2 ;;
+    *)
+      if [[ "$MODE" == link && -z "$TARGET" ]]; then TARGET="$1"; shift
+      else echo "oe-register: unexpected argument: $1" >&2; usage; exit 2; fi ;;
+  esac
+done
+# `--` の後ろに残った link target を拾う
+if [[ "$MODE" == link && -z "$TARGET" && $# -ge 1 ]]; then TARGET="$1"; shift; fi
+[[ $# -eq 0 ]] || { echo "oe-register: unexpected extra arguments: $*" >&2; usage; exit 2; }
+
+# --- 生存ペイン一覧（list-panes 失敗は環境エラー exit 2・resolve/gc と同型） ---
+LIVE_PANES=""
+load_live_panes() {
+  # set -e 下では out="$(cmd)"; rc=$? が cmd 失敗時に代入行で即 exit(1) し rc 捕捉前に落ちる。
+  # `|| rc=$?` で失敗を compound 化して set -e を回避し、環境エラーを exit 2 に正しく倒す。
+  local out rc=0
+  out="$(tmux list-panes -a -F '#{pane_id}' 2>&1)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "oe-register: tmux list-panes failed (rc=${rc}): ${out}" >&2; exit 2
+  fi
+  LIVE_PANES="$out"
+}
+is_live() { printf '%s\n' "$LIVE_PANES" | grep -qxF "$1"; }
+
+entry_file() { printf '%s/%s.json' "$OE_DELEGATE_STATE_DIR" "$(_oe_reg_key "$1")"; }
+entry_exists() { [[ -f "$(entry_file "$1")" ]]; }
+entry_parent() { jq -r '.parent_pane // empty' "$(entry_file "$1")" 2>/dev/null || true; }
+
+record_or_die() { # <pane> <label> <workspace> <parent>
+  oe_reg_record "$1" "$2" "$3" "$4" || { echo "oe-register: failed to record registry entry" >&2; exit 1; }
+}
+
+# ============================================================================
+if [[ "$MODE" == root ]]; then
+  load_live_panes
+  if entry_exists "$SELF"; then
+    parent="$(entry_parent "$SELF")"
+    if [[ -n "$parent" && "$parent" != "$SELF" ]] && is_live "$parent" && [[ "$FORCE" -ne 1 ]]; then
+      echo "oe-register: this pane is registered as a child of live parent ${parent}; refusing to self-root (use --force to re-root)" >&2
+      exit 1
+    fi
+    # parent 空（既に root）/ parent gone（orphan）/ --force → 許可
+  fi
+  [[ "$WS_EXPLICIT" -eq 1 ]] || WORKSPACE="$(pwd)"
+  record_or_die "$SELF" "$LABEL" "$WORKSPACE" ""
+  echo "oe-register: registered ${SELF} as root${LABEL:+ (label: ${LABEL})}" >&2
+  exit 0
+fi
+
+# ============================================================================
+# link
+[[ -n "$TARGET" ]] || { echo "oe-register: link requires a target pane %N" >&2; usage; exit 2; }
+[[ "$TARGET" =~ ^%[0-9]+$ ]] || { echo "oe-register: link target must be a raw pane id (%N), got: ${TARGET}" >&2; exit 2; }
+[[ "$TARGET" != "$SELF" ]] || { echo "oe-register: cannot link a pane to itself (${TARGET} == self)" >&2; exit 1; }
+
+load_live_panes
+is_live "$TARGET" || { echo "oe-register: target ${TARGET} is not a live pane (try: oe-list)" >&2; exit 1; }
+
+if entry_exists "$TARGET"; then
+  tparent="$(entry_parent "$TARGET")"
+  if [[ -n "$tparent" && "$tparent" != "$SELF" ]] && is_live "$tparent" && [[ "$FORCE" -ne 1 ]]; then
+    echo "oe-register: ${TARGET} is already a live child of ${tparent}; refusing to steal (use --force to reparent)" >&2
+    exit 1
+  fi
+  # tparent == self（冪等）/ tparent 空（元 root を adopt）/ tparent gone（orphan 引き取り）/ --force → 許可
+fi
+
+if [[ "$WS_EXPLICIT" -ne 1 ]]; then
+  # 対象 pane の実 cwd を workspace とする（best-effort。取れなければ空）。
+  WORKSPACE="$(tmux display-message -p -t "$TARGET" '#{pane_current_path}' 2>/dev/null || true)"
+fi
+record_or_die "$TARGET" "$LABEL" "$WORKSPACE" "$SELF"
+echo "oe-register: linked ${TARGET} under ${SELF}${LABEL:+ (label: ${LABEL})}" >&2
+exit 0

--- a/projects/orchestration-engine/bin/oe-register
+++ b/projects/orchestration-engine/bin/oe-register
@@ -17,6 +17,13 @@
 #         既に自分の子 → 冪等。
 #   root: 自 entry が生きた親を持つ（委譲された子が cold-start 手順で誤って自己 root 化）→ 拒否
 #         （detach 防止・--force で明示 re-root）/ 既に root or orphan → 許可。
+#   corrupt: 既存 entry の JSON が読めなければ fail-closed（--force なしは拒否）。
+#
+# 限界（TOCTOU・実装SO で明示）: guard は read-check-write で非原子的。複数 link の同時実行や
+#   判定後の親/自ペイン終了は last-write-wins に内在する競合窓で、これは registry 基盤の性質＝
+#   oe-delegate（生存確認→record の同じ窓）と同断面。verb 側では (a) SELF の形式+生存確認、
+#   (b) target 生存確認、(c) record 後の entry 存在再確認（die-after-check の成功偽装を正直化）
+#   まで固め、原子的所有権（flock 等）は基盤課題として scope 外に置く。
 #
 # registry の write path（oe_reg_record）は無変更。本 verb はそれを呼ぶだけ（additive・#259）。
 # oe-tree の root 判定 = parent 空の entry を root 描画。self-parent は [cycle] 化するため空 parent が正。
@@ -108,22 +115,42 @@ is_live() { printf '%s\n' "$LIVE_PANES" | grep -qxF "$1"; }
 
 entry_file() { printf '%s/%s.json' "$OE_DELEGATE_STATE_DIR" "$(_oe_reg_key "$1")"; }
 entry_exists() { [[ -f "$(entry_file "$1")" ]]; }
-entry_parent() { jq -r '.parent_pane // empty' "$(entry_file "$1")" 2>/dev/null || true; }
+# read_parent <pane> — 既存 entry の parent_pane を stdout に。JSON が壊れて読めなければ jq が
+# rc≠0（fail-closed 判定用）。`|| true` で空 parent と同一視すると corrupt entry で live-parent
+# guard が fail-open し保護対象を上書きできる（実装SO codex 指摘）ため rc を握り潰さない。
+read_parent() { jq -r '.parent_pane // empty' "$(entry_file "$1")" 2>/dev/null; }
 
 record_or_die() { # <pane> <label> <workspace> <parent>
   oe_reg_record "$1" "$2" "$3" "$4" || { echo "oe-register: failed to record registry entry" >&2; exit 1; }
 }
 
+# --- link mode の cheap validation（tmux 前に形式を弾く） ---
+if [[ "$MODE" == link ]]; then
+  [[ -n "$TARGET" ]] || { echo "oe-register: link requires a target pane %N" >&2; usage; exit 2; }
+  [[ "$TARGET" =~ ^%[0-9]+$ ]] || { echo "oe-register: link target must be a raw pane id (%N), got: ${TARGET}" >&2; exit 2; }
+  [[ "$TARGET" != "$SELF" ]] || { echo "oe-register: cannot link a pane to itself (${TARGET} == self)" >&2; exit 1; }
+fi
+
+# --- 生存ペイン一覧を1回だけ取得し、SELF 自身の妥当性（形式 + 生存）を先に固める ---
+# stale/spoofed TMUX_PANE では root が GC で即消え・link が生存 target を死んだ親の下に orphan
+# 登録して成功を装う（実装SO codex 指摘）。self を live 起点にしてからでないと guard 全体が崩れる。
+load_live_panes
+[[ "$SELF" =~ ^%[0-9]+$ ]] || { echo "oe-register: TMUX_PANE is not a valid pane id (${SELF})" >&2; exit 1; }
+is_live "$SELF" || { echo "oe-register: this pane (${SELF}) is not a live tmux pane (stale TMUX_PANE?)" >&2; exit 1; }
+
 # ============================================================================
 if [[ "$MODE" == root ]]; then
-  load_live_panes
   if entry_exists "$SELF"; then
-    parent="$(entry_parent "$SELF")"
-    if [[ -n "$parent" && "$parent" != "$SELF" ]] && is_live "$parent" && [[ "$FORCE" -ne 1 ]]; then
-      echo "oe-register: this pane is registered as a child of live parent ${parent}; refusing to self-root (use --force to re-root)" >&2
-      exit 1
+    if sparent="$(read_parent "$SELF")"; then
+      if [[ -n "$sparent" && "$sparent" != "$SELF" ]] && is_live "$sparent" && [[ "$FORCE" -ne 1 ]]; then
+        echo "oe-register: this pane is registered as a child of live parent ${sparent}; refusing to self-root (use --force to re-root)" >&2
+        exit 1
+      fi
+      # parent 空（既に root）/ parent gone（orphan）/ --force → 許可
+    else
+      # entry はあるが JSON が読めない（corrupt）→ fail-closed（--force で明示上書き）
+      [[ "$FORCE" -eq 1 ]] || { echo "oe-register: cannot read existing entry for ${SELF} (corrupt/unreadable); refusing (use --force to override)" >&2; exit 1; }
     fi
-    # parent 空（既に root）/ parent gone（orphan）/ --force → 許可
   fi
   [[ "$WS_EXPLICIT" -eq 1 ]] || WORKSPACE="$(pwd)"
   record_or_die "$SELF" "$LABEL" "$WORKSPACE" ""
@@ -133,20 +160,19 @@ fi
 
 # ============================================================================
 # link
-[[ -n "$TARGET" ]] || { echo "oe-register: link requires a target pane %N" >&2; usage; exit 2; }
-[[ "$TARGET" =~ ^%[0-9]+$ ]] || { echo "oe-register: link target must be a raw pane id (%N), got: ${TARGET}" >&2; exit 2; }
-[[ "$TARGET" != "$SELF" ]] || { echo "oe-register: cannot link a pane to itself (${TARGET} == self)" >&2; exit 1; }
-
-load_live_panes
 is_live "$TARGET" || { echo "oe-register: target ${TARGET} is not a live pane (try: oe-list)" >&2; exit 1; }
 
 if entry_exists "$TARGET"; then
-  tparent="$(entry_parent "$TARGET")"
-  if [[ -n "$tparent" && "$tparent" != "$SELF" ]] && is_live "$tparent" && [[ "$FORCE" -ne 1 ]]; then
-    echo "oe-register: ${TARGET} is already a live child of ${tparent}; refusing to steal (use --force to reparent)" >&2
-    exit 1
+  if tparent="$(read_parent "$TARGET")"; then
+    if [[ -n "$tparent" && "$tparent" != "$SELF" ]] && is_live "$tparent" && [[ "$FORCE" -ne 1 ]]; then
+      echo "oe-register: ${TARGET} is already a live child of ${tparent}; refusing to steal (use --force to reparent)" >&2
+      exit 1
+    fi
+    # tparent == self（冪等）/ tparent 空（元 root を adopt）/ tparent gone（orphan 引き取り）/ --force → 許可
+  else
+    # entry はあるが JSON が読めない（corrupt）→ fail-closed（--force で明示上書き）
+    [[ "$FORCE" -eq 1 ]] || { echo "oe-register: cannot read existing entry for ${TARGET} (corrupt/unreadable); refusing (use --force to override)" >&2; exit 1; }
   fi
-  # tparent == self（冪等）/ tparent 空（元 root を adopt）/ tparent gone（orphan 引き取り）/ --force → 許可
 fi
 
 if [[ "$WS_EXPLICIT" -ne 1 ]]; then
@@ -154,5 +180,12 @@ if [[ "$WS_EXPLICIT" -ne 1 ]]; then
   WORKSPACE="$(tmux display-message -p -t "$TARGET" '#{pane_current_path}' 2>/dev/null || true)"
 fi
 record_or_die "$TARGET" "$LABEL" "$WORKSPACE" "$SELF"
+# record 内の GC は非生存 pane の entry を消す。is_live 判定〜record の間に target が終了すると
+# entry が消え成功表示だけ残る（実装SO codex の success-faking 指摘）。書込後に存在を再確認し、
+# 消えていれば honest に失敗させる（並行 steal の窓は last-write-wins 基盤に内在＝§ヘッダ参照）。
+if ! entry_exists "$TARGET"; then
+  echo "oe-register: ${TARGET} entry did not persist after write (target likely exited); registration failed" >&2
+  exit 1
+fi
 echo "oe-register: linked ${TARGET} under ${SELF}${LABEL:+ (label: ${LABEL})}" >&2
 exit 0

--- a/projects/orchestration-engine/bin/oe-register
+++ b/projects/orchestration-engine/bin/oe-register
@@ -23,7 +23,8 @@
 #   判定後の親/自ペイン終了は last-write-wins に内在する競合窓で、これは registry 基盤の性質＝
 #   oe-delegate（生存確認→record の同じ窓）と同断面。verb 側では (a) SELF の形式+生存確認、
 #   (b) target 生存確認、(c) record 後の entry 存在再確認（die-after-check の成功偽装を正直化）
-#   まで固め、原子的所有権（flock 等）は基盤課題として scope 外に置く。
+#   まで固め、加えて (d) 冪等再登録では --label/-w 省略時に既存 label/workspace を保つ（空で
+#   潰さない）。原子的所有権（flock 等）による race 防止は基盤課題として scope 外に置く。
 #
 # registry の write path（oe_reg_record）は無変更。本 verb はそれを呼ぶだけ（additive・#259）。
 # oe-tree の root 判定 = parent 空の entry を root 描画。self-parent は [cycle] 化するため空 parent が正。
@@ -69,6 +70,7 @@ esac
 
 # --- フラグ + 位置引数 ---
 LABEL=""
+LABEL_EXPLICIT=0
 WORKSPACE=""
 WS_EXPLICIT=0
 FORCE=0
@@ -82,7 +84,7 @@ while [[ $# -gt 0 ]]; do
       if [[ "$2" == *$'\n'* || "$2" == *$'\r'* ]]; then
         echo "oe-register: --label must be a single line (no newline)" >&2; exit 2
       fi
-      LABEL="$2"; shift 2 ;;
+      LABEL="$2"; LABEL_EXPLICIT=1; shift 2 ;;
     -w|--workspace)
       [[ $# -ge 2 ]] || { echo "oe-register: --workspace requires a value" >&2; exit 2; }
       WORKSPACE="$2"; WS_EXPLICIT=1; shift 2 ;;
@@ -152,7 +154,12 @@ if [[ "$MODE" == root ]]; then
       [[ "$FORCE" -eq 1 ]] || { echo "oe-register: cannot read existing entry for ${SELF} (corrupt/unreadable); refusing (use --force to override)" >&2; exit 1; }
     fi
   fi
-  [[ "$WS_EXPLICIT" -eq 1 ]] || WORKSPACE="$(pwd)"
+  # 冪等再登録: --label / -w 省略時は既存 entry の値を保つ（空で潰さない・実装SO cursor 指摘）
+  if entry_exists "$SELF"; then
+    [[ "$LABEL_EXPLICIT" -eq 1 ]] || LABEL="$(jq -r '.label // empty' "$(entry_file "$SELF")" 2>/dev/null || true)"
+    [[ "$WS_EXPLICIT" -eq 1 ]] || WORKSPACE="$(jq -r '.workspace // empty' "$(entry_file "$SELF")" 2>/dev/null || true)"
+  fi
+  [[ "$WS_EXPLICIT" -eq 1 || -n "$WORKSPACE" ]] || WORKSPACE="$(pwd)"
   record_or_die "$SELF" "$LABEL" "$WORKSPACE" ""
   echo "oe-register: registered ${SELF} as root${LABEL:+ (label: ${LABEL})}" >&2
   exit 0
@@ -175,16 +182,27 @@ if entry_exists "$TARGET"; then
   fi
 fi
 
+# 冪等再登録: --label 省略時は既存 label を保つ（空で潰さない・実装SO cursor 指摘）
+if [[ "$LABEL_EXPLICIT" -ne 1 ]] && entry_exists "$TARGET"; then
+  LABEL="$(jq -r '.label // empty' "$(entry_file "$TARGET")" 2>/dev/null || true)"
+fi
 if [[ "$WS_EXPLICIT" -ne 1 ]]; then
-  # 対象 pane の実 cwd を workspace とする（best-effort。取れなければ空）。
-  WORKSPACE="$(tmux display-message -p -t "$TARGET" '#{pane_current_path}' 2>/dev/null || true)"
+  # -w 省略時: 既存 entry の workspace を保つ（冪等）→ 無ければ対象 pane の実 cwd（best-effort）。
+  WORKSPACE=""
+  if entry_exists "$TARGET"; then WORKSPACE="$(jq -r '.workspace // empty' "$(entry_file "$TARGET")" 2>/dev/null || true)"; fi
+  [[ -n "$WORKSPACE" ]] || WORKSPACE="$(tmux display-message -p -t "$TARGET" '#{pane_current_path}' 2>/dev/null || true)"
 fi
 record_or_die "$TARGET" "$LABEL" "$WORKSPACE" "$SELF"
-# record 内の GC は非生存 pane の entry を消す。is_live 判定〜record の間に target が終了すると
-# entry が消え成功表示だけ残る（実装SO codex の success-faking 指摘）。書込後に存在を再確認し、
-# 消えていれば honest に失敗させる（並行 steal の窓は last-write-wins 基盤に内在＝§ヘッダ参照）。
+# post-check: entry が残り かつ 自分の所有（parent==SELF）であることを確認。GC 消去（die-after-check）
+# と並行上書き（steal race）を honest に失敗化する。原子的所有権は last-write-wins 基盤の限界＝
+# scope 外（§ヘッダ）。ここは防止でなく「勝てなかった」ことの検知に留める。
 if ! entry_exists "$TARGET"; then
   echo "oe-register: ${TARGET} entry did not persist after write (target likely exited); registration failed" >&2
+  exit 1
+fi
+postparent="$(read_parent "$TARGET" 2>/dev/null || true)"
+if [[ "$postparent" != "$SELF" ]]; then
+  echo "oe-register: ${TARGET} was concurrently re-registered under ${postparent:-?} (lost last-write-wins race); registration did not take effect" >&2
   exit 1
 fi
 echo "oe-register: linked ${TARGET} under ${SELF}${LABEL:+ (label: ${LABEL})}" >&2

--- a/projects/orchestration-engine/bin/oe-register
+++ b/projects/orchestration-engine/bin/oe-register
@@ -22,7 +22,8 @@
 # 限界（TOCTOU・実装SO で明示）: guard は read-check-write で非原子的。複数 link の同時実行や
 #   判定後の親/自ペイン終了は last-write-wins に内在する競合窓で、これは registry 基盤の性質＝
 #   oe-delegate（生存確認→record の同じ窓）と同断面。verb 側では (a) SELF の形式+生存確認、
-#   (b) target 生存確認、(c) record 後の entry 存在再確認（die-after-check の成功偽装を正直化）
+#   (b) target 生存確認、(c) record 後の entry 存在+所有者（link=parent==SELF / root=parent 空）
+#   再確認（die-after-check / 並行上書きの成功偽装を正直化）
 #   まで固め、加えて (d) 冪等再登録では --label/-w 省略時に既存 label/workspace を保つ（空で
 #   潰さない）。原子的所有権（flock 等）による race 防止は基盤課題として scope 外に置く。
 #
@@ -161,6 +162,17 @@ if [[ "$MODE" == root ]]; then
   fi
   [[ "$WS_EXPLICIT" -eq 1 || -n "$WORKSPACE" ]] || WORKSPACE="$(pwd)"
   record_or_die "$SELF" "$LABEL" "$WORKSPACE" ""
+  # post-check（link と対称）: entry が残り かつ parent 空（＝root のまま）を確認。並行上書きを
+  # honest 検知（自ペイン実行ゆえ die-after-check は稀だが header 記述と非対称にしない・実装SO cursor 指摘）。
+  if ! entry_exists "$SELF"; then
+    echo "oe-register: ${SELF} entry did not persist after write; root registration failed" >&2
+    exit 1
+  fi
+  spost="$(read_parent "$SELF" 2>/dev/null || true)"
+  if [[ -n "$spost" ]]; then
+    echo "oe-register: ${SELF} was concurrently re-parented under ${spost} after write; root registration did not take effect" >&2
+    exit 1
+  fi
   echo "oe-register: registered ${SELF} as root${LABEL:+ (label: ${LABEL})}" >&2
   exit 0
 fi

--- a/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
@@ -3,7 +3,7 @@ id: "01KXN127119AT8VSEMSKN5C1RZ"
 title: "#259 episode（heavy）— oe-register（自己登録 + 委譲 link）と role 導出述語の締め"
 date: 2026-07-16
 type: episode
-status: draft
+status: stable
 related:
   - type: parent_issue
     ref: "https://github.com/stlwolf/ai-development-hub/issues/259"
@@ -61,6 +61,47 @@ tags: [orchestration, delegate-registry, oe-register, role-derivation, episode-2
 - **SO 終了判断**: 弱SO は 1 周が要件。2 周で fixable な指摘（SELF 生存 / fail-open / 冪等 / success-faking）は全て解消。残る codex の「原子的 race 防止」は scope 外の基盤課題で 3 周目は loop になる → **disclose して進む**（弱SO の partial 規約）。test_oe_register 48/0・全 suite green・shellcheck PASS。
 - （次: PR → closure → Copilot）
 
-### closure（gate 5・マージ前）
+### closure（gate 5・マージ前・リアルタイム追記＝reconstructed でない）
 
-（PR レビュー後・マージ前に追記）
+**tier = heavy**（トリガ: 実行中の方針転回〔設計SO が v0 refuted・実装SO が 2 round refuted〕/ 意図的に起動した外部レビュー〔`oe-refute` 設計SO + `oe-review` 実装SO〕/ 非自明な設計判断〔DJ-1 述語締め・role:"root" 案を棄却〕/ 昇格候補あり〔role 導出の existence-based 性質〕）。PR: https://github.com/stlwolf/ai-development-hub/pull/261 。
+
+**closure gate checklist**:
+- **Context / なぜ**: 冒頭 Context 節に自己完結（手動起動 pane の登記手段不在・#257 §3 の `parent_pane` 焼き込み root cause）。
+- **次の消費者**: (1) owner（gate 6 マージ / issue close 判断 / canonical sync 配布）(2) #238 succession/topology クラスタ（role 導出が existence-based という知見の消費先）(3) 手動起動統括の運用者（cold-start で `oe-register root`）。
+- **follow-up routing**:
+  - 並行 link の原子的 race 防止（flock/CAS）→ **追わない（scope 外・基盤課題）**。last-write-wins registry の性質で `oe-delegate` と同断面。将来 registry substrate を触る時に併せて検討（engine track・issue 未起票）。
+  - role:"root" フィールドの forward-looking 導入 → **追わない（YAGNI）**。消費者が role 値を読む時点の follow-up。現状は述語（existence + parent 非空）で十分。
+  - oe-register の topology-change event 発行（link 時）→ **追わない（scope 外）**。QDD/plan に無く registration≠spawn。
+  - role 導出が existence-based という知見 → **昇格候補（discussion/decision）**。#238/#257 succession/topology クラスタへ。owner が gate 6 で判断。
+- **status 確定**: draft → **stable**（達成度=達成。受け入れ基準5条件すべて満たす・全 `tests/test_*.sh` green・shellcheck PASS・PR #261 作成済）。
+- **evidence anchor**: 主要 verdict / material 指摘は本文転記済（設計SO refuted・audit `20260716051325NHD2DNSKVKH8` / 実装SO round1・round2 とも refuted・reviewed SHA `da67c00`）。生出力（`.oe/`〔本 worktree に無く親 checkout 側〕・`tmp/oe-refute-*`・`tmp/oe-review-*`・`tmp/so-closure-259`）は gitignored の揮発アンカー。secondary risk の逐条（round-2 cursor full 等）は揮発ログにのみ残り、要点は本文の残課題へ routing 済。
+- **SO 証跡リンク**: 設計SO = `.oe/oe-refute-259.json`（verdict/dissent 本文転記）/ 実装SO = scratchpad（揮発・verdict/dissent 本文 + PR に転記）。
+
+**事実・失敗（SO で refute された点と対応）**:
+- 設計SO（round 1・refuted）: v0 前提「role field は moot」が崩れた。self entry の存在が oe-ident/event-bus を child 誤導出 → 述語締めで対応（DJ-1）。
+- 実装SO round 1（codex・refuted）: SELF 生存未検証 / corrupt entry で guard fail-open / guard 非原子。→ SELF 形式+生存検証・`read_parent` fail-closed・link post-record 存在確認を追加。
+- 実装SO round 2（cursor material / codex 再掲・refuted）: 冪等再登録が既存 label/workspace を空で上書き（非冪等）→ 既存値保持 + test[16]。codex の非原子 race → ownership-aware post-check（防止でなく検知）。
+- **Step 4 closure 監査（codex）が自 closure の欠陥を検出**: (i) round-2 cursor の full 出力に secondary 指摘（root post-record 欠如・root label 解決制約）があり dissent 1 行だけ見て routing 漏れ、(ii) closure に事実・失敗節なし・決定と根拠が round-1/2 の採否を欠く、(iii)「success-faking 全て解消」が root post-check 欠如で過大、(iv) evidence anchor の包括表現が過大。→ 本 closure で是正（下記）+ **root post-record ownership check を追加**（link と対称化）。dissent 要約だけで満足せず full 出力を読む教訓。
+
+**決定と根拠**:
+- DJ-1: role:"root" 案（optional 第5引数で lib 拡張）を**棄却**し「判定述語を締める」を採用。棄却理由 = readers は `.role` field を読まず entry 存在から role を導出するため role:"root" は無効・既存 entry は全て parent 非空ゆえ述語締めは既存データに bit-identical で lib write path も無変更。
+- SELF 生存確認 / corrupt entry fail-closed / 冪等時の label/workspace 保持 / link・root の ownership-aware post-check: いずれも「verb 側 guard の correctness・honesty を上げる」採用。既存 lib（`oe_reg_record`）は無変更を維持。
+- guard の原子性: flock/CAS を**棄却**（last-write-wins registry 基盤の変更＝additive scope 外）。verb 側は SELF/target 生存確認 + ownership-aware post-check で「勝てなかった」の honest 検知に留め、race **防止**は基盤課題へ defer。
+- F2「key と `.pane` 不整合」: guard は `_oe_reg_key` で引く（**key を信頼**）方針を採用（`.pane` 照合はしない）。oe-register 自身は key と `.pane` が常に一致する entry しか書かない（`oe_reg_record` の不変条件）。
+
+**わかったこと（W）**:
+- registry の role は `.role` field でなく **entry の存在**から read-time 導出される（`oe-ident:60-71` / `event-bus.sh:49,68-76`）。`parent_pane` 非空を足すと自己 root を child と誤導出しない。この「stored field でなく existence-derived」性質は #238 succession の topology 表現設計に直結。
+- `oe-review` の cursor レーンは大 diff で timeout しやすい（round1 で 360s `timeout_empty`）。round2 で返り idempotency 退行を検出。
+
+**原則（Pattern / Anti-pattern）**:
+- Anti-pattern: 「reader は field X を読まないから field 値は moot」→ reader が field でなく **entry の存在 / 形**から派生値を導出していないか確認する（existence 派生は field 追加で直らない）。
+- Pattern: last-write-wins state に verb 側 guard を足すとき、race 防止（原子性）は基盤の責務・verb は「勝てなかった」の honest 検知に留める（防止と検知を分ける）。
+
+**蒸留シグナル**: 昇格候補 = **discussion/decision**（role の existence-based 導出 → #238/#257 succession/topology クラスタ）。skill/rule 昇格は **なし**。
+
+**残課題**:
+- 原子的 race 防止 / role:"root" / topology event 発行 → follow-up routing 参照（「追わない」or「昇格候補」）。
+- **root の registry `--label` は他ペインから label 解決に使えない**（`oe_reg_resolve`/`oe_reg_list` が `parent_pane==$self` scope＝子のみ・root は parent 空で非該当。round-2 cursor 指摘）→ **追わない（lib 無変更の既存制約・oe-tree/cockpit で root は表示され jump 可なので実害小）**。root を label で send する需要が出たら lib 側で対応（engine track）。
+- die-after-check / 並行 steal / root 並行上書きの post-check は stateful mock が要り単体テスト未整備 → **追わない**（実運用の稀パス・機能は防止でなく honest 検知）。
+
+**Step 4（heavy 外部チェック・`so-compare` codex closure 監査）**: closure honesty の欠陥を検出 → 全て是正: (a) 事実・失敗節を新設、(b) 決定と根拠に round-1/2 の採否を追記、(c)「全て解消」の過大表現を訂正し **root post-record check を追加**（link と対称）、(d) root label 解決制約を routing、(e) evidence anchor を正確化。監査対象 = `tmp/so-closure-259/`（揮発）。**closure 監査が実 material 欠陥（routing 漏れ + code 非対称）を捕捉＝Step 4 の価値実証**。辞退せず実施して正解だった。

--- a/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
@@ -50,7 +50,12 @@ tags: [orchestration, delegate-registry, oe-register, role-derivation, episode-2
 - **テスト**: `tests/test_oe_register.sh`（33 checks・guard 3態 + SO 抜け3〔非生存 target / %self / detach〕 + 形式エラー + env エラー）。`test_oe_ident.sh`（+3: 自己 root neutral / 子持ち→parent / 既存形不変）・`test_event_bus.sh`（+4: `_oe_event_ident` の自己 root neutral / 既存形 child 不変）に述語テスト追加。
 - **gate（全 green + shellcheck）**: 新規 33 + 既存 tests/test_*.sh 全 green（test_delegate_registry 20/0・test_oe_delegate 20/0・test_oe_ident 14/0・test_event_bus 66/0・test_oe_tree ok 等）。shellcheck 新規/変更 6 ファイル PASS。
 - **doc**: `bin/README.md` に oe-register verb 節 / `delegate-task` skill に register 操作節 + 全体像表 + 関連 / `doc-flow-guardrail` cold-start に自己登記 1 行（#259 が予告した接続の完成）。
-- （次: gate 4 実装SO → PR → closure → Copilot）
+- **gate 4 実装SO（`oe-review --lanes 2 --base master`）→ verdict=refuted**（codex material・cursor=`timeout_empty`＝360s タイムアウトで verdict なし＝機構エラー）。codex 指摘3件（すべて一次コード確認で material 判定・自分の guard の堅牢性欠陥＝scope 内）:
+  - Critical: guard が read-check-write で非原子的（並行 link の横取り / die-after-check の成功偽装）。
+  - Critical: SELF（TMUX_PANE）が非空しか検証されず、stale/spoofed で root が GC で即消え・link が生存 target を死んだ親の下に orphan 登録して成功を装う。テストも常に self を live に含め未検出。
+  - Warning: 既存 entry の JSON 読取失敗を `|| true` で空 parent 同一視 → live-parent guard が corrupt entry で fail-open。
+- **修正**: (a) `load_live_panes` を hoist し SELF の形式+生存を先に検証 / (b) `read_parent` を rc 保持にして corrupt entry は fail-closed（`--force` で上書き）/ (c) link は record 後に entry 存在を再確認し die-after-check を honest 失敗化 / (d) 並行 steal の窓は last-write-wins 基盤に内在（`oe-delegate:148` と同断面）として header に限界明記・原子的所有権（flock）は基盤課題として scope 外。テスト [14]（dead SELF）[15]（corrupt entry fail-closed / --force）を追加。test_oe_register 33→44・既存 spot-check 全 green・shellcheck PASS。
+- （次: 修正を再 SO で確認 → PR → closure → Copilot）
 
 ### closure（gate 5・マージ前）
 

--- a/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
@@ -55,7 +55,11 @@ tags: [orchestration, delegate-registry, oe-register, role-derivation, episode-2
   - Critical: SELF（TMUX_PANE）が非空しか検証されず、stale/spoofed で root が GC で即消え・link が生存 target を死んだ親の下に orphan 登録して成功を装う。テストも常に self を live に含め未検出。
   - Warning: 既存 entry の JSON 読取失敗を `|| true` で空 parent 同一視 → live-parent guard が corrupt entry で fail-open。
 - **修正**: (a) `load_live_panes` を hoist し SELF の形式+生存を先に検証 / (b) `read_parent` を rc 保持にして corrupt entry は fail-closed（`--force` で上書き）/ (c) link は record 後に entry 存在を再確認し die-after-check を honest 失敗化 / (d) 並行 steal の窓は last-write-wins 基盤に内在（`oe-delegate:148` と同断面）として header に限界明記・原子的所有権（flock）は基盤課題として scope 外。テスト [14]（dead SELF）[15]（corrupt entry fail-closed / --force）を追加。test_oe_register 33→44・既存 spot-check 全 green・shellcheck PASS。
-- （次: 修正を再 SO で確認 → PR → closure → Copilot）
+- **gate 4 実装SO 再実行（round 2・hardened diff）→ verdict=refuted（2/2）**:
+  - cursor（新規 material）: 冪等再登録で `--label` 省略時に `oe_reg_record` が既存 label/workspace を空で上書き＝非冪等（受け入れ(3)違反）。test [6] は parent のみ検証で退行未検出。→ **修正**: `--label`/`-w` 省略時は既存 entry の値を保つ。test [16] 追加。cursor は全テストも実行し 44/0 green を確認。
+  - codex（再掲）: guard の read-check-write が非原子的 + post-check が所有者未検証 → 並行 link の横取り成功偽装。→ **ownership-aware post-check を追加**（record 後に parent==SELF を再確認し「勝てなかった」を honest 失敗化）。**原子的 race 防止（flock 等）は last-write-wins registry 基盤の限界＝oe-delegate と同断面・lib 変更を要し #259 の additive scope 外**（plan §10 で pre-register 済・owner 承認 plan に明記）。
+- **SO 終了判断**: 弱SO は 1 周が要件。2 周で fixable な指摘（SELF 生存 / fail-open / 冪等 / success-faking）は全て解消。残る codex の「原子的 race 防止」は scope 外の基盤課題で 3 周目は loop になる → **disclose して進む**（弱SO の partial 規約）。test_oe_register 48/0・全 suite green・shellcheck PASS。
+- （次: PR → closure → Copilot）
 
 ### closure（gate 5・マージ前）
 

--- a/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md
@@ -1,0 +1,57 @@
+---
+id: "01KXN127119AT8VSEMSKN5C1RZ"
+title: "#259 episode（heavy）— oe-register（自己登録 + 委譲 link）と role 導出述語の締め"
+date: 2026-07-16
+type: episode
+status: draft
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/259"
+    reason: "自己登録 + 委譲 link の新 verb oe-register"
+  - type: derived_from
+    ref: "projects/orchestration-engine/docs/discussions/2026-07-13-discussion-supervisor-succession-recovery-and-observability.md"
+    reason: "#257 §3 root cause（parent_pane 焼き込み・rewrite 機構なし）/ §4 並列 peer 原則"
+  - type: design_input
+    ref: ".oe/plan-259-oe-register.md"
+    reason: "plan-first の設計正本（DJ-1〜6・guard 真理値表・設計SO 反映）"
+tags: [orchestration, delegate-registry, oe-register, role-derivation, episode-259]
+---
+
+# #259 episode（heavy）— oe-register と role 導出述語の締め
+
+> 冒頭注記: 本 episode の「前段（plan-first）」節は実装フェーズ着手時に plan §3/§9 から **reconstructed**（後追い再構成）。「実装フェーズ」以降はリアルタイム追記。
+
+## Context（なぜ始まったか）
+
+手動起動 pane（統括）が oe-tree / cockpit に現れない痛点（自己登録手段の不在）と、手動起動 pane 間の委譲に関係を登記する手段の不在。同根 = registry が spawn 時 `parent_pane` 焼き込みしか表現できない（#257 §3 verified）。QDD で scope を「自己登録 + 委譲 link の2操作・単一 verb `oe-register`・guard 既定・付随 doc 2点」に確定（`oe-reseat`＝board 張替は次の増分）。plan-first で親統括（7代目）から委譲され、gate 3 承認済で実装着手。tier=heavy（設計SO が v0 を refute した非自明な設計 pivot + role 導出述語の変更 + durable 知見の昇格見込み）。
+
+## 実行ログ
+
+### 前段（plan-first フェーズ・reconstructed）
+
+- 一次読解（delegate-registry.sh / oe-delegate / oe-tree / oe-list / tests / #257 discussion）→ plan `.oe/plan-259-oe-register.md` 作成。
+- gate 1（predecision-exploration）: DJ-1〜6 のゼロベース探索木を確定前に外部化。当初推奨 = 純追加（既存 lib/verb 無変更）・role:"child" 維持・guard は verb 側。
+- gate 2（弱設計SO・`oe-refute --claim .oe/claim-259-oe-register.md --rubric exploration --lanes 3`）→ **verdict=refuted（3/3 lane material）**。material 指摘:
+  - **F1（最重要・grounding 訂正）**: role は `.role` field でなく **entry 存在**から導出される（`oe-ident:60-71` / `event-bus.sh:49,68-76`）。自己 root 登録した無子 pane は最初の子 spawn まで「child」表示 + event に `role:"child"` 焼き込み（`oe-activity:148` / `oe-undelivered:177` が消費）。当初 grounding「readers は role を読まない」は不完全。
+  - **F2（DJ-5 guard 抜け）**: target 生存未確認（record 直後 GC で無言 no-op）/ `%self` self-cycle / 自己 root モードで生きた親を持つ委譲子の暗黙 detach / read-check-write TOCTOU / key と .pane 不整合。
+  - **F3（DJ-2×DJ-6）**: 自己 label スロット未定義・positional 二義（typo が silently self-label 化）。
+- gate 3（owner HG）承認・実装 go。owner 確定3点:
+  1. **DJ-1 = 判定述語を締める**: `is_child = 自 entry 存在 かつ parent_pane 非空`（既存 entry は全て parent 非空 → 既存データに bit-identical・新 role 値なし・空 parent は role 中立）。受け入れ基準5 は「既存データに対する挙動不変」と読み替え。述語テスト追加。
+  2. **episode 暫定運用**: worktree 直後・実装前に枠作成 + 設計節を plan から reconstructed 書き起こし → 以降リアルタイム（規範は #159 別途）。
+  3. **残フロー**: worktree → episode → 実装+テスト → README/canonical 2 skill → 実装SO（oe-review 2社）→ PR → closure → Copilot。PR 完成で親へ報告。マージ/掃除/close はしない。
+
+### 実装フェーズ（リアルタイム）
+
+- worktree `feat/#259_oe-register` を子が自作（`--base master`）。Claude cwd は追従せず絶対パスで作業。
+- **episode 枠を着手時に作成**（本ファイル・reconstructed 前段付き）。
+- **bin/oe-register 実装**: `root` / `link` サブコマンド（DJ-6・positional 二義を排し typo は exit 2）。root=`oe_reg_record "$SELF" "" "$ws" ""`（parent 空）/ link=`oe_reg_record "%N" "$label" "$ws" "$SELF"`。guard は verb 側（§4 真理値表 rev.2）。**lib write path は無変更**（既存 `oe_reg_record` を呼ぶだけ）。
+  - 実装中の bug: `set -e` 下で `out="$(tmux ...)"; rc=$?` が list-panes 失敗時に代入行で即 exit(1) し rc 捕捉前に落ちる（test [12] が exit 2 期待に対し 1 で検出）→ `|| rc=$?` で compound 化して修正。
+- **DJ-1 述語締め**: `bin/oe-ident`（is_child）と `lib/event-bus.sh`（`_oe_event_ident`）を「自 entry 存在 かつ parent_pane 非空」へ。既存 entry は全て parent 非空ゆえ既存データに bit-identical・新 role 値なし。event-bus の report/kick 方向判定は関係（fparent==tp）で上書きするため、parent 空の自己 root sender は honest neutral になり誤 report 化が消える（SO 予測どおりの改善）。
+- **テスト**: `tests/test_oe_register.sh`（33 checks・guard 3態 + SO 抜け3〔非生存 target / %self / detach〕 + 形式エラー + env エラー）。`test_oe_ident.sh`（+3: 自己 root neutral / 子持ち→parent / 既存形不変）・`test_event_bus.sh`（+4: `_oe_event_ident` の自己 root neutral / 既存形 child 不変）に述語テスト追加。
+- **gate（全 green + shellcheck）**: 新規 33 + 既存 tests/test_*.sh 全 green（test_delegate_registry 20/0・test_oe_delegate 20/0・test_oe_ident 14/0・test_event_bus 66/0・test_oe_tree ok 等）。shellcheck 新規/変更 6 ファイル PASS。
+- **doc**: `bin/README.md` に oe-register verb 節 / `delegate-task` skill に register 操作節 + 全体像表 + 関連 / `doc-flow-guardrail` cold-start に自己登記 1 行（#259 が予告した接続の完成）。
+- （次: gate 4 実装SO → PR → closure → Copilot）
+
+### closure（gate 5・マージ前）
+
+（PR レビュー後・マージ前に追記）

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -46,7 +46,7 @@ OE_PANE_ISSUE_DIR="${OE_PANE_ISSUE_DIR:-${HOME}/.claude/state/pane-issue}"
 OE_EVENT_DIR="${OE_EVENT_DIR:-${HOME}/.claude/state}"
 
 # _oe_event_ident <pane> — pane の識別子を read 時投影し "role<US>label<US>parent_pane" を返す。
-#   role  : parent（この pane を parent_pane に持つ子 entry が在る） > child（自身の spawn entry が在る） > ""
+#   role  : parent（この pane を parent_pane に持つ子 entry が在る） > child（自身の spawn entry が在り かつ parent_pane 非空・#259） > ""
 #   label : pane-issue(.name) 優先 → spawn-registry(.label)
 #   parent_pane : 自身の spawn entry の parent_pane（無ければ空）。message の report/kick 方向判定に使う。
 #   file 読みのみ・tmux 不要・best-effort（jq 不在は全空）。
@@ -64,8 +64,10 @@ _oe_event_ident() {
   fi
   own="${OE_DELEGATE_STATE_DIR}/${key}.json"
   if [[ -f "$own" ]]; then
-    is_child=1
     parent="$(jq -r '.parent_pane // empty' "$own" 2>/dev/null)" || parent=""
+    # role=child は「自 entry が在り かつ parent 非空」に限る（#259）。parent 空の自己 root entry
+    # を child と誤導出しない。既存 entry は全て parent 非空ゆえ既存データに挙動不変。
+    [[ -n "$parent" ]] && is_child=1
     [[ -z "$label" ]] && label="$(jq -r '.label // empty' "$own" 2>/dev/null)"
   fi
   # 現サーバ pid の子 entry を走査して parent 判定（別サーバの stale で pane-id 衝突しても誤検知しない）。

--- a/projects/orchestration-engine/tests/test_event_bus.sh
+++ b/projects/orchestration-engine/tests/test_event_bus.sh
@@ -125,6 +125,21 @@ ck "from.role empty" "" "$(last | jq -r .from.role)"
 ck "to.role empty"   "" "$(last | jq -r .to.role)"
 ck "type"            "message_sent" "$(last | jq -r .type)"
 
+echo "[9b] 自己 root entry（parent 空）: _oe_event_ident の role は中立（child でない）・#259 述語締め"
+# 子を持つ前に評価する（is_parent 判定より先）。parent 空 → is_child=0 → role 空。
+jq -cn '{pane:"%90",label:"#259 sup",workspace:"/w",parent_pane:"",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %90).json"
+IFS=$'\037' read -r _r90 _l90 _p90 < <(_oe_event_ident "%90") || true
+ck "self-root role neutral"  ""         "$_r90"
+ck "self-root label kept"    "#259 sup" "$_l90"
+ck "self-root parent empty"  ""         "$_p90"
+
+echo "[9c] 既存形（parent 非空）は child のまま（既存データに bit-identical）"
+jq -cn '{pane:"%91",label:"#c",workspace:"/w",parent_pane:"%90",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %91).json"
+IFS=$'\037' read -r _r91 _ _ < <(_oe_event_ident "%91") || true
+ck "existing-shape still child" "child" "$_r91"
+
 echo "[10] 結線: oe-delegate を PATH-stub tmux で起動 → child_spawned が実 bin から emit"
 reset_events
 STUB_BIN="$_TMP_DIR/bin"; mkdir -p "$STUB_BIN"

--- a/projects/orchestration-engine/tests/test_oe_ident.sh
+++ b/projects/orchestration-engine/tests/test_oe_ident.sh
@@ -77,5 +77,17 @@ rc=0; out="$(bash "$OE_IDENT" 2>/dev/null)" || rc=$?
 ck "missing arg empty" "" "$out"
 ck "missing arg exit0" "0" "$rc"
 
+echo "[10] 自己 root entry（parent_pane 空）-> role 中立・label のみ（#259 述語締め）"
+# oe-register root が書く形。parent 空なので is_child=0（子を spawn するまで child と誤導出しない）。
+jq -cn '{pane:"%20",label:"#259 supervisor",workspace:"/w",parent_pane:"",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %20).json"
+ck "self-root neutral (no child prefix)" "#259 supervisor" "$(run %20)"
+
+echo "[11] 自己 root が子を持つ -> parent（is_parent 判定は不変）"
+jq -cn '{pane:"%21",label:"#c",workspace:"/w",parent_pane:"%20",role:"child"}' \
+  > "$OE_DELEGATE_STATE_DIR/$(keyfor %21).json"
+ck "self-root with child -> parent" "parent #259 supervisor" "$(run %20)"
+ck "existing-shape child unchanged" "child #c" "$(run %21)"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_register.sh
+++ b/projects/orchestration-engine/tests/test_oe_register.sh
@@ -188,5 +188,18 @@ run_reg "%1" root --force
 ck "corrupt self root --force"  "0" "$RC"
 ck "force wrote valid root"     ""  "$(ent_parent %1)"
 
+echo "[16] 冪等再登録で --label/-w 省略時に既存 label/workspace を保つ（空で潰さない・実装SO cursor 指摘）"
+reset_state; export MOCK_LIVE_PANES="%1 %5"
+put_entry %5 %1 "#keep"        # 既存 label=#keep / workspace=/w / parent=%1（自分の子）
+run_reg "%1" link %5           # --label / -w 省略の再 link
+ck "re-link preserves label"     "#keep" "$(jq -r '.label' "$OE_DELEGATE_STATE_DIR/$(keyfor %5).json")"
+ck "re-link preserves workspace" "/w"    "$(jq -r '.workspace' "$OE_DELEGATE_STATE_DIR/$(keyfor %5).json")"
+run_reg "%1" link %5 --label "#new"   # 明示指定は更新
+ck "re-link updates label w/ --label" "#new" "$(jq -r '.label' "$OE_DELEGATE_STATE_DIR/$(keyfor %5).json")"
+# root 側: 既存 label を --label 無しで保持
+put_entry %1 "" "#sup"
+run_reg "%1" root
+ck "re-root preserves label" "#sup" "$(jq -r '.label' "$OE_DELEGATE_STATE_DIR/$(keyfor %1).json")"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_register.sh
+++ b/projects/orchestration-engine/tests/test_oe_register.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test_oe_register.sh — oe-register（自己 root 登録 + 委譲 link・#259）の検証。
+#
+# 実 tmux / Claude は起動せず、PATH 先頭の tmux mock で list-panes / display-message を差し替える
+# （test_oe_delegate.sh と同イディオム）。state dir は mktemp で隔離し、キー生成は lib の
+# _oe_reg_key を共有する（手書き複製のドリフト回避・test_oe_ident.sh と同方針）。
+#
+# guard 真理値表（plan §4 rev.2）と設計SO が挙げた縁ケース（target 非生存 no-op / %self
+# self-cycle / 自己 root の生きた親 detach）を機械検証する。
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OE_REGISTER="$PROJECT_DIR/bin/oe-register"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$_TMP_DIR"' EXIT
+export OE_DELEGATE_STATE_DIR="$_TMP_DIR/oe-delegate"
+export OE_PANE_ISSUE_DIR="$_TMP_DIR/pane-issue"
+mkdir -p "$OE_DELEGATE_STATE_DIR" "$OE_PANE_ISSUE_DIR"
+
+# 固定 server pid をキー名前空間に注入（本体 _oe_reg_key と同一契約）。
+PID=9999
+export TMUX="oe,${PID},0"
+# shellcheck source=../lib/delegate-registry.sh
+source "$PROJECT_DIR/lib/delegate-registry.sh"
+keyfor() { _oe_reg_key "$1"; }
+
+# --- PATH 先頭 tmux mock（MOCK_LIVE_PANES / MOCK_TMUX_FAIL / MOCK_CWD を env で受ける） ---
+STUB_BIN="$_TMP_DIR/bin"; mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-panes)
+    if [[ -n "${MOCK_TMUX_FAIL:-}" ]]; then echo "no server running" >&2; exit 1; fi
+    # shellcheck disable=SC2086
+    printf '%s\n' ${MOCK_LIVE_PANES:-} ;;
+  display-message) printf '%s\n' "${MOCK_CWD:-/mock/cwd}" ;;
+  *) : ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB_BIN/tmux"
+export PATH="${STUB_BIN}:${PATH}"
+export MOCK_LIVE_PANES=""
+export MOCK_CWD="/mock/cwd"
+
+PASS=0; FAIL=0
+ck() { # <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1));
+  else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi
+}
+
+reset_state() { rm -f "$OE_DELEGATE_STATE_DIR"/*.json 2>/dev/null; }
+put_entry() { # <pane> <parent_pane> [label]
+  jq -cn --arg p "$1" --arg pp "$2" --arg l "${3:-}" \
+    '{pane:$p,label:$l,workspace:"/w",parent_pane:$pp,role:"child"}' \
+    > "$OE_DELEGATE_STATE_DIR/$(keyfor "$1").json"
+}
+ent_exists() { [[ -f "$OE_DELEGATE_STATE_DIR/$(keyfor "$1").json" ]] && echo yes || echo no; }
+ent_parent() { jq -r '.parent_pane // "MISSING"' "$OE_DELEGATE_STATE_DIR/$(keyfor "$1").json" 2>/dev/null || echo MISSING; }
+run_reg() { # <self-pane> <args...>  -> sets global RC
+  local self="$1"; shift
+  RC=0
+  TMUX_PANE="$self" bash "$OE_REGISTER" "$@" >/dev/null 2>&1 || RC=$?
+}
+
+echo "[1] root: 引数なし相当 -> 自 entry が parent_pane 空で書かれる"
+reset_state; export MOCK_LIVE_PANES="%1"
+run_reg "%1" root
+ck "root exit 0"        "0"  "$RC"
+ck "root entry exists"  "yes" "$(ent_exists %1)"
+ck "root parent empty"  ""   "$(ent_parent %1)"
+
+echo "[2] link %5: %5 entry が parent_pane=self(%1) で書かれる"
+reset_state; export MOCK_LIVE_PANES="%1 %5"
+run_reg "%1" link %5 --label "#259 child"
+ck "link exit 0"          "0"   "$RC"
+ck "link entry exists"    "yes" "$(ent_exists %5)"
+ck "link parent = self"   "%1"  "$(ent_parent %5)"
+
+echo "[3] guard: 生存する別親を持つ %5 -> 拒否・entry 不変"
+reset_state; export MOCK_LIVE_PANES="%1 %5 %9"
+put_entry %5 %9 "#other"        # %5 は生存 %9 の子
+run_reg "%1" link %5
+ck "steal rejected exit 1" "1"  "$RC"
+ck "parent unchanged (%9)"  "%9" "$(ent_parent %5)"
+
+echo "[4] guard: orphan（親 %9 が gone）-> 引き取り可・reparent"
+reset_state; export MOCK_LIVE_PANES="%1 %5"   # %9 は非生存
+put_entry %5 %9 "#orphan"
+run_reg "%1" link %5
+ck "orphan adopt exit 0"   "0"  "$RC"
+ck "reparented to self"    "%1" "$(ent_parent %5)"
+
+echo "[5] guard: --force で生存別親を上書き（reparent）"
+reset_state; export MOCK_LIVE_PANES="%1 %5 %9"
+put_entry %5 %9 "#other"
+run_reg "%1" link %5 --force
+ck "force reparent exit 0"  "0" "$RC"
+ck "force parent = self"    "%1" "$(ent_parent %5)"
+
+echo "[6] 冪等: 既に自分の子 %5 を再 link / 既に root を再 root"
+reset_state; export MOCK_LIVE_PANES="%1 %5"
+put_entry %5 %1 "#mine"
+run_reg "%1" link %5
+ck "idempotent link exit 0" "0"  "$RC"
+ck "still my child"          "%1" "$(ent_parent %5)"
+put_entry %1 "" "#sup"          # %1 は既に root
+run_reg "%1" root
+ck "idempotent root exit 0"  "0" "$RC"
+ck "root stays empty parent"  "" "$(ent_parent %1)"
+
+echo "[7] guard: target %5 が非生存 -> 拒否・record しない（無言 no-op 防止・SO 抜け1）"
+reset_state; export MOCK_LIVE_PANES="%1"        # %5 は居ない
+run_reg "%1" link %5
+ck "dead target exit 1"    "1"  "$RC"
+ck "no entry written"      "no" "$(ent_exists %5)"
+
+echo "[8] guard: link %self -> 拒否（self-cycle・SO 抜け2）"
+reset_state; export MOCK_LIVE_PANES="%1"
+run_reg "%1" link %1
+ck "self-link exit 1"      "1"  "$RC"
+ck "no self-cycle entry"   "no" "$(ent_exists %1)"
+
+echo "[9] guard: 生きた親を持つ委譲子が自己 root -> 拒否（detach 防止・SO 抜け3）/ --force で許可"
+reset_state; export MOCK_LIVE_PANES="%1 %9"
+put_entry %1 %9 "#delegated"    # %1 は生存 %9 の子
+run_reg "%1" root
+ck "self-root detach rejected" "1"  "$RC"
+ck "parent unchanged (%9)"     "%9" "$(ent_parent %1)"
+run_reg "%1" root --force
+ck "force re-root exit 0"      "0"  "$RC"
+ck "force re-rooted (empty)"   ""   "$(ent_parent %1)"
+
+echo "[10] --label に LF/CR -> exit 2・書込なし"
+reset_state; export MOCK_LIVE_PANES="%1 %5"
+run_reg "%1" link %5 --label $'bad\nlabel'
+ck "LF label exit 2"       "2"  "$RC"
+ck "no entry on LF label"  "no" "$(ent_exists %5)"
+
+echo "[11] 形式エラー: 不正 target / 未知 subcommand -> exit 2（typo を silently 通さない・DJ-6）"
+reset_state; export MOCK_LIVE_PANES="%1 %5"
+run_reg "%1" link 5           ; ck "non-%N target exit 2" "2" "$RC"
+run_reg "%1" link "%5x"       ; ck "malformed %N exit 2"  "2" "$RC"
+run_reg "%1" bogus            ; ck "unknown subcommand 2" "2" "$RC"
+run_reg "%1"                  ; ck "missing subcommand 2" "2" "$RC"
+
+echo "[12] tmux list-panes 失敗 -> exit 2・書込なし"
+reset_state; export MOCK_LIVE_PANES="%1 %5"; export MOCK_TMUX_FAIL=1
+run_reg "%1" link %5
+ck "list-panes fail exit 2" "2"  "$RC"
+ck "no entry on tmux fail"  "no" "$(ent_exists %5)"
+unset MOCK_TMUX_FAIL
+
+echo "[13] TMUX_PANE 未設定 -> 明示エラー（exit 1）"
+reset_state
+RC=0; TMUX_PANE="" bash "$OE_REGISTER" root >/dev/null 2>&1 || RC=$?
+ck "no TMUX_PANE exit 1" "1" "$RC"
+
+echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
+[[ "$FAIL" -eq 0 ]]

--- a/projects/orchestration-engine/tests/test_oe_register.sh
+++ b/projects/orchestration-engine/tests/test_oe_register.sh
@@ -161,5 +161,32 @@ reset_state
 RC=0; TMUX_PANE="" bash "$OE_REGISTER" root >/dev/null 2>&1 || RC=$?
 ck "no TMUX_PANE exit 1" "1" "$RC"
 
+echo "[14] SELF（TMUX_PANE）が非生存 -> 拒否（stale/spoofed TMUX_PANE・実装SO codex 指摘）"
+reset_state; export MOCK_LIVE_PANES="%5"        # %1(self) が live 一覧に居ない
+run_reg "%1" root
+ck "dead self root exit 1"  "1"  "$RC"
+ck "no root entry written"  "no" "$(ent_exists %1)"
+run_reg "%1" link %5
+ck "dead self link exit 1"  "1"  "$RC"
+ck "no link entry written"  "no" "$(ent_exists %5)"
+
+echo "[15] 既存 entry が corrupt -> fail-closed（--force で上書き・実装SO codex 指摘）"
+reset_state; export MOCK_LIVE_PANES="%1 %5"
+printf 'not-json{{{' > "$OE_DELEGATE_STATE_DIR/$(keyfor %5).json"
+run_reg "%1" link %5
+ck "corrupt target reject exit 1" "1"   "$RC"
+ck "corrupt entry not overwritten" "yes" "$(ent_exists %5)"
+run_reg "%1" link %5 --force
+ck "corrupt target --force exit 0" "0"  "$RC"
+ck "force wrote valid parent"      "%1" "$(ent_parent %5)"
+# root 側: 自 entry が corrupt
+reset_state; export MOCK_LIVE_PANES="%1"
+printf 'broken' > "$OE_DELEGATE_STATE_DIR/$(keyfor %1).json"
+run_reg "%1" root
+ck "corrupt self root reject"   "1" "$RC"
+run_reg "%1" root --force
+ck "corrupt self root --force"  "0" "$RC"
+ck "force wrote valid root"     ""  "$(ent_parent %1)"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 概要

手動起動した pane（`oe-delegate` の spawn を経ないため registry に出ない）を登記する新 verb `oe-register` を追加する。`root` で自分を root として、`link %N` で相手 %N を自分の下の子として登記し、`oe-tree` / cockpit（`oe-select` / `--pick`）に現す。既存 verb・registry の write path（`oe_reg_record`）は無変更＝**additive**。

痛点の同根 = registry が spawn 時の `parent_pane` 焼き込みしか表現できない（[#257 discussion](https://github.com/stlwolf/ai-development-hub/issues/257) §3 verified）。`oe-reseat`（board 張替系）は次の増分＝本 PR の scope 外。

## 変更内容

- `projects/orchestration-engine/bin/oe-register`（新 verb・root/link サブコマンド + guard）
- `projects/orchestration-engine/bin/oe-ident` / `projects/orchestration-engine/lib/event-bus.sh` — role 導出述語を「自 entry 存在 **かつ** `parent_pane` 非空」へ締める（設計SO 指摘の反映・下記）
- `projects/orchestration-engine/tests/test_oe_register.sh`（新規 48 checks）/ `test_oe_ident.sh`・`test_event_bus.sh` に述語テスト追加
- `projects/orchestration-engine/bin/README.md` verb 節 / `canonical/skills/delegate-task/SKILL.md` register 操作節 / `canonical/skills/doc-flow-guardrail/SKILL.md` cold-start に自己登記1行
- `projects/orchestration-engine/docs/episodes/2026-07-16-episode-259-oe-register.md`（episode）

## guard 真理値表（verb 側で保持）

- **link**: target 非生存 → 拒否 / `%self`（self-cycle）→ 拒否 / 生存する別親の子 → 拒否（`--force` で reparent）/ orphan（親 gone）→ 引き取り可 / 既に自分の子 → 冪等 / 既存 entry が corrupt → fail-closed（`--force` で上書き）
- **root**: 生きた親を持つ委譲子の自己 root 化 → 拒否（detach 防止・`--force` で明示 re-root）/ 既に root or orphan → 許可
- `--label`/`-w` 省略の冪等再登録は既存 label/workspace を保つ（空で潰さない）

## 設計判断（DJ-1・設計SO で判明）

設計SO（`oe-refute --rubric exploration --lanes 3` → refuted）が指摘: role は `.role` field でなく **entry の存在**から導出される（`oe-ident` / `event-bus.sh`）。よって自己 root entry を書くだけで、最初の子 spawn まで pane border に「child」と誤表示され event に `role:"child"` が焼き込まれる。

owner 決定 = **判定述語を締める**: `is_child = 自 entry 存在 かつ parent_pane 非空`。既存 entry は全て `parent_pane` 非空ゆえ**既存データに bit-identical**（新 role 値を導入しない）。空 parent の自己 root は role 中立になる。

## 実装SO（`oe-review` 2 lane・2 round）

- round 1（refuted）: SELF 生存未検証 / corrupt entry で guard fail-open / guard 非原子。→ SELF 形式+生存検証・`read_parent` の fail-closed 化・record 後の存在再確認を追加。
- round 2（refuted）: 冪等再登録の label/workspace 上書き（cursor・material）→ **修正**（既存値保持 + test）。guard の原子性（codex・再掲）→ post-check を ownership-aware 化。
- **既知の限界（disclose）**: 並行 `link` の横取り防止には原子的所有権（flock 等）が要るが、これは last-write-wins registry 基盤の性質で `oe-delegate` と同断面。lib 変更を要し本 PR の additive scope 外（verb 側は SELF/target 生存確認 + ownership-aware post-check で「勝てなかった」の honest 検知まで固める）。弱SO の partial disclose で進行。

## 受け入れ基準

- [x] (1) 自己 root 登記 → `oe-tree` に root 表示（`parent_pane=""` の entry を root 描画・既存機構）
- [x] (2) `link %N` で親子 edge
- [x] (3) guard 3態（生存別親=拒否 / orphan=引取り / `--force`=上書き）+ 縁ケースをテスト検証
- [x] (4) 新テスト（48）+ 既存 `tests/test_*.sh` 全 green + `shellcheck` PASS
- [x] (5) 既存 verb 挙動不変（lib write path 無変更 / 述語締めは既存データに bit-identical）

## テスト

- `test_oe_register.sh` 48/0・`test_oe_ident.sh` 14/0・`test_event_bus.sh` 66/0・`test_delegate_registry.sh` 20/0・`test_oe_delegate.sh` 20/0・`test_oe_tree.sh` ok。全 `tests/test_*.sh` green・`shellcheck` PASS。

Refs #259
