### PR TITLE
feat(oe): statusLine にプラン消費%（7d 常時・5h 閾値超え時）を表示

### DIFF
--- a/canonical/claude/statusline/statusline-oe-heartbeat.sh
+++ b/canonical/claude/statusline/statusline-oe-heartbeat.sh
@@ -80,10 +80,38 @@ if [[ -n "${OE_HEARTBEAT_WRAP_CMD:-}" ]]; then
   # wrap 失敗時は最小行へフォールバック（表示を空にしない）。
 fi
 
-# 最小 statusLine（model + context%）。
+# 最小 statusLine（model + context% [+ プラン消費% 7d/5h]）。
+#
+# 人間が /usage で見ているプラン消費率を statusLine に載せる（#276）。stdin JSON の
+# rate_limits.{seven_day,five_hour}（used_percentage / resets_at）を使う。これらは
+# Pro/Max 等のサブスク認証時・初回 API 応答後のみ載る（API 利用時などは欠落）。
+#   - 7d（週次）  : 常時表示・パーセントのみ。context% の右隣。
+#   - 5h（5時間枠）: used_percentage >= 閾値（既定 80・OE_STATUSLINE_5H_THRESHOLD で上書き可）の
+#                    ときだけ、7d の右にリセット残り時間つきで表示（出るときは最右）。
+# 欠落・非数値・rate_limits 非提供では当該セグメントを黙って出さない（表示は壊さない）。
+# context% は既存どおり "N% ctx" を連続文字列で保つ（表示アサートは部分一致）。
 if command -v jq >/dev/null 2>&1; then
