### PR TITLE
docs(skill): 統括 spawn 経路に doc-flow-guardrail cold-start の入口を配線

### DIFF
--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -73,6 +73,8 @@ BIN="$REPO/projects/orchestration-engine/bin"
 "$BIN/oe-delegate" -w "$REPO" --label "#N" "Issue #N を実装して。リポジトリ: $REPO。実装規律は $REPO/canonical/skills/implementer-contract/SKILL.md を読んで従うこと"
 ```
 
+**統括（並列 root）を spawn する場合** — brief 冒頭で `doc-flow-guardrail` の cold-start ロードを明示する（実装子と違い固定節でなくフロー全体が要るため）。
+
 ### 改行制約
 
 - タスク引数・ad-hoc に **改行バイトを含めない**（`oe_send_line` が改行を検出すると送信を拒否する）。複数文は句点・セミコロンで区切る

--- a/canonical/skills/doc-flow-guardrail/SKILL.md
+++ b/canonical/skills/doc-flow-guardrail/SKILL.md
@@ -92,6 +92,8 @@ raw log 層（docs/raw-logs/・gitignored・verbatim・別レイヤー）
 
 ## ③ cold-start（新 repo / 新統括セッション）
 
+**統括 spawn の入口**: あなたが並列統括として起動された場合（`oe-delegate` で子登記後に `oe-register root --force` で並列 root へ自己昇格した、または spawn を経ず手動起動した）は、まずこのスキルを読んで cold-start（フロー地図・routing・固定節テンプレ・spec 解決規約）を立ち上げてから統括業務に入る。
+
 memory が無くても、このスキル1本を読めばフロー + 参照ポインタが立ち上がる:
 
 1. フロー地図（①）と routing 表（下記）で、いま居る層と次に通すゲートを掴む。


### PR DESCRIPTION
## 目的

統括（並列 root）として spawn された新セッションに「`doc-flow-guardrail` を cold-start としてロードせよ」という明文化された手順が無く、フロー制御が親の記憶に載る暗黙依存が残っていた（`oe-register` #259 の dogfood で発見）。この入口を2スキルへ純追加で配線する。

Refs #266

## 変更内容（純追加・2ファイル・各1行）

- `canonical/skills/doc-flow-guardrail/SKILL.md` — `## ③ cold-start` 節の冒頭に「統括 spawn の入口」を追加。並列統括として起動された場合（`oe-delegate` で子登記後に `oe-register root --force` で並列 root へ自己昇格、または spawn を経ず手動起動）は、まずこのスキルを読んで cold-start を立ち上げてから統括業務に入る、という自己参照の発火条件。
- `canonical/skills/delegate-task/SKILL.md` — delegate（親→子）節の実装委譲例の直後に「統括（並列 root）を spawn する場合は brief 冒頭で cold-start ロードを明示する」を追加。

既存の ①〜③ 本文・②固定節テンプレ・routing 表は bit 不変（削除ゼロ・4 insertions のみ）。

## 受け入れ基準

- [x] 両スキルのどちらを見ても「新統括に guardrail cold-start を明示ロードさせる」規約に辿り着く（delegate-task = 親側 / doc-flow-guardrail = 子側の相補ペア）
- [x] 既存記述・固定節テンプレは純追加のみで不変（`git diff` = 4 insertions・0 deletions）
- [x] markdown-conventions 準拠・hazard（制御バイト / キリル / client ID）なし

## 検証

- `git diff --stat` = 2 files / 4 insertions(+) / 0 deletions・`git diff --check` clean
- 制御バイト・キリル文字の grep スキャン = clean
- 弱 SO（gate 4 実装SO・doc-only ゆえ弱1周）: `so-compare`（codex + claude）2レーンとも返却（2/2 success）。両者とも CRITICAL/WARNING なし・純追加は安全・自己参照は有害な循環でない・両スキル間に矛盾なし。SO 指摘で「手動起動を spawn の傘に含める語の緩さ」が両レーン共通で挙がったため、追加行を `spawn された場合` → `起動された場合`（`または spawn を経ず手動起動`）へ精緻化し、リポジトリの `手動起動 = spawn を経ない` の対比と整合させた（依然 pure-add の1行）。

## follow-up（本 PR スコープ外・surface のみ）

- SO（claude レーン）が、`delegate-task` の追加行は先行4パターンと違いコード例（具体 kick 文字列）を持たず構造が非対称、と指摘。actionability を上げるならコードブロック1個の追記候補あり。ただし brief の「1行追加」指示・薄い枠方針・Minimal Scope の外のため本 PR では実装せず surface に留める（採否は owner の設計判断）。

## episode

episode opt-out: 純追加 doc・設計は #266/brief に既述
