### PR TITLE
feat(oe): spawn 段 owner 承認ハンドシェイク v0（承認パッケージ + digest binding + audit）

### DIFF
--- a/canonical/skills/delegate-task/SKILL.md
+++ b/canonical/skills/delegate-task/SKILL.md
@@ -95,6 +95,45 @@ BIN="$REPO/projects/orchestration-engine/bin"
 - **per-issue は end-to-end で子へ**: 各 issue の §0 洗い出し以降（設計 SO / 調査 / 実装）を統括が自分の会話で巻き取らず、issue ごとに子スレッドへ一気通貫で委譲する（親 lean）。§0 の一括 read-only 洗い出しだけは親 or 使い捨て subagent が担ってよい。
 - **マージ・worktree 掃除は親 / 人間（Human Gate、HG）**: 子は完了報告のみ行い、マージも worktree 掃除もしない。
 
+### elevated 子 spawn の owner 承認ハンドシェイク（#262）
+
+**いつ発火するか（限定）**: 子が **elevated**（`bypassPermissions`、または本番 / 機微アクセスを持つタスク）のときだけ。通常のローカル auto 委譲は対象外で従来どおり（ハンドシェイクを掛けない）。
+
+**なぜ要るか**: 親が elevated 子を spawn しようとすると、ハーネスの auto-mode classifier が**親の spawn tool-call を評価して block** する（解除は owner の直接アクションのみ・安全機構として正しい）。分類器は繰り返し block された後にしか in-TUI プロンプトを出さないので、親が叩き直すと #262 の「混乱した往復」になる。これを、owner が 1 アクションで判断できる**整形済み承認パッケージを spawn 前に先出し**することで断つ。**分類器は尊重する（変えない・迂回しない）**。
+
+**手順（3 ステップ）**:
+
+本番 / 機微アクセスの auto 子は `--elevated` を**必ず宣言する**（engine は本番アクセスを自動検知できないため。`--elevated` を付けると実 spawn は承認済みダイジェストを必須にする。`bypassPermissions` 子は宣言せずとも elevated 扱い）。
+
+```bash
+# 1. spawn せず承認パッケージ + ダイジェストを印字（print は子を作らないので classifier に block されない）
+"$BIN/oe-delegate" -w "$REPO" --label "#N" --elevated \
+  --claude-arg --permission-mode --claude-arg auto \
+  --reason "本番隣接の非対話 deploy が要る" \
+  --print-approval "タスク1行"
+# → owner 向けパッケージ（要求権限モード / elevated 宣言 / 対象子 / 理由 / 作業ディレクトリ /
+#    blast radius / 承認ダイジェスト）と、そのまま実行できる実 spawn コマンド（--approved-digest 付き）を印字。
+
+# 2. owner が 1 アクションで承認（表示された実 spawn を承認する / owner が自分で実行する）。
+
+# 3. 実 spawn（同じ引数 + 承認ダイジェスト）。oe-delegate が引数から digest を再計算して照合し、
+#    承認後にコマンドが変わっていれば拒否（exit 3）＝承認↔実行の binding。--elevated 宣言も digest に
+#    束縛されるので、非 elevated の承認に後から --elevated を付けて escalation することはできない。
+"$BIN/oe-delegate" -w "$REPO" --label "#N" --elevated \
+  --claude-arg --permission-mode --claude-arg auto \
+  --reason "本番隣接の非対話 deploy が要る" \
+  --approved-digest "<step1 のダイジェスト>" "タスク1行"
+```
+
+- **binding**: `--print-approval` が出すダイジェストは workspace 絶対パス / label / claude 引数 / brief 絶対パス + 内容 hash / task / elevated 宣言 から決定論計算する（`--reason` は注記なので含めない）。実 spawn 時に不一致なら spawn せず exit 3。親（モデル）が承認済みと違うコマンド（属性含む）を走らせる drift を機構で捕まえる。
+- **classifier は迂回しない**: 実 spawn 自体は従来どおり owner ゲート（分類器）を通る。ハンドシェイクは「owner が 1 アクションで判断するための情報とタイミング」を標準化するだけ。
+- **audit**: elevated spawn は `child_spawned` イベントに `permission_mode` + `elevated` を焼き込む（auto でも elevated 宣言の有無で通常 spawn と事後区別できる・registry は変更しない）。
+- **v0 の限界（plan §8・意図的な defer）**:
+  - ダイジェストは公開入力からの決定論チェックサムで、**owner 承認の暗号的証明ではない**（nonce / 期限 / 消費状態を持たない）。**authZ の実体はハーネスの分類器**（agent は elevated spawn の block を自己解除できない）で、ダイジェストは「owner が見た内容 = 実行内容」を保証する drift-guard。両者は別レイヤー。
+  - brief は承認時に内容 hash を束縛するが、spawn 後に子が読むまでの差し替え（read-time TOCTOU）までは束縛しない。
+  - `permission_mode` は CLI 引数からの best-effort 推定（継承 config は反映しない）。enforcement は明示 `--elevated` を主ゲートにするので本番ケースは mode 推定に依存しない。
+- 規範（なぜ owner 承認が要るか）は `orchestration-toolkit`、ゲート位置は `doc-flow-guardrail` の routing 表、engine フラグの詳細は `oe-delegate -h` を参照（3軸分離）。
+
 ---
 
 ## send（既存ペインへの送信）

--- a/canonical/skills/doc-flow-guardrail/SKILL.md
+++ b/canonical/skills/doc-flow-guardrail/SKILL.md
@@ -116,6 +116,9 @@ memory が無くても、このスキル1本を読めばフロー + 参照ポイ
 | 4 | 実装 → PR | 実装SO（`so.impl`）+ テスト実行 + Copilot | `so-compare` / `peer-ai-review` + `copilot-review-response` |
 | 5 | PR → merge | episode closure（マージ前・後追いは `reconstructed`）→ owner マージ | `episode-retrospective` |
 | 6 | merge 後 | issue close 判断（keep-open 明示）+ worktree 掃除（親）+ 昇格判定 | `branch-finish` + `document-format.md`〔§13〕 |
+| S | elevated 子 spawn 時（委譲操作軸・別軸） | owner 承認ハンドシェイク: 分類器 block を見越して整形済み承認パッケージ + ダイジェストを spawn 前に先出しし、承認↔実行を binding | `delegate-task`（手順）+ `orchestration-toolkit`（規範） |
+
+- 行 **S** は蒸留フロー軸（0-6・§11）ではなく**委譲操作軸**のゲート（§11 との 1:1 索引の対象外・番号を持たない）。子が **elevated**（`bypassPermissions` / 本番・機微アクセス）のときだけ発火し、通常のローカル auto 委譲は対象外。分類器は尊重する（迂回しない）。#262。
 
 ## 関連
 

--- a/canonical/skills/orchestration-toolkit/SKILL.md
+++ b/canonical/skills/orchestration-toolkit/SKILL.md
@@ -24,6 +24,7 @@ oe-* ツール群を **1 つのパッケージとして一貫理解する**た�
 - 蒸留パイプライン doc の型・入口・ライフサイクルは **`doc-flow-guardrail`**（フロー地図）と `document-format.md`〔文書型別テンプレート §8 / ライフサイクル規範 §12〕が正本。closure は `episode-retrospective`（マージ前・後追いは `reconstructed` 明示）。
 - **完全移譲**: 自律委譲子は discussion/設計SO から 実装→実装SO→Episode→PR→Copilot→closure まで**一気通貫**（親は巻き取らない）。
 - **自律委譲子の権限（運用・opt-in）**: `oe-delegate`/`oe-kick` は既定で permission-mode を付けない。自律子には `--claude-arg --permission-mode --claude-arg auto` を**明示的に渡す**。`bypassPermissions` は委譲子では即死するため `auto` を使う（実機学び・コード強制ではない）。auto/full 権限の自律子はガードレールでユーザー明示承認が要る。
+  - **elevated 子 spawn の owner 承認ハンドシェイク（#262）**: 子が elevated（bypass / 本番・機微アクセス）のとき、親は spawn 前に `oe-delegate --print-approval` で整形済み承認パッケージ + ダイジェストを owner へ先出しし、承認後に `--approved-digest` 付きで実 spawn する（承認↔実行を binding・分類器は迂回しない）。**規範はここ・操作手順は `delegate-task`・ゲート位置は `doc-flow-guardrail`**（3軸分離）。通常のローカル auto 委譲は対象外。
 
 ## malform hygiene（生 capture の会話混入を断つ）
 

