### PR TITLE
feat(oe): oe-delegate/oe-send の --kickoff を --brief へ整合（alias 存続）

### DIFF
--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -8,7 +8,7 @@ description: 親子 Claude Code セッション間の委譲操作を行う。del
 ## いつ使うか
 
 - 別 Claude Code セッション（子）に作業を委譲したいとき（**delegate**）
-- 既に動いている別ペインへ追加指示・キックオフ・関連の薄い会話を投げたいとき（**send**）
+- 既に動いている別ペインへ追加指示・brief・関連の薄い会話を投げたいとき（**send**）
 - どのペインに何を任せているか宛先候補を確認したいとき（**list**）
 - 子セッションから親へ申し送り・レビュー依頼・完了報告を送るとき（**report**）
 
@@ -26,7 +26,7 @@ description: 親子 Claude Code セッション間の委譲操作を行う。del
 | コマンド | 方向 | 役割 |
 |---------|------|------|
 | `oe-delegate` | 親 → 子 | 子ペインを起動（spawn）し、最初のキックを送る。registry に登録 |
-| `oe-send` | 任意 → 任意 | 既存ペインへ 1 行 / キックオフを送る汎用入口。宛先はラベル or `%N` |
+| `oe-send` | 任意 → 任意 | 既存ペインへ 1 行 / brief を送る汎用入口。宛先はラベル or `%N` |
 | `oe-list` | — | 宛先候補を source 列付きで一覧（誤送信防止） |
 | `oe-register` | — | 手動起動 pane を登記（`root`=自己 root / `link %N`=相手を自分の下に）。spawn を経ない pane を oe-tree / cockpit に現す |
 | `oe-report` | 子 → 親 | （legacy）子→親の申し送り。**戻しは oe-send に一本化**（論点E で整理） |
@@ -58,14 +58,14 @@ BIN="$REPO/projects/orchestration-engine/bin"
 "$BIN/oe-delegate" -w "$REPO" --label "#N" --claude-arg --permission-mode --claude-arg auto "Issue #N の内容を確認して調査して。リポジトリ: $REPO"
 ```
 
-**キックオフ doc を渡す（4層ドキュメント方式 / リッチな事前情報）**
+**brief doc（委譲指示書）を渡す（4層ドキュメント方式 / リッチな事前情報）**
 
 ```bash
-"$BIN/oe-delegate" -w "$REPO" --label "#N" --kickoff "$REPO/path/to/kickoff.md" "補足の要望があればここに1行で"
+"$BIN/oe-delegate" -w "$REPO" --label "#N" --brief "$REPO/path/to/brief.md" "補足の要望があればここに1行で"
 ```
 
-- `--kickoff <path>` は子へ `"<path> を読んで進めて。"` を付加し、子が読めるよう doc のディレクトリを `--add-dir` で開示する
-- doc が無い軽いケースは、親で組み立てた内容を **workspace 配下**（例 `<workspace>/.oe/kickoff-*.md`）に書いてから `--kickoff` で渡す（`/tmp` は対話型 claude が読めないので避ける）。`.oe/` はこのリポジトリでは gitignore 済み。
+- `--brief <path>` は子へ `"<path> を読んで進めて。"` を付加し、子が読めるよう doc のディレクトリを `--add-dir` で開示する（旧 `--kickoff` は deprecated alias として存続・#255。新規は `--brief` を使う）
+- doc が無い軽いケースは、親で組み立てた内容を **workspace 配下**（例 `<workspace>/.oe/brief-*.md`）に書いてから `--brief` で渡す（`/tmp` は対話型 claude が読めないので避ける）。`.oe/` はこのリポジトリでは gitignore 済み。
 
 **実装委譲（implementer-contract 併用）**
 
@@ -78,12 +78,12 @@ BIN="$REPO/projects/orchestration-engine/bin"
 ### 改行制約
 
 - タスク引数・ad-hoc に **改行バイトを含めない**（`oe_send_line` が改行を検出すると送信を拒否する）。複数文は句点・セミコロンで区切る
-- 改行が必要な長文は **issue/plan のパスや番号を渡して子に取得させる**か、`--kickoff` でパス渡しする
+- 改行が必要な長文は **issue/plan のパスや番号を渡して子に取得させる**か、`--brief` でパス渡しする
 
 ### delegate は report を内包しない
 
 `oe-delegate` は spawn + キックに専念し、戻し（report）を一切焼き付けない（Unix 哲学・単機能）。
-子に報告させたいなら、その指示は **task / kickoff の本文に自分で書く**。戻しの送信自体は子が
+子に報告させたいなら、その指示は **task / brief の本文に自分で書く**。戻しの送信自体は子が
 汎用の `oe-send "$PARENT_TMUX_PANE" "..."` で行う（下記「戻し」）。
 
 ### worktree 作成分担（子が自作・統括は hands-off）
@@ -99,7 +99,7 @@ BIN="$REPO/projects/orchestration-engine/bin"
 
 ## send（既存ペインへの送信）
 
-`oe-delegate` で起動した子に限らず、**既に動いているペイン**へ 1 行やキックオフを送る。親→子の追加指示、関連の薄い側道会話、（必要なら）子→親の返しにも使える汎用入口。
+`oe-delegate` で起動した子に限らず、**既に動いているペイン**へ 1 行や brief を送る。親→子の追加指示、関連の薄い側道会話、（必要なら）子→親の返しにも使える汎用入口。
 
 ```bash
 # ラベルで送る（registry / pane-issue で解決）