+  # プラン消費% セグメント用パラメータ（既定はインライン宣言・env で上書き可: lib idiom）。
+  _now="$(date +%s 2>/dev/null)"; [[ "$_now" =~ ^[0-9]+$ ]] || _now=0
+  _th="${OE_STATUSLINE_5H_THRESHOLD:-80}"; [[ "$_th" =~ ^[0-9]+([.][0-9]+)?$ ]] || _th=80
   line="$(printf '%s' "$input" \
-    | jq -r '"[\(.model.display_name // "?")] \(.context_window.used_percentage // 0)% ctx"' 2>/dev/null)" || line=""
+    | jq -r --argjson now "$_now" --argjson th "$_th" '
+        def n($x): ($x | if type=="number" then . else (tonumber? // null) end);
+        def remain($resets):
+          (($resets - $now) | floor) as $d
+          | if $d <= 0 then "0m"
+            elif (($d / 3600) | floor) > 0 then "\(($d/3600)|floor)h\((($d%3600)/60)|floor)m"
+            else "\(($d/60)|floor)m" end;
+        ("[\(.model.display_name // "?")] \(.context_window.used_percentage // 0)% ctx") as $base
+        | (n(.rate_limits.seven_day.used_percentage?))  as $d7
+        | (n(.rate_limits.five_hour.used_percentage?))  as $d5
+        | (n(.rate_limits.five_hour.resets_at?))        as $r5
+        | ($base
+           + (if $d7 != null then " · 7d \($d7|round)%" else "" end)
+           + (if ($d5 != null and $d5 >= $th)
+                then " · 5h \($d5|round)%" + (if $r5 != null then " (\(remain($r5)))" else "" end)
+                else "" end))
+      ' 2>/dev/null)" || line=""
   if [[ -n "$line" ]]; then
     printf '%s\n' "$line"
   else

--- a/canonical/claude/statusline/statusline-oe-heartbeat.sh
+++ b/canonical/claude/statusline/statusline-oe-heartbeat.sh
@@ -92,7 +92,8 @@ fi
 # context% は既存どおり "N% ctx" を連続文字列で保つ（表示アサートは部分一致）。
 if command -v jq >/dev/null 2>&1; then
   # プラン消費% セグメント用パラメータ（既定はインライン宣言・env で上書き可: lib idiom）。
-  _now="$(date +%s 2>/dev/null)"; [[ "$_now" =~ ^[0-9]+$ ]] || _now=0
+  # now が取れないと残り時間が誤値になる。取得失敗時は _now=null を渡し、jq 側で時間表示を抑止する。
+  _now="$(date +%s 2>/dev/null)"; [[ "$_now" =~ ^[0-9]+$ ]] || _now=null
   _th="${OE_STATUSLINE_5H_THRESHOLD:-80}"; [[ "$_th" =~ ^[0-9]+([.][0-9]+)?$ ]] || _th=80
   line="$(printf '%s' "$input" \
     | jq -r --argjson now "$_now" --argjson th "$_th" '
@@ -102,6 +103,9 @@ if command -v jq >/dev/null 2>&1; then
           | if $d <= 0 then "0m"
             elif (($d / 3600) | floor) > 0 then "\(($d/3600)|floor)h\((($d%3600)/60)|floor)m"
             else "\(($d/60)|floor)m" end;
+        # resets_at と now が両方揃うときだけ残り時間を出す（now 欠落時の誤表示を回避）。
+        def reset_suffix($resets):
+          if ($resets != null and $now != null) then " (\(remain($resets)))" else "" end;
         ("[\(.model.display_name // "?")] \(.context_window.used_percentage // 0)% ctx") as $base
         | (n(.rate_limits.seven_day.used_percentage?))  as $d7
         | (n(.rate_limits.five_hour.used_percentage?))  as $d5
@@ -109,7 +113,7 @@ if command -v jq >/dev/null 2>&1; then
         | ($base
            + (if $d7 != null then " · 7d \($d7|round)%" else "" end)
            + (if ($d5 != null and $d5 >= $th)
-                then " · 5h \($d5|round)%" + (if $r5 != null then " (\(remain($r5)))" else "" end)
+                then " · 5h \($d5|round)%" + reset_suffix($r5)
                 else "" end))
       ' 2>/dev/null)" || line=""
   if [[ -n "$line" ]]; then

--- a/projects/orchestration-engine/tests/test_oe_heartbeat_producer.sh
+++ b/projects/orchestration-engine/tests/test_oe_heartbeat_producer.sh
@@ -171,6 +171,16 @@ ckc "閾値 env 上書きで 5h 表示" "$OUT" "· 5h 50%"
 ck  "sidecar キーは従来どおり" "context_pct pane ts" "$(field 01R2 'keys_unsorted | sort | join(" ")')"
 ck  "sidecar context_pct=34（rate_limits 混入なし）" "34" "$(field 01R2 '.context_pct')"
 
+echo "[14] now 取得不可（date 失敗）→ 5h% は出すが残り時間は抑止（Copilot 指摘・誤値回避）"
+mkhb f14
+# date が失敗する stub を PATH 先頭に置く（jq/mktemp 等は元 PATH で解決される）。
+STUB="$_TMP_DIR/stub-bin"; mkdir -p "$STUB"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB/date"; chmod +x "$STUB/date"
+OUT="$(printf '%s' "{\"session_id\":\"01R6\",\"model\":{\"display_name\":\"Opus 4.8\"},\"context_window\":{\"used_percentage\":34},\"rate_limits\":{\"five_hour\":{\"used_percentage\":83,\"resets_at\":9999999999}}}" \
+  | env OE_HEARTBEAT_DIR="$HBDIR" TMUX_PANE='%1' PATH="$STUB:$PATH" bash "$PRODUCER")"
+ckc "date 失敗でも 5h% は出す" "$OUT" "· 5h 83%"
+ncc "now 欠落 → 残り時間の括弧は出さない" "$OUT" "5h 83% ("
+
 # ============================================================================
 echo ""
 echo "=== RESULT: PASS=$PASS FAIL=$FAIL ==="

--- a/projects/orchestration-engine/tests/test_oe_heartbeat_producer.sh
+++ b/projects/orchestration-engine/tests/test_oe_heartbeat_producer.sh
@@ -27,6 +27,7 @@ PASS=0; FAIL=0
 ck()  { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (want=[$2] got=[$3])"; FAIL=$((FAIL+1)); fi; }
 ckc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (missing [$3] in [$2])"; FAIL=$((FAIL+1)); fi; }
 ncc() { if printf '%s' "$2" | grep -qF -- "$3"; then echo "  FAIL: $1 (unexpected [$3])"; FAIL=$((FAIL+1)); else echo "  PASS: $1"; PASS=$((PASS+1)); fi; }
+ckr() { if printf '%s' "$2" | grep -qE -- "$3"; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (no match /$3/ in [$2])"; FAIL=$((FAIL+1)); fi; }
 
 # 隔離した sidecar dir を都度用意
 HBDIR=""
@@ -128,6 +129,47 @@ OUT="$(printf '%s' '{"session_id":"01WFAIL","model":{"display_name":"Opus"},"con
 ck  "wrap 失敗でも exit 0" "0" "$rc"
 ckc "最小行へフォールバック" "$OUT" "3% ctx"
 ck  "wrap 失敗でも beat は書く" "3" "$(field 01WFAIL '.context_pct')"
+
+echo "[13] プラン消費%（#276）: 7d 常時・5h は閾値超え時のみ・7d の右（最右）・リセット残り時間つき"
+mkhb f13
+_now=$(date +%s); _reset=$((_now + 6420))  # +1h47m
+
+# rate_limits 無し → セグメント無し（従来どおり）
+OUT="$(run '{"session_id":"01R0","model":{"display_name":"Opus 4.8"},"context_window":{"used_percentage":34}}' '%1')"
+ckc "base: context% は出る" "$OUT" "34% ctx"
+ncc "rate_limits 無し → 7d 出さない" "$OUT" "7d"
+ncc "rate_limits 無し → 5h 出さない" "$OUT" "5h"
+
+# 7d あり・5h < 80 → 7d のみ（5h 非表示）
+OUT="$(run '{"session_id":"01R1","model":{"display_name":"Opus 4.8"},"context_window":{"used_percentage":34},"rate_limits":{"seven_day":{"used_percentage":41},"five_hour":{"used_percentage":50}}}' '%1')"
+ckc "7d は常時表示" "$OUT" "· 7d 41%"
+ncc "5h < 80 → 非表示" "$OUT" "5h"
+
+# 5h >= 80 + resets_at → 7d の右に 5h・残り時間つき・最右
+OUT="$(run "{\"session_id\":\"01R2\",\"model\":{\"display_name\":\"Opus 4.8\"},\"context_window\":{\"used_percentage\":34},\"rate_limits\":{\"seven_day\":{\"used_percentage\":41},\"five_hour\":{\"used_percentage\":83,\"resets_at\":$_reset}}}" '%1')"
+ckc "5h >= 80 で表示" "$OUT" "· 5h 83%"
+ckc "順序: 7d の右に 5h（最右）" "$OUT" "· 7d 41% · 5h 83%"
+ckr "5h にリセット残り時間 (XhYm)" "$OUT" '· 5h 83% \([0-9hm]+\)'
+
+# 5h >= 80 だが resets_at 欠落 → % のみ・時間なし（graceful）
+OUT="$(run '{"session_id":"01R3","model":{"display_name":"Opus 4.8"},"context_window":{"used_percentage":34},"rate_limits":{"five_hour":{"used_percentage":83}}}' '%1')"
+ckc "resets_at 欠落でも 5h% は出す" "$OUT" "· 5h 83%"
+ncc "resets_at 欠落 → 括弧の時間は出さない" "$OUT" "5h 83% ("
+
+# float % は round（41.6→42・82.4→82）context% は従来どおり保持
+OUT="$(run "{\"session_id\":\"01R4\",\"model\":{\"display_name\":\"Opus 4.8\"},\"context_window\":{\"used_percentage\":23.5},\"rate_limits\":{\"seven_day\":{\"used_percentage\":41.6},\"five_hour\":{\"used_percentage\":82.4,\"resets_at\":$_reset}}}" '%1')"
+ckc "context% は保持（23.5）" "$OUT" "23.5% ctx"
+ckc "7d 41.6 → 42（round）" "$OUT" "· 7d 42%"
+ckc "5h 82.4 → 82（round）" "$OUT" "· 5h 82%"
+
+# 閾値 env 上書き（OE_STATUSLINE_5H_THRESHOLD=40 で 5h 50% を出す）
+OUT="$(printf '%s' "{\"session_id\":\"01R5\",\"model\":{\"display_name\":\"Opus 4.8\"},\"context_window\":{\"used_percentage\":34},\"rate_limits\":{\"five_hour\":{\"used_percentage\":50,\"resets_at\":$_reset}}}" \
+  | env OE_HEARTBEAT_DIR="$HBDIR" TMUX_PANE='%1' OE_STATUSLINE_5H_THRESHOLD=40 bash "$PRODUCER")"
+ckc "閾値 env 上書きで 5h 表示" "$OUT" "· 5h 50%"
+
+# rate_limits があっても sidecar 契約は不変（{ts,context_pct,pane}・context_pct のみ）
+ck  "sidecar キーは従来どおり" "context_pct pane ts" "$(field 01R2 'keys_unsorted | sort | join(" ")')"
+ck  "sidecar context_pct=34（rate_limits 混入なし）" "34" "$(field 01R2 '.context_pct')"
 
 # ============================================================================
 echo ""


### PR DESCRIPTION
## 目的

現在の statusLine（`canonical/claude/statusline/statusline-oe-heartbeat.sh`）はモデル名と context 使用率を表示している（主にオーケストレーション側が把握するための情報。[#239](https://github.com/stlwolf/ai-development-hub/issues/239) の heartbeat producer 由来）。

人間が `/usage` を都度叩いて確認しているプラン消費率（5時間枠・週次）を statusLine に載せ、一目で確認できるようにする。

Claude Code の statusLine には `rate_limits.five_hour` / `rate_limits.seven_day`（`used_percentage` と `resets_at`）が渡ってくる（[Available data](https://code.claude.com/docs/en/statusline.md#available-data)）。この既存フィールドを表示に足す。

## 変更内容

- `canonical/claude/statusline/statusline-oe-heartbeat.sh` の**最小表示行のみ**拡張:
  - 7d（週次）: 常時表示・パーセントのみ。context% の右隣。
  - 5h（5時間枠）: `used_percentage >= 閾値`（既定 80・`OE_STATUSLINE_5H_THRESHOLD` で上書き可）のときだけ、7d の右にリセット残り時間つきで表示。出るときは最右。
  - 欠落・非数値・rate_limits 非提供（API 利用時など）では当該セグメントを黙って出さない。`N% ctx` は連続文字列のまま保持。
- `projects/orchestration-engine/tests/test_oe_heartbeat_producer.sh` に fixture 節（`[13]`）を追加。

```
通常（5h < 80%）:   [Opus 4.8] 34% ctx · 7d 41%
5h が 80% 以上:     [Opus 4.8] 34% ctx · 7d 41% · 5h 83% (1h47m)
```

## 影響範囲・非破壊

- sidecar 書き出し契約（`{ts, context_pct, pane}`）と wrap 分岐（`OE_HEARTBEAT_WRAP_CMD`）には触れていない。#239 の consumer（`bin/oe-vitals`）は sidecar JSON のみを読むため、表示行の変更は機械契約に影響しない。
- `rate_limits.*` はリポジトリ内で未使用のフィールド（greenfield）。

## 検証

- `shellcheck`: producer / test とも findings なし。
- テスト（回帰なし）:
  - `test_oe_heartbeat_producer.sh`: PASS=47 FAIL=0（新 `[13]` 節 16 件を含む）
  - `test_sync_claude_statusline.sh`: PASS=17 FAIL=0
  - `test_oe_vitals.sh`: pass=77 fail=0
- 実機: デプロイ先は本リポジトリへの symlink のため、編集は sync なしで反映済み。`rate_limits` が実際に載るか（Pro/Max 認証・初回 API 応答後の条件）は、statusLine に `7d NN%` が出るかで確認できる。

## 非対象

- `/usage` の内訳（skill / subagent / plugin / MCP への帰属分解）。statusLine には渡ってこないため対象外。
- 外部ツール（ccusage 等）による推計。ネイティブの `rate_limits.*` が実値のためそちらを使う。

Refs #276
Refs #239