--- a/projects/orchestration-engine/bin/oe-delegate
+++ b/projects/orchestration-engine/bin/oe-delegate
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # oe-delegate — 子 Claude セッションを起動し、タスクをキックする
 #
-# usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
+# usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>]
+#                    [--reason <text>] [--elevated] [--print-approval | --approved-digest <digest>] [--] <task>
+#
+# elevated（bypass / 本番アクセス）子の spawn 段 owner 承認ハンドシェイク（#262 v0）:
+#   --print-approval は spawn せず、正規化 argv のダイジェストと owner 向け承認パッケージを印字する
+#   （print は子を作らないので auto-mode classifier に block されない）。owner が承認したのち、
+#   同じ引数 + --approved-digest <digest> で実 spawn する。oe-delegate は spawn 直前にダイジェストを
+#   再計算して照合し、承認内容と実行が一致すること（binding）を機構的に保証する。実 spawn 自体は
+#   従来どおり owner ゲート（分類器）を通る——ハンドシェイクは分類器を迂回しない。
+#   --elevated（or bypassPermissions）を宣言した spawn は承認済みダイジェストを必須にする
+#   （承認を経ず到達する迂回を engine 側で塞ぐ）。通常のローカル auto 委譲は対象外・不変。
 #
 # 子ペインを tmux split-window で起動し、キックは bin/oe-send 経由で注入する
 # （spawn + send の合成）。delegate は委譲（起動とキック）に専念し、戻し（report）の処理は
@@ -20,7 +30,8 @@ source "${BIN_DIR}/../lib/event-bus.sh" 2>/dev/null || true
 
 usage() {
   cat >&2 <<'EOF'
-usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>] [--] <task>
+usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude-arg <arg>]
+                   [--reason <text>] [--elevated] [--print-approval | --approved-digest <digest>] [--] <task>
 
   <task>              子 Claude セッションへ送るタスク（1行テキスト・改行不可）
                       --brief があれば省略可
@@ -32,6 +43,16 @@ usage: oe-delegate [-w WORKSPACE] [--brief <path>] [--label <#N|name>] [--claude
                       省略時はラベル無しで登録（wt switch 後は pane-issue の #N で解決可）
   --claude-arg <arg>  子 Claude 起動時に渡す追加引数（repeatable）。
                       例: --claude-arg --permission-mode --claude-arg auto
+  --reason <text>     承認パッケージに載せる理由（1行・#262 elevated 承認ハンドシェイク用）。
+  --elevated          この子を elevated（本番 / 機微アクセス等）と宣言する。宣言すると実 spawn は
+                      owner 承認済みダイジェスト（--approved-digest）を必須にする（無ければ exit 3）。
+                      bypassPermissions 子は宣言せずとも elevated 扱い。通常のローカル auto 委譲は対象外。
+  --print-approval    spawn せず、正規化 argv のダイジェスト + owner 向け承認パッケージを印字。
+                      elevated 子の spawn 前に owner 承認を取るのに使う（print は子を作らないので block されない）。
+  --approved-digest <digest>
+                      実 spawn 時に承認済みダイジェストを渡す。oe-delegate が引数から再計算した
+                      ダイジェストと照合し、不一致なら spawn を拒否（承認↔実行の binding・不一致は exit 3）。
+                      渡された場合は空文字でも必ず照合する（照合スキップ迂回を塞ぐ）。
   -h, --help          このヘルプを表示
 
 環境変数:
@@ -47,6 +68,11 @@ WORKSPACE="$(pwd)"
 BRIEF=""
 LABEL=""
 CLAUDE_ARGS=()
+REASON=""
+PRINT_APPROVAL=""
+APPROVED_DIGEST=""
+APPROVED_DIGEST_SET=""
+ELEVATED=""
 while [[ "${1:-}" == -* ]]; do
   case "$1" in
     -w|--workspace)
@@ -74,6 +100,25 @@ while [[ "${1:-}" == -* ]]; do
         exit 2
       fi
       CLAUDE_ARGS+=("$2"); shift 2 ;;
+    --reason)
+      [[ $# -ge 2 ]] || { echo "oe-delegate: --reason requires a value" >&2; exit 2; }
+      if [[ "$2" == *$'\n'* || "$2" == *$'\r'* ]]; then
+        echo "oe-delegate: --reason value must be a single line (no newline)" >&2
+        exit 2
+      fi
+      REASON="$2"; shift 2 ;;
+    --print-approval)
+      PRINT_APPROVAL=1; shift ;;
+    --elevated)
+      ELEVATED=1; shift ;;
+    --approved-digest)
+      [[ $# -ge 2 ]] || { echo "oe-delegate: --approved-digest requires a value" >&2; exit 2; }
+      if [[ "$2" == *$'\n'* || "$2" == *$'\r'* ]]; then
+        echo "oe-delegate: --approved-digest value must be a single line (no newline)" >&2
+        exit 2
+      fi
+      # フラグが渡されたこと自体を記録（空文字を渡して照合をスキップする迂回を塞ぐ・実装SO D2）。
+      APPROVED_DIGEST="$2"; APPROVED_DIGEST_SET=1; shift 2 ;;
     -h|--help) usage ;;
     --) shift; break ;;
     *) echo "oe-delegate: unknown option: $1" >&2; usage ;;
@@ -93,12 +138,30 @@ if [[ "$TASK" == *$'\n'* || "$TASK" == *$'\r'* ]]; then
   exit 2
 fi
 
-# tmux 内でのみ実行可能
+# workspace を検証・絶対化する（実装SO D1/D4）。
+#   - 制御文字は承認パッケージ（owner 判断のセキュリティ表示）へ偽の「承認ダイジェスト:」行を注入し得る
+#     ため fail-fast 拒否（label 等と同方針）。
+#   - 相対パスは cwd 依存で、別 cwd から同じ相対 -w が同一 digest になり binding を迂回できる。
+#     絶対化して digest / パッケージ / spawn の -c を一致させる（DJ-2 の「workspace 絶対パス」担保）。
+if [[ "$WORKSPACE" =~ [[:cntrl:]] ]]; then
+  echo "oe-delegate: --workspace value must not contain control characters" >&2
+  exit 2
+fi
+if _ws_abs="$(cd "$WORKSPACE" 2>/dev/null && pwd)"; then
+  WORKSPACE="$_ws_abs"
+else
+  echo "oe-delegate: workspace directory not found: ${WORKSPACE}" >&2
+  exit 2
+fi
+
+# tmux 内でのみ実行可能（--print-approval は spawn しないため tmux 不要）
 PARENT_PANE="${TMUX_PANE:-}"
-[[ -n "$PARENT_PANE" ]] || {
-  echo "oe-delegate: TMUX_PANE is not set — must run inside a tmux session" >&2
-  exit 1
-}
+if [[ -z "$PRINT_APPROVAL" ]]; then
+  [[ -n "$PARENT_PANE" ]] || {
+    echo "oe-delegate: TMUX_PANE is not set — must run inside a tmux session" >&2
+    exit 1
+  }
+fi
 
 # --brief を絶対パス化し、子（対話型 claude）が読めるよう doc のディレクトリを
 # --add-dir で開示する。spawn.sh の envelope は claude -p + --add-dir /tmp で読ませているが、
@@ -109,6 +172,11 @@ if [[ -n "$BRIEF" ]]; then
   case "$BRIEF" in
     *\'*) echo "oe-delegate: --brief path must not contain a single quote" >&2; exit 2 ;;
   esac
+  # 制御文字は承認パッケージ表示への行/端末制御注入経路（実装SO D4/R2）。単一引用符に加えて拒否する。
+  if [[ "$BRIEF" =~ [[:cntrl:]] ]]; then
+    echo "oe-delegate: --brief path must not contain control characters" >&2
+    exit 2
+  fi
   kdir="$(cd "$(dirname "$BRIEF")" && pwd)"
   BRIEF_ABS="${kdir}/$(basename "$BRIEF")"
 fi
@@ -135,6 +203,147 @@ build_child_command() {
   printf '%s\n' "$cmd"
 }
 