@@ -108,16 +108,16 @@ BIN="$REPO/projects/orchestration-engine/bin"
 # 生のペインIDで送る（ラベルが無いペイン・側道会話）
 "$BIN/oe-send" "%37" "さっきの設計の続きだけど、TTL は 24h で合ってる？"
 
-# キックオフ doc を既存ペインに読ませる
-"$BIN/oe-send" --kickoff "$REPO/path/to/kickoff.md" "#142" "前提が変わったので読み直して"
+# brief doc を既存ペインに読ませる
+"$BIN/oe-send" --brief "$REPO/path/to/brief.md" "#142" "前提が変わったので読み直して"
 
 # Enter を撃たずに投入だけ（人間が読んでから送る／セッションを汚さない）
 "$BIN/oe-send" --no-enter "%37" "確認してほしい下書き"
 ```
 
-> `--kickoff` のパスは **対象ペインの可読ルート内**（cwd / `--add-dir` 済みの場所）に置く。
+> `--brief` のパスは **対象ペインの可読ルート内**（cwd / `--add-dir` 済みの場所）に置く。
 > 稼働中ペインには後付けで `--add-dir` できないため、ルート外だと子が権限プロンプトで止まる。
-> （`oe-delegate --kickoff` は起動時に doc dir を `--add-dir` 開示するので問題ない）
+> （`oe-delegate --brief` は起動時に doc dir を `--add-dir` 開示するので問題ない）
 
 ### 誤送信を防ぐ
 

--- a/projects/orchestration-engine/bin/README.md
+++ b/projects/orchestration-engine/bin/README.md
@@ -77,13 +77,14 @@ oe-review [--lanes N] [--base <ref>] [--context <doc>]
 
 ## oe-delegate — 子セッション起動 + キック（親子委譲）
 
-子 Claude を `tmux split-window` で起動し、タスク（または kickoff doc）をキック（spawn + send の合成）。
+子 Claude を `tmux split-window` で起動し、タスク（または brief doc）をキック（spawn + send の合成）。
 
 ```bash
-oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
+oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
 ```
 
-- `--kickoff <path>` … `"<path> を読んで進めて。"` を送り、doc のディレクトリを `--add-dir` で子に開示
+- `--brief <path>` … `"<path> を読んで進めて。"` を送り、doc のディレクトリを `--add-dir` で子に開示
+- `--kickoff <path>` … `--brief` の deprecated alias（後方互換・#255）。新規は `--brief` を使う
 - `--label <#N|name>` … registry 登録ラベル（後で `oe-send <label>` で指す）
 - `--claude-arg <arg>` … 子 Claude 起動時に追加引数を渡す（repeatable）。例: `--claude-arg --permission-mode --claude-arg auto`
 - tmux 内必須（`TMUX_PANE` から親ペイン取得、`PARENT_TMUX_PANE` を子へ継承）
@@ -113,10 +114,11 @@ oe-kick [-w WORKSPACE] [--claude-arg <arg>] [--] <#N|kickoff-path> [ad-hoc...]
 親→子の追送、子→親の戻し、関連の薄い側道会話を一手に担う送信口。
 
 ```bash
-oe-send [--kickoff <path>] [--no-enter] [--] <target> [ad-hoc...]
+oe-send [--brief <path>] [--no-enter] [--] <target> [ad-hoc...]
 ```
 
 - `<target>` … 生ペインID（`%N`）または ラベル（`#N` / 任意名。registry で解決）
+- `--brief <path>` … `"<path> を読んで進めて。"` を payload 先頭に付ける（旧 `--kickoff` は deprecated alias・#255）
 - `--no-enter` … 投入のみ（ステージ＝人間が読んで Enter）
 - 子→親の戻し: `oe-send "$PARENT_TMUX_PANE" "申し送り..."`
 - payload は 1 行保証（改行は fail-fast で拒否）。自動 Enter 後に観測ベース finalize（`OE_SEND_FINALIZE=0` で無効）

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # oe-delegate — 子 Claude セッションを起動し、タスクをキックする
 #
-# usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
+# usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
 #
 # 子ペインを tmux split-window で起動し、キックは bin/oe-send 経由で注入する
 # （spawn + send の合成）。delegate は委譲（起動とキック）に専念し、戻し（report）の処理は
@@ -20,13 +20,14 @@ source "${BIN_DIR}/../lib/event-bus.sh" 2>/dev/null || true
 
 usage() {
   cat >&2 <<'EOF'
-usage: oe-delegate [-w WORKSPACE] [--kickoff <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
+usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
 
   <task>              子 Claude セッションへ送るタスク（1行テキスト・改行不可）
-                      --kickoff があれば省略可
+                      --brief があれば省略可
   -w, --workspace DIR 子セッションの作業ディレクトリ（デフォルト: カレントディレクトリ）
-  --kickoff <path>    キックオフ doc を子に読ませる（"<path> を読んで進めて。" を付加）。
+  --brief <path>      brief doc（委譲指示書）を子に読ませる（"<path> を読んで進めて。" を付加）。
                       子から読めるよう doc のディレクトリを --add-dir で開示する
+  --kickoff <path>    --brief の deprecated alias（後方互換・#255）。新規は --brief を使う
   --label <#N|name>   子を registry に登録する際のラベル（後で oe-send <label> で指す）。
                       省略時はラベル無しで登録（wt switch 後は pane-issue の #N で解決可）
   --claude-arg <arg>  子 Claude 起動時に渡す追加引数（repeatable）。
@@ -43,7 +44,7 @@ EOF
 }
 
 WORKSPACE="$(pwd)"
-KICKOFF=""
+BRIEF=""
 LABEL=""
 CLAUDE_ARGS=()
 while [[ "${1:-}" == -* ]]; do
@@ -51,9 +52,11 @@ while [[ "${1:-}" == -* ]]; do
     -w|--workspace)
       [[ $# -ge 2 ]] || { echo "oe-delegate: --workspace requires a value" >&2; exit 2; }
       WORKSPACE="$2"; shift 2 ;;
-    --kickoff)
-      [[ $# -ge 2 ]] || { echo "oe-delegate: --kickoff requires a value" >&2; exit 2; }
-      KICKOFF="$2"; shift 2 ;;
+    --brief|--kickoff)
+      # --kickoff は --brief の deprecated alias（後方互換・#255）。エラー文言は実際に
+      # 渡された flag（$1）を映す。
+      [[ $# -ge 2 ]] || { echo "oe-delegate: $1 requires a value" >&2; exit 2; }
+      BRIEF="$2"; shift 2 ;;
     --label)
       [[ $# -ge 2 ]] || { echo "oe-delegate: --label requires a value" >&2; exit 2; }
       # 改行（LF/CR）を含むラベルは registry 経由で oe_reg_list 出力を複数行化し、消費者
@@ -78,15 +81,15 @@ while [[ "${1:-}" == -* ]]; do
 done
 
 TASK="${1:-}"
-# task は --kickoff があれば省略可。どちらも無ければエラー。
-if [[ -z "$TASK" && -z "$KICKOFF" ]]; then
-  echo "oe-delegate: task argument is required (or pass --kickoff)" >&2
+# task は --brief があれば省略可。どちらも無ければエラー。
+if [[ -z "$TASK" && -z "$BRIEF" ]]; then
+  echo "oe-delegate: task argument is required (or pass --brief)" >&2
   usage
 fi
 # task は 1 行。改行を含むなら spawn 前に弾く（送信は oe_send_line が拒否するため、
 # spawn 後に気づくと無キックの孤児ペインが残る。preflight で防ぐ）。
 if [[ "$TASK" == *$'\n'* || "$TASK" == *$'\r'* ]]; then
-  echo "oe-delegate: task must be a single line (no newline); 長文は --kickoff <path> で渡す" >&2
+  echo "oe-delegate: task must be a single line (no newline); 長文は --brief <path> で渡す" >&2
   exit 2
 fi
 
@@ -97,17 +100,17 @@ PARENT_PANE="${TMUX_PANE:-}"
   exit 1
 }
 
-# --kickoff を絶対パス化し、子（対話型 claude）が読めるよう doc のディレクトリを
+# --brief を絶対パス化し、子（対話型 claude）が読めるよう doc のディレクトリを
 # --add-dir で開示する。spawn.sh の envelope は claude -p + --add-dir /tmp で読ませているが、
 # こちらは素の対話型 claude のため明示開示が要る（so 指摘）。
-KICKOFF_ABS=""
-if [[ -n "$KICKOFF" ]]; then
-  [[ -f "$KICKOFF" ]] || { echo "oe-delegate: --kickoff file not found: ${KICKOFF}" >&2; exit 2; }
-  case "$KICKOFF" in
-    *\'*) echo "oe-delegate: --kickoff path must not contain a single quote" >&2; exit 2 ;;
+BRIEF_ABS=""
+if [[ -n "$BRIEF" ]]; then
+  [[ -f "$BRIEF" ]] || { echo "oe-delegate: --brief file not found: ${BRIEF}" >&2; exit 2; }
+  case "$BRIEF" in
+    *\'*) echo "oe-delegate: --brief path must not contain a single quote" >&2; exit 2 ;;
   esac
-  kdir="$(cd "$(dirname "$KICKOFF")" && pwd)"
-  KICKOFF_ABS="${kdir}/$(basename "$KICKOFF")"
+  kdir="$(cd "$(dirname "$BRIEF")" && pwd)"
+  BRIEF_ABS="${kdir}/$(basename "$BRIEF")"
 fi
 
 shell_quote() {
@@ -126,7 +129,7 @@ build_child_command() {
   for arg in ${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}; do
     cmd="${cmd} $(shell_quote "$arg")"
   done
-  if [[ -n "$KICKOFF" ]]; then
+  if [[ -n "$BRIEF" ]]; then
     cmd="${cmd} --add-dir $(shell_quote "$kdir")"
   fi
   printf '%s\n' "$cmd"
@@ -160,7 +163,7 @@ fi
 
 # キックを oe-send で注入する。delegate は report を内包しない（戻しは子が oe-send で行う）。
 SEND_ARGS=()
-if [[ -n "$KICKOFF_ABS" ]]; then SEND_ARGS+=(--kickoff "$KICKOFF_ABS"); fi
+if [[ -n "$BRIEF_ABS" ]]; then SEND_ARGS+=(--brief "$BRIEF_ABS"); fi
 SEND_ARGS+=(-- "$CHILD_PANE")
 if [[ -n "$TASK" ]]; then SEND_ARGS+=("$TASK"); fi
 "${BIN_DIR}/oe-send" "${SEND_ARGS[@]}"

--- a/projects/orchestration-engine/bin/oe-send
+++ b/projects/orchestration-engine/bin/oe-send
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # oe-send — 既存セッション（ペイン）へ 1 行を送る汎用入口
 #
-# usage: oe-send [--kickoff <path>] [--] <target> [ad-hoc...]
+# usage: oe-send [--brief <path>] [--] <target> [ad-hoc...]
 #
 # 親→子の追加指示、子→親の戻し、関連の薄い側道会話など「既存ペインへの送信」を
 # 一手に担う。payload は delegate-send.sh の oe_send_line で 1 行保証して注入する。
@@ -19,28 +19,31 @@ source "${BIN_DIR}/../lib/delegate-registry.sh"
 
 usage() {
   cat >&2 <<'EOF'
-usage: oe-send [--kickoff <path>] [--] <target> [ad-hoc...]
+usage: oe-send [--brief <path>] [--] <target> [ad-hoc...]
 
   <target>            送信先。生のペインID（例: %5）か ラベル（#142 / 任意名）。
                       ラベルは registry で解決（候補は oe-list で確認）
   ad-hoc...           1 行の追加指示（複数語は空白連結、改行は不可）
-  --kickoff <path>    "<path> を読んで進めて。" を payload 先頭に付ける
+  --brief <path>      "<path> を読んで進めて。" を payload 先頭に付ける
+  --kickoff <path>    --brief の deprecated alias（後方互換・#255）。新規は --brief を使う
   --no-enter          テキスト投入のみで Enter を発火しない（投入＝送信をしない／ステージ）
   -h, --help          このヘルプを表示
 
-payload は「--kickoff のパス指示」＋「ad-hoc テキスト」を 1 行に連結して送る。
+payload は「--brief のパス指示」＋「ad-hoc テキスト」を 1 行に連結して送る。
 どちらか一方は必須。改行を含む場合は送信せず失敗する（途中送信の防止）。
 EOF
   exit 1
 }
 
-KICKOFF=""
+BRIEF=""
 SEND_ENTER=1
 while [[ "${1:-}" == -* ]]; do
   case "$1" in
-    --kickoff)
-      [[ $# -ge 2 ]] || { echo "oe-send: --kickoff requires a value" >&2; exit 2; }
-      KICKOFF="$2"; shift 2 ;;
+    --brief|--kickoff)
+      # --kickoff は --brief の deprecated alias（後方互換・#255）。エラー文言は実際に
+      # 渡された flag（$1）を映す。
+      [[ $# -ge 2 ]] || { echo "oe-send: $1 requires a value" >&2; exit 2; }
+      BRIEF="$2"; shift 2 ;;
     --no-enter) SEND_ENTER=0; shift ;;
     -h|--help) usage ;;
     --) shift; break ;;
@@ -58,9 +61,9 @@ PANE="$(oe_reg_resolve "$TARGET")" || exit
 
 # payload 組立
 payload=""
-if [[ -n "$KICKOFF" ]]; then
-  [[ -e "$KICKOFF" ]] || echo "oe-send: warning: kickoff path not found locally: ${KICKOFF} (child may resolve it in its workspace)" >&2
-  payload="${KICKOFF} を読んで進めて。"
+if [[ -n "$BRIEF" ]]; then
+  [[ -e "$BRIEF" ]] || echo "oe-send: warning: brief path not found locally: ${BRIEF} (child may resolve it in its workspace)" >&2
+  payload="${BRIEF} を読んで進めて。"
 fi
 if [[ -n "$ADHOC" ]]; then
   if [[ -n "$payload" ]]; then
@@ -69,7 +72,7 @@ if [[ -n "$ADHOC" ]]; then
     payload="$ADHOC"
   fi
 fi
-[[ -n "$payload" ]] || { echo "oe-send: nothing to send (provide --kickoff and/or ad-hoc text)" >&2; usage; }
+[[ -n "$payload" ]] || { echo "oe-send: nothing to send (provide --brief and/or ad-hoc text)" >&2; usage; }
 
 rc=0
 oe_send_line "$PANE" "$payload" "$SEND_ENTER" || rc=$?

--- a/projects/orchestration-engine/docs/episodes/2026-07-17-episode-255-brief-flag-rename.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-17-episode-255-brief-flag-rename.md
@@ -1,0 +1,78 @@
+---
+id: "01KXQ9AN6ZNB1J10MZW8ZBM8QQ"
+title: "#255 episode（heavy）— oe-delegate/oe-send の --kickoff を --brief へ rename（alias 存続）"
+date: 2026-07-17
+type: episode
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/255"
+    reason: "委譲ツールの flag 型名を brief へ整合させる follow-up"
+  - type: derived_from
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/249"
+    reason: "document-format v2（PR #254）で委譲文書の型名 brief を確定した元"
+  - type: design_input
+    ref: ".oe/brief-255-brief-flag-rename.md"
+    reason: "統括（cockpit 7代目）発行の委譲 brief（確定仕様・後方互換つき rename）"
+tags: [orchestration, delegate-task, oe-delegate, oe-send, brief-rename, episode-255]
+---
+
+# #255 episode（heavy）— oe-delegate/oe-send の --kickoff を --brief へ rename（alias 存続）
+
+> 冒頭注記: 本 episode は closure 時（実装 + 実装SO 完了後）に **reconstructed**（後追い再構成）。リアルタイム追記ログではないため、形式比較のデータとしてはリアルタイム追記と同列に扱わない。
+
+## Context（なぜ始まったか）
+
+document-format v2（#249・PR #254）で、統括→子の使い捨て委譲指示書の型名を `brief` に確定した（旧称 kickoff）。フロー層 kickoff（committed・`plan-to-kickoff` の出力）との名前被りを解消するため。しかし engine 側の委譲ツール（`oe-delegate` / `oe-send`）の flag 名は旧称 `--kickoff` のまま残っていた。v2 spec では「flag rename は engine コード変更ゆえ spec scope 外」として移行注記に留め、行き先を #255 に surface していた。本 episode はその follow-up＝flag と型名の齟齬解消。
+
+## タスク性質と tier
+
+確定仕様の後方互換つき rename（設計判断はほぼ無し）。統括 brief は「tier standard 目安」としていたが、closure 時の機械トリガ（`episode-retrospective` Step 1）で **heavy** と判定した。理由は 1 点のみ: 実装SO として **意図的に `oe-review`（so-compare 2 レーン＝codex/cursor）を起動した**こと。これは「品質ゲート目的で明示起動した外部レビュー」に該当し、単独で heavy トリガ。他の heavy トリガ（失敗・撤回、学習主成果、非自明な設計判断の棄却、昇格候補）は該当なし。
+
+- 補足: skill の既知の限界に「episode 内で既に意図的 SO 済みなら Step4 を免除する重複排除ルール」が未 land と明記されている。それが land すれば本件のような「SO 起動が唯一の heavy 要因」ケースは standard に戻り得る。現状は未 land ゆえ heavy とし、Step4 は下記の条件付き辞退で処理する。
+
+## 実行ログ（reconstructed）
+
+- scope を brief + `gh issue view 255` で確定。更新面は bin パーサ 2 本 + help + README + delegate-task skill + テスト。
+- `--brief` を主 flag、`--kickoff` を deprecated alias（`--brief|--kickoff` の合成 case）として実装。内部変数 `KICKOFF`→`BRIEF`（`KICKOFF_ABS`→`BRIEF_ABS`）も rename し、flag 名と内部表現の齟齬を残さない。エラー文言は実際に渡された flag（`$1`）を映すようにし、alias 経由でも正しい flag 名でエラーが出る。
+- `oe-delegate` 内部の `oe-send` 呼び出しは新 primary `--brief` へ dogfood 移行。
+- テスト: `test_oe_delegate.sh` を `--brief` 主に更新 + `--kickoff` alias 回帰（oe-delegate 側）+ `oe-send` の `--brief`/`--kickoff` 両パースの直接検証 + `--brief` 値必須（rc=2）を追加。26/0。
+- 検証: engine 全 34 test file green / shellcheck（oe-delegate・oe-send・test）clean。
+- 実装SO（gate 4・弱1周）: `oe-review --lanes 2 --base master`。verdict=**survived**（codex・cursor とも material 欠陥なし）。reviewed_sha=`328eba0`、diff_base=`master`、diff_hash=`b674bf19`、audit_id=`20260717053450V5GMMJJHHJVH`。
+
+## 決定と根拠（diff から復元できない「なぜ」）
+
+- **runtime の deprecation warning は出さない（documentation-only deprecation）**。issue 候補 (a)「`--brief` 追加 + `--kickoff` alias」を採り、brief は「warning は出しても止めない」と許可のみで必須化していない。ここで警告を出さない判断の根拠:
+  - `--kickoff` は scope 外の内部呼び出し元（`oe-kick` → `oe-delegate --kickoff` / `oe-select` → `oe-send --kickoff`）と board（gitignored・自然 attrition・一括置換しない方針）で現に多用中。runtime 警告を出すと、それら現行経路のほぼ全委譲で stderr に警告が出続ける。
+  - 削除計画は brief で明示的に「やらない」。除去予定のない deprecation 警告は移行を促す実益より騒音になる。
+  - よって help / README / skill 上で「deprecated alias」と明記する documentation-based deprecation に留め、runtime は静かにする。これが最小かつ非破壊。
+- **内部変数を `KICKOFF`→`BRIEF` に rename した**。primary flag が `--brief` になった以上、内部表現が `KICKOFF` のままだと後続の読み手が躓く。rename の対象（WHAT）は flag だが、内部整合は HOW の範囲で、これを揃えるのが「誠実な rename」。
+- **`oe-kick` / `oe-select` は触らない（別 verb・scope 外）が、これが alias 存続の設計意図と噛み合う**。両者は内部で `--kickoff` を `oe-delegate`/`oe-send` に渡し続けるが、alias が生きているため runtime は不変。かつ両者のテストは mock 越しに `--kickoff` の受け渡しを assert しているので、**alias を残したことが両テストを green に保つ根拠そのもの**になっている（alias を消していれば全委譲と両テストが壊れた）。
+
+## わかったこと（W）
+
+- `oe_reg_resolve` は `%N`（生ペインID）を registry を経ずに即 passthrough する（`^%[0-9]+$` 判定）。このため `oe-send` を registry 状態なしで直接テストでき、mock の `list-panes` が `%9` を alive と返す前提だけで payload 経路を検証できた（新規テスト [13]/[14] の成立根拠）。
+
+## 原則（Pattern / Anti-pattern）
+
+- Pattern: 後方互換 rename は「新 primary を主に据え、旧名を alias 化 + 内部呼び出し元を新名へ dogfood 移行 + 旧名回帰テストを残す」。alias の存続を回帰テストで固定しておくと、scope 外の内部呼び出し元を触らずに済む安全域が可視化される。
+- Anti-pattern: 除去計画のない deprecation に runtime 警告を付けること。移行を促す実益が薄く、現行経路への騒音が確実。
+
+## 蒸留シグナル
+
+- Decision / skill / rule 昇格候補: **なし**（既存方針の素直な適用に留まる）。
+- `episode-retrospective` の既知課題（意図的 SO が唯一の heavy 要因のとき Step4 を重複排除で免除するルール）に、本件は実例を 1 つ足す。トリガ較正の判断材料。
+
+## 残課題（follow-up routing）
+
+- `oe-kick`（`bin/README.md` の該当節含む）と `oe-select` は内部で `--kickoff` を emit し続ける（alias で動作・#255 scope 外）。**行き先: 追わない（自然 attrition）**。runtime 警告を将来入れるなら、まずこれら内部呼び出し元を `--brief` へ移行してから、が前提（そうしないと自家警告になる）。→ 将来 warning を検討する時点で別 issue 化。
+- board（gitignored・実運用 doc）の `--kickoff` 記述: **行き先: 追わない（自然 attrition）**。brief 明示方針。
+- delegate-task skill frontmatter の `description` は「キックオフ送信」の語を残した。**行き先: 追わない**（skill routing 用のマッチ文言で、生成語を変えると trigger 挙動に影響しうるため触らない）。
+
+## closure
+
+- 達成度: **達成**（受け入れ基準 (1)〜(5) 充足。`--brief` 主・`--kickoff` alias 回帰 green・全 test green + shellcheck PASS・doc 一貫・engine 他挙動不変）。
+- 次の消費者: PR #255 レビュア（owner / Copilot）。マージ後に delegate-task skill 変更を canonical から sync 配布するのは親統括（gate 6）。
+- status: **stable**。
+- SO 証跡: `oe-review` verdict=survived / audit_id=`20260717053450V5GMMJJHHJVH`（audit stream は gitignored ゆえ本文へ verdict + sha + hash を転記済み）。
+- Step4 辞退: 実行中に失敗・撤回・指摘なし（clean rename + 実装SO survived）で closure 品質 4 観点が低リスク・該当なし / 既存チェックで覆った観点: routing（follow-up 全件に行き先付与）・evidence anchor（SO verdict + reviewed_sha + diff_hash を本文転記）・省略チェック（省略対象の失敗が存在しない）・back-propagation（他文書の欠陥なし） / 未実施観点と判断: なし。

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -97,14 +97,14 @@ reset_logs
 run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg --permission-mode --claude-arg auto "arg task"
 ck "claude args in child command" "PARENT_TMUX_PANE='%1' claude '--permission-mode' 'auto'" "$(cat "$_TMP_DIR/logs/split-command.log")"
 
-echo "[3] --claude-arg combines with --kickoff add-dir"
+echo "[3] --claude-arg combines with --brief add-dir"
 reset_logs
-kickoff="${_TMP_DIR}/ws/.oe/kickoff.md"
-printf '%s\n' '# kickoff' > "$kickoff"
-run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg --permission-mode --claude-arg auto --kickoff "$kickoff" "kickoff task"
+brief="${_TMP_DIR}/ws/.oe/brief.md"
+printf '%s\n' '# brief' > "$brief"
+run_delegate -w "$_TMP_DIR/ws" --label "#152" --claude-arg --permission-mode --claude-arg auto --brief "$brief" "brief task"
 expected_cmd="PARENT_TMUX_PANE='%1' claude '--permission-mode' 'auto' --add-dir '${_TMP_DIR}/ws/.oe'"
-ck "kickoff add-dir follows claude args" "$expected_cmd" "$(cat "$_TMP_DIR/logs/split-command.log")"
-ck "kickoff path sent" "yes" "$(grep -qF -- "$kickoff を読んで進めて。 kickoff task" "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+ck "brief add-dir follows claude args" "$expected_cmd" "$(cat "$_TMP_DIR/logs/split-command.log")"
+ck "brief path sent" "yes" "$(grep -qF -- "$brief を読んで進めて。 brief task" "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
 
 echo "[4] --claude-arg shell-quotes single quotes"
 reset_logs
@@ -159,6 +159,35 @@ run_delegate -w "$_TMP_DIR/ws" --label "#152" "target task"
 # （フォーカス中ペインではなく親ペインを分割する）。子コマンド内の PARENT_TMUX_PANE='%1' と混同しない。
 ck "split-window -t targets parent pane" "%1" "$(awk '/^-t$/{getline; print; exit}' "$_TMP_DIR/logs/split-argv.log")"
 ck "split child command unchanged" "PARENT_TMUX_PANE='%1' claude" "$(cat "$_TMP_DIR/logs/split-command.log")"
+
+echo "[12] --kickoff は --brief の deprecated alias（回帰・#255）"
+# oe-delegate 側の alias。--brief と同一に add-dir 開示 + payload を組む。
+reset_logs
+alias_brief="${_TMP_DIR}/ws/.oe/alias-brief.md"
+printf '%s\n' '# brief' > "$alias_brief"
+run_delegate -w "$_TMP_DIR/ws" --label "#152" --kickoff "$alias_brief" "alias task"
+ck "alias add-dir opens brief dir" "PARENT_TMUX_PANE='%1' claude --add-dir '${_TMP_DIR}/ws/.oe'" "$(cat "$_TMP_DIR/logs/split-command.log")"
+ck "alias path sent identically" "yes" "$(grep -qF -- "$alias_brief を読んで進めて。 alias task" "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+
+echo "[13] oe-send --brief が payload を組む"
+# oe-send を直接叩く（%N は素通し。mock list-panes が %9 を alive と返す）。
+reset_logs
+send_brief="${_TMP_DIR}/ws/.oe/send-brief.md"
+printf '%s\n' '# brief' > "$send_brief"
+bash "$PROJECT_DIR/bin/oe-send" --brief "$send_brief" -- %9 "adhoc" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log"
+ck "oe-send --brief payload" "yes" "$(grep -qF -- "$send_brief を読んで進めて。 adhoc" "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+
+echo "[14] oe-send --kickoff は deprecated alias（回帰・#255）"
+reset_logs
+bash "$PROJECT_DIR/bin/oe-send" --kickoff "$send_brief" -- %9 "adhoc" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log"
+ck "oe-send --kickoff payload identical" "yes" "$(grep -qF -- "$send_brief を読んで進めて。 adhoc" "$_TMP_DIR/logs/send-keys.log" && echo yes || echo no)"
+
+echo "[15] --brief は値が必須（rc=2）"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --brief >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "missing brief value rc=2" "2" "$rc"
+ck "missing brief error names --brief" "yes" "$(grep -qF -- '--brief requires a value' "${_TMP_DIR}/stderr.log" && echo yes || echo no)"
 
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 目的

document-format v2（[#249](https://github.com/stlwolf/ai-development-hub/issues/249)・[PR #254](https://github.com/stlwolf/ai-development-hub/pull/254)）で委譲文書の型名が `brief` に確定した整合。engine 側委譲ツールの flag 名が旧称 `--kickoff` のまま残っていたのを **`--brief` 主 flag へ rename**する（フロー層 kickoff との名前被り解消）。

**後方互換**: `--kickoff` は **deprecated alias として存続**（board / skill / 実運用で多用中のため削除しない）。

## 変更内容

- `oe-delegate` / `oe-send` の引数パーサを `--brief|--kickoff` の合成 case に（`--brief` 主・`--kickoff` alias）。内部変数 `KICKOFF`→`BRIEF`、エラー文言（実際に渡された flag `$1` を映す）・help・`oe-delegate` 内部の `oe-send` 呼び出しも `--brief` 主に整合。
- `bin/README.md` の oe-delegate / oe-send 節、`canonical/skills/delegate-task/SKILL.md` の例を `--brief` 主に更新（`--kickoff` alias 存続を明記・`.oe/kickoff-*.md`→`.oe/brief-*.md`）。
- `tests/test_oe_delegate.sh`: `--brief` 主ケースへ更新 + `--kickoff` alias 回帰（oe-delegate 側）+ `oe-send` の `--brief`/`--kickoff` 両パースの直接検証 + `--brief` 値必須（rc=2）を追加。

## 設計判断

- **runtime の deprecation 警告は出さない（documentation-only deprecation）**。`--kickoff` は scope 外の内部呼び出し元（`oe-kick` / `oe-select`）と board で現に多用中で、除去計画も無い（brief 明示）。警告を出すと現行経路のほぼ全委譲で騒音になるため、help / README / skill 上で「deprecated alias」と明記する documentation-based deprecation に留めた。

## 検証

- engine 全 34 test file green（`test_oe_delegate.sh` 26/0 含む）。
- shellcheck（`oe-delegate` / `oe-send` / `test_oe_delegate.sh`）clean。
- 実装SO（gate 4・弱1周）: `oe-review --lanes 2 --base master` → **verdict=survived**（codex・cursor とも material 欠陥なし）。reviewed_sha=`328eba0` / diff_hash=`b674bf19` / audit_id=`20260717053450V5GMMJJHHJVH`。

## 受け入れ基準

- [x] `--brief <path>` が従来の `--kickoff` と同一に機能
- [x] `--kickoff <path>` が deprecated alias として依然機能（回帰テスト green）
- [x] 新旧テスト + 既存 `test_*.sh` 全 green + shellcheck PASS
- [x] help / README / delegate-task skill が `--brief` 主・`--kickoff` alias と一貫
- [x] engine の他挙動不変

## やらないこと（scope 外・自然 attrition）

- `--kickoff` の削除（後方互換維持）。
- `oe-kick` / `oe-select` の内部 `--kickoff` emit（alias で動作・別 verb）。将来 runtime 警告を入れるなら先にこれらを `--brief` へ移行が前提。
- board（gitignored・実運用 doc）の一括置換。

## episode

- [projects/orchestration-engine/docs/episodes/2026-07-17-episode-255-brief-flag-rename.md](https://github.com/stlwolf/ai-development-hub/blob/feat/%23255_brief-flag/projects/orchestration-engine/docs/episodes/2026-07-17-episode-255-brief-flag-rename.md)（tier=heavy／意図的 oe-review 起動が唯一の heavy 要因・Step4 は条件付き辞退）

Refs #255