+# --- #262 spawn 段 owner 承認ハンドシェイク（binding + approval package） ---
+
+# _sha256 — stdin を sha256 し hex を stdout（darwin=shasum / linux=sha256sum）。
+_sha256() {
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then sha256sum | awk '{print $1}'
+  else return 1; fi
+}
+
+# _strip_cntrl — 表示用に制御文字を除去（ESC 等での承認表示 spoof を断つ・実装SO R2）。
+_strip_cntrl() { printf '%s' "$1" | tr -d '\000-\037\177'; }
+
+# extract_permission_mode — CLAUDE_ARGS から子の実効 permission mode を推定（audit / パッケージ用）。
+#   --permission-mode <v> / --permission-mode=<v> / --dangerously-skip-permissions を認識。無ければ default。
+extract_permission_mode() {
+  local arg prev="" mode="default"
+  for arg in ${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}; do
+    case "$arg" in
+      --dangerously-skip-permissions) mode="bypassPermissions" ;;
+      --permission-mode=*) mode="${arg#--permission-mode=}" ;;
+    esac
+    [[ "$prev" == "--permission-mode" ]] && mode="$arg"
+    prev="$arg"
+  done
+  printf '%s' "$mode"
+}
+
+# compute_spawn_digest — 承認対象の正規化ダイジェスト（承認↔実行 binding 用）を stdout。
+#   実行される子コマンドの承認面（workspace 絶対パス / label / claude 引数列 / brief 絶対パス
+#   + その内容 hash / task / elevated 宣言）。ephemeral な PARENT_TMUX_PANE と注記の --reason は含めない。
+#   WORKSPACE は呼び出し前に絶対化済み（相対 -w のクロス cwd 迂回を防ぐ・実装SO D1）。
+#   brief は path だけでなく内容 hash も含め、承認後の内容差し替え（TOCTOU）を捕まえる。
+compute_spawn_digest() {
+  command -v jq >/dev/null 2>&1 || { echo "oe-delegate: jq is required for the approval digest" >&2; return 2; }
+  # claude 引数配列を JSON へ。値が --permission-mode 等の option 形なので jq --args は使わず
+  # （jq が option と誤認する）、--argjson で 1 要素ずつ安全に append する。
+  local args_json="[]" arg
+  for arg in ${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}; do
+    args_json="$(jq -cn --argjson acc "$args_json" --arg a "$arg" '$acc + [$a]')" || return 1
+  done
+  local brief_hash=""
+  if [[ -n "$BRIEF_ABS" && -f "$BRIEF_ABS" ]]; then
+    brief_hash="$(_sha256 < "$BRIEF_ABS")" || return 1
+  fi
+  # elevated 宣言も束縛する（実装SO R2）。含めないと、非 elevated の承認 digest に後から
+  # --elevated を付けて escalation できる（逆に downgrade も）。digest に焼くことで、owner が
+  # 見た elevated 宣言と実 spawn の elevated 属性が一致しなければ照合が落ちる。
+  local elevated_json; elevated_json="$([[ -n "$ELEVATED" ]] && echo true || echo false)"
+  local canon
+  canon="$(jq -cn \
+    --arg ws "$WORKSPACE" --arg label "$LABEL" --arg brief "$BRIEF_ABS" \
+    --arg bh "$brief_hash" --arg task "$TASK" --argjson el "$elevated_json" \
+    --argjson ca "$args_json" \
+    '{workspace:$ws, label:$label, brief:$brief, brief_content:$bh, task:$task, elevated:$el, claude_args:$ca}')" || return 1
+  printf '%s' "$canon" | _sha256 | cut -c1-16
+}
+
+# build_approval_command — owner が承認 / 実行する実 spawn コマンドを正規順で再構成して stdout。
+build_approval_command() {
+  local d="$1" cmd arg
+  cmd="$(shell_quote "${BIN_DIR}/oe-delegate") -w $(shell_quote "$WORKSPACE")"
+  [[ -n "$LABEL" ]] && cmd="${cmd} --label $(shell_quote "$LABEL")"
+  for arg in ${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"}; do
+    cmd="${cmd} --claude-arg $(shell_quote "$arg")"
+  done
+  [[ -n "$BRIEF_ABS" ]] && cmd="${cmd} --brief $(shell_quote "$BRIEF_ABS")"
+  [[ -n "$REASON" ]] && cmd="${cmd} --reason $(shell_quote "$REASON")"
+  [[ -n "$ELEVATED" ]] && cmd="${cmd} --elevated"
+  cmd="${cmd} --approved-digest $(shell_quote "$d")"
+  [[ -n "$TASK" ]] && cmd="${cmd} -- $(shell_quote "$TASK")"
+  printf '%s' "$cmd"
+}
+
+# print_approval_package — spawn せず owner 向け承認パッケージ + ダイジェストを stdout。
+#   表示値は _strip_cntrl でサニタイズする（digest は raw 値で計算・表示は無害化）。
+#   WORKSPACE / BRIEF は入力段で制御文字を fail-fast 済み。
+print_approval_package() {
+  local digest pm task_summary is_elev="no" s_label s_task s_reason
+  digest="$(compute_spawn_digest)" || { echo "oe-delegate: failed to compute the approval digest" >&2; exit 2; }
+  pm="$(extract_permission_mode)"
+  { [[ -n "$ELEVATED" ]] || [[ "$pm" == "bypassPermissions" ]]; } && is_elev="yes"
+  task_summary="$TASK"
+  [[ -n "$task_summary" ]] || task_summary="(brief 参照: ${BRIEF_ABS:-none})"
+  s_label="$(_strip_cntrl "${LABEL:-(ラベル無し)}")"
+  s_task="$(_strip_cntrl "$task_summary")"
+  s_reason="$(_strip_cntrl "${REASON:-(呼び出し側が会話で補足)}")"
+  cat <<EOF
+========================================================================
+[spawn 承認要求] elevated な子セッションを起動します。owner の承認をお願いします。
+------------------------------------------------------------------------
+  対象の子        : ${s_label}
+  要求権限モード  : ${pm}
+  elevated 宣言   : ${is_elev}
+  作業ディレクトリ: ${WORKSPACE}
+  brief           : ${BRIEF_ABS:-(なし)}
+  タスク          : ${s_task}
+  理由            : ${s_reason}
+  blast radius    : auto 子は作業ディレクトリ内で権限プロンプトを自動承認しうる。
+                    破壊的コマンドは block-destructive hook が引き続き block する
+                    （限定的パターンブロッカーであり完全な sandbox ではない）。
+  承認ダイジェスト: ${digest}
+------------------------------------------------------------------------
+承認方法（owner の 1 アクション）: 下記コマンドを承認する / owner が実行する。
+実 spawn コマンド（承認内容と実行の一致をダイジェストで束縛）:
+
+  $(build_approval_command "$digest")
+
+注意: auto-mode classifier は実 spawn の段で評価する。この表示は spawn しない
+ため block されない。実 spawn は owner ゲートのまま（分類器は迂回しない）。
+========================================================================
+EOF
+}
+
+# --print-approval: spawn せず承認パッケージを印字して終了（enforcement より前＝承認取得のため）。
+if [[ -n "$PRINT_APPROVAL" ]]; then
+  print_approval_package
+  exit 0
+fi
+
+# elevated 判定: 明示 --elevated、または権限無効化モード（bypassPermissions）。通常のローカル
+# auto 委譲は elevated ではない（owner: 通常委譲は不変）。auto + 本番アクセスは engine から
+# 検知できないため呼び出し側が --elevated を宣言する（skill が指示・分類器が二重ゲート）。
+PERM_MODE="$(extract_permission_mode)"
+IS_ELEVATED=""
+{ [[ -n "$ELEVATED" ]] || [[ "$PERM_MODE" == "bypassPermissions" ]]; } && IS_ELEVATED=1
+
+# elevated spawn は owner 承認済みダイジェストを必須にする（承認を経ず到達する迂回を塞ぐ・実装SO D3）。
+if [[ -n "$IS_ELEVATED" && -z "$APPROVED_DIGEST_SET" ]]; then
+  echo "oe-delegate: elevated spawn には owner 承認済みダイジェストが必須 — 先に --print-approval で承認を取り、その --approved-digest を渡すこと" >&2
+  exit 3
+fi
+
+# --approved-digest が渡されたら（空文字でも）必ず照合する（-n で空をスキップさせない・実装SO D2）。
+if [[ -n "$APPROVED_DIGEST_SET" ]]; then
+  _computed="$(compute_spawn_digest)" || { echo "oe-delegate: failed to compute the approval digest" >&2; exit 2; }
+  if [[ "$_computed" != "$APPROVED_DIGEST" ]]; then
+    echo "oe-delegate: approved digest mismatch — the spawn command changed since approval (approved=${APPROVED_DIGEST} computed=${_computed}). 再度 --print-approval で承認を取り直すこと。" >&2
+    exit 3
+  fi
+fi
+
 # 子ペインを作成し claude を起動（PARENT_TMUX_PANE を env として渡す）。
 # split は親ペイン（$PARENT_PANE = oe-delegate を起動した pane）を -t で明示する。-t を省くと
 # tmux はフォーカス中ペインを分割するため、親が別ウィンドウを active にしている間に委譲すると
@@ -157,8 +366,10 @@ tmux list-panes -a -F "#{pane_id}" | grep -qxF "$CHILD_PANE" || {
 oe_reg_record "$CHILD_PANE" "$LABEL" "$WORKSPACE" "$PARENT_PANE" || true
 
 # 活動ログに child_spawned を best-effort emit（registry 登録後 ＝ 親 label 解決可）。本体は壊さない。
+# permission_mode + elevated を焼き込み、elevated spawn を通常 spawn と事後区別できるようにする
+# （#262・audit・実装SO D5＝auto でも elevated 宣言の有無で区別可能に）。
 if declare -F oe_event_child_spawned >/dev/null 2>&1; then
-  oe_event_child_spawned "$PARENT_PANE" "$CHILD_PANE" "$LABEL" || true
+  oe_event_child_spawned "$PARENT_PANE" "$CHILD_PANE" "$LABEL" "$PERM_MODE" "${IS_ELEVATED:+true}" || true
 fi
 
 # キックを oe-send で注入する。delegate は report を内包しない（戻しは子が oe-send で行う）。

--- a/projects/orchestration-engine/docs/decisions/2026-07-17-decision-spawn-permission-handshake.md
+++ b/projects/orchestration-engine/docs/decisions/2026-07-17-decision-spawn-permission-handshake.md
@@ -1,0 +1,72 @@
+---
+id: "01KXQXK8152C2RZMRPTBN0GQFT"
+title: "spawn 段 owner 承認ハンドシェイク v0 — 発火層・authZ↔binding 二層・engine 薄層採用"
+date: 2026-07-17
+type: decision
+status: stable
+related:
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/262"
+    reason: "委譲 auto-mode 子の spawn 段 friction のフィードバック起点"
+  - type: reference
+    ref: "projects/orchestration-engine/docs/decisions/2026-05-14-decision-permission-separation-mvp.md"
+    reason: "別軸の権限 ADR（DI-13=OS/sandbox 分離 vs 本 ADR=ハーネス permission-mode 軸）。重複設計しない"
+  - type: reference
+    ref: "projects/orchestration-engine/docs/episodes/2026-07-17-episode-262-permission-handshake.md"
+    reason: "実装・SO 反証履歴・具象修正の実行詳細（本 ADR は durable な決定に絞り §13.2 で重複回避）"
+  - type: integration_target
+    ref: "projects/orchestration-engine/bin/oe-delegate"
+    reason: "承認ハンドシェイクの実体（--print-approval / --approved-digest / --elevated）"
+tags: [orchestration, permission, spawn, handshake, delegate, security, decision]
+---
+
+# spawn 段 owner 承認ハンドシェイク v0 — 発火層・authZ↔binding 二層・engine 薄層採用
+
+## コンテキスト
+
+委譲フロー（親 → 子 spawn・子 auto-mode）で、親が elevated 権限の子を spawn する段に来ると friction が起きていた（issue #262）。本 ADR は、その v0 対処として採用した設計の **durable な決定**を記録する。scope 確定（QDD gate 0）と設計判断は plan-first で設計SO（`oe-refute`）+ owner HG を通し、実装は実装SO（`oe-review`）で反証・修正済み。反証の往復や具象修正の詳細は related の episode を参照する（本 ADR では再掲しない）。
+
+本 ADR は DI-13（権限分離 MVP）とは**別軸**である。DI-13 は OS/sandbox による分離（Docker / OS ユーザー / 破壊コマンド hook）を扱い「MVP では実装しない」と決めた。本 ADR はハーネスの **permission-mode 軸**（auto / bypass の分類器と、その owner 承認）を扱う。両者は直交し、互いを再litigate しない。
+
+## 検討した選択肢（実体の置き場＝engine か skill か）
+
+- **案 (a) skill のみ**: 承認パッケージのテンプレを skill に持たせ、engine は変更しない。
+- **案 (b) engine 薄層 binding**【採用】: `oe-delegate` に、spawn せずに正規化 argv のダイジェストと承認パッケージを印字する経路（`--print-approval`）と、実 spawn 時にダイジェストを再計算して照合する経路（`--approved-digest`）を足す。
+- **案 (c) 軽量版**: 新経路を足さず `oe-kick --elevated` 等の既存ラッパー拡張で整形だけ行う。
+
+## 決定
+
+1. **発火層の同定**: block は**親の tool-call 段で、ハーネス組み込みの auto-mode classifier が親の spawn（Bash tool-call）を評価して弾いている**。ローカルの破壊コマンド hook でも、ローカル設定の権限ルールでも、Task/subagent tool 専用の層でもない（消去法・観測ベース）。**trigger は「auto モードそのもの」ではなく危険シグナル**（`bypassPermissions`、または子のタスクが本番 / 機微アクセスを持つこと）。通常のローカル auto 委譲は block されない。
+
+2. **authZ ↔ binding の二層分離**: 認可（authZ）の実体は**ハーネスの分類器**であり、その解除は owner の直接アクションのみ（エージェントは自己解除できない）。engine が足すダイジェストは**認可の証明ではなく drift-guard**＝「owner が承認パッケージで見た内容 = 実際に起動される内容」を保証する整合性チェック。両者は別レイヤーであり、**分類器を迂回しない**のが不変条件。
+
+3. **実体は案 (b) engine 薄層 binding を採用**。`oe-delegate` に `--print-approval` / `--approved-digest` / `--elevated` を追加し、承認パッケージの整形と、承認↔実行のダイジェスト束縛、elevated 宣言の enforcement を engine 側で担う。3軸 doc（規範=`orchestration-toolkit` / 操作=`delegate-task` / ゲート=`doc-flow-guardrail`）で運用を明文化する。監査は `child_spawned` イベントに `permission_mode` + `elevated` を additive 追記する（registry は変更しない）。
+
+4. **汎用原則（本設計から抽出・転用可能）**:
+   - **print は spawn しないので分類器を尊重できる**: 承認パッケージ生成（`--print-approval`）は子を作らないため分類器に block されず、実 spawn だけが owner ゲートに残る。安全機構を迂回せずに friction だけ除ける構図。
+   - **権限確認と一致保証は分ける**: 「owner が承認したか」（authZ＝分類器）と「承認内容と実行が一致するか」（integrity＝ダイジェスト）は別レイヤーとして設計する。セキュリティ関連の属性（elevated 宣言を含む）は**すべて整合性ダイジェストに束縛**する。**enforcement を伴わない opt-in binding は実効性がない**（「必須」と謳うゲートは機構で強制する）。
+
+## 根拠
+
+- 発火層が親の tool-call 段（spawn 実行より前）である以上、「検知＋承認要求」は engine では担えず親エージェント側の振る舞いになる。一方、**承認↔実行の一致保証は skill だけでは閉じない**（親が承認済みと違うコマンドを走らせる drift を機械照合できない）。案 (a) skill-only はこの binding gap ゆえ設計SO で否決された。behavioral のみの規律は採用不確実性も高い。
+- よって「検知は親／整形と binding と enforcement は engine 薄層」に責務を割る案 (b) を採る。案 (c) は (b) の軽量サブセットで、binding と enforcement を機構化する要件を満たさないため (b) に包含・不採用。
+- 分類器の「owner 直接アクションのみ・エージェント自己昇格不可」はハーネスの設計意図であり、ai-hub の変更対象外。ダイジェストを認可の証明に格上げしようとせず drift-guard に留めるのは、この意図を尊重するため。
+
+## 結果（影響・v0 受容限界・defer）
+
+- **効果**: elevated（bypass / 本番アクセス）子の spawn で、owner が 1 アクションで判断できる整形済みパッケージが spawn 前に出る。elevated / bypass 宣言の spawn は承認済みダイジェストを必須とし、承認を経ずに到達する経路を engine が塞ぐ。通常のローカル auto 委譲は不変。
+- **v0 の受容限界（意図的な defer・追加実装しない）**:
+  - **暗号的な承認証明を持たない**: ダイジェストは公開入力からの決定論チェックサムで、nonce / 期限 / 消費状態を持たない（エージェントによる自己発行・再利用が理論上可能）。authZ は分類器が担うため v0 では drift-guard で足りると判断。強い承認証明（generation-token 等）は defer。
+  - **実行段 friction**（本番 IAM deploy の auto-approve flag を子が自己付与できない件）は本 v0 の対象外（別フェーズ）。
+  - **durable pre-auth**（owner が一度宣言してセッション持続で elevated spawn を通す／親 bypass mode-flip）は観測上不確実ゆえ defer。
+  - **kickoff の read-time TOCTOU**（spawn 後〜子が読むまでの差し替え）は束縛しない。承認時〜spawn の drift は kickoff 内容 hash で捕捉するが、read 時点までの厳密束縛は defer。
+  - `permission_mode` は CLI 引数からの best-effort 推定（継承 config 非反映）。enforcement は明示 `--elevated` を主ゲートにするので本番判定は推定精度に依存しない。
+
+## 将来の変更トリガー
+
+以下のいずれかで本 ADR を再評価する:
+
+- 委譲子の自己発行・再利用が実運用で実害化した場合 → 暗号的承認証明（generation-token・owner 秘密の導入）を検討。
+- 実行段 friction（本番 mutation の非対話実行）を正面から解く必要が出た場合 → 別フェーズとして設計（issue #262 keep-open）。
+- kickoff 内容の read-time 差し替えが脅威として顕在化した場合 → 承認時スナップショット等の厳密束縛を検討。
+- 共同開発 / チーム運用（DI-13 と共通の将来トリガ）で信頼境界が広がった場合。

--- a/projects/orchestration-engine/docs/episodes/2026-07-17-episode-262-permission-handshake.md
+++ b/projects/orchestration-engine/docs/episodes/2026-07-17-episode-262-permission-handshake.md
@@ -1,0 +1,106 @@
+---
+id: "01KXQPRSZTVM4H55DNXCZHZT7V"
+title: "#262 v0 — spawn 段 owner 承認ハンドシェイク（binding + audit + 3軸 doc）"
+date: 2026-07-17
+type: episode
+status: draft
+related:
+  - type: derived_from
+    ref: ".oe/plan-262-permission-handshake.md"
+    reason: "plan-first の実装計画（設計SO refuted 反映後 rev.2・owner HG gate 3 通過）"
+  - type: parent_issue
+    ref: "https://github.com/stlwolf/ai-development-hub/issues/262"
+    reason: "委譲 auto-mode 子の本番 mutation friction の事象フィードバック"
+tags: [orchestration, permission, spawn, handshake, delegate, audit]
+---
+
+# #262 v0 — spawn 段 owner 承認ハンドシェイク
+
+## なぜ始まったか
+
+委譲フロー（親→子 spawn・子 auto-mode）で、親が elevated 権限（bypass / 本番アクセス）の子を spawn しようとすると、ハーネスの auto-mode classifier が親の Bash tool-call を評価して block する（安全機構として正しい）。しかし解決経路が非自明で「混乱した往復」が起きていた（issue #262 事象1）。v0 はこの spawn 段の friction を、分類器を尊重したまま **owner 承認ハンドシェイク**で構造的に解消する。
+
+設計は plan-first で進め、設計SO（`oe-refute` 3 lane exploration）が当初案（skill のみ・helper なし・記録なし）を refuted。中核 gap は「承認↔実行の binding」で、owner HG で DJ-3=(b) engine 薄層採用が決まった。発火層は observation-based spike で「親の Bash tool-call を auto-mode classifier が評価」と結論（bypass / 本番アクセス子のみ発火・通常委譲は不変）。
+
+## 設計判断（確定・plan §3 / gate 0-3）
+
+- gate 0（反証外）: v0=spawn 段 / per-spawn clean escalation。
+- DJ-3=(b): engine 薄層 `oe-delegate --print-approval`（spawn せず正規化 argv + digest を印字）+ 実 spawn 時 `--approved-digest` で digest 照合 → 承認↔実行を binding。
+- DJ-4=yes: `child_spawned.extra.permission_mode` を追記（append-only・registry 非変更）。
+- DJ-6: 3軸分離（規範=orchestration-toolkit / ゲート=doc-flow-guardrail routing 表 / 操作=delegate-task）。
+- 発火層は分類器そのもの（ハーネス設計意図）で変更対象外。print は spawn しないので block されない・実 spawn は owner ゲートのまま。
+
+## 実装ログ
+
+- worktree `feat/#262_permission-handshake` を作成（子が自作・master 起点）。
+- **`oe-delegate`**: `--print-approval`（spawn せず正規化 argv のダイジェスト + 承認パッケージを印字）/ `--approved-digest`（実 spawn 前に引数から digest を再計算して照合・不一致は exit 3）/ `--reason`（パッケージ注記）を追加。ダイジェストは workspace / label / claude 引数 / kickoff / task から決定論計算（`--reason` と ephemeral な `PARENT_TMUX_PANE` は含めない）。
+- **audit**: `oe_event_child_spawned` に任意 4th 引数 `permission_mode` を追加し、`oe-delegate` が `extract_permission_mode` で抽出して渡す。`child_spawned.extra.permission_mode` に焼き込み（append-only・registry 非変更）。schema に optional property を additive 追記。
+- **docs（3軸分離）**: 規範=`orchestration-toolkit`（なぜ owner 承認が要るか）/ 操作=`delegate-task`（print-approval → owner → approved-digest の 3 手順）/ ゲート=`doc-flow-guardrail` の routing 表に行 **S**（委譲操作軸・別軸・番号なし）。
+- **落とし穴（実装中に発見・SO 前に自己修正）**: 初版で `jq ... --args ${CLAUDE_ARGS[@]}` を使ったが、claude 引数が `--permission-mode` 等 option 形のため jq が option と誤認して失敗した。`--argjson` で 1 要素ずつ配列 append する方式へ修正。smoke test で検出。
+- **テスト**: `test_oe_delegate.sh` に [12]-[15]（print-approval 無 spawn + digest 印字 / matching digest で spawn / mismatch は exit 3 無 spawn / reason は digest 不変・task は digest 変化）。`test_event_bus.sh` に [1b]（permission_mode 焼込・省略時無し）。全 shellcheck clean。回帰: test_oe_delegate 28/0・test_event_bus 68/0・consumer（undelivered 54 / activity 70 / ack 41）0 fail。
+
+## 実装SO（gate 4）ラウンド1 — refuted → 修正
+
+`oe-review`（codex + cursor 2 lane）が **refuted**（2/2 material）。当初の binding は複数の迂回を許していた。指摘と修正:
+
+- **D1（High・両 lane）相対 workspace 未正規化 → クロス cwd で binding 迂回**: `-w .` が別 cwd から同一 digest になり、owner が承認した作業ディレクトリと別のディレクトリで elevated 子が起動できた。→ WORKSPACE を実行前に絶対化（`cd && pwd`）し digest / パッケージ / spawn を一致。実測で別 cwd の digest が異なることを確認。
+- **D2（High・cursor）空 `--approved-digest ""` で照合スキップ**: `-n` ガードが空文字を falsy 扱いし照合なしで spawn した。→ フラグ提供の有無を `APPROVED_DIGEST_SET` で追跡し、渡されたら空でも必ず照合。
+- **D3（High・codex）elevated 経路が承認なしで到達可能**: engine が「必須」と謳う elevated ゲートを機構保証していなかった。→ `--elevated` 宣言（or `bypassPermissions` 自動検知）の spawn は承認済み digest を必須にし、無ければ exit 3。通常のローカル auto 委譲は対象外（不変）。auto + 本番アクセスは engine 非検知ゆえ呼び出し側が `--elevated` を宣言する。
+- **D4（High・codex）承認表示への行注入**: workspace / kickoff が未検証で、改行入り値が承認パッケージへ偽の「承認ダイジェスト:」行を注入し owner 表示を spoof できた。→ workspace / kickoff の LF/CR を fail-fast 拒否。
+- **D5（Med・codex）audit が elevated auto と通常 auto を区別できない**: permission_mode だけでは両者 auto で同じ。→ `child_spawned.extra.elevated` を追加（schema additive）。
+- **付随**: kickoff は path だけでなく**内容 hash** も digest に含め、承認後の内容差し替え（TOCTOU）を捕まえる。
+
+全修正後: shellcheck clean・test_oe_delegate 38/0（D1-D4 の反証テスト追加）・test_event_bus 71/0（elevated 焼込）・consumer 回帰 0 fail。
+
+## 実装SO（gate 4）ラウンド2 — refuted → 具象修正 + 限界の明文化
+
+再 `oe-review` が **refuted**（2/2）。核心の具象欠陥 1 件 + 固有の v0 限界。
+
+- **R2 具象（両 lane）: elevated が digest に未束縛**。非 elevated の承認 digest に後から `--elevated` を付けて escalation（逆に downgrade）できた。→ `compute_spawn_digest` に elevated 宣言を束縛。反証テスト [22]（escalation/downgrade とも exit 3）。
+- **R2 具象（codex）: skill の本番アクセス手順例に `--elevated` が無い** → 例どおりだと D3 強制に到達しない。→ delegate-task 例に `--elevated` を追加。
+- **R2 具象（codex）: LF/CR のみ検証で ESC 等の制御文字で承認表示 spoof 可**。→ workspace / kickoff を制御文字全般で fail-fast 拒否 + パッケージ表示値を `_strip_cntrl` でサニタイズ。反証テスト [21]（ESC workspace → exit 2）。
+
+### 明文化した v0 の限界（plan §8 の owner 承認済み defer と整合・SO で再浮上したが追加実装しない）
+
+- **ダイジェストは owner 承認の暗号的証明ではない**（nonce / 期限 / 消費状態なし・自己発行/再利用が理論上可能）。**authZ の実体はハーネスの分類器**（agent は elevated spawn の block を自己解除できない）で、ダイジェストは「owner が見た内容 = 実行内容」を保証する drift-guard。別レイヤーであり、この設計の前提（分類器を迂回しない）そのもの。
+- kickoff の read-time TOCTOU（spawn 後〜子読取までの差し替え）は束縛しない（承認時〜spawn の drift は内容 hash で捕捉）。
+- `permission_mode` は CLI 引数からの best-effort 推定（継承 config 非反映）。enforcement は明示 `--elevated` を主ゲートにする。
+
+これらは plan §8 で defer 済みの範囲。SO が「material」と再提起したが、追加実装は v0 スコープ外＝owner のマージ判断に surface する（gate 4 は 2 ラウンドで具象を潰し、残りは disclose）。
+
+全修正後: shellcheck clean・test_oe_delegate 43/0・test_event_bus 71/0・consumer 回帰 0 fail。
+
+## フィードバック（closure・heavy tier・マージ前・達成=v0 core 達成 + 限界 disclose）
+
+### closure gate
+
+- **Context / なぜ**: 冒頭「なぜ始まったか」に自己完結（委譲子 spawn 段の分類器 friction を分類器尊重のまま解消）。
+- **次の消費者**:
+  - owner（PR #269 のマージ判断＝v0 の受容限界を認めるか / 暗号的承認証明を pull-in するか）。
+  - elevated 子を委譲する将来の統括（`delegate-task` の承認ハンドシェイク節を読んで `--elevated` + print-approval を使う）。
+  - engine 保守者（durable pre-auth / generation-token を実装する後続フェーズ・#262 keep-open）。
+- **follow-up routing**（全て #262 keep-open へ）: 実行段 friction（auto-approve flag 自己付与）/ durable pre-auth（親 bypass mode-flip）/ 暗号的承認証明（nonce・期限・消費状態）/ kickoff read-time TOCTOU の厳密束縛。いずれも plan §8 で defer 済み・v0 スコープ外と宣言。
+  - **追わない（宣言）**: `permission_mode` の継承 config 非反映は follow-up にしない。enforcement は明示 `--elevated` を主ゲートにするので本番判定は mode 推定精度に依存せず、推定は audit の補助情報どまり（load-bearing でない）。
+- **status 確定**: draft → stable（v0 core 達成。PR #269 レビュー中・マージは owner HG）。
+- **evidence anchor**: 設計SO（`oe-refute` audit_id `20260717055324WKAECVQX64RG`）・実装SO R1（`202607170947064J99GK77YTMR`）/ R2（`20260717100600AKC452WSC83N`）。verdict/主要指摘は本 episode 本文へ転記済み（output_dir は tmp/ で揮発するためパス依存にしない）。
+
+### 出力型
+
+- **事実・失敗**（**R1/R2 詳細節〔上〕が全件の正本**。本要約は圧縮）: 初版で `jq --args` が claude option を誤解して digest 計算失敗 → smoke で自己検出し `--argjson` 逐次 append へ。実装SO は R1/R2 とも refuted。潰した具象は binding 迂回系（相対 ws / 空 digest / elevated 未束縛 / 表示注入 / 承認なし到達）に加え、**D5 audit の elevated/通常 auto 非区別・kickoff 内容の digest 未束縛・公式手順の `--elevated` 欠落**（要約に圧縮しきれない別カテゴリ。詳細節に全件）。
+- **決定と根拠**: engine-vs-skill は skill-only（設計SO で refuted）を棄却し engine 薄層 binding を採用。核心の layering＝**authZ はハーネス分類器・digest は drift-guard**（別レイヤー）。elevated は明示 `--elevated`（engine が本番アクセスを検知不能なため）+ bypass 自動検知で enforce。
+- **わかったこと**: 発火層 = auto-mode classifier が親の Bash tool-call を評価（spike 結論）。trigger は auto そのものでなく **bypass / 本番アクセス**。
+- **原則（pattern / anti-pattern）**:
+  - Pattern: owner 向けセキュリティ表示は制御文字を拒否/サニタイズし、**セキュリティ関連属性（elevated 含む）を全て整合性 digest に束縛**する（一部でも外すと後付け改ざんの穴）。
+  - Anti-pattern: enforcement 無しの opt-in binding は theater（elevated が承認を経ず到達可能）。「必須」と謳うゲートは機構で強制する。
+- **行動変更**: 委譲統括は elevated（bypass / 本番アクセス）子を spawn する前に承認ハンドシェイクを通す。トリガ=elevated 子 spawn・機構=`oe-delegate --print-approval` / `--approved-digest`・着地=`delegate-task` skill 節 + `doc-flow-guardrail` routing 行 S。
+- **蒸留シグナル**: **ADR 昇格済み**（§13・マージ前）→ `projects/orchestration-engine/docs/decisions/2026-07-17-decision-spawn-permission-handshake.md`。durable な決定 (a) 発火層の結論 (b) authZ↔binding layering (c) engine 薄層採用と却下案 (d) 汎用原則 (e) v0 受容限界と defer を収録。本 episode は実装・SO 反証履歴の**実行詳細 pointer**（ADR は決定に絞り §13.2 で重複回避）。
+- **残課題**: 上記 follow-up routing（全て #262 keep-open）。
+
+### Step 4（外部チェック・実施済み）
+
+`so-compare`（codex + claude・出力 `tmp/so-20260717-192148/`）で closure 品質の focused check を実施。claude は 4 観点すべて合格判定。codex が 2 点指摘し、いずれも反映済み:
+
+- 「事実・失敗」要約が D5 / kickoff 内容束縛 / 手順 `--elevated` 欠落を圧縮していた → 要約に別カテゴリとして明記 + 「R1/R2 詳細節が全件の正本」と宣言。
+- `permission_mode` 継承 config 非反映が follow-up に無かった → 「追わない」を理由付きで明示（enforcement は `--elevated` 主ゲートで mode 推定非依存）。
+
+両者の一致点: 揮発パス放置なし（audit_id で anchor）・back-propagation は 3軸 doc へ反映済み・ADR 昇格候補は握りつぶさず §13 へ回付。省略は隠蔽性のものではないと判定。

--- a/projects/orchestration-engine/lib/event-bus.sh
+++ b/projects/orchestration-engine/lib/event-bus.sh
@@ -111,20 +111,29 @@ oe_event_emit() {
   return 0
 }
 
-# oe_event_child_spawned <parent_pane> <child_pane> [child_label]
+# oe_event_child_spawned <parent_pane> <child_pane> [child_label] [permission_mode] [elevated]
 #   oe-delegate が子 spawn + registry 登録の直後に呼ぶ。role は構築上 parent/child で確定。
+#   permission_mode / elevated（任意・#262）を渡すと extra に焼き込み、elevated spawn を通常
+#   spawn と事後区別できるようにする（append-only ログへの additive 追記・registry は変更しない）。
+#   permission_mode が auto でも elevated=true の有無で区別できる（実装SO D5）。起動コマンド自体は
+#   出さない（schema 方針の維持）。両方省略時は従来どおり extra={}。
 oe_event_child_spawned() {
   [[ "${OE_EVENT_LOG:-1}" != "0" ]] || return 0
   command -v jq >/dev/null 2>&1 || return 0
-  local pp="${1:-}" cp="${2:-}" clabel="${3:-}"
-  local plabel clabel_r
+  local pp="${1:-}" cp="${2:-}" clabel="${3:-}" pmode="${4:-}" elevated="${5:-}"
+  local plabel clabel_r extra="{}"
   # role/parent は構築上 parent/child で確定するため捨てる（label だけ使う）。
   IFS=$'\037' read -r _ plabel _ < <(_oe_event_ident "$pp") || true
   if [[ -z "$clabel" ]]; then
     IFS=$'\037' read -r _ clabel_r _ < <(_oe_event_ident "$cp") || true
     clabel="$clabel_r"
   fi
-  oe_event_emit "child_spawned" "$pp" "parent" "$plabel" "$cp" "child" "$clabel" "{}"
+  # permission_mode / elevated が来たら extra へ（encode 失敗は best-effort で extra={} に degrade）。
+  if [[ -n "$pmode" || -n "$elevated" ]]; then
+    extra="$(jq -cn --arg pm "$pmode" --argjson el "$([[ "$elevated" == "true" ]] && echo true || echo false)" \
+      '({} + (if $pm != "" then {permission_mode:$pm} else {} end) + {elevated:$el})' 2>/dev/null)" || extra="{}"
+  fi
+  oe_event_emit "child_spawned" "$pp" "parent" "$plabel" "$cp" "child" "$clabel" "$extra"
 }
 
 # oe_event_message_sent <from_pane> <to_pane> <preview-text> [delivery_signal]

--- a/projects/orchestration-engine/schemas/oe-events.schema.json
+++ b/projects/orchestration-engine/schemas/oe-events.schema.json
@@ -29,6 +29,14 @@
       "type": "string",
       "description": "message_sent のみ: payload 先頭 ~100 codepoint の切り詰め（情報過多回避・行を PIPE_BUF 内に保つ）。spawn の起動コマンドは出さない。"
     },
+    "permission_mode": {
+      "type": "string",
+      "description": "child_spawned のみ・任意（#262）: 子の実効 permission mode（auto / bypassPermissions / default 等）。elevated spawn を通常 spawn と事後区別するための additive フィールド。起動コマンド自体は出さない（preview と同方針）。省略時（従来イベント）は不明。"
+    },
+    "elevated": {
+      "type": "boolean",
+      "description": "child_spawned のみ・任意（#262）: この spawn が elevated（--elevated 宣言 or bypassPermissions）として owner 承認ハンドシェイクを通ったか。permission_mode が auto でも本フィールドで elevated 宣言の有無を事後区別できる。省略時（従来イベント）は不明。"
+    },
     "delivery_signal": {
       "type": "string",
       "description": "message_sent のみ: 配送シグナル。suspected_miss=finalize が未着候補を観測 / none=未着シグナル無し（delivered の確証ではない）。#144 信号を読むのみで reliability の再実装はしない。",

--- a/projects/orchestration-engine/tests/test_event_bus.sh
+++ b/projects/orchestration-engine/tests/test_event_bus.sh
@@ -57,6 +57,19 @@ ck "to.role"     "child"          "$(last | jq -r .to.role)"
 ck "to.label"    "#206 impl"      "$(last | jq -r .to.label)"
 ck "ts present"  "true"           "$(last | jq -r '(.ts|type=="string") and (.ts|length>0)')"
 
+echo "[1b] child_spawned: permission_mode / elevated を extra に焼き込む・省略時は無し（#262）"
+reset_events
+oe_event_child_spawned "%59" "%66" "#206 impl" "auto" "true"
+ck "permission_mode=auto"          "auto"  "$(last | jq -r '.permission_mode // "MISSING"')"
+ck "elevated=true"                 "true"  "$(last | jq -r '.elevated')"
+reset_events
+oe_event_child_spawned "%59" "%66" "#206 impl" "auto"
+ck "elevated 省略時は false"        "false" "$(last | jq -r '.elevated')"
+reset_events
+oe_event_child_spawned "%59" "%66" "#206 impl"
+ck "pmode/elevated 両省略で pmode 無し" "null" "$(last | jq -r '.permission_mode')"
+ck "両省略で elevated も無し"           "null" "$(last | jq -r '.elevated')"
+
 echo "[2] message_sent report（子→親）: 直接 parent リンクで from=child/to=parent に確定"
 reset_events
 oe_event_message_sent "%66" "%59" "実装完了しました" "none"

--- a/projects/orchestration-engine/tests/test_oe_delegate.sh
+++ b/projects/orchestration-engine/tests/test_oe_delegate.sh
@@ -189,5 +189,89 @@ bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --brief >"${_TMP_DIR}/stdo
 ck "missing brief value rc=2" "2" "$rc"
 ck "missing brief error names --brief" "yes" "$(grep -qF -- '--brief requires a value' "${_TMP_DIR}/stderr.log" && echo yes || echo no)"
 
+echo "[16] --print-approval prints a digest and does NOT spawn (#262)"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --label "#262" --claude-arg --permission-mode --claude-arg auto --reason "本番隣接 deploy" --print-approval "elevated task"
+ck "print-approval does not spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+ck "print-approval prints 16-hex digest" "yes" "$(grep -qE '承認ダイジェスト: [0-9a-f]{16}' "$_TMP_DIR/stdout.log" && echo yes || echo no)"
+ck "print-approval echoes --approved-digest" "yes" "$(grep -q -- '--approved-digest' "$_TMP_DIR/stdout.log" && echo yes || echo no)"
+
+echo "[17] --approved-digest matching -> spawns; binding holds (#262)"
+digest="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --label "#262" --claude-arg --permission-mode --claude-arg auto --print-approval "bind task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --label "#262" --claude-arg --permission-mode --claude-arg auto --approved-digest "$digest" "bind task"
+ck "matching digest spawns child" "PARENT_TMUX_PANE='%1' claude '--permission-mode' 'auto'" "$(cat "$_TMP_DIR/logs/split-command.log")"
+
+echo "[18] --approved-digest mismatch -> rc=3 and no spawn (#262)"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --label "#262" --claude-arg --permission-mode --claude-arg auto --approved-digest "deadbeefdeadbeef" "bind task" >"${_TMP_DIR}/stdout.log" 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "mismatch rc=3" "3" "$rc"
+ck "mismatch does not spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[19] --reason is excluded from the digest (annotation, not execution) (#262)"
+d1="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg auto --reason "r1" --print-approval "same task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+d2="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg auto --reason "r2 different" --print-approval "same task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+ck "reason change -> digest stable" "yes" "$( [[ -n "$d1" && "$d1" == "$d2" ]] && echo yes || echo no )"
+d3="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg auto --print-approval "DIFFERENT task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+ck "task change -> digest differs" "yes" "$( [[ "$d1" != "$d3" ]] && echo yes || echo no )"
+
+echo "[20] relative --workspace is normalized to absolute in the package (#262 D1)"
+reset_logs
+expected_ws="$(cd "$_TMP_DIR/ws" && pwd)"
+absout="$(cd "$_TMP_DIR/ws" && bash "$PROJECT_DIR/bin/oe-delegate" -w . --print-approval "abs task" 2>/dev/null)"
+ck "relative -w shown as absolute" "yes" "$(printf '%s\n' "$absout" | grep -qF "作業ディレクトリ: ${expected_ws}" && echo yes || echo no)"
+
+echo "[21] empty --approved-digest still verifies (no skip) -> refuse (#262 D2)"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg auto --approved-digest "" "t" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "empty digest rc=3" "3" "$rc"
+ck "empty digest no spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[22] --elevated without --approved-digest is refused (#262 D3)"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --elevated --claude-arg --permission-mode --claude-arg auto "t" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "elevated no-digest rc=3" "3" "$rc"
+ck "elevated no-digest no spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[23] bypassPermissions is treated as elevated -> requires approval (#262 D3)"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg bypassPermissions "t" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "bypass no-digest rc=3" "3" "$rc"
+ck "bypass no-digest no spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+
+echo "[24] --elevated with matching digest spawns (#262 D3 positive)"
+edig="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --elevated --claude-arg --permission-mode --claude-arg auto --print-approval "el task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+reset_logs
+run_delegate -w "$_TMP_DIR/ws" --elevated --claude-arg --permission-mode --claude-arg auto --approved-digest "$edig" "el task"
+ck "elevated + matching digest spawns" "PARENT_TMUX_PANE='%1' claude '--permission-mode' 'auto'" "$(cat "$_TMP_DIR/logs/split-command.log")"
+
+echo "[25] --workspace with control chars is rejected before spawn (#262 D4/R2)"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w $'/tmp\nfake' --print-approval "t" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "newline workspace rc=2" "2" "$rc"
+ck "newline workspace no spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w $'/tmp\x1b[2Kfake' --print-approval "t" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "ESC workspace rc=2" "2" "$rc"
+
+echo "[26] --elevated is bound in the digest — no escalation/downgrade via flag tamper (#262 R2)"
+nedig="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg auto --print-approval "esc task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --elevated --claude-arg --permission-mode --claude-arg auto --approved-digest "$nedig" "esc task" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "escalation (add --elevated) rc=3" "3" "$rc"
+ck "escalation no spawn" "no" "$( [[ -e "$_TMP_DIR/logs/split-command.log" ]] && echo yes || echo no )"
+eldig="$(bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --elevated --claude-arg --permission-mode --claude-arg auto --print-approval "esc task" 2>/dev/null | sed -n 's/.*承認ダイジェスト: //p' | tr -d ' ')"
+reset_logs
+rc=0
+bash "$PROJECT_DIR/bin/oe-delegate" -w "$_TMP_DIR/ws" --claude-arg --permission-mode --claude-arg auto --approved-digest "$eldig" "esc task" >/dev/null 2>"${_TMP_DIR}/stderr.log" || rc=$?
+ck "downgrade (drop --elevated) rc=3" "3" "$rc"
+ck "elevated toggles digest" "yes" "$( [[ "$nedig" != "$eldig" ]] && echo yes || echo no )"
+
 echo "=== RESULT: pass=${PASS} fail=${FAIL} ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## 目的

委譲フロー（親→子 spawn・子 auto-mode）で、親が **elevated**（`bypassPermissions` / 本番・機微アクセス）子を spawn する段で、ハーネスの auto-mode classifier が親の tool-call を block する friction（Refs #262 の「混乱した往復」）を、**分類器を尊重したまま** owner 承認ハンドシェイクで構造的に解消する v0。

発火層は observation-based spike で「親の Bash tool-call を auto-mode classifier が評価する」と結論（bypass / 本番アクセス子のみ block・通常のローカル auto 委譲は通る）。

## 変更内容

- **`oe-delegate`**
  - `--print-approval`: spawn せず、正規化 argv のダイジェスト + owner 向け承認パッケージ（要求権限モード / elevated 宣言 / 対象子 / 理由 / 作業ディレクトリ / blast radius / ダイジェスト / 実 spawn コマンド）を印字。print は子を作らないので分類器に block されない。
  - `--approved-digest <digest>`: 実 spawn 前に引数からダイジェストを再計算して照合し、承認後にコマンドが変わっていれば spawn を拒否（exit 3）＝**承認↔実行の binding**。渡されたら空文字でも必ず照合する。
  - `--elevated`: 子を elevated と宣言。宣言（or `bypassPermissions`）した spawn は承認済みダイジェストを必須にする（無ければ exit 3）。elevated 宣言自体もダイジェストに束縛（後付け escalation / downgrade を封鎖）。
  - `--reason <text>`: 承認パッケージの注記（ダイジェストには含めない）。
  - ダイジェストは workspace **絶対パス** / label / claude 引数 / kickoff 絶対パス + **内容 hash** / task / elevated 宣言 から決定論計算。workspace / kickoff は制御文字を fail-fast 拒否、表示値はサニタイズ（承認表示への注入・spoof を封鎖）。
- **audit**: `child_spawned` イベントに `permission_mode` + `elevated` を追記（append-only ログへ additive・registry 非変更）。auto でも elevated 宣言の有無で通常 spawn と事後区別できる。schema に optional property を additive 追加。
- **docs（3軸分離）**: 規範=`orchestration-toolkit` / 操作=`delegate-task`（print-approval → owner → approved-digest の 3 手順）/ ゲート=`doc-flow-guardrail` の routing 表 行 S（委譲操作軸・別軸）。

## 設計・ゲート

- plan-first（設計SO refuted 反映後 rev.2）→ owner HG（gate 3）通過後に実装。発火層 spike で DJ-3=(b) engine 薄層 / DJ-4=audit 追記 / DJ-6=3軸分離を確定。
- 実装SO（gate 4・`oe-review` 2 lane）を **2 ラウンド**実施。いずれも refuted で、検出された具象欠陥をすべて修正:
  - R1: 相対 workspace 未正規化の binding 迂回 / 空 `--approved-digest` 照合スキップ / elevated 経路が承認なしで到達可能 / 承認表示への改行注入 / audit の elevated 非区別。
  - R2: elevated 宣言が digest 未束縛（後付け escalation）/ 手順例の `--elevated` 欠落 / ESC 等制御文字の表示 spoof。
- **残る SO 指摘は v0 の受容限界（下記）** で、plan §8 で defer 済みの範囲。追加実装せず disclose し、owner のマージ判断に委ねる。

## v0 の受容限界（disclose・plan §8 の defer と整合）

- **ダイジェストは owner 承認の暗号的証明ではない**（nonce / 期限 / 消費状態を持たない・自己発行や再利用が理論上可能）。**authZ の実体はハーネスの auto-mode classifier**（agent は elevated spawn の block を自己解除できない）で、ダイジェストは「owner が見た内容 = 実行内容」を保証する drift-guard。両者は別レイヤーであり、分類器を迂回しないという本設計の前提そのもの。
- kickoff の read-time TOCTOU（spawn 後〜子が読むまでの差し替え）は束縛しない（承認時〜spawn の drift は内容 hash で捕捉）。
- `permission_mode` は CLI 引数からの best-effort 推定（継承 config 非反映）。enforcement は明示 `--elevated` を主ゲートにするので本番ケースは mode 推定に依存しない。

## テスト

- `test_oe_delegate.sh` 43/0: print-approval 無 spawn + digest 印字 / matching digest で spawn / mismatch exit 3 / reason は digest 不変・task は変化 / relative -w の絶対化 / 空 digest 拒否 / --elevated・bypass の承認必須 / 制御文字 workspace 拒否 / elevated 宣言の digest 束縛（escalation・downgrade 拒否）。
- `test_event_bus.sh` 71/0: `child_spawned.extra` の permission_mode + elevated 焼込・省略時無し。
- 回帰: consumer（undelivered 54 / activity 70 / ack 41）0 fail・全 shellcheck clean。

## 影響範囲 / 不変条件

- **通常委譲は不変**: 非 elevated / 通常 auto 委譲はハンドシェイクを掛けず従来どおり（子コマンド構築・既存フラグ無変更、既存テスト pass）。
- **分類器は変えない / 迂回しない**: print は spawn しない・実 spawn は owner ゲートのまま。
- registry スキーマは非変更（audit は event-bus の additive フィールドのみ）。

## scope 外 / follow-up

- 実行段 friction（本番 IAM deploy の auto-approve flag 自己付与）・durable pre-auth（親 bypass mode-flip）・暗号的承認証明（generation-token）・read-time TOCTOU の厳密束縛は別フェーズ（Refs #262 keep-open）。

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
